### PR TITLE
Fix failing WritingSystemSetupPMTests unit tests

### DIFF
--- a/Palaso/WritingSystems/WritingSystemRepositoryBase.cs
+++ b/Palaso/WritingSystems/WritingSystemRepositoryBase.cs
@@ -148,7 +148,9 @@ namespace Palaso.WritingSystems
 
 		public bool Contains(string identifier)
 		{
-			return _writingSystems.ContainsKey(identifier);
+			// identifier should not be null, but some unit tests never define StoreID
+			// on their temporary WritingSystemDefinition objects.
+			return identifier != null && _writingSystems.ContainsKey(identifier);
 		}
 
 		public bool CanSet(IWritingSystemDefinition ws)


### PR DESCRIPTION
These failures were introduced by a bugfix yesterday.
