### PR TITLE
Improvements to reporting dialogs

### DIFF
--- a/Palaso/Reporting/ErrorReport.cs
+++ b/Palaso/Reporting/ErrorReport.cs
@@ -150,8 +150,10 @@ namespace Palaso.Reporting
 				version += " (apparent build date: ";
 				try
 				{
-					string path = assembly.CodeBase.Replace(@"file:///", "");
-					version += File.GetLastWriteTimeUtc(path).Date.ToShortDateString() + ")";
+					string path = assembly.CodeBase.Replace(@"file://", "");
+					if (Palaso.PlatformUtilities.Platform.IsWindows)
+						path = path.TrimStart('/');
+					version += File.GetLastWriteTimeUtc(path).ToString("dd-MMM-yyyy") + ")";
 				}
 				catch
 				{
@@ -203,8 +205,9 @@ namespace Palaso.Reporting
 			{
 				var asm = Assembly.GetEntryAssembly();
 				var ver = asm.GetName().Version;
-				var file = asm.CodeBase.Replace("file:", string.Empty);
-				file = file.TrimStart('/');
+				var file = asm.CodeBase.Replace("file://", string.Empty);
+				if (Palaso.PlatformUtilities.Platform.IsWindows)
+					file = file.TrimStart('/');
 				var fi = new FileInfo(file);
 
 				return string.Format(

--- a/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.cs
+++ b/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.cs
@@ -320,7 +320,7 @@ namespace Palaso.UI.WindowsForms.Reporting
 		/// ------------------------------------------------------------------------------------
 		protected void GatherData()
 		{
-			_details.Text += "\r\nTo Reproduce: " + m_reproduce.Text + "\r\n";
+			_details.Text += Environment.NewLine + "To Reproduce: " + m_reproduce.Text + Environment.NewLine;
 		}
 
 		 public void Report(Exception error, Form owningForm)
@@ -365,8 +365,8 @@ namespace Palaso.UI.WindowsForms.Reporting
 			 //we want the developer to read.
 			 if (innerMostException != null)
 			 {
-				 _details.Text += "Inner-most exception:\r\n" + ErrorReport.GetExceptionText(innerMostException) +
-								  "\r\n\r\nFull, hierarchical exception contents:\r\n" + _details.Text;
+				_details.Text = string.Format("Inner-most exception:{2}{0}{2}{2}Full, hierarchical exception contents:{2}{1}",
+					ErrorReport.GetExceptionText(innerMostException), _details.Text, Environment.NewLine);
 			 }
 
 			 AddErrorReportingPropertiesToDetails();
@@ -624,7 +624,8 @@ namespace Palaso.UI.WindowsForms.Reporting
 			 {
 				 PutOnClipboard();
 				 ErrorReport.NotifyUserOfProblem(error,
-					 "This program wasn't able to get your email program, if you have one, to send the error message.  The contents of the error message has been placed on your Clipboard.");
+					"This program wasn't able to get your email program, if you have one, to send the error message.  " +
+					"The contents of the error message has been placed on your Clipboard.");
 				 return false;
 			 }
 			 return false;
@@ -719,14 +720,14 @@ namespace Palaso.UI.WindowsForms.Reporting
 		 private void _privacyNoticeButton_Click(object sender, EventArgs e)
 		 {
 			MessageBox.Show(
-				@"If you don’t care who reads your bug report, you can skip this notice.
+				@"If you don't care who reads your bug report, you can skip this notice.
 
-When you submit a crash report or other issue, the contents of your email go in our issue tracking system, “jira”, which is available via the web at http://jira.palso.org/issues. This is the normal way to handle issues in an open-source project.
+When you submit a crash report or other issue, the contents of your email go in our issue tracking system, ""jira"", which is available via the web at http://jira.palaso.org/issues. This is the normal way to handle issues in an open-source project.
 
 Our issue-tracking system is not searchable by those without an account. Therefore, someone searching via Google will not find your bug reports.
 
-However, anyone can make an account and then read what you sent us. So if you have something private to say, please send it to one of the developers privately with a note that you don’t want the issue in our issue tracking system. If need be, we’ll make some kind of sanitized place-holder for your issue so that we don’t lose it.
-");
+However, anyone can make an account and then read what you sent us. So if you have something private to say, please send it to one of the developers privately with a note that you don't want the issue in our issue tracking system. If need be, we'll make some kind of sanitized place-holder for your issue so that we don't lose it.
+", "Privacy Notice");
 		 }
 
 		 private void ExceptionReportingDialog_KeyPress(object sender, KeyPressEventArgs e)

--- a/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.resx
+++ b/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.resx
@@ -403,7 +403,7 @@
 	<value>1</value>
   </data>
   <data name="_emailAddress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Bottom, Right</value>
+	<value>Bottom, Left</value>
   </data>
   <data name="_emailAddress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
 	<value>NoControl</value>
@@ -412,7 +412,7 @@
 	<value>25, 434</value>
   </data>
   <data name="_emailAddress.Size" type="System.Drawing.Size, System.Drawing">
-	<value>154, 14</value>
+	<value>296, 23</value>
   </data>
   <data name="_emailAddress.TabIndex" type="System.Int32, mscorlib">
 	<value>29</value>

--- a/PalasoUIWindowsForms/Reporting/ProblemNotificationDialog.Designer.cs
+++ b/PalasoUIWindowsForms/Reporting/ProblemNotificationDialog.Designer.cs
@@ -136,7 +136,6 @@ namespace Palaso.UI.WindowsForms.Reporting
 			this.ClientSize = new System.Drawing.Size(466, 189);
 			this.ControlBox = false;
 			this.Controls.Add(this.tableLayoutOuter);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.MinimumSize = new System.Drawing.Size(450, 38);


### PR DESCRIPTION
- Make ProblemNotificationDialog resizable
- Fix build date reporting on Linux
- Fix newlines in exception reporting dialog
- Fix single and double quotes in Privacy Notice message box
- Display privacy notice message box with title
- Improve display of email address in exception reporting dialog

Change-Id: If3646561a3ebaf03c14a78cfa9bbdd19dc596388
