### PR TITLE
Fix finding the default keyboard for Mint 17/Cinnamon

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
+++ b/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
@@ -166,7 +166,18 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 
 		    public IKeyboardDefinition DefaultKeyboard
 			{
-				get { return Adaptors.First(adaptor => adaptor.Type == KeyboardType.System).DefaultKeyboard; }
+				get
+				{
+					var defaultKbd = Adaptors.First(adaptor => adaptor.Type == KeyboardType.System).DefaultKeyboard;
+#if __MonoCS__
+					if (defaultKbd == null && CinnamonKeyboardHandling)
+					{
+						CinnamonIbusAdaptor cinn = Adaptors.First(adaptor => adaptor is CinnamonIbusAdaptor) as CinnamonIbusAdaptor;
+						defaultKbd = cinn.DefaultKeyboard;
+					}
+#endif
+					return defaultKbd;
+				}
 			}
 
 			public IKeyboardDefinition GetKeyboard(string layoutNameWithLocale)
@@ -282,8 +293,8 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 				if (CinnamonKeyboardHandling)
 				{
 #if __MonoCS__
-					CinnamonIbusAdaptor wasta = Adaptors.First(adaptor => adaptor.GetType().ToString().Contains("CinnamonIbus")) as CinnamonIbusAdaptor;
-					wasta.ActivateDefaultKeyboard();
+					CinnamonIbusAdaptor cinn = Adaptors.First(adaptor => adaptor is CinnamonIbusAdaptor) as CinnamonIbusAdaptor;
+					cinn.ActivateDefaultKeyboard();
 #endif
 				}
 				else

--- a/PalasoUIWindowsForms/Keyboarding/Linux/CinnamonIbusAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CinnamonIbusAdaptor.cs
@@ -400,6 +400,47 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			//	Console.Write("  '{0}'", _latinLayouts[i]);
 			//Console.WriteLine();
 		}
+
+		private IKeyboardDefinition _defaultKeyboard;
+
+		/// <summary>
+		/// This adaptor doesn't make use of XkbKeyboardDefinition objects, so we have to
+		/// figure out the default keyboard here, searching the available keyboards for the
+		/// best match to _defaultLayout.  An explicit xkb: keyboard is preferred, but we
+		/// settle for another match (or anything at all) if we need to.
+		/// </summary>
+		public override IKeyboardDefinition DefaultKeyboard
+		{
+			get
+			{
+				if (_defaultKeyboard == null)
+				{
+					var desired = String.Format("xkb:{0}:", _defaultLayout);
+					if (!String.IsNullOrEmpty (_defaultVariant))
+						desired = String.Format ("xkb:{0}\\{1}:", _defaultLayout, _defaultVariant);
+					var pattern = String.Format("[^A-Za-z]{0}[^A-Za-z]|^{0}[^A-Za-z]|.*[^A-Za-z]{0}$", _defaultLayout);
+					var regex = new System.Text.RegularExpressions.Regex(pattern);
+					IKeyboardDefinition first = null;
+					foreach (var kbd in Keyboard.Controller.AllAvailableKeyboards)
+					{
+						if (first == null)
+							first = kbd;	// last-ditch value if all else fails
+						if (kbd.Layout.StartsWith(desired) || kbd.Layout == _defaultLayout)
+						{
+							_defaultKeyboard = kbd;
+							break;
+						}
+						if (regex.IsMatch(kbd.Layout))
+						{
+							_defaultKeyboard = kbd;
+						}
+					}
+					if (_defaultKeyboard == null)
+						_defaultKeyboard = first;
+				}
+				return _defaultKeyboard;
+			}
+		}
 	}
 }
 #endif

--- a/PalasoUIWindowsForms/Keyboarding/Linux/CommonBaseAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CommonBaseAdaptor.cs
@@ -178,7 +178,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			}
 		}
 
-		public IKeyboardDefinition DefaultKeyboard
+		public virtual IKeyboardDefinition DefaultKeyboard
 		{
 			get
 			{

--- a/PalasoUIWindowsForms/Keyboarding/Linux/XkbKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/XkbKeyboardAdaptor.cs
@@ -211,25 +211,14 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 		/// </summary>
 		/// <remarks>
 		/// For Xkb the default keyboard has GroupIndex set to zero.
-		/// Wasta/Cinnamon keyboarding doesn't always have the system keyboard at index 0.
-		/// It may have an IBus keyboard at that position.
+		/// Wasta/Cinnamon keyboarding doesn't use XkbKeyboardDescription objects.
 		/// </remarks>
 		public IKeyboardDefinition DefaultKeyboard
 		{
 			get
 			{
-				int minGroup = Int32.MaxValue;
-				IKeyboardDefinition retval = null;
-				foreach (var kbd in Keyboard.Controller.AllAvailableKeyboards)
-				{
-					if (kbd is XkbKeyboardDescription && kbd.Type == KeyboardType.System &&
-						((XkbKeyboardDescription)kbd).GroupIndex < minGroup)
-					{
-						retval = kbd;
-						minGroup = ((XkbKeyboardDescription)kbd).GroupIndex;
-					}
-				}
-				return retval;
+				return Keyboard.Controller.AllAvailableKeyboards.Where (kbd => kbd.Type == KeyboardType.System)
+					.FirstOrDefault (x => x is XkbKeyboardDescription && ((XkbKeyboardDescription)x).GroupIndex == 0);
 			}
 		}
 


### PR DESCRIPTION
This fixes https://jira.sil.org/browse/WS-285 "Crash while trying
to switch keyboards in Wasta".  Also did a bit of code cleanup in
related keyboarding code.
