### PR TITLE
When looking up languages, allow for differences in spelling

### DIFF
--- a/Palaso.Tests/WritingSystems/EthnologueLookupTests.cs
+++ b/Palaso.Tests/WritingSystems/EthnologueLookupTests.cs
@@ -31,6 +31,12 @@ namespace Palaso.Tests.WritingSystems
 		}
 
 		[Test]
+		public void SuggestLanguages_LargeMispelling_StillFinds()
+		{
+			Assert.AreEqual(_ethnologue.SuggestLanguages("angrish").Count(), 1);
+		}
+
+		[Test]
 		public void SuggestLanguages_Thai_ReturnsThaiAsFirstChoiceLanguage()
 		{
 			/*	tha	KH 	D	Thai Koh Kong

--- a/PalasoUIWindowsForms/WritingSystems/LookupISOCodeModel.cs
+++ b/PalasoUIWindowsForms/WritingSystems/LookupISOCodeModel.cs
@@ -37,29 +37,7 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			if(_ethnologueLookup==null)
 				_ethnologueLookup = new EthnologueLookup { Force3LetterCodes = Force3LetterCodes };
 
-			/* This works, but the results are satisfactory yet (they could be with some enancement to the matcher
-			 We would need it to favor exact prefix matches... currently an exact match could be several items down the list.
-
-			var d = new ApproximateMatcher.GetStringDelegate<WritingSystemDefinition.Iso639LanguageCode>(c => c.Name);
-			var languages = ApproximateMatcher.FindClosestForms(_languageCodes, d, s, ApproximateMatcherOptions.IncludePrefixedAndNextClosestForms);
-			*/
-
-//            typedText = typedText.ToLowerInvariant();
-//
-//            foreach (Iso639LanguageCode lang in _languageCodes)
-//            {
-//                if (string.IsNullOrEmpty(typedText) // in which case, show all of them
-//                    || (lang.InvariantLowerCaseCode.StartsWith(typedText)
-//                        || lang.Name.ToLowerInvariant().StartsWith(typedText)))
-//                {
-//                    yield return lang;
-//                }
-//            }
-			foreach (var language in _ethnologueLookup.SuggestLanguages(typedText))
-			{
-				yield return language;
-			}
-
+			return _ethnologueLookup.SuggestLanguages(typedText);
 		}
 
 


### PR DESCRIPTION
I watched someone in Uganda frustrated because she couldn't get
Bloom to find her language, because the Ethnologue has it misspelled.
