### PR TITLE
Keyman 9: Improve input method change detection (LT-15826)

### DIFF
--- a/Palaso/WritingSystems/IWritingSystemRepository.cs
+++ b/Palaso/WritingSystems/IWritingSystemRepository.cs
@@ -217,6 +217,29 @@ namespace Palaso.WritingSystems
 		///			ActiveWritingSystem, wsRepo.AllWritingSystems.ToArray())
 		/// }
 		/// Linux usage will have to be determined, no InputLangChanged event gets raised in Mono.
-		IWritingSystemDefinition GetWsForInputLanguage(string layoutName, CultureInfo cultureInfo, IWritingSystemDefinition wsCurrent, IWritingSystemDefinition[] candidates);
+		IWritingSystemDefinition GetWsForInputLanguage(string layoutName, CultureInfo cultureInfo,
+			IWritingSystemDefinition wsCurrent, IWritingSystemDefinition[] candidates);
+
+		/// <summary>
+		/// Get the writing system that is most probably intended by the user, when the input
+		/// method changes to the specified <paramref name="inputMethod"/>, given the indicated
+		/// candidates, and that <paramref name="wsCurrent"/> is the preferred result if it is
+		/// a possible WS for the specified input method. wsCurrent is also returned if none
+		/// of the <paramref name="candidates"/> is found to match the specified inputs.
+		/// </summary>
+		/// <param name="inputMethod">The input method or keyboard</param>
+		/// <param name="wsCurrent">The writing system that is currently active in the form.
+		/// This serves as a default that will be returned if no writing system can be
+		/// determined from the first argument. It may be null. Also, if there is more than
+		/// one equally promising match in candidates, and wsCurrent is one of them, it will
+		/// be preferred. This ensures that we don't change WS on the user unless the keyboard
+		/// they have selected definitely indicates a different WS.</param>
+		/// <param name="candidates">The writing systems that should be considered as possible
+		/// return values.</param>
+		/// <returns>The best writing system for <paramref name="inputMethod"/>.</returns>
+		/// <remarks>This method replaces IWritingSystemRepository.GetWsForInputLanguage and
+		/// should preferably be used.</remarks>
+		IWritingSystemDefinition GetWsForInputMethod(IKeyboardDefinition inputMethod,
+			IWritingSystemDefinition wsCurrent, IWritingSystemDefinition[] candidates);
 	}
 }

--- a/Palaso/WritingSystems/WritingSystemRepositoryBase.cs
+++ b/Palaso/WritingSystems/WritingSystemRepositoryBase.cs
@@ -434,6 +434,43 @@ namespace Palaso.WritingSystems
 			return layoutMatch ?? cultureMatch ?? wsCurrent;
 		}
 
