### PR TITLE
Display 11 major languages in the language instead of English

### DIFF
--- a/Palaso/WritingSystems/EthnologueLookup.cs
+++ b/Palaso/WritingSystems/EthnologueLookup.cs
@@ -30,16 +30,16 @@ namespace Palaso.WritingSystems
 
 			foreach (var line in LanguageRegistryResources.CountryCodes.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries))
 			{
-				var items = line.Split('\t');//id name area
-				CountryCodeToCountryName.Add(items[0].Trim(),items[1].Trim());
+				var items = line.Split('\t'); //id name area
+				CountryCodeToCountryName.Add(items[0].Trim(), items[1].Trim());
 			}
-			CountryCodeToCountryName.Add("?","?");//for unlisted language
+			CountryCodeToCountryName.Add("?", "?"); //for unlisted language
 
 			//LanguageIndex.txt Format: LangID	CountryID	NameType	Name
 			//a language appears on one row for each of its alternative langauges
 			List<string> entries = new List<string>(LanguageRegistryResources.LanguageIndex.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries));
 			entries.Add("qaa\t?\tL\tUnlisted Language");
-			foreach (string entry in entries.Skip(1))//skip the header
+			foreach (string entry in entries.Skip(1)) //skip the header
 			{
 				var items = entry.Split('\t');
 				if (items.Length != 4)
@@ -56,20 +56,38 @@ namespace Palaso.WritingSystems
 				{
 					while (language.Names.Contains(name))
 						language.Names.Remove(name);
-					language.Names.Insert(0,name);
+					language.Names.Insert(0, name);
 				}
 				else
 				{
-					if(!language.Names.Contains(name))
-						language.Names.Add(name);//intentionally not lower-casing
+					if (!language.Names.Contains(name))
+						language.Names.Add(name); //intentionally not lower-casing
 				}
 			}
+
+			//Why just this small set? Only out of convenience. Ideally we'd have a db of all languages as they write it in their literature.
+			this.CodeToLanguageIndex["fr"].LocalName =  "français";
+			this.CodeToLanguageIndex["es"].LocalName =  "español";
+			this.CodeToLanguageIndex["zho"].LocalName =  "中文"; //chinese
+			this.CodeToLanguageIndex["hi"].LocalName =  "हिन्दी"; //hindi
+			this.CodeToLanguageIndex["bn"].LocalName =  "বাংলা"; //bengali
+			this.CodeToLanguageIndex["te"].LocalName =  "తెలుగు"; //telugu
+			this.CodeToLanguageIndex["ta"].LocalName =  "தமிழ்"; //tamil
+			this.CodeToLanguageIndex["ur"].LocalName =  "اُردُو"; //urdu
+			this.CodeToLanguageIndex["ar"].LocalName =  "العربية/عربي"; //arabic
+			this.CodeToLanguageIndex["th"].LocalName = "ภาษาไทย"; //thai
+			this.CodeToLanguageIndex["id"].LocalName = "Bahasa Indonesia"; //indonesian
+
 
 			foreach (var languageInfo in CodeToLanguageIndex.Values)
 			{
 				foreach (var name in languageInfo.Names)
 				{
 					GetOrCreateListFromName(name).Add(languageInfo);
+				}
+				if (!string.IsNullOrEmpty(languageInfo.LocalName))
+				{
+					GetOrCreateListFromName(languageInfo.LocalName).Add(languageInfo);
 				}
 			}
 		}
@@ -183,6 +201,12 @@ namespace Palaso.WritingSystems
 		public List<string> Names=new List<string>();
 		public string Country;
 		public string Code;
+
+		/// <summary>
+		/// Currently, we only have English names in our database. This holds the language name in the language, when we know it
+		/// </summary>
+		public string LocalName;
+
 		private string _desiredName;
 
 		/// <summary>

--- a/PalasoUIWindowsForms/WritingSystems/LookupISOControl.cs
+++ b/PalasoUIWindowsForms/WritingSystems/LookupISOControl.cs
@@ -154,6 +154,11 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 				{
 					_desiredLanguageDisplayName.Text = _incomingLanguageInfo.DesiredName;
 				}
+				// for names like "Chinese", we're going to assume they want the displayed name to be "中文" (and French/français, etc.)
+				else if (!string.IsNullOrEmpty(_model.LanguageInfo.LocalName))
+				{
+					_desiredLanguageDisplayName.Text = _model.LanguageInfo.LocalName;
+				}
 				else if (_model.ISOCode == "qaa")
 				{
 					if (_searchText.Text != "?")
@@ -225,10 +230,12 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 				var itemSelected = false;
 				foreach (LanguageInfo lang in _model.GetMatchingLanguages(typedText))
 				{
-					ListViewItem item = new ListViewItem(lang.Names[0]);
+					var mainName = string.IsNullOrEmpty(lang.LocalName) ? lang.Names[0] : lang.LocalName;
+					ListViewItem item = new ListViewItem(mainName);
 					item.SubItems.Add(lang.Code);
 					item.SubItems.Add(lang.Country);
-					item.SubItems.Add(string.Join(", ", lang.Names.Skip(1)));
+					var numberOfNamesAlreadyUsed = string.IsNullOrEmpty(lang.LocalName) ? 1 : 0;
+					item.SubItems.Add(string.Join(", ", lang.Names.Skip(numberOfNamesAlreadyUsed)));
 					item.SubItems.Add(lang.Country);
 					item.Tag = lang;
 					toShow.Add(item);
@@ -249,6 +256,11 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 				_desiredLanguageDisplayName.Enabled = itemSelected;
 				_listView.Items.AddRange(toShow.ToArray());
 
+				//scroll down to the selected item
+				if (_listView.SelectedItems.Count>0)
+				{
+					_listView.SelectedItems[0].EnsureVisible();
+				}
 			}
 			_listView.ResumeLayout();
 			//            if (_listView.Items.Count > 0)


### PR DESCRIPTION
The root driver for this change is Bloom's
https://jira.sil.org/browse/BL-700. User choose "French", but
then see "French" on the covers of the book, when really they should
see français. What they see comes from the "Desired Name" field which
clients optionally enable (Bloom enables it).

Our database doesn't tell us what these language names are. But we
now specify it for some 11 languages common in language work.
This "LocalName" is then given precedence over the English name.

As an added benefit, the user can now search for the language using
this "LocalName" form (in addition to any other name, including the
English one). They also see it as the "primary" name,
which seems good, rather than seeing the English name (even if in a
localized version of the app). The English name is still the first
name listed in the "Other Names" column.
