### PR TITLE
Don't crash if there are no ibus keyboards installed (FWNX-1382)

### DIFF
--- a/PalasoUIWindowsForms.Tests/Keyboarding/IbusKeyboardAdaptorTests.cs
+++ b/PalasoUIWindowsForms.Tests/Keyboarding/IbusKeyboardAdaptorTests.cs
@@ -107,6 +107,11 @@ namespace PalasoUIWindowsForms.Tests.Keyboarding
 			protected override void InitKeyboards()
 			{
 			}
+
+			protected override IBusEngineDesc[] GetIBusKeyboards()
+			{
+				return new IBusEngineDesc[0];
+			}
 		}
 
 		private static IbusKeyboardDescription CreateMockIbusKeyboard(IbusKeyboardAdaptor ibusKeyboardAdapter,

--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusCommunicator.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusCommunicator.cs
@@ -312,7 +312,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			{
 				if (m_inputContext != null)
 					return m_inputContext;
-				if (m_contextCreated)
+				if (m_contextCreated || !Connected)
 					return null;		// we must have had an error that cleared m_inputContext
 				CreateInputContext();
 				return m_inputContext;

--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
@@ -68,7 +68,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			}
 		}
 
-		private IBusEngineDesc[] GetIBusKeyboards()
+		protected virtual IBusEngineDesc[] GetIBusKeyboards()
 		{
 			if (!IBusCommunicator.Connected)
 				return new IBusEngineDesc[0];


### PR DESCRIPTION
If IBus is running but there are no ibus input methods listed in
the IBus Preferences we shouldn't try to set an ibus keyboard. This
might actually fix FWNX-1382.

This is an improved version of the previous reverted commit.
The additional changes will hopefully allow the tests to pass on TC.

Change-Id: I51518666648e516399c1f8426785469aaa1b263c
