### PR TITLE
Use UTC to calculate built-on date in about dialog (BL-492)

### DIFF
--- a/PalasoUIWindowsForms/SIL/SILAboutBox.cs
+++ b/PalasoUIWindowsForms/SIL/SILAboutBox.cs
@@ -143,7 +143,9 @@ namespace Palaso.UI.WindowsForms.SIL
 				file = file.TrimStart('/');
 			var fi = new FileInfo(file);
 
-			return string.Format("Built on {0}", fi.CreationTime.ToString("dd-MMM-yyyy"));
+			// Use UTC for calculation of build-on-date so that we get the same date regardless
+			// of timezone setting.
+			return string.Format("Built on {0}", fi.CreationTimeUtc.ToString("dd-MMM-yyyy"));
 		}
 
 		private string GetShortVersionInfo()


### PR DESCRIPTION
Using UTC helps so that we get the same date regardless of the
user's time zone setting.

Change-Id: Ia0a555a417895eaccff55dc76c9e6407d7f4e0a9