### PR TITLE
Fix #176 AcquireToken fails if token isn't immediately available

### DIFF
--- a/PalasoUIWindowsForms/UniqueToken/UniqueToken.cs
+++ b/PalasoUIWindowsForms/UniqueToken/UniqueToken.cs
@@ -69,12 +69,11 @@ namespace Palaso.UI.WindowsForms.UniqueToken
 				dlg.Show();
 				try
 				{
-					for (int i=0; i < secondsToWait; i++)
-				{
-						tokenAcquired = AcquireTokenQuietly(uniqueIdentifier);
-						if (tokenAcquired)
-							break;
-						Thread.Sleep(1000);
+					var timeoutTime = DateTime.Now.AddSeconds(secondsToWait);
+					while(DateTime.Now < timeoutTime && !tokenAcquired)
+					{
+						tokenAcquired = s_fileLock.TryAcquireLock();
+						Thread.Sleep(500);
 					}
 				}
 				catch (Exception e)


### PR DESCRIPTION
The cause of the bug is that while waiting, AcquireToken was calling AcquireTokenQuietly().  AcquireTokenQuietly() first checks the static s_fileLock is null and throws if it is not. But it isn't null, it just hasn't been acquired yet. So this fix, instead of delegating to AcquireTokenQuietly(), just takes the existing static lock and tells it to try and acquire.