### PR TITLE
Bugfix for issue WS-55

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/WSSortControl.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WSSortControl.cs
@@ -37,11 +37,8 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			_defaultFontSize = _sortRulesTextBox.Font.SizeInPoints;
 
 			// default text for testing the sort rules
-			_testSortText.Text = @"pear
-apple
-orange
-mango
-peach";
+			// default text for testing the sort rules; bug fix for WS-55 so all platforms have the right line ending
+			_testSortText.Text = String.Join(Environment.NewLine, new string[] { "pear", "apple", "orange", "mango", "peach" });
 		}
 
 		public void BindToModel(WritingSystemSetupModel model)


### PR DESCRIPTION
Windows line ending issue with the default
text for testing the sort rules in the
WeSay configuration Tool.
