### PR TITLE
All keyboards should use CombinedKeyboardAdaptor on Trusty

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Linux/CombinedKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CombinedKeyboardAdaptor.cs
@@ -190,6 +190,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 				return;
 			}
 			KeyboardController.CombinedKeyboardHandling = true;
+			KeyboardController.Manager.ClearAllKeyboards();
 
 			AddAllKeyboards(g_variant_print(sources, false).Trim('[', ']'));
 		}


### PR DESCRIPTION
The default keyboard was still trying to use XkbKeyboardAdaptor, which
doesn't work on Trusty.  Thus, for example, the keyboard would never
switch back to the English keyboard after switching to the vernacular
language's keyboard in WeSay.  The same would probably happen in FW.
