### PR TITLE
Improve AOR test form on Linux

### DIFF
--- a/PalasoUIWindowsForms.TestApp/ArtOfReadingTestForm.cs
+++ b/PalasoUIWindowsForms.TestApp/ArtOfReadingTestForm.cs
@@ -14,6 +14,7 @@ using Palaso.UI.WindowsForms.WritingSystems;
 using Palaso.WritingSystems;
 using Palaso.WritingSystems.Migration.WritingSystemsLdmlV0To1Migration;
 using PalasoUIWindowsForms.TestApp.Properties;
+using Palaso.PlatformUtilities;
 
 namespace PalasoUIWindowsForms.TestApp
 {
@@ -28,16 +29,21 @@ namespace PalasoUIWindowsForms.TestApp
 		{
 			ThumbnailViewer.UseWebViewer = _useGeckoVersion.Checked;
 			var images = new ArtOfReadingImageCollection();
-			images.LoadIndex(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "ImageGallery/artofreadingindexv3_en.txt"));
+			images.LoadIndex(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "ImageGallery/ArtOfReadingIndexV3_en.txt"));
 			images.RootImagePath = RootImagePath.Text;
-			var form = new PictureChooser(images, "duck");
-			form.ShowDialog();
-			Result.Text = "Result: " + form.ChosenPath;
+			using (var form = new PictureChooser(images, "duck"))
+			{
+				form.ShowDialog();
+				Result.Text = "Result: " + form.ChosenPath;
+			}
 		}
 
 		private void OnLoad(object sender, EventArgs e)
 		{
-			RootImagePath.Text = @"C:\ProgramData\SIL\Art Of Reading\images";
+			if (Platform.IsWindows)
+				RootImagePath.Text = @"C:\ProgramData\SIL\Art Of Reading\images";
+			else
+				RootImagePath.Text = "/usr/share/ArtOfReading/images";
 		}
 	}
 }


### PR DESCRIPTION
Fix case of filename and default path to images on Linux. Also fix
dispose issue that causes a crash.

Change-Id: I0e6e9c82fd4de3ff496460a57c76e7905ae76792
