### PR TITLE
Add extension method to delete nodes

### DIFF
--- a/Palaso.Tests/Xml/XmlNodeExtensionsTests.cs
+++ b/Palaso.Tests/Xml/XmlNodeExtensionsTests.cs
@@ -45,5 +45,41 @@ namespace Palaso.Tests.Xml
 			var div = textarea.SelectSingleNodeHonoringDefaultNS("ancestor::div");
 			Assert.IsNotNull(div);
 		}
+
+		[Test]
+		public void DeleteNodes()
+		{
+			var dom = new XmlDocument();
+			dom.LoadXml(@"<?xml version='1.0' encoding='utf-8'?>
+<html xmlns='http://www.w3.org/1999/xhtml'>
+	<body>
+		<div class='A'><textarea></textarea></div>
+		<div class='B'><textarea></textarea></div>
+		<div class='A'><textarea></textarea></div>
+	</body>
+</html>");
+
+			dom.DeleteNodes("descendant-or-self::*[contains(@class, 'A')]");
+			Assert.AreEqual(1, dom.SafeSelectNodes("html/body/div").Count);
+		}
+
+		[Test]
+		public void DeleteNodes_NestedNodes()
+		{
+			var dom = new XmlDocument();
+			dom.LoadXml(@"<?xml version='1.0' encoding='utf-8'?>
+<html>
+	<body>
+		<div class='A'><div class='A'>child</div></div>
+		<div class='B'><div class='A'>child</div><textarea></textarea></div>
+		<div class='A'><textarea></textarea></div>
+	</body>
+</html>");
+
+			dom.DeleteNodes("descendant-or-self::*[contains(@class, 'A')]");
+
+			Assert.AreEqual(1, dom.SafeSelectNodes("html/body/div").Count);
+			Assert.AreEqual("<textarea></textarea>", dom.SafeSelectNodes("html/body/div")[0].InnerXml);
+		}
 	}
 }

--- a/Palaso/Xml/XmlNodeExtensions.cs
+++ b/Palaso/Xml/XmlNodeExtensions.cs
@@ -66,6 +66,17 @@ namespace Palaso.Xml
 			return x;
 		}
 
+		/// <summary>
+		/// Deletes the specified nodes from their parents.
+		/// </summary>
+		/// <remarks>We shouldn't delete the nodes while iterating over the
+		/// node list because that modifies the enumeration that we're looping over.</remarks>
+		public static void DeleteNodes(this XmlNode node, string path)
+		{
+			foreach (var toDelete in node.SafeSelectNodes(path).OfType<XmlElement>().ToArray())
+				toDelete.ParentNode.RemoveChild(toDelete);
+		}
+
 		public static string SelectTextPortion(this XmlNode node, string path, params object[] args)
 		{
 			var x = node.SelectNodes(string.Format(path, args));


### PR DESCRIPTION
We can't delete nodes while we're iterating over a node list because
that modifies the enumeration we're looping over. The new extension method
converts the list to an array and enumerates over the array.
