### PR TITLE
Fix file replace

### DIFF
--- a/Palaso.Tests/IO/FileUtilsTests.cs
+++ b/Palaso.Tests/IO/FileUtilsTests.cs
@@ -151,6 +151,18 @@ namespace Palaso.Tests.IO
 		}
 
 		[Test]
+		public void ReplaceFileWithUserInteractionIfNeeded_DestinationDoesntExist_OK()
+		{
+			using (var destination = TempFile.CreateAndGetPathButDontMakeTheFile())
+			using (var source = new TempFile("one"))
+			{
+				Assert.That(() => FileUtils.ReplaceFileWithUserInteractionIfNeeded(source.Path, destination.Path, null),
+					Throws.Nothing);
+				Assert.That(File.ReadAllText(destination.Path), Is.EqualTo("one"));
+			}
+		}
+
+		[Test]
 		public void GrepFile_FileContainsPattern_True()
 		{
 			using (var e = new TestEnvironment())

--- a/Palaso.Tests/IO/TempFileTests.cs
+++ b/Palaso.Tests/IO/TempFileTests.cs
@@ -66,5 +66,15 @@ namespace Palaso.Tests.IO
 			tempFile.Dispose();
 			Assert.That(Directory.Exists(directoryName), Is.False);
 		}
+
+		[Test]
+		public void CreateAndGetPathButDontMakeTheFile_ReturnsUniqueFilenames()
+		{
+			using (var file1 = TempFile.CreateAndGetPathButDontMakeTheFile())
+			using (var file2 = TempFile.CreateAndGetPathButDontMakeTheFile())
+			{
+				Assert.That(file1.Path, Is.Not.EqualTo(file2.Path));
+			}
+		}
 	}
 }

--- a/Palaso.Tests/Palaso.Tests.csproj
+++ b/Palaso.Tests/Palaso.Tests.csproj
@@ -313,6 +313,7 @@
     <Compile Include="Progress\StringBuilderTests.cs" />
     <Compile Include="PlatformUtilities\PlatformTests.cs" />
     <Compile Include="IO\PathUtilitiesTests.cs" />
+    <Compile Include="SetupFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Palaso\Palaso.csproj">

--- a/Palaso.Tests/SetupFixture.cs
+++ b/Palaso.Tests/SetupFixture.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2015 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
+using NUnit.Framework;
+using Palaso.Reporting;
+
+namespace Palaso.Tests
+{
+	/// <summary>
+	/// Class with test initialization code that is valid for all tests
+	/// </summary>
+	[SetUpFixture]
+	public class SetupFixture
+	{
+		[SetUp]
+		public void RunBeforeAnyTests()
+		{
+			ErrorReport.IsOkToInteractWithUser = false;
+		}
+	}
+}
+

--- a/Palaso/IO/FileUtils.cs
+++ b/Palaso/IO/FileUtils.cs
@@ -285,7 +285,10 @@ namespace Palaso.IO
 		private static void ReportFailedReplacement(string destinationPath, Exception error)
 		{
 			var result = ErrorReport.NotifyUserOfProblem(new ShowAlwaysPolicy(), "Give Up", ErrorResult.No,
-				EntryAssembly.ProductName + " was unable to update the file '" + destinationPath + "'.  Please ensure there is not another copy of this program running, nor any other program that might have that file open, then click the 'OK' button below.\r\nThe error was: \r\n" + error.Message);
+				string.Format("{0} was unable to update the file '{1}'.  Please ensure there is not another " +
+					"copy of this program running, nor any other program that might have that file open, " +
+					"then click the 'OK' button below.{3}The error was: {3}{2}",
+					EntryAssembly.ProductName, destinationPath, error.Message, Environment.NewLine));
 			if (result == ErrorResult.No)
 			{
 				throw error; // pass it up to the caller

--- a/Palaso/IO/FileUtils.cs
+++ b/Palaso/IO/FileUtils.cs
@@ -222,6 +222,8 @@ namespace Palaso.IO
 						(!string.IsNullOrEmpty(backupPath) && !PathUtilities.PathsAreOnSameVolume(sourcePath,backupPath))
 						||
 						!PathUtilities.PathsAreOnSameVolume(sourcePath, destinationPath)
+						||
+						!File.Exists(destinationPath)
 						)
 					{
 						//can't use File.Replace or File.Move across volumes (sigh)

--- a/Palaso/IO/TempFile.cs
+++ b/Palaso/IO/TempFile.cs
@@ -22,7 +22,7 @@ namespace Palaso.IO
 
 		public TempFile()
 		{
-			 _path = System.IO.Path.GetTempFileName();
+			_path = System.IO.Path.GetTempFileName();
 		}
 
 		public TempFile(bool dontMakeMeAFileAndDontSetPath)

--- a/Palaso/IO/TempFile.cs
+++ b/Palaso/IO/TempFile.cs
@@ -86,8 +86,11 @@ namespace Palaso.IO
 
 		public static TempFile CreateAndGetPathButDontMakeTheFile()
 		{
-			TempFile t = new TempFile();
-			File.Delete(t.Path);
+			// it's safer to use GetRandomFileName here because otherwise we might end up with
+			// identical files with the same name if the app creates temp files quickly enough
+			// while deleting the created file.
+			var t = new TempFile(System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+				System.IO.Path.GetRandomFileName()), false);
 			return t;
 		}
 

--- a/Palaso/Reporting/ConsoleErrorReporter.cs
+++ b/Palaso/Reporting/ConsoleErrorReporter.cs
@@ -16,27 +16,22 @@ namespace Palaso.Reporting
 			WriteExceptionToConsole(error, null, Severity.Fatal);
 		}
 
-		public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label, ErrorResult resultIfAlternateButtonPressed, string message)
+		public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label,
+			ErrorResult resultIfAlternateButtonPressed, string message)
 		{
 			if (!policy.ShouldShowMessage(message))
 			{
 				return ErrorResult.OK;
 			}
 
-
 			if (ErrorReport.IsOkToInteractWithUser)
 			{
-				if (ErrorReport.IsOkToInteractWithUser)
-				{
-					Console.WriteLine(message);
-					Console.WriteLine(policy.ReoccurenceMessage);
-				}
+				Console.WriteLine(message);
+				Console.WriteLine(policy.ReoccurenceMessage);
 				return ErrorResult.OK;
 			}
-			else
-			{
-				throw new ErrorReport.ProblemNotificationSentToUserException(message);
-			}
+
+			throw new ErrorReport.ProblemNotificationSentToUserException(message);
 		}
 
 		public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)


### PR DESCRIPTION
Allow to call ReplaceFileWithUserInteractionIfNeeded() if the destination file doesn't exist.

Also two additional changes/fixes that I noticed while debugging this issue.