### PR TITLE
Ignore a UsingUNCLocalHostPath test on Linux

### DIFF
--- a/Palaso.Tests/IO/FileUtilsTests.cs
+++ b/Palaso.Tests/IO/FileUtilsTests.cs
@@ -107,6 +107,7 @@ namespace Palaso.Tests.IO
 		/// this would fail as it couldn't find a drive letter.
 		/// </summary>
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "ConvertToUNCLocalHostPath only works on Windows")]
 		public void ReplaceFileWithUserInteractionIfNeeded_UsingUNCLocalHostPath()
 		{
 			using (var source = new TempFile("new"))


### PR DESCRIPTION
Exclude ReplaceFileWithUserInteractionIfNeeded_UsingUNCLocalHostPath test on Linux

Per the discussion on https://github.com/sillsdev/libpalaso/pull/131
ConvertToUNCLocalHostPath currently only works on Windows

This unit test should be ignored on Linux builds
