### PR TITLE
Don't crash if there are no ibus keyboards installed (FWNX-1382)

### DIFF
--- a/PalasoUIWindowsForms.Tests/Keyboarding/IbusKeyboardAdaptorTests.cs
+++ b/PalasoUIWindowsForms.Tests/Keyboarding/IbusKeyboardAdaptorTests.cs
@@ -107,6 +107,11 @@ namespace PalasoUIWindowsForms.Tests.Keyboarding
 			protected override void InitKeyboards()
 			{
 			}
+
+			protected override IBusEngineDesc[] GetIBusKeyboards()
+			{
+				return new IBusEngineDesc[0];
+			}
 		}
 
 		private static IbusKeyboardDescription CreateMockIbusKeyboard(IbusKeyboardAdaptor ibusKeyboardAdapter,

--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusCommunicator.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusCommunicator.cs
@@ -312,7 +312,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			{
 				if (m_inputContext != null)
 					return m_inputContext;
-				if (m_contextCreated)
+				if (m_contextCreated || !Connected)
 					return null;		// we must have had an error that cleared m_inputContext
 				CreateInputContext();
 				return m_inputContext;

--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
@@ -68,7 +68,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			}
 		}
 
-		private IBusEngineDesc[] GetIBusKeyboards()
+		protected virtual IBusEngineDesc[] GetIBusKeyboards()
 		{
 			if (!IBusCommunicator.Connected)
 				return new IBusEngineDesc[0];
@@ -424,7 +424,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			// Don't turn on any Ibus IME keyboard until requested explicitly.
 			// If we do nothing, the first Ibus IME keyboard is automatically activated.
 			IBusCommunicator.FocusIn();
-			if (GlobalCachedInputContext.InputContext != null)
+			if (GlobalCachedInputContext.InputContext != null && GetIBusKeyboards().Length > 0)
 			{
 				var context = GlobalCachedInputContext.InputContext;
 				context.Reset();


### PR DESCRIPTION
If IBus is running but there are no ibus input methods listed in
the IBus Preferences we shouldn't try to set an ibus keyboard. This
might actually fix FWNX-1382.

This is an improved version of the previous reverted commit.
The additional changes will hopefully allow the tests to pass on TC.
