### PR TITLE
Temp: Work-around crash in WeSay with GeckoFx 29

### DIFF
--- a/PalasoUIWindowsForms/Progress/LogBox.cs
+++ b/PalasoUIWindowsForms/Progress/LogBox.cs
@@ -163,7 +163,13 @@ namespace Palaso.UI.WindowsForms.Progress
 
 		public override string Text
 		{
-			get { return "Box:" + _box.Text + "Verbose:" + _verboseBox.Text; }
+			get {
+				// The Text property get called during ctor so return an 
+				// empty string in that case.  This works around a crash 
+				// in WeSay.
+				if (_box == null || _verboseBox == null) return String.Empty;
+				return "Box:" + _box.Text + "Verbose:" + _verboseBox.Text; 
+			}
 		}
 
 		public string Rtf


### PR DESCRIPTION
During a backup, a LogBox is created and the Text property is
accessed during ctor chain.  It seems like there has always been an
C# Null Pointer Exception here, but it now it causes a SIGSEGV in
xulrunner29.  This change will keep the C# Null Pointer Exception
from happening and allow WeSay to work while we figure out the
problem with xulrunner29.
