### PR TITLE
Stop saving metadata back into the original file

### DIFF
--- a/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.cs
@@ -276,7 +276,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 					Guard.AgainstNull(dlg.Metadata, " dlg.Metadata");
 					_imageInfo.Metadata = dlg.Metadata;
 					SetupMetaDataControls(_imageInfo.Metadata);
-					_imageInfo.SaveUpdatedMetadataIfItMakesSense();
+					//Not doing this anymore, too risky. See https://jira.sil.org/browse/BL-1001 _imageInfo.SaveUpdatedMetadataIfItMakesSense();
 					_imageInfo.Metadata.StoreAsExemplar(Metadata.FileCategory.Image);
 				}
 			}
@@ -319,7 +319,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 		{
 			_imageInfo.Metadata.LoadFromStoredExemplar(Metadata.FileCategory.Image);
 			SetupMetaDataControls(ImageInfo.Metadata);
-			_imageInfo.SaveUpdatedMetadataIfItMakesSense();
+			//Not doing this anymore, too risky. See https://jira.sil.org/browse/BL-1001  _imageInfo.SaveUpdatedMetadataIfItMakesSense();
 		}
 	}
 

--- a/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
@@ -186,7 +186,8 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 				throw new NotImplementedException();
 			}
 		}
-			
+#if ifWeEverWantToSaveToOriginalAgain			
+		We're not doing this anymore, too risky. See https://jira.sil.org/browse/BL-1001 
 		/// <summary>
 		/// If you edit the metadata, call this. If it happens to have an actual file associated, it will save it.
 		/// If not (e.g. the image came from a scanner), it won't do anything.
@@ -227,7 +228,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 					throw;
 			}
 		}
-
+#endif
 		/// <summary>Returns if the format of the image file supports metadata</summary>
 		public bool FileFormatSupportsMetadata
 		{


### PR DESCRIPTION
In BL-1001(bloom) we found that we were actually corrupting someone's original tiff file. Now that we are using taglibsharp instead of the "industry standard" exiftool (which wasn't unicode safe), we realize that it's just too risk to let taglib sharp touch people's original files.