### PR TITLE
Fix problem with AboutDialog

### DIFF
--- a/PalasoUIWindowsForms/SIL/SILAboutBox.Designer.cs
+++ b/PalasoUIWindowsForms/SIL/SILAboutBox.Designer.cs
@@ -108,6 +108,7 @@ namespace Palaso.UI.WindowsForms.SIL
 			this._browser.Size = new System.Drawing.Size(395, 435);
 			this._browser.TabIndex = 9;
 			this._browser.Url = new System.Uri("about:blank", System.UriKind.Absolute);
+			this._browser.AllowNavigation = false;
 			// 
 			// _checkForUpdates
 			// 


### PR DESCRIPTION
Links in the AboutDialog should be opened in an external browser.
This got broken in the recent refactoring of the AboutDialog.

Change-Id: Ic802d304d4b7e26ae0bb66520a482b5e833003bf
