### PR TITLE
About Box Customisation

### DIFF
--- a/PalasoUIWindowsForms/ImageToolbox/ArtOfReadingChooser.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ArtOfReadingChooser.cs
@@ -187,6 +187,12 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 #if DEBUG
 				//  _searchTermsBox.Text = @"flower";
 #endif
+				if (string.IsNullOrEmpty(_searchTermsBox.Text))
+				{
+					_messageLabel.Visible = true;
+					_messageLabel.Font = new Font(SystemFonts.DialogFont.FontFamily, 10);
+					_messageLabel.Text = "This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.".Localize("ImageToolbox.EnterSearchTerms");
+				}
 				_thumbnailViewer.SelectedIndexChanged += new EventHandler(_thumbnailViewer_SelectedIndexChanged);
 			}
 


### PR DESCRIPTION
I changed the About Box to arrange controls using a table layout. I think that will help with future maintenance. Everything should be within a pixel or two of its original position. I also made the AboutBox resizable. That's probably not critical, but with the majority of the info being an HTML view, if the user really wants to see stuff easily, being able to increase the size helps. (I set the minimum to be the existing size so no app should have to worry about it getting sized so small that stuff gets clipped or lays out wrong.
The main functional change was to add a button and a link label that give the ability for the host application to help the user check for updates and see release notes. If the host app doesn't hook up an event handler for these controls, they will be hidden, so there will be no change for existing apps. This change was needed for HearThis, which is switching over to use the standard About Box.
