### PR TITLE
Change platform-specific properties to support Mac

### DIFF
--- a/Palaso.Tests/IO/PathUtilitiesTests.cs
+++ b/Palaso.Tests/IO/PathUtilitiesTests.cs
@@ -17,7 +17,7 @@ namespace Palaso.Tests.IO
 		[TestFixtureSetUp]
 		public void FixtureSetUp()
 		{
-			if (Palaso.PlatformUtilities.Platform.IsLinux)
+			if (Palaso.PlatformUtilities.Platform.IsUnix)
 				TmpAndRootOnDifferentPartitions = StatFile("/tmp") != StatFile("/");
 		}
 
@@ -213,9 +213,10 @@ namespace Palaso.Tests.IO
 		{
 			using (var process = new Process())
 			{
+				var statFlags = Palaso.PlatformUtilities.Platform.IsMac ? "-f" : "-c";
 				process.StartInfo = new ProcessStartInfo {
 					FileName = "stat",
-					Arguments = string.Format("-c %d {0}", path),
+					Arguments = string.Format("{0} %d {1}", statFlags, path),
 					UseShellExecute = false,
 					RedirectStandardOutput = true,
 					CreateNoWindow = true

--- a/Palaso.Tests/Palaso.Tests.csproj
+++ b/Palaso.Tests/Palaso.Tests.csproj
@@ -198,6 +198,9 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition= " '$(_system_name)' != '' ">
+    <DefineConstants>$(DefineConstants);SYSTEM_$(_system_name)</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Palaso.Tests/PlatformUtilities/PlatformTests.cs
+++ b/Palaso.Tests/PlatformUtilities/PlatformTests.cs
@@ -4,6 +4,25 @@ using System;
 using NUnit.Framework;
 using Palaso.PlatformUtilities;
 
+// For code shipped with products, please try to use runtime checks to select code to run.
+// There are cases that require compile-time conditionals (e.g. when testing the runtime or
+// referencing platform specific imported assemblies like MonoMac.dll).  In this case, do
+// The following:
+// 1) include the following PropertyGroup in the .csproj after all of the DefineConstants
+//    elements.  [Note: _system_name and _system_type are defined by xbuild in later 
+//    versions of Mono.  We tested with Mono 3.12 that comes with Xamarin Studio for 
+//    Mac.  To verify, add /verbosity:diag to xbuild command-line. YMMV.]
+//
+// <PropertyGroup Condition= " '$(_system_name)' != '' ">
+//   <DefineConstants>$(DefineConstants);SYSTEM_$(_system_name)</DefineConstants>
+// </PropertyGroup>
+//
+// 2) In code use a conditional based on the desired platform.
+// 
+// #if SYSTEM_OSX
+// using MonoMac.Foundation;
+// #endif
+
 namespace Palaso.Tests.PlatformUtilities
 {
 	[TestFixture]
@@ -37,32 +56,92 @@ namespace Palaso.Tests.PlatformUtilities
 			Assert.That(Platform.IsDotNet, Is.True);
 		}
 
+#if SYSTEM_OSX
+		[Test]
+		public void IsLinux_Mac()
+		{
+			Assert.That(Platform.IsLinux, Is.False);
+		}
+#else
 		[Test]
 		[Platform(Include="Linux")]
 		public void IsLinux_Linux()
 		{
 			Assert.That(Platform.IsLinux, Is.True);
 		}
+#endif
 
 		[Test]
-		[Platform(Exclude="Linux")]
+		[Platform(Include="Win")]
 		public void IsLinux_Windows()
 		{
 			Assert.That(Platform.IsLinux, Is.False);
 		}
 
+#if SYSTEM_OSX
+		[Test]
+		public void IsWindows_Mac()
+		{
+			Assert.That(Platform.IsWindows, Is.False);
+		}
+#else
 		[Test]
 		[Platform(Include="Linux")]
 		public void IsWindows_Linux()
 		{
 			Assert.That(Platform.IsWindows, Is.False);
 		}
+#endif
 
 		[Test]
-		[Platform(Exclude="Linux")]
+		[Platform(Include="Win")]
 		public void IsWindows_Windows()
 		{
 			Assert.That(Platform.IsWindows, Is.True);
+		}
+
+#if SYSTEM_OSX
+		[Test]
+		public void IsMac_Mac()
+		{
+			Assert.That(Platform.IsMac, Is.True);
+		}
+#else
+		[Test]
+		[Platform(Include="Linux")]
+		public void IsMac_Linux()
+		{
+			Assert.That(Platform.IsMac, Is.False);
+		}
+#endif
+
+		[Test]
+		[Platform(Include="Win")]
+		public void IsMac_Windows()
+		{
+			Assert.That(Platform.IsMac, Is.False);
+		}
+
+#if SYSTEM_OSX
+		[Test]
+		public void IsUnix_Mac()
+		{
+			Assert.That(Platform.IsUnix, Is.True);
+		}
+#else
+		[Test]
+		[Platform(Include="Linux")]
+		public void IsUnix_Linux()
+		{
+			Assert.That(Platform.IsUnix, Is.True);
+		}
+#endif
+
+		[Test]
+		[Platform(Include="Win")]
+		public void IsUnix_Windows()
+		{
+			Assert.That(Platform.IsUnix, Is.False);
 		}
 	}
 }

--- a/Palaso/IO/FileLocator.cs
+++ b/Palaso/IO/FileLocator.cs
@@ -207,7 +207,7 @@ namespace Palaso.IO
 		public static string LocateExecutable(bool throwExceptionIfNotFound, params string[] partsOfTheSubPath)
 		{
 			var exe = LocateExecutableDistributedWithApplication(partsOfTheSubPath);
-			if (string.IsNullOrEmpty(exe) && Platform.IsLinux)
+			if (string.IsNullOrEmpty(exe) && Platform.IsUnix)
 			{
 				var newParts = new List<string>(partsOfTheSubPath);
 				newParts[newParts.Count - 1] = Path.GetFileNameWithoutExtension(newParts.Last());
@@ -221,7 +221,7 @@ namespace Palaso.IO
 				newParts.Remove(exeFileName);
 				exe = LocateInProgramFiles(exeFileName, true, newParts.ToArray());
 
-				if (string.IsNullOrEmpty(exe) && Platform.IsLinux)
+				if (string.IsNullOrEmpty(exe) && Platform.IsUnix)
 				{
 					exeFileName = Path.GetFileNameWithoutExtension(exeFileName);
 					exe = LocateInProgramFiles(exeFileName, true, newParts.ToArray());

--- a/Palaso/IO/PathUtilities.cs
+++ b/Palaso/IO/PathUtilities.cs
@@ -102,10 +102,11 @@ namespace Palaso.IO
 
 			using (var process = new Process())
 			{
+				var statFlags = Palaso.PlatformUtilities.Platform.IsMac ? "-f" : "-c";
 				process.StartInfo = new ProcessStartInfo
 				{
 					FileName = "stat",
-					Arguments = string.Format("-c %d \"{0}\"", pathToCheck),
+					Arguments = string.Format("{0} %d \"{1}\"", statFlags, pathToCheck),
 					UseShellExecute = false,
 					RedirectStandardOutput = true,
 					CreateNoWindow = true

--- a/Palaso/PlatformUtilities/Platform.cs
+++ b/Palaso/PlatformUtilities/Platform.cs
@@ -1,21 +1,35 @@
 // Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+// Parts based on code by MJ Hutchinson http://mjhutchinson.com/journal/2010/01/25/integrating_gtk_application_mac
 using System;
 
 namespace Palaso.PlatformUtilities
 {
 	public static class Platform
 	{
+		private static readonly string UnixNameMac = "Darwin";
+		private static readonly string UnixNameLinux = "Linux";
 		private static bool? m_isMono;
+		private static string m_unixName;
 
-		public static bool IsLinux
+		public static bool IsUnix
 		{
 			get { return Environment.OSVersion.Platform == PlatformID.Unix; }
 		}
 
+		public static bool IsLinux
+		{
+			get { return IsUnix && (UnixName == UnixNameLinux); }
+		}
+
+		public static bool IsMac
+		{
+			get { return IsUnix && (UnixName == UnixNameMac); }
+		}
+
 		public static bool IsWindows
 		{
-			get { return !IsLinux; }
+			get { return !IsUnix; }
 		}
 
 		public static bool IsMono
@@ -33,5 +47,36 @@ namespace Palaso.PlatformUtilities
 		{
 			get { return !IsMono; }
 		}
+
+		private static string UnixName
+		{
+			get
+			{
+				if (m_unixName == null)
+				{
+					IntPtr buf = IntPtr.Zero;
+					try
+					{
+						buf = System.Runtime.InteropServices.Marshal.AllocHGlobal (8192);
+						// This is a hacktastic way of getting sysname from uname ()
+						if (uname (buf) == 0)
+							m_unixName = System.Runtime.InteropServices.Marshal.PtrToStringAnsi (buf);
+					}
+					catch
+					{
+						m_unixName = String.Empty;
+					}
+					finally {
+						if (buf != IntPtr.Zero)
+							System.Runtime.InteropServices.Marshal.FreeHGlobal (buf);
+					}
+				}
+
+				return m_unixName;
+			}
+		}
+
+		[System.Runtime.InteropServices.DllImport ("libc")]
+		static extern int uname (IntPtr buf);
 	}
 }


### PR DESCRIPTION
* Add Platform.IsMac and Platform.IsUnix (and Unit Tests)
* Change Platform.IsLinux to return true for ONLY Linux (this should
have been Platform.IsUnix)
* Change implementation that used Platform.IsLinux to use
  Platform.IsUnix (not used in chorus, wesay, or fieldworks)
* Change calls to stat to use correct flags for Mac and Linux
* NUnit 2.6.2 added MacOsX to PlatformAttribute's supported
  platforms, however Mono doesn't return MacOsX for
  Environment.OSVersion.Platform so the NUnit implementation
  doesn't work (https://github.com/nunit/nunit/issues/515).
  Therefore UnitTests that run only on Mac have to use a
  compile-time conditional.
  See Palaso.Tests/PlatformUtilities/PlatformTests.cs for
  how system-specific conditionals are defined.