### PR TITLE
Fixes text truncation on language name in ConfigTool Input Systems tab

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/WritingSystemSetupView.Designer.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WritingSystemSetupView.Designer.cs
@@ -117,8 +117,7 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			//
 			// _languageName
 			//
-			this._languageName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
+			this._languageName.Dock = System.Windows.Forms.DockStyle.Fill;
 			this._languageName.BorderStyle = System.Windows.Forms.BorderStyle.None;
 			this._languageName.Font = new System.Drawing.Font("Segoe UI", 9F);
 			this._languageName.Location = new System.Drawing.Point(3, 3);


### PR DESCRIPTION
Bugfix for WS-51 where letters with descenders like "g" were cut off
in Linux.
