### PR TITLE
Fix deleting copied and modified writing systems in config

### DIFF
--- a/Palaso/WritingSystems/IWritingSystemDefinition.cs
+++ b/Palaso/WritingSystems/IWritingSystemDefinition.cs
@@ -96,9 +96,12 @@ namespace Palaso.WritingSystems
 		string Bcp47Tag { get; }
 
 		/// <summary>
-		/// The identifier for this writing syetm definition. Use this in files and as a key to the IWritingSystemRepository.
+		/// The identifier for this writing system definition. Use this in files and as a key to the IWritingSystemRepository.
 		/// Note that this is usually identical to the Bcp47 tag and should rarely differ.
 		/// </summary>
+		/// <remarks>
+		/// StoreID is the actual key for IWritingSystemRepository methods.  It is usually the same as Id, but not always.
+		/// </remarks>
 		string Id { get; }
 
 		/// <summary>

--- a/Palaso/WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/Palaso/WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -294,14 +294,19 @@ namespace Palaso.WritingSystems
 			_changeLog.LogConflate(wsToConflate, wsToConflateWith);
 		}
 
-		override public void Remove(string identifier)
+		override public void Remove(string storeId)
 		{
+			if (!Contains(storeId))
+				throw new ArgumentOutOfRangeException("storeId");
+			// Remove() uses the StoreID field, but file storage uses the Id field.
+			var ws = Get(storeId);
+			string identifier = ws.Id;	// may differ from storeId!!
 			//we really need to get it in the trash, else, if was auto-provided,
 			//it'll keep coming back!
-			if (!File.Exists(GetFilePathFromIdentifier(identifier)) && Contains(identifier))
+			if (!File.Exists(GetFilePathFromIdentifier(identifier)))
 			{
-				var ws = Get(identifier);
 				SaveDefinition(ws);
+				storeId = ws.StoreID;	// Save() may change StoreID.
 			}
 
 			if (File.Exists(GetFilePathFromIdentifier(identifier)))
@@ -315,7 +320,7 @@ namespace Palaso.WritingSystems
 				}
 				File.Move(GetFilePathFromIdentifier(identifier), destination);
 			}
-			base.Remove(identifier);
+			base.Remove(storeId);
 			if (!Conflating)
 			{
 				_changeLog.LogDelete(identifier);

--- a/Palaso/WritingSystems/WritingSystemRepositoryBase.cs
+++ b/Palaso/WritingSystems/WritingSystemRepositoryBase.cs
@@ -73,6 +73,15 @@ namespace Palaso.WritingSystems
 			Conflating = false;
 		}
 
+		/// <summary>
+		/// Remove the specified WritingSystemDefinition.
+		/// </summary>
+		/// <param name="identifier">the StoreID of the WritingSystemDefinition</param>
+		/// <remarks>
+		/// Note that ws.StoreID may differ from ws.Id.  The former is the key into the
+		/// dictionary, but the latter is what gets persisted to disk (and shown to the
+		/// user).
+		/// </remarks>
 		virtual public void Remove(string identifier)
 		{
 			if (identifier == null)
@@ -83,13 +92,19 @@ namespace Palaso.WritingSystems
 			{
 				throw new ArgumentOutOfRangeException("identifier");
 			}
+			// Remove() uses the StoreID field, but file storage and UI use the Id field.
+			string realId = _writingSystems[identifier].Id;
 			// Delete from us
 			//??? Do we really delete or just mark for deletion?
+
 			_writingSystems.Remove(identifier);
-			_writingSystemsToIgnore.Remove(identifier);
+			if (_writingSystemsToIgnore.ContainsKey(identifier))
+				_writingSystemsToIgnore.Remove(identifier);
+			if (_writingSystemsToIgnore.ContainsKey(realId))
+				_writingSystemsToIgnore.Remove(realId);
 			if (!Conflating && WritingSystemDeleted != null)
 			{
-				WritingSystemDeleted(this, new WritingSystemDeletedEventArgs(identifier));
+				WritingSystemDeleted(this, new WritingSystemDeletedEventArgs(realId));
 			}
 			//TODO: Could call the shared store to advise that one has been removed.
 			//TODO: This may be useful if writing systems were reference counted.

--- a/PalasoUIWindowsForms/WritingSystems/WritingSystemSetupModel.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WritingSystemSetupModel.cs
@@ -1223,9 +1223,16 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 											CurrentDefinition.Id, message));
 						return;
 					}
-					if (CurrentDefinition != null && _writingSystemRepository.Contains(CurrentDefinition.Id))
+					// If you play around with renaming/revising writing systems, the Id assigned to
+					// the writing system keeps up with the changes, but the StoreID which is the
+					// real key for IWritingSystemRepository methods stays the same.  I find this
+					// a questionable design decision myself, but there may be good reasons for it.
+					// However, not calling _writingSystemRepository.Remove() can cause problems
+					// with data getting out of sync.  (See https://jira.sil.org/browse/WS-281 for
+					// an example of such problems.)
+					if (CurrentDefinition != null && _writingSystemRepository.Contains(CurrentDefinition.StoreID))
 					{
-						_writingSystemRepository.Remove(CurrentDefinition.Id);
+						_writingSystemRepository.Remove(CurrentDefinition.StoreID);
 					}
 					break;
 			}


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/WS-281 "[Linux] WS Config Tool - Identifier argument out of range".  Looking at the code, I can't see why this would be limited to Linux.
