### PR TITLE
Automate cleanup of global resources opened by Palaso assembly

### DIFF
--- a/Palaso/Palaso.csproj
+++ b/Palaso/Palaso.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
 	<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -221,6 +221,7 @@
 	<Compile Include="Network\HttpUtilityFromMono.cs" />
 	<Compile Include="Network\ProxyCredentialSettings.Designer.cs" />
 	<Compile Include="Network\RobustNetworkOperation.cs" />
+	<Compile Include="PalasoSetup.cs" />
 	<Compile Include="Progress\Commands\AsyncCommand.cs" />
 	<Compile Include="Progress\BackgroundWorkerState.cs" />
 	<Compile Include="Progress\Commands\BasicCommand.cs" />

--- a/Palaso/PalasoSetup.cs
+++ b/Palaso/PalasoSetup.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Palaso
+{	/// <summary>
+	/// Provide global setup and shutdown for the Palaso assembly.
+	/// </summary>
+	/// <remarks>
+	/// This should be used something like the following in a program's Main() method:
+	/// using (new PalasoSetup())
+	/// {
+	/// 	Application.Run(new MainWindow(args));
+	/// }
+	/// </remarks>
+	/// <remarks>
+	/// At the moment, this is needed only if the program implicitly or explicitly
+	/// uses Palaso.UsbDrive on Linux/Mono.
+	/// </remarks>
+	public class PalasoSetup : IDisposable
+	{
+		public PalasoSetup()
+		{
+		}
+		private bool disposed = false;
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			if (disposing)
+			{
+			}
+#if __MonoCS__
+			// Using Palaso.UseDrive on Linux/Mono results in NDesk spinning up a thread that
+			// continues until NDesk Bus is closed.  Failure to close the thread results in a
+			// program hang when closing.  Closing the system bus allows the thread to close,
+			// and thus the program to close.  Closing the system bus can happen safely only
+			// at the end of the program.
+			NDesk.DBus.Bus.System.Close();
+#endif
+			disposed = true;
+		}
+
+		~PalasoSetup()
+		{
+			Dispose(false);
+		}
+	}
+}
+


### PR DESCRIPTION
At the moment, this applies only to Linux/Mono for one particular
resource, but could be extended as needed.

See https://jira.sil.org/browse/WS-11 (and probably https://jira.sil.org/browse/FWNX-1363) for why this is needed.