+		/// <summary>
+		/// Get the writing system that is most probably intended by the user, when the input
+		/// method changes to the specified <paramref name="inputMethod"/>, given the indicated
+		/// candidates, and that <paramref name="wsCurrent"/> is the preferred result if it is
+		/// a possible WS for the specified input method. wsCurrent is also returned if none
+		/// of the <paramref name="candidates"/> is found to match the specified inputs.
+		/// </summary>
+		/// <param name="inputMethod">The input method or keyboard</param>
+		/// <param name="wsCurrent">The writing system that is currently active in the form.
+		/// This serves as a default that will be returned if no writing system can be
+		/// determined from the first argument. It may be null. Also, if there is more than
+		/// one equally promising match in candidates, and wsCurrent is one of them, it will
+		/// be preferred. This ensures that we don't change WS on the user unless the keyboard
+		/// they have selected definitely indicates a different WS.</param>
+		/// <param name="candidates">The writing systems that should be considered as possible
+		/// return values.</param>
+		/// <returns>The best writing system for <paramref name="inputMethod"/>.</returns>
+		/// <remarks>This method replaces IWritingSystemRepository.GetWsForInputLanguage and
+		/// should preferably be used.</remarks>
+		public IWritingSystemDefinition GetWsForInputMethod(IKeyboardDefinition inputMethod,
+			IWritingSystemDefinition wsCurrent, IWritingSystemDefinition[] candidates)
+		{
+			if (inputMethod == null)
+				throw new ArgumentNullException("inputMethod");
+
+			// See if the default is suitable.
+			if (wsCurrent != null && inputMethod.Equals(wsCurrent.LocalKeyboard))
+				return wsCurrent;
+
+			foreach (var ws in candidates)
+			{
+				if (inputMethod.Equals(ws.LocalKeyboard))
+					return ws;
+			}
+			return wsCurrent;
+		}
+
 		bool WsMatchesLayout(string layoutName, IWritingSystemDefinition ws)
 		{
 			var wsd = ws as WritingSystemDefinition;

--- a/PalasoUIWindowsForms.Tests/Keyboarding/WindowsKeyboardControllerTests.cs
+++ b/PalasoUIWindowsForms.Tests/Keyboarding/WindowsKeyboardControllerTests.cs
@@ -1,4 +1,4 @@
-#if !MONO
+#if !__MonoCS__
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -182,17 +182,6 @@ namespace PalasoUIWindowsForms.Tests.Keyboarding
 			Assert.Greater(keyboards.Count(), 1, "This test requires that the Windows IME has at least two languages installed.");
 
 			Assert.That(keyboards.Select(keyboard => ((KeyboardDescription)keyboard).Engine), Is.All.TypeOf<WinKeyboardAdaptor>());
-		}
-
-		[Test]
-		public void CheckWindowsAssumptions()
-		{
-			// For Windows we expect to have exactly one keyboard adaptor. If we implement
-			// additional ones, e.g. for Keyman, we might need to change some methods, e.g.
-			// ActivateDefaultKeyboard, DefaultForWritingSystem and CreateKeyboardDefinition.
-			Assert.That(KeyboardController.Adaptors.Length, Is.EqualTo(1));
-			Assert.That(KeyboardController.Adaptors.Select(adaptor => adaptor.Type),
-				Has.All.EqualTo(KeyboardType.System));
 		}
 
 		[Test]

--- a/PalasoUIWindowsForms/Keyboarding/Interfaces/IWindowsLanguageProfileSink.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Interfaces/IWindowsLanguageProfileSink.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2015 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using Palaso.WritingSystems;
+
+namespace Palaso.UI.WindowsForms.Keyboarding.Interfaces
+{
+	/// <summary>
+	/// Events for switching keyboards
+	///
+	/// This interface can be implemented by an application that wants to be notified when the
+	/// user switches the input method, either by shortcut key or by using the language bar.
+	///
+	/// An application should use this interface instead of relying on the
+	/// WM_INPUTLANGCHANGE messages or Form.InputLanguageChanged events. These messages and events
+	/// don't work reliably when the user switches between two text services (e.g. Chinese and
+	/// Keyman), and they won't reliably tell which input method is the newly activated one (see
+	/// also Michael S. Kaplan's blog post http://www.siao2.com/2006/05/16/598980.aspx).
+	///
+	/// The method in this interface gets called when the TSF Text Services sends a notification
+	/// that the keyboard or text service got changed. The Windows keyboard adaptor falls back
+	/// to using Windows messages in case the text services are not available.
+	/// </summary>
+	public interface IWindowsLanguageProfileSink
+	{
+		/// <summary>
+		/// Called after the language profile has changed.
+		/// </summary>
+		/// <param name="previousKeyboard">The previous input method</param>
+		/// <param name="newKeyboard">The new input method</param>
+		void OnInputLanguageChanged(IKeyboardDefinition previousKeyboard, IKeyboardDefinition newKeyboard);
+	}
+}

--- a/PalasoUIWindowsForms/Keyboarding/InternalInterfaces/IKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/InternalInterfaces/IKeyboardAdaptor.cs
@@ -76,6 +76,13 @@ namespace Palaso.UI.WindowsForms.Keyboarding.InternalInterfaces
 		IKeyboardDefinition DefaultKeyboard { get; }
 
 		/// <summary>
