### PR TITLE
Allow WSFontControl to be set to ReadOnly (PG-94)

### DIFF
--- a/PalasoUIWindowsForms/WritingSystems/WSFontControl.cs
+++ b/PalasoUIWindowsForms/WritingSystems/WSFontControl.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
-using System.Data;
-using System.Text;
 using System.Windows.Forms;
 using Palaso.UI.WindowsForms.Keyboarding;
 using Palaso.WritingSystems;
@@ -27,6 +24,16 @@ namespace Palaso.UI.WindowsForms.WritingSystems
 			_promptForFontTestArea.SetPrompt(_testArea, "Use this area to type something to test out your font.");
 			if (KeyboardController.IsInitialized)
 				KeyboardController.Register(_testArea);
+		}
+
+		public bool ReadOnly
+		{
+			set
+			{
+				_fontComboBox.Enabled = !value;
+				_fontSizeComboBox.Enabled = !value;
+				_rightToLeftCheckBox.AutoCheck = !value;
+			}
 		}
 
 		public void BindToModel(WritingSystemSetupModel model)


### PR DESCRIPTION
As opposed to Disabled which affects the labels