### PR TITLE
Add option to display full version in AboutBox

### DIFF
--- a/PalasoUIWindowsForms.TestApp/Properties/AssemblyInfo.cs
+++ b/PalasoUIWindowsForms.TestApp/Properties/AssemblyInfo.cs
@@ -29,5 +29,6 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.3.4")]
+[assembly: AssemblyFileVersion("5.6.7.8")]
+[assembly: AssemblyInformationalVersion("9.10.11.3fe549")]

--- a/PalasoUIWindowsForms.TestApp/TestAppForm.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.cs
@@ -109,25 +109,27 @@ namespace PalasoUIWindowsForms.TestApp
 
 		private void OnSilAboutBoxClicked(object sender, EventArgs e)
 		{
-			ShowSilAboutBox(XWebBrowser.BrowserType.Default);
+			ShowSilAboutBox(XWebBrowser.BrowserType.Default, true);
 		}
 
 		private void OnSilAboutBoxGeckoClicked(object sender, EventArgs e)
 		{
-			ShowSilAboutBox(XWebBrowser.BrowserType.GeckoFx);
+			ShowSilAboutBox(XWebBrowser.BrowserType.GeckoFx, false);
 		}
 
-		private static void ShowSilAboutBox(XWebBrowser.BrowserType browserType)
+		private static void ShowSilAboutBox(XWebBrowser.BrowserType browserType, bool useFullVersionNumber)
 		{
 			XWebBrowser.DefaultBrowserType = browserType;
-			using(var tempfile = TempFile.WithExtension("html"))
+			using (var tempfile = TempFile.WithExtension("html"))
 			{
 				File.WriteAllText(tempfile.Path,
 					@"<html><body><h3>Copyright 2014 <a href=""http://sil.org"">SIL International</a></h3>" +
 					@"<p>Testing the <b>about box</b></p></body></html>");
 				var uri = new Uri(tempfile.Path);
-				using(var dlg = new SILAboutBox(uri.AbsoluteUri))
+				using (var dlg = new SILAboutBox(uri.AbsoluteUri, useFullVersionNumber))
+				{
 					dlg.ShowDialog();
+				}
 			}
 		}
 

--- a/PalasoUIWindowsForms/SIL/SILAboutBox.cs
+++ b/PalasoUIWindowsForms/SIL/SILAboutBox.cs
@@ -18,12 +18,18 @@ namespace Palaso.UI.WindowsForms.SIL
 		///
 		/// </summary>
 		/// <param name="pathToAboutBoxHtml">For example, use FileLocator.GetFileDistributedWithApplication("distfiles", "aboutBox.htm")</param>
-		public SILAboutBox(string pathToAboutBoxHtml)
+		/// <param name="useFullVersionNumber"><c>false</c> to only display the first three
+		/// parts of the version number, i.e. "MajorVersion.MinorVersion.Build",
+		/// <c>true</c> to display the full version number as found in Application.ProductVersion.
+		/// Passing <c>true</c> is useful if you want to display e.g. the git or hg revision of
+		/// the build. Typically this would be set in the AssemblyInformationalVersion.</param>
+		public SILAboutBox(string pathToAboutBoxHtml, bool useFullVersionNumber = false)
 		{
 			_assembly = Assembly.GetEntryAssembly(); // assembly;
 			_pathToAboutBoxHtml = pathToAboutBoxHtml;
 			InitializeComponent();
-			_versionNumber.Text = GetShortVersionInfo();
+			_versionNumber.Text = useFullVersionNumber ? Application.ProductVersion :
+				GetShortVersionInfo();
 			_buildDate.Text = GetBuiltOnDate();
 			Text = "About " + GetTitle();
 		}


### PR DESCRIPTION
When using a DVCS it's useful to add the SHA1 as revision to the version
number so that it easier to see the state of the code that was used to
build. This can be done by using the AssemblyInformationalVersion
attribute which gets used by Application.ProductVersion.

This change adds the option to display the full version number as taken
from Application.ProductVersion. The default behavior doesn't change and
will still show the short version number (MajorVersion.MinorVersion.Build).
To display the full version number the value TRUE can be passed to the
SILAboutBox c'tor.
