### PR TITLE
Do not attempt to add metadata to a filetype that does not support it

### DIFF
--- a/PalasoUIWindowsForms/ClearShare/MetaData.cs
+++ b/PalasoUIWindowsForms/ClearShare/MetaData.cs
@@ -350,9 +350,21 @@ namespace Palaso.UI.WindowsForms.ClearShare
 			Write(_path);
 		}
 
-		public void Write(string path)
+		/// <summary>Returns if the format of the image file supports metadata</summary>
+		public bool FileFormatSupportsMetadata(string path)
 		{
 			var file = TagLib.File.Create(path) as TagLib.Image.File;
+			return file != null && !file.GetType().FullName.Contains("NoMetadata");
+		}
+
+		public void Write(string path)
+		{
+			// do not attempt to add metadata to a file type that does not support it.
+			if (!FileFormatSupportsMetadata(path))
+				throw new NotSupportedException(String.Format("The image file {0} is in a format that does not support metadata.", Path.GetFileName(path)));
+
+			var file = TagLib.File.Create(path) as TagLib.Image.File;
+
 			file.GetTag(TagTypes.XMP, true); // The Xmp tag, at least, must exist so we can store properties into it.
 			// This does nothing if the file is not allowed to have PNG tags, that is, if it's not a PNG file.
 			// If it is, we want this tag to exist, since otherwise tools like exiftool (and hence old versions

--- a/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
@@ -225,10 +225,16 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 					throw;
 			}
 		}
+
+		/// <summary>Returns if the format of the image file supports metadata</summary>
+		public bool FileFormatSupportsMetadata
+		{
+			get { return Metadata.FileFormatSupportsMetadata(_pathForSavingMetadataChanges); }
+		}
+
 		private void SaveUpdatedMetadata()
 		{
 			Metadata.Write(_pathForSavingMetadataChanges);
-			Metadata.HasChanges = false;
 		}
 
 		private static Image LoadImageWithoutLocking(string path)


### PR DESCRIPTION
Bloom allows the user to select an image to insert into the book and edit the copyright text for that image in one step.  The copyright information is then stored in the metadata of the file, and the image is then copied the to book's directory and converted to a .png file if not already in that format.  Finally, if the metadata was not successfully written before the file was copied and converted, it is written to the new .png file.

Before this pull request, if the original image file was in a format that did not support metadata, e.g. a .bmp file, and exception was thrown that resulted in the metadata not being written at all.
