### PR TITLE
Correct PalasoUIWindowsForms.Tests.csproj to have 2-space tabs

### DIFF
--- a/PalasoUIWindowsForms.Tests/PalasoUIWindowsForms.Tests.csproj
+++ b/PalasoUIWindowsForms.Tests/PalasoUIWindowsForms.Tests.csproj
@@ -1,237 +1,237 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-	<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-	<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-	<ProductVersion>9.0.21022</ProductVersion>
-	<SchemaVersion>2.0</SchemaVersion>
-	<ProjectGuid>{6E16866F-FF8D-4136-AD67-36AFE3626432}</ProjectGuid>
-	<OutputType>Library</OutputType>
-	<AppDesignerFolder>Properties</AppDesignerFolder>
-	<RootNamespace>PalasoUIWindowsForms.Tests</RootNamespace>
-	<AssemblyName>PalasoUIWindowsForms.Tests</AssemblyName>
-	<FileUpgradeFlags>
-	</FileUpgradeFlags>
-	<UpgradeBackupLocation>
-	</UpgradeBackupLocation>
-	<OldToolsVersion>3.5</OldToolsVersion>
-	<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-	<PublishUrl>publish\</PublishUrl>
-	<Install>true</Install>
-	<InstallFrom>Disk</InstallFrom>
-	<UpdateEnabled>false</UpdateEnabled>
-	<UpdateMode>Foreground</UpdateMode>
-	<UpdateInterval>7</UpdateInterval>
-	<UpdateIntervalUnits>Days</UpdateIntervalUnits>
-	<UpdatePeriodically>false</UpdatePeriodically>
-	<UpdateRequired>false</UpdateRequired>
-	<MapFileExtensions>true</MapFileExtensions>
-	<ApplicationRevision>0</ApplicationRevision>
-	<ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-	<IsWebBootstrapper>false</IsWebBootstrapper>
-	<UseApplicationTrust>false</UseApplicationTrust>
-	<BootstrapperEnabled>true</BootstrapperEnabled>
-	<TargetFrameworkProfile>
-	</TargetFrameworkProfile>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6E16866F-FF8D-4136-AD67-36AFE3626432}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PalasoUIWindowsForms.Tests</RootNamespace>
+    <AssemblyName>PalasoUIWindowsForms.Tests</AssemblyName>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-	<DebugSymbols>true</DebugSymbols>
-	<DebugType>full</DebugType>
-	<Optimize>false</Optimize>
-	<OutputPath>..\output\Debug</OutputPath>
-	<DefineConstants>DEBUG;TRACE</DefineConstants>
-	<ErrorReport>prompt</ErrorReport>
-	<WarningLevel>4</WarningLevel>
-	<PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\output\Debug</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-	<DebugType>pdbonly</DebugType>
-	<Optimize>true</Optimize>
-	<OutputPath>..\output\Release</OutputPath>
-	<DefineConstants>TRACE</DefineConstants>
-	<ErrorReport>prompt</ErrorReport>
-	<WarningLevel>4</WarningLevel>
-	<PlatformTarget>x86</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\output\Release</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugMono|AnyCPU' ">
-	<DebugSymbols>true</DebugSymbols>
-	<OutputPath>..\output\DebugMono</OutputPath>
-	<DefineConstants>TRACE;DEBUG;MONO</DefineConstants>
-	<DebugType>full</DebugType>
-	<PlatformTarget>AnyCPU</PlatformTarget>
-	<ErrorReport>prompt</ErrorReport>
-	<WarningLevel>4</WarningLevel>
-	<Optimize>false</Optimize>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\output\DebugMono</OutputPath>
+    <DefineConstants>TRACE;DEBUG;MONO</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseMono|AnyCPU' ">
-	<OutputPath>..\output\ReleaseMono</OutputPath>
-	<DefineConstants>TRACE;MONO</DefineConstants>
-	<Optimize>true</Optimize>
-	<DebugType>pdbonly</DebugType>
-	<PlatformTarget>AnyCPU</PlatformTarget>
-	<ErrorReport>prompt</ErrorReport>
-	<WarningLevel>4</WarningLevel>
+    <OutputPath>..\output\ReleaseMono</OutputPath>
+    <DefineConstants>TRACE;MONO</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-	<Reference Include="Moq">
-	  <HintPath>..\lib\common\Moq.dll</HintPath>
-	</Reference>
-	<Reference Include="System" />
-	<Reference Include="System.Core">
-	  <RequiredTargetFramework>3.5</RequiredTargetFramework>
-	</Reference>
-	<Reference Include="System.Data" />
-	<Reference Include="System.Deployment" />
-	<Reference Include="System.Drawing" />
-	<Reference Include="System.Windows.Forms" />
-	<Reference Include="System.Xml" />
-	<Reference Include="nunit.framework">
-	  <HintPath>..\lib\common\nunit.framework.dll</HintPath>
-	</Reference>
-	<Reference Include="ibusdotnet">
-	  <HintPath>..\lib\commonMono\ibusdotnet.dll</HintPath>
-	</Reference>
-	<Reference Include="NDesk.DBus">
-	  <HintPath>..\lib\commonMono\NDesk.DBus.dll</HintPath>
-	</Reference>
+    <Reference Include="Moq">
+      <HintPath>..\lib\common\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Deployment" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\lib\common\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="ibusdotnet">
+      <HintPath>..\lib\commonMono\ibusdotnet.dll</HintPath>
+    </Reference>
+    <Reference Include="NDesk.DBus">
+      <HintPath>..\lib\commonMono\NDesk.DBus.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-	<Compile Include="ClearShare\ClearShareUsage.cs" />
-	<Compile Include="ClearShare\ContributionTests.cs" />
-	<Compile Include="ClearShare\ContributorsListControlViewModelTests.cs" />
-	<Compile Include="ClearShare\MetadataEditorControlTests.cs" />
-	<Compile Include="ClearShare\CreativeCommonsLicenseTests.cs" />
-	<Compile Include="ClearShare\LicenseTests.cs" />
-	<Compile Include="ClearShare\MetadataTests.cs" />
-	<Compile Include="ClearShare\OlacSystemTests.cs" />
-	<Compile Include="ClearShare\RoleTests.cs" />
-	<Compile Include="FontTests\FontHelperTests.cs" />
-	<Compile Include="Hotspot\HotSpotProviderTestForms.cs" />
-	<Compile Include="Hotspot\HotSpotProviderTests.cs" />
-	<Compile Include="Hotspot\HotSpotTests.cs" />
-	<Compile Include="ImageGallery\ArtOfReadingImageCollectionTests.cs" />
-	<Compile Include="ImageToolbox\ImageToolboxTests.cs" />
-	<Compile Include="ClearShare\MetaDataDisplayTests.cs" />
-	<Compile Include="ImageToolbox\PalasoImageTests.cs" />
-	<Compile Include="ImageToolbox\TestImages.Designer.cs">
-	  <AutoGen>True</AutoGen>
-	  <DesignTime>True</DesignTime>
-	  <DependentUpon>TestImages.resx</DependentUpon>
-	</Compile>
-	<Compile Include="Keyboarding\FakeKeyboardController.cs" />
-	<Compile Include="Keyboarding\IBusAdaptorTestsWithIBus.cs" />
-	<Compile Include="Keyboarding\IBusAdaptorTestsWithoutIBus.cs" />
-	<Compile Include="Keyboarding\IBusEnvironmentForTest.cs" />
-	<Compile Include="Keyboarding\InputLanguageWrapperTests.cs" />
-	<Compile Include="Keyboarding\KeyboardControllerTests.cs" />
-	<Compile Include="Keyboarding\KeyboardDescriptionTests.cs" />
-	<Compile Include="Keyboarding\WindowsKeyboardControllerTests.cs" />
-	<Compile Include="Keyboarding\XkbKeyboardAdapterTests.cs" />
-	<Compile Include="Keyboarding\XklEngineTests.cs" />
-	<Compile Include="Progress\Commands\ProgressDialogHandlerTests.cs" />
-	<Compile Include="Progress\ProgressDialogTests.cs" />
-	<Compile Include="Progress\ProgressIndicatorTests.cs" />
-	<Compile Include="Progress\TransformWithProgressDialogTests.cs" />
-	<Compile Include="Properties\AssemblyInfo.cs" />
-	<EmbeddedResource Include="ImageToolbox\TestImages.resx">
-	  <Generator>ResXFileCodeGenerator</Generator>
-	  <LastGenOutput>TestImages.Designer.cs</LastGenOutput>
-	</EmbeddedResource>
-	<EmbeddedResource Include="SettingsProtection\DialogWithLinkToSettings.resx">
-	  <DependentUpon>DialogWithLinkToSettings.cs</DependentUpon>
-	  <SubType>Designer</SubType>
-	</EmbeddedResource>
-	<EmbeddedResource Include="SettingsProtection\DialogWithSomeSettings.resx">
-	  <DependentUpon>DialogWithSomeSettings.cs</DependentUpon>
-	</EmbeddedResource>
-	<EmbeddedResource Include="SuperToolTip\SuperToolTipTestForm.resx">
-	  <DependentUpon>SuperToolTipTestForm.cs</DependentUpon>
-	  <SubType>Designer</SubType>
-	</EmbeddedResource>
-	<Compile Include="SettingsProtection\DialogWithLinkToSettings.cs">
-	  <SubType>Form</SubType>
-	</Compile>
-	<Compile Include="SettingsProtection\DialogWithLinkToSettings.Designer.cs">
-	  <DependentUpon>DialogWithLinkToSettings.cs</DependentUpon>
-	</Compile>
-	<Compile Include="SettingsProtection\DialogWithSomeSettings.cs">
-	  <SubType>Form</SubType>
-	</Compile>
-	<Compile Include="SettingsProtection\DialogWithSomeSettings.Designer.cs">
-	  <DependentUpon>DialogWithSomeSettings.cs</DependentUpon>
-	</Compile>
-	<Compile Include="SettingsProtection\SettingsProtectionUITests.cs" />
-	<Compile Include="SpellChecking\TextBoxSpellChecker.cs" />
-	<Compile Include="SuperToolTip\SuperToolTipTestForm.cs">
-	  <SubType>Form</SubType>
-	</Compile>
-	<Compile Include="SuperToolTip\SuperToolTipTestForm.Designer.cs">
-	  <DependentUpon>SuperToolTipTestForm.cs</DependentUpon>
-	</Compile>
-	<Compile Include="Widgets\PromptTests.cs" />
-	<Compile Include="WritingSystems\LookupIsoCodeModelTests.cs" />
-	<Compile Include="WritingSystems\UITests.cs" />
-	<Compile Include="WritingSystems\Tree\WritingSystemTreeItemTests.cs" />
-	<Compile Include="WritingSystems\Tree\WritingSystemVariantSuggestorTests.cs" />
-	<Compile Include="WritingSystems\WritingSystemDefinitionVariantHelperTests.cs" />
-	<Compile Include="WritingSystems\WritingSystemSetupPMTests.cs" />
-	<Compile Include="WritingSystems\WritingSystemFromWindowsLocaleProviderTests.cs" />
-	<Compile Include="Keyboarding\LinuxKeyboardControllerTests.cs" />
-	<Compile Include="WritingSystems\Tree\WritingSystemTreeModelTests.cs" />
-	<Compile Include="ErrorReporting\ErrorReportingTests.cs" />
-	<Compile Include="Progress\LogBox\LogBoxFormForTest.cs" />
-	<Compile Include="Progress\LogBox\LogBoxTests.cs" />
-	<Compile Include="Keyboarding\IbusDefaultEventHandlerTests.cs" />
-	<Compile Include="Keyboarding\IbusKeyboardAdaptorTests.cs" />
-	<Compile Include="Keyboarding\WinKeyboardAdaptorTests.cs" />
-	<Compile Include="Keyboarding\WinKeyboardDescriptionTests.cs" />
+    <Compile Include="ClearShare\ClearShareUsage.cs" />
+    <Compile Include="ClearShare\ContributionTests.cs" />
+    <Compile Include="ClearShare\ContributorsListControlViewModelTests.cs" />
+    <Compile Include="ClearShare\MetadataEditorControlTests.cs" />
+    <Compile Include="ClearShare\CreativeCommonsLicenseTests.cs" />
+    <Compile Include="ClearShare\LicenseTests.cs" />
+    <Compile Include="ClearShare\MetadataTests.cs" />
+    <Compile Include="ClearShare\OlacSystemTests.cs" />
+    <Compile Include="ClearShare\RoleTests.cs" />
+    <Compile Include="FontTests\FontHelperTests.cs" />
+    <Compile Include="Hotspot\HotSpotProviderTestForms.cs" />
+    <Compile Include="Hotspot\HotSpotProviderTests.cs" />
+    <Compile Include="Hotspot\HotSpotTests.cs" />
+    <Compile Include="ImageGallery\ArtOfReadingImageCollectionTests.cs" />
+    <Compile Include="ImageToolbox\ImageToolboxTests.cs" />
+    <Compile Include="ClearShare\MetaDataDisplayTests.cs" />
+    <Compile Include="ImageToolbox\PalasoImageTests.cs" />
+    <Compile Include="ImageToolbox\TestImages.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>TestImages.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Keyboarding\FakeKeyboardController.cs" />
+    <Compile Include="Keyboarding\IBusAdaptorTestsWithIBus.cs" />
+    <Compile Include="Keyboarding\IBusAdaptorTestsWithoutIBus.cs" />
+    <Compile Include="Keyboarding\IBusEnvironmentForTest.cs" />
+    <Compile Include="Keyboarding\InputLanguageWrapperTests.cs" />
+    <Compile Include="Keyboarding\KeyboardControllerTests.cs" />
+    <Compile Include="Keyboarding\KeyboardDescriptionTests.cs" />
+    <Compile Include="Keyboarding\WindowsKeyboardControllerTests.cs" />
+    <Compile Include="Keyboarding\XkbKeyboardAdapterTests.cs" />
+    <Compile Include="Keyboarding\XklEngineTests.cs" />
+    <Compile Include="Progress\Commands\ProgressDialogHandlerTests.cs" />
+    <Compile Include="Progress\ProgressDialogTests.cs" />
+    <Compile Include="Progress\ProgressIndicatorTests.cs" />
+    <Compile Include="Progress\TransformWithProgressDialogTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="ImageToolbox\TestImages.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>TestImages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SettingsProtection\DialogWithLinkToSettings.resx">
+      <DependentUpon>DialogWithLinkToSettings.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SettingsProtection\DialogWithSomeSettings.resx">
+      <DependentUpon>DialogWithSomeSettings.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SuperToolTip\SuperToolTipTestForm.resx">
+      <DependentUpon>SuperToolTipTestForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <Compile Include="SettingsProtection\DialogWithLinkToSettings.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="SettingsProtection\DialogWithLinkToSettings.Designer.cs">
+      <DependentUpon>DialogWithLinkToSettings.cs</DependentUpon>
+    </Compile>
+    <Compile Include="SettingsProtection\DialogWithSomeSettings.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="SettingsProtection\DialogWithSomeSettings.Designer.cs">
+      <DependentUpon>DialogWithSomeSettings.cs</DependentUpon>
+    </Compile>
+    <Compile Include="SettingsProtection\SettingsProtectionUITests.cs" />
+    <Compile Include="SpellChecking\TextBoxSpellChecker.cs" />
+    <Compile Include="SuperToolTip\SuperToolTipTestForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="SuperToolTip\SuperToolTipTestForm.Designer.cs">
+      <DependentUpon>SuperToolTipTestForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Widgets\PromptTests.cs" />
+    <Compile Include="WritingSystems\LookupIsoCodeModelTests.cs" />
+    <Compile Include="WritingSystems\UITests.cs" />
+    <Compile Include="WritingSystems\Tree\WritingSystemTreeItemTests.cs" />
+    <Compile Include="WritingSystems\Tree\WritingSystemVariantSuggestorTests.cs" />
+    <Compile Include="WritingSystems\WritingSystemDefinitionVariantHelperTests.cs" />
+    <Compile Include="WritingSystems\WritingSystemSetupPMTests.cs" />
+    <Compile Include="WritingSystems\WritingSystemFromWindowsLocaleProviderTests.cs" />
+    <Compile Include="Keyboarding\LinuxKeyboardControllerTests.cs" />
+    <Compile Include="WritingSystems\Tree\WritingSystemTreeModelTests.cs" />
+    <Compile Include="ErrorReporting\ErrorReportingTests.cs" />
+    <Compile Include="Progress\LogBox\LogBoxFormForTest.cs" />
+    <Compile Include="Progress\LogBox\LogBoxTests.cs" />
+    <Compile Include="Keyboarding\IbusDefaultEventHandlerTests.cs" />
+    <Compile Include="Keyboarding\IbusKeyboardAdaptorTests.cs" />
+    <Compile Include="Keyboarding\WinKeyboardAdaptorTests.cs" />
+    <Compile Include="Keyboarding\WinKeyboardDescriptionTests.cs" />
   </ItemGroup>
   <ItemGroup>
