### PR TITLE
Resize drawing size so warning label avoids text clipping in windows

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/WSIdentifiers/ScriptRegionVariantView.Designer.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WSIdentifiers/ScriptRegionVariantView.Designer.cs
@@ -147,7 +147,7 @@
 			//
 			// ScriptRegionVariantView
 			//
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 14F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.Controls.Add(this._regionCombo);
 			this.Controls.Add(this._variant);


### PR DESCRIPTION
Just so you know, I've tested this in both windows and linux.
