### PR TITLE
WS-130: Fix label Text

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/WSAddDuplicateMoreButtonBar.Designer.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WSAddDuplicateMoreButtonBar.Designer.cs
@@ -78,7 +78,7 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			//
 			this._exportMenuItem.Name = "_exportMenuItem";
 			this._exportMenuItem.Size = new System.Drawing.Size(259, 22);
-			this._exportMenuItem.Text = "&Save a Coy of the {0} LDML File...";
+			this._exportMenuItem.Text = "&Save a Copy of the {0} LDML File...";
 			this._exportMenuItem.Click += new System.EventHandler(this.ExportMenuClick);
 			//
 			// _importMenuItem


### PR DESCRIPTION
When no language is selected, one of the labels says,
"Save a Coy of the {0} LDML File...".  Replace Coy with Copy.

Note to reviewers, if you can suggest a substitution string for
{0} that should be used when no language is selected, then I
will consider adding that substitution to this fix.  It seems
ugly to see "{0}" in actual UI.  However, after a language is
selected, you can't unselect one.  Maybe the fix to this is to
select the first language when the dialog is opened.
