### PR TITLE
NAudio should not be referenced by Linux builds

### DIFF
--- a/Palaso.Media.Tests/AudioPlayerTests.cs
+++ b/Palaso.Media.Tests/AudioPlayerTests.cs
@@ -3,10 +3,10 @@ using System.ComponentModel;
 using System.IO;
 using System.Media;
 using System.Threading;
-using NAudio.Wave;
 using NUnit.Framework;
 using Palaso.IO;
 #if !MONO
+using NAudio.Wave;
 using Palaso.Media.Naudio;
 #endif
 using Palaso.Media.Tests.Properties;


### PR DESCRIPTION
During SourcePackage builds of libpalaso, Windows DLLs are not
present and the build breaks due to "using NAudio.Wave" which
should not be used in Linux (since NAudio is Windows-only).
