### PR TITLE
Fix polarity bug in SaveUpdateMetadataIfItMakeSense

### DIFF
--- a/Palaso/Code/Guard.cs
+++ b/Palaso/Code/Guard.cs
@@ -12,9 +12,9 @@ namespace Palaso.Code
 	{
 		/// <summary>
 		/// Will throw a <see cref="InvalidOperationException"/> if the assertion
-		/// is true, with the specificied message.
+		/// is true, with the supplied message.
 		/// </summary>
-		/// <param name="assertion">if set to <c>true</c> [assertion].</param>
+		/// <param name="expressionThatIsFalseIfEverythingIsOk">if set to <c>true</c> [assertion].</param>
 		/// <param name="message">The message.</param>
 		/// <example>
 		/// Sample usage:
@@ -22,11 +22,24 @@ namespace Palaso.Code
 		/// Guard.Against(string.IsNullOrEmpty(name), "Name must have a value");
 		/// </code>
 		/// </example>
-		public static void Against(bool assertion, string message)
+		public static void Against(bool expressionThatIsFalseIfEverythingIsOk, string message)
 		{
-			if (assertion == false)
+			if(expressionThatIsFalseIfEverythingIsOk == false)
 				return;
 			throw new InvalidOperationException(message);
+		}
+		/// <summary>
+		/// Will throw if assertion is false
+		/// </summary>
+		/// <param name="assertion"></param>
+		/// <param name="message"></param>
+		/// <exception cref="InvalidOperationException"></exception>
+		public static void AssertThat(bool assertion, string message)
+		{
+			if (!assertion)
+			{
+				throw new InvalidOperationException(message);
+			}
 		}
 
 		public static void AgainstNull(object value, string valueName)

--- a/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
@@ -199,7 +199,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 		public void SaveUpdatedMetadataIfItMakesSense()
 		{
 			ThrowIfDisposedOfAlready();
-			Guard.Against(FileFormatSupportsMetadata, "We can't put metadata into images of this format.");
+			Guard.AssertThat(FileFormatSupportsMetadata, "We can't put metadata into images of this format.");
 
 			if (Metadata != null && Metadata.HasChanges && !string.IsNullOrEmpty(_pathForSavingMetadataChanges) && File.Exists(_pathForSavingMetadataChanges))
 				SaveUpdatedMetadata();


### PR DESCRIPTION
Also changed the name of the parameter so that this doesn't happen to anyone else. Having "assertion" be something that is supposed to be "false" is just too dissonant. Also added an even clearer option to Guard, "AssertThat" which takes a true-is-expected argument.