### PR TITLE
Preserve <span> information in MultiText strings

### DIFF
--- a/Palaso.DictionaryServices/Lift/LexEntryFromLiftBuilder.cs
+++ b/Palaso.DictionaryServices/Lift/LexEntryFromLiftBuilder.cs
@@ -480,7 +480,7 @@ namespace Palaso.DictionaryServices.Lift
 
 		private static void MergeIn(MultiTextBase multiText, LiftMultiText forms)
 		{
-			multiText.MergeIn(MultiText.Create(forms.AsSimpleStrings));
+			multiText.MergeIn(MultiText.Create(forms.AsSimpleStrings, forms.AllSpans));
 			AddAnnotationsToMultiText(forms, multiText);
 		}
 

--- a/Palaso.DictionaryServices/Lift/LiftWriter.cs
+++ b/Palaso.DictionaryServices/Lift/LiftWriter.cs
@@ -680,6 +680,7 @@ namespace Palaso.DictionaryServices.Lift
 		{
 			foreach (LanguageForm form in forms)
 			{
+				var spans = form.Spans;
 				Writer.WriteStartElement(wrapper);
 				Writer.WriteAttributeString("lang", form.WritingSystemId);
 				if (doMarkTheFirst)
@@ -712,19 +713,97 @@ namespace Palaso.DictionaryServices.Lift
 				if(isTextWellFormedXml)
 				{
 					Writer.WriteStartElement("text");
-					Writer.WriteRaw(form.Form.EscapeAnyUnicodeCharactersIllegalInXml());
+					if (spans.Count > 0)
+					{
+						Writer.WriteString("");		// trick writer into knowing this is "mixed mode".
+						int index = 0;
+						int count;
+						foreach (var span in spans)
+						{
+							if (index < span.Index)
+							{
+								count = span.Index - index;
+								string txtBefore = String.Empty;
+								if (index + count <= form.Form.Length)
+									txtBefore = form.Form.Substring(index, count);
+								else if (index < form.Form.Length)
+									txtBefore = form.Form.Substring(index);
+								Writer.WriteRaw(txtBefore.EscapeAnyUnicodeCharactersIllegalInXml());
+							}
+							var txtInner = WriteSpanStartElementAndGetText(form, span);
+							Writer.WriteRaw(txtInner.EscapeAnyUnicodeCharactersIllegalInXml());
+							Writer.WriteEndElement();
+							index = span.Index + span.Length;
+						}
+						if (index < form.Form.Length)
+						{
+							var txtAfter = form.Form.Substring(index);
+							Writer.WriteRaw(txtAfter.EscapeAnyUnicodeCharactersIllegalInXml());
+						}
+					}
+					else
+					{
+						Writer.WriteRaw(form.Form.EscapeAnyUnicodeCharactersIllegalInXml());
+					}
 					Writer.WriteEndElement();
-//                    Writer.WriteRaw(wrappedTextToExport.EscapeAnyUnicodeCharactersIllegalInXml());// .WriteRaw(wrappedTextToExport);
 				}
 				else
 				{
 					Writer.WriteStartElement("text");
-					Writer.WriteRaw(form.Form.EscapeSoXmlSeesAsPureTextAndEscapeCharactersIllegalInXml());
+					if (spans.Count > 0)
+					{
+						Writer.WriteString("");		// trick writer into knowing this is "mixed mode".
+						int index = 0;
+						int count;
+						foreach (var span in spans)
+						{
+							if (index < span.Index)
+							{
+								count = span.Index - index;
+								string txtBefore = String.Empty;
+								if (index + count <= form.Form.Length)
+									txtBefore = form.Form.Substring(index, count);
+								else if (index < form.Form.Length)
+									txtBefore = form.Form.Substring(index);
+								Writer.WriteRaw(txtBefore.EscapeSoXmlSeesAsPureTextAndEscapeCharactersIllegalInXml());
+							}
+							var txtInner = WriteSpanStartElementAndGetText(form, span);
+							Writer.WriteRaw(txtInner.EscapeSoXmlSeesAsPureTextAndEscapeCharactersIllegalInXml());
+							Writer.WriteEndElement();
+							index = span.Index + span.Length;
+						}
+						if (index < form.Form.Length)
+						{
+							var txtAfter = form.Form.Substring(index);
+							Writer.WriteRaw(txtAfter.EscapeSoXmlSeesAsPureTextAndEscapeCharactersIllegalInXml());
+						}
+					}
+					else
+					{
+						Writer.WriteRaw(form.Form.EscapeSoXmlSeesAsPureTextAndEscapeCharactersIllegalInXml());
+					}
 					Writer.WriteEndElement();
 				}
 				WriteFlags(form);
 				Writer.WriteEndElement();
 			}
+		}
+
+		string WriteSpanStartElementAndGetText(LanguageForm form, LanguageForm.FormatSpan span)
+		{
+			Writer.WriteStartElement("span");
+			if (!String.IsNullOrEmpty(span.Lang))
+				Writer.WriteAttributeString("lang", span.Lang);
+			if (!String.IsNullOrEmpty(span.Class))
+				Writer.WriteAttributeString("class", span.Class);
+			if (!String.IsNullOrEmpty(span.LinkURL))
+				Writer.WriteAttributeString("href", span.LinkURL);
+			if (span.Index + span.Length <= form.Form.Length)
+				return form.Form.Substring(span.Index, span.Length);
+			else if (span.Index < form.Form.Length)
+				return form.Form.Substring(span.Index);
+			else
+				return String.Empty;
 		}
 
 		private void WriteFlags(IAnnotatable thing)

