### PR TITLE
Fix for updating <span> boundaries during user editing

### DIFF
--- a/Palaso.DictionaryServices/Lift/LiftWriter.cs
+++ b/Palaso.DictionaryServices/Lift/LiftWriter.cs
@@ -720,6 +720,9 @@ namespace Palaso.DictionaryServices.Lift
 						int count;
 						foreach (var span in spans)
 						{
+							// User edits may have effectively deleted the text of this span.
+							if (span.Length <= 0)
+								continue;
 							if (index < span.Index)
 							{
 								count = span.Index - index;
@@ -757,6 +760,9 @@ namespace Palaso.DictionaryServices.Lift
 						int count;
 						foreach (var span in spans)
 						{
+							// User edits may have effectively deleted the text of this span.
+							if (span.Length <= 0)
+								continue;
 							if (index < span.Index)
 							{
 								count = span.Index - index;

--- a/Palaso.Tests/Text/LanguageFormTest.cs
+++ b/Palaso.Tests/Text/LanguageFormTest.cs
@@ -233,5 +233,144 @@ namespace Palaso.Tests.Text
 			LanguageForm form2 = null;
 			Assert.That(form1.Equals((object)form2), Is.False);
 		}
+
+		[Test]
+		public void UpdateSpans_Insert()
+		{
+			// In these tests, we're testing (inserting) edits to the formatted string
+			// "This is a <span class='Strong'>test</span> of <span class='Weak'>something</span> or other."
+			// See http://jira.palaso.org/issues/browse/WS-34799 for a discussion of what we want to achieve.
+			List<LanguageForm.FormatSpan> spans = new List<LanguageForm.FormatSpan>();
+			string oldString = "This is a test of something or other.";
+
+			// before any spans (add 3 characters)
+			var expected = CreateSpans(spans, 3, 0, 3, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This isn't a test of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// before any spans, but right next to the first span (add 5 characters)
+			expected = CreateSpans(spans, 5, 0, 5, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a good test of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// after any spans (add 5 characters, but spans don't change)
+			expected = CreateSpans(spans, 0, 0, 0, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a test of something else or other.", spans);
+			VerifySpans(expected, spans);
+
+			// inside the first span (increase its length by 2)
+			expected = CreateSpans(spans, 0, 2, 2, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a tessst of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// after the first span, but right next to it (increase its length by 3)
+			expected = CreateSpans(spans, 0, 3, 3, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a testing of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// inside the second span (increase its length by 9)
+			expected = CreateSpans(spans, 0, 0, 0, 9);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a test of some kind of thing or other.", spans);
+			VerifySpans(expected, spans);
+
+			// between the two spans (effectively add 1 character)
+			expected = CreateSpans(spans, 0, 0, 1, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a test for something or other.", spans);
+			VerifySpans(expected, spans);
+		}
+
+		[Test]
+		public void AdjustSpans_Delete()
+		{
+			// In these tests, we're testing (deleting) edits to the formatted string
+			// "This is a <span class='Strong'>test</span> of <span class='Weak'>something</span> or other."
+			// See http://jira.palaso.org/issues/browse/WS-34799 for a discussion of what we want to achieve.
+			List<LanguageForm.FormatSpan> spans = new List<LanguageForm.FormatSpan>();
+			string oldString = "This is a test of something or other.";
+
+			// before any spans (remove 3 characters)
+			var expected = CreateSpans(spans, -3, 0, -3, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This a test of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// before any spans, but next to first span (remove 2 characters)
+			expected = CreateSpans(spans, -2, 0, -2, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is test of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// start before any spans, but including part of first span (remove 2 before and 2 inside span)
+			expected = CreateSpans(spans, -2, -2, -4, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is st of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// start before any spans, but extending past first span (remove 2 before, 4 inside, and 4 after/between)
+			// The span length going negative is okay, and the same as going to zero: the span is ignored thereafter.
+			expected = CreateSpans(spans, -2, -8, -10, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// delete exactly the first span (remove 4 inside)
+			expected = CreateSpans(spans, 0, -4, -4, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a  of something or other.", spans);
+			VerifySpans(expected, spans);
+
+			// after any spans (effectively no change)
+			expected = CreateSpans(spans, 0, 0, 0, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a test of something or other", spans);
+			VerifySpans(expected, spans);
+
+			// after any spans, but adjacent to last span (effectively no change)
+			expected = CreateSpans(spans, 0, 0, 0, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a test of somethingther.", spans);
+			VerifySpans(expected, spans);
+
+			// delete from middle of first span to middle of second span
+			expected = CreateSpans(spans, 0, -2, -6, -7);
+			LanguageForm.AdjustSpansForTextChange(oldString, "This is a teng or other.", spans);
+			VerifySpans(expected, spans);
+
+			// change text without changing length of string
+			// (alas, we can't handle this kind of wholesale change, so effectively no change to the spans)
+			expected = CreateSpans(spans, 0, 0, 0, 0);
+			LanguageForm.AdjustSpansForTextChange(oldString, "That is a joke of some other topic!!!", spans);
+			VerifySpans(expected, spans);
+		}
+
+		static List<LanguageForm.FormatSpan> CreateSpans(List<LanguageForm.FormatSpan> spans, int deltaloc1, int deltalen1, int deltaloc2, int deltalen2)
+		{
+			spans.Clear();
+			spans.Add(new LanguageForm.FormatSpan {
+				Index = 10,
+				Length = 4,
+				Class = "Strong"
+			});
+			spans.Add(new LanguageForm.FormatSpan {
+				Index = 18,
+				Length = 9,
+				Class = "Weak"
+			});
+			var expected = new List<LanguageForm.FormatSpan>();
+			expected.Add(new LanguageForm.FormatSpan {
+				Index = 10 + deltaloc1,
+				Length = 4 + deltalen1,
+				Class = "Strong"
+			});
+			expected.Add(new LanguageForm.FormatSpan {
+				Index = 18 + deltaloc2,
+				Length = 9 + deltalen2,
+				Class = "Weak"
+			});
+			return expected;
+		}
+
+		void VerifySpans (List<LanguageForm.FormatSpan> expected, List<LanguageForm.FormatSpan> spans)
+		{
+			Assert.AreEqual(expected[0].Index, spans[0].Index, "first span index wrong");
+			Assert.AreEqual(expected[0].Length, spans[0].Length, "first span length wrong");
+			Assert.AreEqual(expected[0].Class, spans[0].Class, "first span class wrong");
+			Assert.AreEqual(expected[1].Index, spans[1].Index, "second span index wrong");
+			Assert.AreEqual(expected[1].Length, spans[1].Length, "second span length wrong");
+			Assert.AreEqual(expected[1].Class, spans[1].Class, "second span class wrong");
+		}
 	}
 }

--- a/Palaso/Text/LanguageForm.cs
+++ b/Palaso/Text/LanguageForm.cs
@@ -36,6 +36,13 @@ namespace Palaso.Text
 			_form =  form;
 		}
 
+		public LanguageForm(LanguageForm form, MultiTextBase parent)
+			: this(form.WritingSystemId, form.Form, parent)
+		{
+			foreach (var span in form.Spans)
+				AddSpan(span.Index, span.Length, span.Lang, span.Class, span.LinkURL);
+		}
+
 		[XmlAttribute("ws")]
 		public string WritingSystemId
 		{
@@ -159,6 +166,83 @@ namespace Palaso.Text
 		{
 			var span = new FormatSpan {Index=index, Length=length, Lang=lang, Class=style, LinkURL=url};
 			_spans.Add(span);
+		}
+
+		/// <summary>
+		/// Adjusts the spans for the changes from oldText to newText.  Assume that only one chunk of
+		/// text has changed between the two strings.
+		/// </summary>
+		public static void AdjustSpansForTextChange(string oldText, string newText, List<FormatSpan> spans)
+		{
+			// Be paranoid and check for null strings...  Just convert them to empty strings for our purposes.
+			// (I don't think they'll ever be null, but that fits the category of famous last words...)
+			if (oldText == null)
+				oldText = String.Empty;
+			if (newText == null)
+				newText = String.Empty;
+			// If there are no spans, the text hasn't actually changed, or the text length hasn't changed,
+			// then we'll assume we don't need to do anything.
+			if (spans == null || spans.Count == 0 || newText == oldText || newText.Length == oldText.Length)
+				return;
+			// Get the locations of the first changing character in the old string.
+			// We assume that OnTextChanged gets called for every single change, so that
+			// pinpoints the location, and the change in string length tells us the length
+			// of the change itself. (>0 = insertion, <0 = deletion)
+			int minLength = Math.Min(newText.Length, oldText.Length);
+			int diffLocation = minLength;
+			for (int i = 0; i < minLength; ++i)
+			{
+				if (newText[i] != oldText[i])
+				{
+					diffLocation = i;
+					break;
+				}
+			}
+			int diffLength = newText.Length - oldText.Length;
+			foreach (var span in spans)
+				AdjustSpan(span, diffLocation, diffLength);
+		}
+
+		private static void AdjustSpan(FormatSpan span, int location, int length)
+		{
+			if (span.Length <= 0)
+				return;		// we've already deleted all the characters in the span.
+			if (location > span.Index + span.Length || length == 0)
+				return;		// the change doesn't affect the span.
+			// Adding characters to the end of the span is probably desireable if they differ.
+			if (length > 0)
+			{
+				// Inserting characters is fairly easy to deal with.
+				if (location <= span.Index)
+					span.Index += length;
+				else
+					span.Length += length;
+			}
+			// The span changes only if the deletion starts before the end of the span.
+			else if (location < span.Index + span.Length)
+			{
+				// Deleting characters has a number of cases to deal with.
+				// Remember, length is a negative number here!
+				if (location < span.Index)
+				{
+					if (span.Index + length >= location)
+					{
+						span.Index += length;
+					}
+					else
+					{
+						int before = span.Index - location;
+						span.Index = location;
+						span.Length += (before + length);
+					}
+				}
+				else
+				{
+					span.Length += length;
+					if (span.Length < location - span.Index)
+						span.Length = location - span.Index;
+				}
+			}
 		}
 	}
 }

--- a/Palaso/Text/MultiTextBase.cs
+++ b/Palaso/Text/MultiTextBase.cs
@@ -172,6 +172,18 @@ namespace Palaso.Text
 		}
 
 		/// <summary>
+		/// Gets the Spans for the exact alternative or null.
+		/// </summary>
+		public List<LanguageForm.FormatSpan> GetExactAlternativeSpans(string writingSystemId)
+		{
+			LanguageForm alt = Find(writingSystemId);
+			if (null == alt)
+				return null;
+			else
+				return alt.Spans;
+		}
+
+		/// <summary>
 		/// Gives the string of the requested id if it exists, else the 'first'(?) one that does exist, else Empty String
 		/// </summary>
 		/// <returns></returns>
@@ -350,7 +362,7 @@ namespace Palaso.Text
 			}
 
 			//actually copy the contents, as we must now be the parent
-			forms[Forms.Length] = new LanguageForm(languageForm.WritingSystemId, languageForm.Form, this);
+			forms[Forms.Length] = new LanguageForm(languageForm, this);
 			Array.Sort(forms);
 			_forms = forms;
 		}


### PR DESCRIPTION
This partially (and alas imperfectly) implements the third stage
described in http://jira.palaso.org/issues/browse/WS-34799.  Of course, perfection is probably unobtainable.