+		/// Gets the currently active keyboard. This only needs to be implemented by the (first) adapter of
+		/// type system, and only if the implementation in KeyboardControllerImpl (which uses layoutname
+		/// and culturename based on the current input language) isn't sufficient.
+		/// </summary>
+		IKeyboardDefinition ActiveKeyboard { get; }
+
+		/// <summary>
 		/// Gets the type of keyboards this adaptor handles: system or other (like Keyman, ibus...)
 		/// </summary>
 		KeyboardType Type { get; }

--- a/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
+++ b/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
@@ -164,7 +164,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 			}
 			#endregion
 
-		    public IKeyboardDefinition DefaultKeyboard
+			public IKeyboardDefinition DefaultKeyboard
 			{
 				get
 				{
@@ -333,13 +333,17 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 				{
 					if (m_ActiveKeyboard == null)
 					{
-						try
+						m_ActiveKeyboard = Adaptors.First(adaptor => adaptor.Type == KeyboardType.System).ActiveKeyboard;
+						if (m_ActiveKeyboard == null)
 						{
-							var lang = InputLanguage.CurrentInputLanguage;
-							m_ActiveKeyboard = GetKeyboard(lang.LayoutName, lang.Culture.Name);
-						}
-						catch (CultureNotFoundException)
-						{
+							try
+							{
+								var lang = InputLanguage.CurrentInputLanguage;
+								m_ActiveKeyboard = GetKeyboard(lang.LayoutName, lang.Culture.Name);
+							}
+							catch (CultureNotFoundException)
+							{
+							}
 						}
 						if (m_ActiveKeyboard == null)
 							m_ActiveKeyboard = KeyboardDescription.Zero;

--- a/PalasoUIWindowsForms/Keyboarding/Linux/CommonBaseAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CommonBaseAdaptor.cs
@@ -186,6 +186,14 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			}
 		}
 
+		public virtual IKeyboardDefinition ActiveKeyboard
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+		}
+
 		public KeyboardType Type
 		{
 			get

--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardAdaptor.cs
@@ -491,9 +491,17 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 		}
 
 		/// <summary>
-		/// Implemenation is not required because this is not the primary (Type System) adapter.
+		/// Implementation is not required because this is not the primary (Type System) adapter.
 		/// </summary>
 		public IKeyboardDefinition DefaultKeyboard
+		{
+			get { throw new NotImplementedException(); }
+		}
+
+		/// <summary>
+		/// Implementation is not required because this is not the primary (Type System) adapter.
+		/// </summary>
+		public IKeyboardDefinition ActiveKeyboard
 		{
 			get { throw new NotImplementedException(); }
 		}

--- a/PalasoUIWindowsForms/Keyboarding/Linux/XkbKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/XkbKeyboardAdaptor.cs
@@ -222,6 +222,16 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			}
 		}
 
+		/// <summary>
+		/// Implementation is not required because the default implementation of KeyboardController
+		/// is sufficient.
+		/// </summary>
+		public IKeyboardDefinition ActiveKeyboard
+		{
+			get { return null; }
+		}
+
+
 		private string _missingKeyboardFmt;
 		/// <summary>
 		/// Creates and returns a keyboard definition object based on the layout and locale.

--- a/PalasoUIWindowsForms/Keyboarding/Windows/KeymanKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Windows/KeymanKeyboardAdaptor.cs
@@ -158,6 +158,14 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Windows
 		}
 
 		/// <summary>
+		/// Implementation is not required because this is not the primary (Type System) adapter.
+		/// </summary>
+		public IKeyboardDefinition ActiveKeyboard
+		{
+			get { throw new NotImplementedException(); }
+		}
+
+		/// <summary>
 		/// The type of keyboards this adaptor handles: system or other (like Keyman, ibus...)
 		/// </summary>
 		public KeyboardType Type