--- a/Palaso.Lift/MultiText.cs
+++ b/Palaso.Lift/MultiText.cs
@@ -201,6 +201,33 @@ namespace Palaso.Lift
 			return m;
 		}
 
+		public static MultiText Create(Dictionary<string, string> forms, Dictionary<string, List<LiftSpan>> spans)
+		{
+			if (forms == null)
+				throw new ArgumentNullException("forms");
+			if (spans == null)
+				spans = new Dictionary<string, List<LiftSpan>>();
+			MultiText m = new MultiText();
+			CopyForms(forms, m);
+			m.CopySpans(spans);
+			return m;
+		}
+
+		void CopySpans(Dictionary<string, List<LiftSpan>> spans)
+		{
+			foreach (var key in spans.Keys)
+			{
+				LanguageForm form = Find(key);
+				if (form == null)
+					continue;
+				foreach (var span in spans[key])
+				{
+					form.AddSpan(span.Index, span.Length, span.Lang, span.Class, span.LinkURL);
+				}
+			}
+		}
+
+
 		public static string ConvertLiftStringToSimpleStringWithMarkers(LiftString liftString)
 		{
 			string stringWithSpans = liftString.Text;

--- a/Palaso.Lift/Parsing/LiftMultiText.cs
+++ b/Palaso.Lift/Parsing/LiftMultiText.cs
@@ -252,6 +252,25 @@ namespace Palaso.Lift.Parsing
 		}
 
 		/// <summary>
+		/// For WeSay, to allow spans to be carried along even if not used.
+		/// </summary>
+		public Dictionary<string, List<LiftSpan>> AllSpans
+		{
+			get
+			{
+				Dictionary<string, List<LiftSpan>> result = new Dictionary<string, List<LiftSpan>>();
+				foreach (KeyValuePair<string, LiftString> pair in this)
+				{
+					if (pair.Value != null)
+					{
+						result.Add(pair.Key, pair.Value.Spans);
+					}
+				}
+				return result;
+			}
+		}
+
+		/// <summary>
 		/// Check whether this LiftMultiText is empty.
 		/// </summary>
 		public bool IsEmpty

--- a/Palaso.Tests/Text/LanguageFormTest.cs
+++ b/Palaso.Tests/Text/LanguageFormTest.cs
@@ -21,12 +21,19 @@ namespace Palaso.Tests.Text
 			get {  return "|_parent|"; }
 		}
 
+		public override string EqualsExceptionList
+		{
+			//_spans: is a List<T> which doesn't compare well with Equals (two separate empty lists are deemed different for example)
+			get {  return "|_spans|"; }
+		}
+
 		protected override List<ValuesToSet> DefaultValuesForTypes
 		{
 			get { return new List<ValuesToSet>
 							 {
 								 new ValuesToSet("string", "not string"),
-								 new ValuesToSet(new Annotation{IsOn = false}, new Annotation{IsOn = true})
+								 new ValuesToSet(new Annotation{IsOn = false}, new Annotation{IsOn = true}),
+								 new ValuesToSet(new List<LanguageForm.FormatSpan>(), new List<LanguageForm.FormatSpan>{new LanguageForm.FormatSpan()})
 							 }; }
 		}
 	}

