### PR TITLE
WS-273 "Help" link not visible in Linux

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/WSSortControl.Designer.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WSSortControl.Designer.cs
@@ -133,7 +133,7 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			//
 			// tableLayoutPanel3
 			//
-			this.tableLayoutPanel3.AutoSize = true;
+			this.tableLayoutPanel3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
 			this.tableLayoutPanel3.ColumnCount = 2;
 			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
 			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());


### PR DESCRIPTION
With Linux, the Help link does not move as the
screen size is adjusted.  If the original location
specified is not visible on the screen, the link
does not appear.  The table layout panel next to
this one containing the sort results adjusts
correctly. This change makes the parameters
associated with the two panels identical.  The
link now adjusts relative to the panel size in
both windows and linux.