--- a/PalasoUIWindowsForms/Keyboarding/Windows/MsTsfInterfaces.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Windows/MsTsfInterfaces.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Unmanaged.TSF
 
 		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		[return: MarshalAs(UnmanagedType.Interface)]
-		IEnumTfLanguageProfiles EnumLanguageProfiles(short langid);
+		IEnumTfLanguageProfiles EnumLanguageProfiles(ushort langid);
 
 		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		void EnableLanguageProfile(ref Guid rclsid, ushort langid, ref Guid guidProfile, [MarshalAs(UnmanagedType.VariantBool)] bool fEnable);
@@ -196,7 +196,7 @@ namespace Microsoft.Unmanaged.TSF
 
 		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		[return: MarshalAs(UnmanagedType.Interface)]
-		public virtual extern IEnumTfLanguageProfiles EnumLanguageProfiles(short langid);
+		public virtual extern IEnumTfLanguageProfiles EnumLanguageProfiles(ushort langid);
 
 		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
 		public virtual extern void EnableLanguageProfile(ref Guid rclsid, ushort langid, ref Guid guidProfile, [MarshalAs(UnmanagedType.VariantBool)] bool fEnable);
@@ -304,6 +304,38 @@ namespace Microsoft.Unmanaged.TSF
 	}
 	#endregion
 
+	#region ITfLanguageProfileNotifySink
+	[ComImport]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[Guid("43c9fe15-f494-4c17-9de2-b8a4ac350aa8")]
+	internal interface ITfLanguageProfileNotifySink
+	{
+		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		//[return: MarshalAs(UnmanagedType.Bool)]
+		bool OnLanguageChange(ushort langid);
+
+		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		void OnLanguageChanged();
+	}
+	#endregion
+
+	#region ITfSource
+	[ComImport]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[Guid("4ea48a35-60ae-446f-8fd6-e6a8d82459f7")]
+	internal interface ITfSource
+	{
+		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		[return: MarshalAs(UnmanagedType.U2)]
+		ushort AdviseSink(ref Guid riid,
+			[MarshalAs(UnmanagedType.Interface)]
+			object punk);
+
+		[MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
+		void UnadviseSink(ushort dwCookie);
+	}
+	#endregion
+
 	#region GUIDs
 	internal class Guids
 	{
@@ -312,6 +344,8 @@ namespace Microsoft.Unmanaged.TSF
 		public static readonly Guid TfcatTipSpeech = new Guid(0xB5A73CD1, 0x8355, 0x426B, 0xA1, 0x61, 0x25, 0x98, 0x08, 0xF2, 0x6B, 0x14);
 		public static readonly Guid TfcatTipHandwriting = new Guid(0x246ecb87, 0xc2f2, 0x4abe, 0x90, 0x5b, 0xc8, 0xb3, 0x8a, 0xdd, 0x2c, 0x43);
 		public static readonly Guid TfcatDisplayAttributeProvider = new Guid(0x046B8C80, 0x1647, 0x40F7, 0x9B, 0x21, 0xB9, 0x3B, 0x81, 0xAA, 0xBC, 0x1B);
+
+		public static readonly Guid ITfLanguageProfileNotifySink = new Guid("43c9fe15-f494-4c17-9de2-b8a4ac350aa8");
 	}
 	#endregion
 }

--- a/PalasoUIWindowsForms/PalasoUIWindowsForms.csproj
+++ b/PalasoUIWindowsForms/PalasoUIWindowsForms.csproj
@@ -453,6 +453,7 @@
     </Compile>
     <Compile Include="ImageToolbox\ImageAcquisitionService.cs" />
     <Compile Include="Keyboarding\Interfaces\IKeyboardErrorDescription.cs" />
