### PR TITLE
Update assembly version so it doesn't include build counter

### DIFF
--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies).     -->
-		<Version>2.5</Version>
+		<Version>2.6</Version>
 	</PropertyGroup>
 	<Target Name="VersionNumbers">
 		<Message Text="BUILD_NUMBER: $(BUILD_NUMBER)" Importance="high"/>


### PR DESCRIPTION
This change makes it so that the assembly version doesn't change with every commit, so that strong naming isn't as much of an issue.
