### PR TITLE
Make two dialogs public again

### DIFF
--- a/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.cs
+++ b/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.cs
@@ -11,7 +11,12 @@ using System.Text;
 
 namespace Palaso.UI.WindowsForms.Reporting
 {
-	internal class ExceptionReportingDialog : Form
+	/// <summary>
+	/// Display exception reporting dialog.
+	/// NOTE: It is recommended to call one of Palaso.Reporting.ErrorReport.Report(Non)Fatal*
+	/// methods instead of instantiating this class.
+	/// </summary>
+	public class ExceptionReportingDialog : Form
 	{
 		#region Local structs
 		private struct ExceptionReportingData

--- a/PalasoUIWindowsForms/Reporting/ProblemNotificationDialog.cs
+++ b/PalasoUIWindowsForms/Reporting/ProblemNotificationDialog.cs
@@ -5,7 +5,12 @@ using Palaso.UI.WindowsForms.Miscellaneous;
 
 namespace Palaso.UI.WindowsForms.Reporting
 {
-	internal partial class ProblemNotificationDialog : Form
+	/// <summary>
+	/// Display problem notification dialog.
+	/// NOTE: It is recommended to call Palaso.Reporting.ErrorReport.NotifyUserOfProblem
+	/// instead of instantiating this class.
+	/// </summary>
+	public partial class ProblemNotificationDialog : Form
 	{
 		private DialogResult _alternateButton1DialogResult;
 

--- a/PalasoUIWindowsForms/Reporting/WinFormsExceptionHandler.cs
+++ b/PalasoUIWindowsForms/Reporting/WinFormsExceptionHandler.cs
@@ -8,7 +8,7 @@ using Palaso.Reporting;
 
 namespace Palaso.UI.WindowsForms.Reporting
 {
-	internal class WinFormsExceptionHandler: ExceptionHandler
+	public class WinFormsExceptionHandler: ExceptionHandler
 	{
 		// see comment on ExceptionReportingDialog.s_reportDataStack
 		internal static Control ControlOnUIThread { get; private set; }


### PR DESCRIPTION
 There shouldn't be any need for a client in accessing the
ProblemNotificationDialog and ExceptionReportingDialog dialogs
directly but at least SayMore and Solid do, so I'm changing this
back.

A better way for the clients would be to call one of the
ErrorReport.NotifyUserOfProblem() or ErrorReport.Report*() methods
instead of instantiating these dialogs.

I'm not sure if any other project uses WinFormsExceptionHandler
directly but I'm tired of this discussion so I'm changing it back
to the bad design as well.

This change basically backs out commit 7e63d7.
