### PR TITLE
BL-966 AoR instructions are truncated

### DIFF
--- a/PalasoUIWindowsForms/ImageToolbox/ArtOfReadingChooser.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ArtOfReadingChooser.cs
@@ -185,6 +185,8 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 				_messageLabel.Visible = true;
 				_messageLabel.Font = new Font(SystemFonts.DialogFont.FontFamily, 10);
 				_messageLabel.Text = @"This computer doesn't appear to have the 'International Illustrations: the Art Of Reading' gallery installed yet.";
+				// Adjust size to avoid text truncation
+				_messageLabel.Size = new Size(400,100);
 				betterLinkLabel1.Visible = true;
 			}
 			else
@@ -197,6 +199,8 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 					_messageLabel.Visible = true;
 					_messageLabel.Font = new Font(SystemFonts.DialogFont.FontFamily, 10);
 					_messageLabel.Text = "This is the 'Art Of Reading' gallery. In the box above, type what you are searching for, then press ENTER. You can type words in English and Indonesian.".Localize("ImageToolbox.EnterSearchTerms");
+					// Adjust size to avoid text truncation
+					_messageLabel.Height = 100;
 				}
 				_thumbnailViewer.SelectedIndexChanged += new EventHandler(_thumbnailViewer_SelectedIndexChanged);
 			}


### PR DESCRIPTION
After applying the text, the size of the text
box causes the instructions to be truncated.
The code change adjusts the size leaving more
than enough vertical space to contain the
string, even if it is resized.