+    <Compile Include="Keyboarding\Interfaces\IWindowsLanguageProfileSink.cs" />
     <Compile Include="Keyboarding\InternalInterfaces\IKeyboardAdaptor.cs" />
     <Compile Include="Keyboarding\InternalInterfaces\IKeyboardControllerImpl.cs" />
     <Compile Include="Keyboarding\KeyboardDescription.cs" />

--- a/TestApps/TestAppKeyboard/KeyboardForm.Designer.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.Designer.cs
@@ -31,6 +31,7 @@ namespace TestAppKeyboard
 		/// </summary>
 		private void InitializeComponent()
 		{
+			System.Windows.Forms.Label label8;
 			this.testAreaA = new System.Windows.Forms.TextBox();
 			this.testAreaB = new System.Windows.Forms.TextBox();
 			this.keyboardsA = new System.Windows.Forms.ComboBox();
@@ -48,113 +49,125 @@ namespace TestAppKeyboard
 			this.cbOnEnter = new System.Windows.Forms.CheckBox();
 			this.label7 = new System.Windows.Forms.Label();
 			this.currentKeyboard = new System.Windows.Forms.ComboBox();
+			this.lblCurrentKeyboard = new System.Windows.Forms.Label();
+			label8 = new System.Windows.Forms.Label();
 			this.groupBox1.SuspendLayout();
 			this.SuspendLayout();
-			//
+			// 
+			// label8
+			// 
+			label8.AutoSize = true;
+			label8.Location = new System.Drawing.Point(97, 276);
+			label8.Name = "label8";
+			label8.Size = new System.Drawing.Size(88, 13);
+			label8.TabIndex = 12;
+			label8.Text = "Current keyboard";
+			label8.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+			// 
 			// testAreaA
-			//
+			// 
 			this.testAreaA.Location = new System.Drawing.Point(12, 33);
 			this.testAreaA.Name = "testAreaA";
 			this.testAreaA.Size = new System.Drawing.Size(173, 20);
 			this.testAreaA.TabIndex = 0;
 			this.testAreaA.Enter += new System.EventHandler(this.testAreaA_Enter);
-			//
+			// 
 			// testAreaB
-			//
+			// 
 			this.testAreaB.Location = new System.Drawing.Point(12, 87);
 			this.testAreaB.Name = "testAreaB";
 			this.testAreaB.Size = new System.Drawing.Size(173, 20);
 			this.testAreaB.TabIndex = 1;
 			this.testAreaB.Enter += new System.EventHandler(this.testAreaB_Enter);
-			//
+			// 
 			// keyboardsA
-			//
+			// 
 			this.keyboardsA.FormattingEnabled = true;
 			this.keyboardsA.Location = new System.Drawing.Point(191, 33);
 			this.keyboardsA.Name = "keyboardsA";
 			this.keyboardsA.Size = new System.Drawing.Size(174, 21);
 			this.keyboardsA.TabIndex = 4;
-			//
+			// 
 			// keyboardsB
-			//
+			// 
 			this.keyboardsB.FormattingEnabled = true;
 			this.keyboardsB.Location = new System.Drawing.Point(191, 87);
 			this.keyboardsB.Name = "keyboardsB";
 			this.keyboardsB.Size = new System.Drawing.Size(174, 21);
 			this.keyboardsB.TabIndex = 5;
-			//
+			// 
 			// label1
-			//
+			// 
 			this.label1.AutoSize = true;
 			this.label1.Location = new System.Drawing.Point(9, 17);
 			this.label1.Name = "label1";
 			this.label1.Size = new System.Drawing.Size(63, 13);
 			this.label1.TabIndex = 4;
 			this.label1.Text = "Test Area A";
-			//
+			// 
 			// label2
-			//
+			// 
 			this.label2.AutoSize = true;
 			this.label2.Location = new System.Drawing.Point(9, 71);
 			this.label2.Name = "label2";
 			this.label2.Size = new System.Drawing.Size(63, 13);
 			this.label2.TabIndex = 5;
 			this.label2.Text = "Test Area B";
-			//
+			// 
 			// label3
-			//
+			// 
 			this.label3.AutoSize = true;
 			this.label3.Location = new System.Drawing.Point(188, 17);
 			this.label3.Name = "label3";
 			this.label3.Size = new System.Drawing.Size(77, 13);
 			this.label3.TabIndex = 6;
 			this.label3.Text = "Keyboard for A";
-			//
+			// 
 			// label4
-			//
+			// 
 			this.label4.AutoSize = true;
 			this.label4.Location = new System.Drawing.Point(188, 71);
 			this.label4.Name = "label4";
 			this.label4.Size = new System.Drawing.Size(77, 13);
 			this.label4.TabIndex = 7;
 			this.label4.Text = "Keyboard for B";
-			//
+			// 
 			// label5
-			//
+			// 
 			this.label5.AutoSize = true;
 			this.label5.Location = new System.Drawing.Point(188, 126);
 			this.label5.Name = "label5";
 			this.label5.Size = new System.Drawing.Size(77, 13);
 			this.label5.TabIndex = 11;
 			this.label5.Text = "Keyboard for C";
-			//
+			// 
 			// label6
-			//
+			// 
 			this.label6.AutoSize = true;
 			this.label6.Location = new System.Drawing.Point(9, 126);
 			this.label6.Name = "label6";
 			this.label6.Size = new System.Drawing.Size(63, 13);
 			this.label6.TabIndex = 10;
 			this.label6.Text = "Test Area C";
-			//
+			// 
 			// keyboardsC
-			//
+			// 
 			this.keyboardsC.FormattingEnabled = true;
 			this.keyboardsC.Location = new System.Drawing.Point(191, 142);
 			this.keyboardsC.Name = "keyboardsC";
 			this.keyboardsC.Size = new System.Drawing.Size(174, 21);
 			this.keyboardsC.TabIndex = 6;
-			//
+			// 
 			// testAreaC
-			//
+			// 
 			this.testAreaC.Location = new System.Drawing.Point(12, 142);
 			this.testAreaC.Name = "testAreaC";
 			this.testAreaC.Size = new System.Drawing.Size(173, 20);
 			this.testAreaC.TabIndex = 2;
 			this.testAreaC.Enter += new System.EventHandler(this.testAreaC_Enter);
-			//
+			// 
 			// groupBox1
-			//
+			// 
 			this.groupBox1.Controls.Add(this.cbOnActivate);
 			this.groupBox1.Controls.Add(this.cbOnEnter);
 			this.groupBox1.Controls.Add(this.label7);
@@ -165,37 +178,9 @@ namespace TestAppKeyboard
 			this.groupBox1.TabIndex = 3;
 			this.groupBox1.TabStop = false;
 			this.groupBox1.Text = "Controls";
-			//
-			// currentKeyboard
-			//
-			this.currentKeyboard.FormattingEnabled = true;
-			this.currentKeyboard.Location = new System.Drawing.Point(179, 19);
-			this.currentKeyboard.Name = "currentKeyboard";
-			this.currentKeyboard.Size = new System.Drawing.Size(168, 21);
-			this.currentKeyboard.TabIndex = 0;
-			//
-			// label7
-			//
-			this.label7.AutoSize = true;
-			this.label7.Location = new System.Drawing.Point(67, 22);
-			this.label7.Name = "label7";
-			this.label7.Size = new System.Drawing.Size(106, 13);
-			this.label7.TabIndex = 1;
-			this.label7.Text = "Set current keyboard";
-			//
-			// cbOnEnter
-			//
-			this.cbOnEnter.AutoSize = true;
-			this.cbOnEnter.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-			this.cbOnEnter.Location = new System.Drawing.Point(61, 46);
-			this.cbOnEnter.Name = "cbOnEnter";
-			this.cbOnEnter.Size = new System.Drawing.Size(131, 17);
-			this.cbOnEnter.TabIndex = 1;
-			this.cbOnEnter.Text = "Set keyboard on enter";
-			this.cbOnEnter.UseVisualStyleBackColor = true;
-			//
+			// 
 			// cbOnActivate
-			//
+			// 
 			this.cbOnActivate.AutoSize = true;
 			this.cbOnActivate.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
 			this.cbOnActivate.Location = new System.Drawing.Point(47, 69);
@@ -204,12 +189,51 @@ namespace TestAppKeyboard
 			this.cbOnActivate.TabIndex = 2;
 			this.cbOnActivate.Text = "Set keyboard on activate";
 			this.cbOnActivate.UseVisualStyleBackColor = true;
-			//
+			// 
+			// cbOnEnter
+			// 
+			this.cbOnEnter.AutoSize = true;
+			this.cbOnEnter.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
+			this.cbOnEnter.Location = new System.Drawing.Point(61, 46);
+			this.cbOnEnter.Name = "cbOnEnter";
+			this.cbOnEnter.Size = new System.Drawing.Size(131, 17);
+			this.cbOnEnter.TabIndex = 1;
+			this.cbOnEnter.Text = "Set keyboard on enter";
+			this.cbOnEnter.UseVisualStyleBackColor = true;
+			// 
+			// label7
+			// 
+			this.label7.AutoSize = true;
+			this.label7.Location = new System.Drawing.Point(67, 22);
+			this.label7.Name = "label7";
+			this.label7.Size = new System.Drawing.Size(106, 13);
+			this.label7.TabIndex = 1;
+			this.label7.Text = "Set current keyboard";
+			// 
+			// currentKeyboard
+			// 
+			this.currentKeyboard.FormattingEnabled = true;
+			this.currentKeyboard.Location = new System.Drawing.Point(179, 19);
+			this.currentKeyboard.Name = "currentKeyboard";
+			this.currentKeyboard.Size = new System.Drawing.Size(168, 21);
+			this.currentKeyboard.TabIndex = 0;
+			// 
+			// lblCurrentKeyboard
+			// 
+			this.lblCurrentKeyboard.AutoSize = true;
+			this.lblCurrentKeyboard.Location = new System.Drawing.Point(192, 276);
+			this.lblCurrentKeyboard.Name = "lblCurrentKeyboard";
+			this.lblCurrentKeyboard.Size = new System.Drawing.Size(0, 13);
+			this.lblCurrentKeyboard.TabIndex = 13;
+			this.lblCurrentKeyboard.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+			// 
 			// KeyboardForm
-			//
+			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(383, 285);
+			this.ClientSize = new System.Drawing.Size(383, 302);
+			this.Controls.Add(this.lblCurrentKeyboard);
+			this.Controls.Add(label8);
 			this.Controls.Add(this.groupBox1);
 			this.Controls.Add(this.label5);
 			this.Controls.Add(this.label6);
@@ -251,5 +275,6 @@ namespace TestAppKeyboard
 		private System.Windows.Forms.Label label7;
 		private System.Windows.Forms.CheckBox cbOnEnter;
 		private System.Windows.Forms.CheckBox cbOnActivate;
+		private System.Windows.Forms.Label lblCurrentKeyboard;
 	}
 }

