### PR TITLE
Fix bug with moving files on Linux

### DIFF
--- a/Palaso/IO/FileUtils.cs
+++ b/Palaso/IO/FileUtils.cs
@@ -217,9 +217,9 @@ namespace Palaso.IO
 			{
 				try
 				{
-					if ((Path.GetPathRoot(sourcePath) != Path.GetPathRoot(destinationPath))
+					if (!PathUtilities.PathsAreOnSameVolume(sourcePath, destinationPath)
 						||
-						((!string.IsNullOrEmpty(backupPath)) && (Path.GetPathRoot(sourcePath) != Path.GetPathRoot(backupPath))))
+						(!string.IsNullOrEmpty(backupPath) && !PathUtilities.PathsAreOnSameVolume(sourcePath,backupPath)))
 					{
 						//can't use File.Replace or File.Move across volumes (sigh)
 						if (!string.IsNullOrEmpty(backupPath) && File.Exists(destinationPath))


### PR DESCRIPTION
When moving files on Linux we didn't detect when the destination
was on a different partition. This change fixes that and implements
and improves several other methods.

There is now a method PathUtilities.PathsAreOnSameVolume() that works
cross-platform.

Change-Id: I6c367c69ef03cd7c7d5849e707203d36a8089ef5
