### PR TITLE
Fix blank About Boxes & allow link-following in external browser

### DIFF
--- a/PalasoUIWindowsForms.GeckoFxWebBrowserAdapter/GeckoFxWebBrowserAdapter.cs
+++ b/PalasoUIWindowsForms.GeckoFxWebBrowserAdapter/GeckoFxWebBrowserAdapter.cs
@@ -413,14 +413,12 @@ namespace Palaso.UI.WindowsForms.HtmlBrowser
 
 		public void Navigate(string urlString)
 		{
-			if(AllowNavigation)
-				CallBrowserMethod(_webBrowser, "Navigate", new object[] { urlString });
+			CallBrowserMethod(_webBrowser, "Navigate", new object[] { urlString });
 		}
 
 		public void Navigate(Uri url)
 		{
-			if(AllowNavigation)
-				CallBrowserMethod(_webBrowser, "Navigate", new object[] { url.AbsoluteUri });
+			Navigate(url.AbsoluteUri);
 		}
 
 		public void Refresh()

--- a/PalasoUIWindowsForms/HtmlBrowser/IWebBrowser.cs
+++ b/PalasoUIWindowsForms/HtmlBrowser/IWebBrowser.cs
@@ -7,7 +7,6 @@ namespace Palaso.UI.WindowsForms.HtmlBrowser
 {
 	public interface IWebBrowser
 	{
-		bool AllowNavigation { get; set; }
 		bool AllowWebBrowserDrop { get; set; }
 		bool CanGoBack { get; }
 		bool CanGoForward { get; }

--- a/PalasoUIWindowsForms/SIL/SILAboutBox.cs
+++ b/PalasoUIWindowsForms/SIL/SILAboutBox.cs
@@ -148,14 +148,11 @@ namespace Palaso.UI.WindowsForms.SIL
 
 		private void SILAboutBoxShown(object sender, EventArgs e)
 		{
-			_browser.Url = new Uri(_pathToAboutBoxHtml);
-			_browser.Navigated += _browser_Navigated;
-		}
-
-		private void _browser_Navigated(object sender, WebBrowserNavigatedEventArgs e)
-		{
-			_browser.Refresh();
-			_browser.ScrollLastElementIntoView();
+			//review: EB had changed from Navigate to this in ab66af23393f74b767ffd78c2182bd1fdc8eb963, presumably to 
+			// get around the AllowNavigation=false problem. It may work on Linux, but it didn't on Windows, which would just show a blank browser.
+			//_browser.Url = new Uri(_pathToAboutBoxHtml);
+			// So I've instead modified the browser wrapper to always let the first navigation get through, regardless
+			_browser.Navigate(_pathToAboutBoxHtml);
 		}
 	}
 }


### PR DESCRIPTION
I changed the meaning of XWebBrowser's AllowNavigation=false to mean: allow first page to load, but after that, open links in the system browser. The winforms meaning, is in contrast: prevent loading even the first page. If manually disabled only after that load, then ignore all link clicks.

Some previous commit left us with initial loads that failed, leading to, for example, empty About boxes in in all LibPalaso clients.