--- a/TestApps/TestAppKeyboard/KeyboardForm.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.cs
@@ -7,11 +7,12 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using Palaso.UI.WindowsForms.Keyboarding;
+using Palaso.UI.WindowsForms.Keyboarding.Interfaces;
 using Palaso.WritingSystems;
 
 namespace TestAppKeyboard
 {
-	public partial class KeyboardForm : Form
+	public partial class KeyboardForm : Form, IWindowsLanguageProfileSink
 	{
 		public KeyboardForm()
 		{
@@ -20,9 +21,9 @@ namespace TestAppKeyboard
 				return;
 
 			KeyboardController.Initialize();
-			KeyboardController.Register(testAreaA);
-			KeyboardController.Register(testAreaB);
-			KeyboardController.Register(testAreaC);
+			KeyboardController.Register(testAreaA, this);
+			KeyboardController.Register(testAreaB, this);
+			KeyboardController.Register(testAreaC, this);
 			LoadKeyboards(this.keyboardsA);
 			LoadKeyboards(this.keyboardsB);
 			LoadKeyboards(this.keyboardsC);
@@ -76,5 +77,17 @@ namespace TestAppKeyboard
 			}
 		}
 
+
+		#region IWindowsLanguageProfileSink Members
+
+		public void OnInputLanguageChanged(IKeyboardDefinition previousKeyboard, IKeyboardDefinition newKeyboard)
+		{
+			Console.WriteLine("TestAppKeyboard.OnLanguageChanged: previous {0}, new {1}",
+				previousKeyboard != null ? previousKeyboard.Layout : "<null>",
+				newKeyboard != null ? newKeyboard.Layout : "<null>");
+			lblCurrentKeyboard.Text = newKeyboard.Layout;
+		}
+
+		#endregion
 	}
 }

