### PR TITLE
Fix a couple of display problems in WS related dialogs

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/CannotFindMyLanguageDialog.cs
+++ b/PalasoUIWindowsForms/WritingSystems/CannotFindMyLanguageDialog.cs
@@ -16,6 +16,19 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			InitializeComponent();
 		}
 
+#if __MonoCS__
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			// The multi-line explanation is cropped on Linux and greyed out.
+			// The OnPaint method that is supposed to reliably display it nicely
+			// is deliberately not called in Mono 2.10.9.  The following adjustments
+			// allow the message to be displayed properly for Linux/Mono.
+			betterLabel1.Enabled = true;
+			betterLabel1.Height = betterLabel1.Height + 20;
+		}
+#endif
+
 		private void _okButton_Click(object sender, EventArgs e)
 		{
 			Close();

--- a/PalasoUIWindowsForms/WritingSystems/LookupISOControl.cs
+++ b/PalasoUIWindowsForms/WritingSystems/LookupISOControl.cs
@@ -83,6 +83,7 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			}
 			if (_desiredLanguageDisplayName.Visible)
 				AdjustDesiredLanguageNameFieldLocations();
+			AdjustCannotFindLanguageLocation();
 
 			UpdateReadiness();
 			_searchTimer.Start();
@@ -105,6 +106,23 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 					var newNameLoc = new System.Drawing.Point(newLabelLoc.X + labelWidth + 6, nameLocation.Y);
 					_desiredLanguageDisplayName.Location = newNameLoc;
 				}
+			}
+		}
+
+		/// <summary>
+		/// The link label for "Cannot find language?" is truncated on Linux/Mono.
+		/// Adjust the location to allow it to display properly.
+		/// </summary>
+		private void AdjustCannotFindLanguageLocation()
+		{
+			//_cannotFindLanguageLink
+			var labelLocation = _cannotFindLanguageLink.Location;
+			var labelWidth = _cannotFindLanguageLink.Width;
+			var shortage = labelLocation.X + labelWidth - this.Width;
+			if (shortage > 0)
+			{
+				var newLoc = new System.Drawing.Point(labelLocation.X - shortage, labelLocation.Y);
+				_cannotFindLanguageLink.Location = newLoc;
 			}
 		}
 


### PR DESCRIPTION
1) A LinkLabel is truncated in the Lookup Language Code dialog.
2) A text message is truncated in the "Can't find language" dialog.
