### PR TITLE
Don't crash if there are no ibus keyboards installed (FWNX-1382)

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
@@ -424,7 +424,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			// Don't turn on any Ibus IME keyboard until requested explicitly.
 			// If we do nothing, the first Ibus IME keyboard is automatically activated.
 			IBusCommunicator.FocusIn();
-			if (GlobalCachedInputContext.InputContext != null)
+			if (GlobalCachedInputContext.InputContext != null && GetIBusKeyboards().Length > 0)
 			{
 				var context = GlobalCachedInputContext.InputContext;
 				context.Reset();


### PR DESCRIPTION
If IBus is running but there are no ibus input methods listed in
the IBus Preferences we shouldn't try to set an ibus keyboard. This
might actually fix FWNX-1382.

Change-Id: I0e9fc9dc8344bc75aa281b7bb8994a2af9c958ee