--- a/TestApps/TestAppKeyboard/KeyboardForm.resx
+++ b/TestApps/TestAppKeyboard/KeyboardForm.resx
@@ -1,120 +1,123 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-	Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-	Version 2.0
-
-	The primary goals of this format is to allow a simple XML format
-	that is mostly human readable. The generation and parsing of the
-	various data types are done through the TypeConverter classes
-	associated with the data types.
-
-	Example:
-
-	... ado.net/XML headers & schema ...
-	<resheader name="resmimetype">text/microsoft-resx</resheader>
-	<resheader name="version">2.0</resheader>
-	<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-	<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-	<data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-	<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-	<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-		<value>[base64 mime encoded serialized .NET Framework object]</value>
-	</data>
-	<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-		<value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-		<comment>This is a comment</comment>
-	</data>
-
-	There are any number of "resheader" rows that contain simple
-	name/value pairs.
-
-	Each data row contains a name, and value. The row also contains a
-	type or mimetype. Type corresponds to a .NET class that support
-	text/value conversion through the TypeConverter architecture.
-	Classes that don't support this are serialized and stored with the
-	mimetype set.
-
-	The mimetype is used for serialized objects, and tells the
-	ResXResourceReader how to depersist the object. This is currently not
-	extensible. For a given mimetype the value must be set accordingly:
-
-	Note - application/x-microsoft.net.object.binary.base64 is the format
-	that the ResXResourceWriter will generate, however the reader can
-	read any of the formats listed below.
-
-	mimetype: application/x-microsoft.net.object.binary.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.soap.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.bytearray.base64
-	value   : The object must be serialized into a byte array
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-	<xsd:element name="root" msdata:IsDataSet="true">
-	  <xsd:complexType>
-		<xsd:choice maxOccurs="unbounded">
-		  <xsd:element name="metadata">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" use="required" type="xsd:string" />
-			  <xsd:attribute name="type" type="xsd:string" />
-			  <xsd:attribute name="mimetype" type="xsd:string" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="assembly">
-			<xsd:complexType>
-			  <xsd:attribute name="alias" type="xsd:string" />
-			  <xsd:attribute name="name" type="xsd:string" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="data">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-				<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-			  <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-			  <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="resheader">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" />
-			</xsd:complexType>
-		  </xsd:element>
-		</xsd:choice>
-	  </xsd:complexType>
-	</xsd:element>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
   </xsd:schema>
   <resheader name="resmimetype">
-	<value>text/microsoft-resx</value>
+    <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-	<value>2.0</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-	<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-	<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="label8.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>False</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Implement more reliable way of notifying client about input method change.
Depending on the Windows messages doesn't work reliably when input
methods like Keyman or IMEs come into play. These input methods don't
necessarily have a unique language identifier which makes it impossible to
detect the correct input method that is currenlty active.

This change implements notification of input method changes the TSF way
and thus works reliably even with input methods. For older Windows
versions we fall back to Windows messages.

Thanks to Marc Durdin for the analysis of the problem.