-	<ProjectReference Include="..\Palaso.Tests\Palaso.Tests.csproj">
-	  <Project>{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}</Project>
-	  <Name>Palaso.Tests</Name>
-	</ProjectReference>
-	<ProjectReference Include="..\Palaso.TestUtilities\Palaso.TestUtilities.csproj">
-	  <Project>{D74CE910-D44A-44F5-8C0F-F5E50B26F85D}</Project>
-	  <Name>Palaso.TestUtilities</Name>
-	</ProjectReference>
-	<ProjectReference Include="..\PalasoUIWindowsForms\PalasoUIWindowsForms.csproj">
-	  <Project>{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}</Project>
-	  <Name>PalasoUIWindowsForms</Name>
-	</ProjectReference>
-	<ProjectReference Include="..\Palaso\Palaso.csproj">
-	  <Project>{3527DA1D-1E25-48BE-A71E-9EBF7F9208D4}</Project>
-	  <Name>Palaso</Name>
-	</ProjectReference>
+    <ProjectReference Include="..\Palaso.Tests\Palaso.Tests.csproj">
+      <Project>{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}</Project>
+      <Name>Palaso.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Palaso.TestUtilities\Palaso.TestUtilities.csproj">
+      <Project>{D74CE910-D44A-44F5-8C0F-F5E50B26F85D}</Project>
+      <Name>Palaso.TestUtilities</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\PalasoUIWindowsForms\PalasoUIWindowsForms.csproj">
+      <Project>{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}</Project>
+      <Name>PalasoUIWindowsForms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Palaso\Palaso.csproj">
+      <Project>{3527DA1D-1E25-48BE-A71E-9EBF7F9208D4}</Project>
+      <Name>Palaso</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-	<None Include="ImageGallery\ArtOfReadingIndexV3_en.txt">
-	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	</None>
+    <None Include="ImageGallery\ArtOfReadingIndexV3_en.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-	<BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-	  <Visible>False</Visible>
-	  <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-	  <Install>false</Install>
-	</BootstrapperPackage>
-	<BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-	  <Visible>False</Visible>
-	  <ProductName>.NET Framework 3.5 SP1</ProductName>
-	  <Install>true</Install>
-	</BootstrapperPackage>
-	<BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-	  <Visible>False</Visible>
-	  <ProductName>Windows Installer 3.1</ProductName>
-	  <Install>true</Install>
-	</BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-	<None Include="Resources\logo.jpg" />
+    <None Include="Resources\logo.jpg" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-	   Other similar extension points exist, see Microsoft.Common.targets.
+       Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">


### PR DESCRIPTION
Visual Studio generates this file with 2-space tabs, so that is
what we need to have in the repo.  Additionally, before this
change, the indentation was a mix of tabs and spaces.
