### PR TITLE
Fix crash on exit in error reporting

### DIFF
--- a/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.cs
+++ b/PalasoUIWindowsForms/Reporting/ExceptionReportingDialog.cs
@@ -393,7 +393,7 @@ namespace Palaso.UI.WindowsForms.Reporting
 					null, owningForm, Thread.CurrentThread.ManagedThreadId));
 			}
 
-			if (WinFormsExceptionHandler.ControlOnUIThread.InvokeRequired)
+			if (WinFormsExceptionHandler.InvokeRequired)
 			{
 				// we got called from a background thread.
 				WinFormsExceptionHandler.ControlOnUIThread.Invoke(
@@ -412,7 +412,7 @@ namespace Palaso.UI.WindowsForms.Reporting
 					stackTrace, owningForm, Thread.CurrentThread.ManagedThreadId));
 			}
 
-			if (WinFormsExceptionHandler.ControlOnUIThread.InvokeRequired)
+			if (WinFormsExceptionHandler.InvokeRequired)
 			{
 				// we got called from a background thread.
 				WinFormsExceptionHandler.ControlOnUIThread.Invoke(
@@ -426,7 +426,7 @@ namespace Palaso.UI.WindowsForms.Reporting
 		private void ReportInternal()
 		{
 			// This method will/should always be called on the UI thread
-			Debug.Assert(!WinFormsExceptionHandler.ControlOnUIThread.InvokeRequired);
+			Debug.Assert(!WinFormsExceptionHandler.InvokeRequired);
 
 			ExceptionReportingData reportingData;
 			lock (s_reportDataStack)

--- a/PalasoUIWindowsForms/Reporting/WinFormsExceptionHandler.cs
+++ b/PalasoUIWindowsForms/Reporting/WinFormsExceptionHandler.cs
@@ -13,6 +13,14 @@ namespace Palaso.UI.WindowsForms.Reporting
 		// see comment on ExceptionReportingDialog.s_reportDataStack
 		internal static Control ControlOnUIThread { get; private set; }
 
+		internal static bool InvokeRequired
+		{
+			get
+			{
+				return !ControlOnUIThread.IsDisposed && ControlOnUIThread.InvokeRequired;
+			}
+		}
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Set exception handler. Needs to be done before we create splash screen (don't


### PR DESCRIPTION
When we get a crash while the application exits (e.g. from the
finalizer method) it's quite possible that the ControlOnUIThread
control already got disposed, so we can't use it anymore.

Change-Id: I93611651663b8afb473063ddf078be8a5a65e682
