### PR TITLE
Save files based on file extension

### DIFF
--- a/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
@@ -107,7 +107,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 		}
 
 		/// <summary>
-		/// Save an image to the given path, with the metadata embeded.
+		/// Save an image to the given path, with the metadata embedded.
 		/// Use the file extension of path to determine to format to save.
 		/// </summary>
 		/// <param name="path"></param>


### PR DESCRIPTION
In SW-34711 (11b8e94), the code to Save an image was change to make
a copy first before saving the Image.  At the same time, there was
word to ensure that files were stored in a web-friendly format
(jpg or png).  However, the extension of the output file was not
changed and the format silently changed. Also, the format of the
originally loaded image was used to determine the output file
format.  To make matters worse, WeSay would always change the
extension to png.  So the only files that would correctly get
imported were png files (even though the dialog allowed for
png, tif, bmp, and jpg).

This changes the PalasoImage.Save method to look at the extension
of the file name used to save the image to determine the format
that will be used.  A helper method is added to assist the caller
if they choose to use a web-friendly format extension (called by
WeSay).
