### PR TITLE
Fix missing keyboard layouts for Linux/Trusty

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Linux/CombinedKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CombinedKeyboardAdaptor.cs
@@ -79,8 +79,8 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 				foreach (var layout in kvp.Value)
 				{
 					int index;
-					if ((XkbKeyboards.TryGetValue(layout.LayoutId, out index) && layout.LayoutId == layout.LanguageCode) ||
-						XkbKeyboards.TryGetValue(string.Format("{0}+{1}", layout.LanguageCode, layout.LayoutId), out index))
+					if ((XkbKeyboards.TryGetValue(layout.LayoutId, out index) && (layout.LayoutId == layout.CountryCode.ToLowerInvariant())) ||
+						XkbKeyboards.TryGetValue(string.Format("{0}+{1}", layout.CountryCode.ToLowerInvariant(), layout.LayoutId), out index))
 					{
 						xkbAdaptor.AddKeyboardForLayout(layout, index, this);
 					}


### PR DESCRIPTION
Some keyboards chosen by the user never showed up in WeSay, while
other keyboards that were not chosen did show up.  Who knew that
Gnome uses country codes for primary keys in keyboard identifiers
instead of language codes?  This fixes WS-148 (and almost certainly
FWNX-1439).
