### PR TITLE
Allow labels in ProgressDialog to display & character

### DIFF
--- a/PalasoUIWindowsForms/Progress/ProgressDialog.cs
+++ b/PalasoUIWindowsForms/Progress/ProgressDialog.cs
@@ -490,6 +490,7 @@ namespace Palaso.UI.WindowsForms.Progress
 			this._statusLabel.Size = new System.Drawing.Size(355, 15);
 			this._statusLabel.TabIndex = 12;
 			this._statusLabel.Text = "#";
+			this._statusLabel.UseMnemonic = false;
 			//
 			// _progressBar
 			//
@@ -530,6 +531,7 @@ namespace Palaso.UI.WindowsForms.Progress
 			this._progressLabel.Size = new System.Drawing.Size(272, 13);
 			this._progressLabel.TabIndex = 9;
 			this._progressLabel.Text = "#";
+			this._progressLabel.UseMnemonic = false;
 			//
 			// _showWindowIfTakingLongTimeTimer
 			//
@@ -556,6 +558,7 @@ namespace Palaso.UI.WindowsForms.Progress
 			this._overviewLabel.Size = new System.Drawing.Size(355, 15);
 			this._overviewLabel.TabIndex = 8;
 			this._overviewLabel.Text = "#";
+			this._overviewLabel.UseMnemonic = false;
 			//
 			// tableLayout
 			//


### PR DESCRIPTION
The default true value of UseMnemonic, intended for labels that actually label
some control, prevents status strings containing & from displaying properly
