### PR TITLE
Ignore failing tests on TC

### DIFF
--- a/Palaso.Lift.Tests/Merging/SynchronicMergerTests.cs
+++ b/Palaso.Lift.Tests/Merging/SynchronicMergerTests.cs
@@ -366,6 +366,7 @@ namespace Palaso.Lift.Tests.Merging
 
 
 		[Test]
+		[Category("SkipOnTeamCity")] // on TC the files don't get set to read-only
 		public void ReadOnlyBaseFile_DoesNothing()
 		{
 			string baseFilePath = Path.Combine(this._directory, _baseLiftFileName);
@@ -387,6 +388,7 @@ namespace Palaso.Lift.Tests.Merging
 		}
 
 		[Test]
+		[Category("SkipOnTeamCity")] // on TC the files don't get set to read-only
 		public void ReadOnlyUpdate_DoesNothing()
 		{
 			string updateFilePath = Path.Combine(this._directory, GetNextUpdateFileName());
@@ -460,8 +462,8 @@ namespace Palaso.Lift.Tests.Merging
 				throw ex;
 		}
 
-
 		[Test]
+		[Category("SkipOnTeamCity")] // on TC the files don't get set to read-only
 		public void ReadOnlyBackupFile_StillMakesBackup()
 		{
 			string backupFilePath = Path.Combine(this._directory, _baseLiftFileName + ".bak");


### PR DESCRIPTION
For whatever reason the tests that require a readonly file fail
on TC. It turns out that we set the file to be readonly, but
mono on TC reports the file always as being writable which causes
the tests to fail. This change works around this problem by
setting the SkipOnTeamCity category.

Change-Id: I5fb252862373838874e307d6e695b0801af37e13