### PR TITLE
Add two new cross-platform methods to PathUtilities

### DIFF
--- a/Palaso/IO/PathUtilities.cs
+++ b/Palaso/IO/PathUtilities.cs
@@ -210,7 +210,7 @@ namespace Palaso.IO
 			switch (fileManager)
 			{
 				case "explorer.exe":
-					arguments = string.Format("/select \"{0}\"", filePath);
+					arguments = string.Format("/select, \"{0}\"", filePath);
 					break;
 				case "nautilus":
 				case "nemo":


### PR DESCRIPTION
- PathUtilities.OpenDirectoryInExplorer opens the directory in
  Explorer or the default file manager.
- PathUtilities.OpenFileInApplication opens a file in the default
  application (like double clicking on the file in explorer).

Change-Id: I199897ca5fe2c3fb78b13a7f71a5e21c7ca36457
