### PR TITLE
Allow component sources to be relative to the installer directory

### DIFF
--- a/Palaso.MSBuildTasks/MakeWixForDirTree/MakeWixForDirTree.cs
+++ b/Palaso.MSBuildTasks/MakeWixForDirTree/MakeWixForDirTree.cs
@@ -35,6 +35,7 @@ namespace Palaso.BuildTasks.MakeWixForDirTree
 		private string[] _filesAndDirsToExclude = null;
 		private Regex _fileMatchPattern = new Regex(@".*");
 		private Regex _ignoreFilePattern = new Regex(@"IGNOREME");
+		private string _installerSourceDirectory;
 
 		//todo: this should just be a list
 		private Dictionary<string, string> m_exclude = new Dictionary<string, string>();
@@ -112,7 +113,15 @@ namespace Palaso.BuildTasks.MakeWixForDirTree
 			set { m_checkOnly = value; }
 		}
 
-
+		/// <summary>
+		/// Directory where the installer source (.wixproj) is located.
+		/// If provided, is used to determine relative path of the components
+		/// </summary>
+		public string InstallerSourceDirectory
+		{
+			get { return _installerSourceDirectory; }
+			set { _installerSourceDirectory = value; }
+		}
 
 
 		[Output, Required]
@@ -134,6 +143,8 @@ namespace Palaso.BuildTasks.MakeWixForDirTree
 			LogMessage(MessageImportance.High, "Creating Wix fragment for " + _rootDir);
 			//make it an absolute path
 			_outputFilePath = Path.GetFullPath(_outputFilePath);
+			if (!string.IsNullOrEmpty(_installerSourceDirectory))
+				_installerSourceDirectory = Path.GetFullPath(_installerSourceDirectory);
 
 			/* hatton removed this... it would leave deleted files referenced in the wxs file
 			 if (File.Exists(_outputFilePath))
@@ -431,7 +442,11 @@ namespace Palaso.BuildTasks.MakeWixForDirTree
 			{
 				elemFile.SetAttribute("KeyPath", "yes");
 			}
-			string relativePath = PathUtil.RelativePathTo(Path.GetDirectoryName(_outputFilePath), path);
+			string relativePath;
+			if (String.IsNullOrEmpty(_installerSourceDirectory))
+				relativePath = PathUtil.RelativePathTo(Path.GetDirectoryName(_outputFilePath), path);
+			else
+				relativePath = PathUtil.RelativePathTo(_installerSourceDirectory, path);
 			elemFile.SetAttribute("Source", relativePath);
 
 			if (GiveAllPermissions)


### PR DESCRIPTION
This is being recommitted after the changes
were somehow lost after the original PR was merged.