--- a/Palaso/Text/LanguageForm.cs
+++ b/Palaso/Text/LanguageForm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Xml.Serialization;
 using Palaso.Annotations;
 using Palaso.Code;
@@ -9,11 +10,11 @@ namespace Palaso.Text
 	/// <summary>
 	/// A LanguageForm is a unicode string plus the id of its writing system
 	/// </summary>
-   // [ReflectorType("alt")]
 	public class LanguageForm : Annotatable, IComparable<LanguageForm>
 	{
 		private string _writingSystemId;
 		private string _form;
+		private readonly List<FormatSpan> _spans = new List<FormatSpan>();
 
 		/// <summary>
 		/// See the comment on MultiText._parent for information on
@@ -35,7 +36,6 @@ namespace Palaso.Text
 			_form =  form;
 		}
 
-		//[ReflectorProperty("ws", Required = true)]
 		[XmlAttribute("ws")]
 		public string WritingSystemId
 		{
@@ -48,12 +48,17 @@ namespace Palaso.Text
 			}
 		}
 
-		//[ReflectorProperty("form", Required = true)]
 		[XmlText]
 		public string Form
 		{
 			get { return _form; }
 			set { _form = value; }
+		}
+
+		[XmlIgnore]
+		public List<FormatSpan> Spans
+		{
+			get { return _spans; }
 		}
 
 		/// <summary>
@@ -81,6 +86,14 @@ namespace Palaso.Text
 			if ((WritingSystemId != null && !WritingSystemId.Equals(other.WritingSystemId)) || (other.WritingSystemId != null && !other.WritingSystemId.Equals(WritingSystemId))) return false;
 			if ((Form != null && !Form.Equals(other.Form)) || (other.Form != null && !other.Form.Equals(Form))) return false;
 			if ((_annotation != null && !_annotation.Equals(other._annotation)) || (other._annotation != null && !other._annotation.Equals(_annotation))) return false;
+			if (_spans != other.Spans)
+			{
+				if (_spans == null || other.Spans == null || _spans.Count != other.Spans.Count) return false;
+				for (int i = 0; i < _spans.Count; ++i)
+				{
+					if (!_spans[i].Equals(other.Spans[i])) return false;
+				}
+			}
 			return true;
 		}
 
@@ -105,7 +118,47 @@ namespace Palaso.Text
 			clone._writingSystemId = _writingSystemId;
 			clone._form = _form;
 			clone._annotation = _annotation == null ? null : _annotation.Clone();
+			foreach (var span in _spans)
+				clone._spans.Add(new FormatSpan{Index=span.Index, Length=span.Length, Class=span.Class, Lang=span.Lang, LinkURL=span.LinkURL});
 			return clone;
+		}
+
+		/// <summary>
+		/// Store formatting information for one span of characters in the form.
+		/// (This information is not used, but needs to be maintained for output.)
+		/// </summary>
+		/// <remarks>
+		/// Although the LIFT standard officially allows nested spans, we don't
+		/// bother because FieldWorks doesn't support them.
+		/// </remarks>
+		public class FormatSpan
+		{
+			/// <summary>Store the starting index of the span</summary>
+			public int Index { get; set; }
+			/// <summary>Store the length of the span</summary>
+			public int Length { get; set; }
+			/// <summary>Store the language of the data in the span</summary>
+			public string Lang { get; set; }
+			/// <summary>Store the class (style) applied to the data in the span</summary>
+			public string Class { get; set; }
+			/// <summary>Store the underlying URL link of the span</summary>
+			public string LinkURL { get; set; }
+
+			public override bool Equals(object other)
+			{
+				var that = other as FormatSpan;
+				if (that == null)
+					return false;
+				if (this.Index != that.Index || this.Length!= that.Length)
+					return false;
+				return (this.Class == that.Class && this.Lang == that.Lang && this.LinkURL == that.LinkURL);
+			}
+		}
+
+		public void AddSpan(int index, int length, string lang, string style, string url)
+		{
+			var span = new FormatSpan {Index=index, Length=length, Lang=lang, Class=style, LinkURL=url};
+			_spans.Add(span);
 		}
 	}
 }


### PR DESCRIPTION
This fixes http://jira.palaso.org/issues/browse/WS-34799, at least
to a first approximation.  No attempt is made to keep the spans in
sync with any editing of the field.  The user is not shown anything
to indicate that spans exist underneath to affect the formatting.
