### PR TITLE
 Don't crash if we don't find a keyboard (LT-15498)

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
+++ b/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
@@ -278,7 +278,8 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 
 			public void SetKeyboard(IKeyboardDefinition keyboard)
 			{
-				keyboard.Activate();
+				if (keyboard != null) // This should prevent the crash from LT-15498
+					keyboard.Activate();
 			}
 
 			/// <summary>

--- a/PalasoUIWindowsForms/Keyboarding/KeyboardDescription.cs
+++ b/PalasoUIWindowsForms/Keyboarding/KeyboardDescription.cs
@@ -26,17 +26,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 		/// <see cref="T:Palaso.UI.WindowsForms.Keyboard.KeyboardDescription"/> class.
 		/// </summary>
 		internal KeyboardDescription(string name, string layout, string locale,
-			IInputLanguage language, IKeyboardAdaptor engine)
-			: this(name, layout, locale, language, engine, KeyboardType.System)
-		{
-		}
-
-		/// <summary>
-		/// Initializes a new instance of the
-		/// <see cref="T:Palaso.UI.WindowsForms.Keyboard.KeyboardDescription"/> class.
-		/// </summary>
-		internal KeyboardDescription(string name, string layout, string locale,
-			IInputLanguage language, IKeyboardAdaptor engine, KeyboardType type)
+			IInputLanguage language, IKeyboardAdaptor engine, KeyboardType type = KeyboardType.System)
 		{
 			InternalName = name;
 			Layout = layout;

--- a/PalasoUIWindowsForms/Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -418,10 +418,10 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Windows
 		/// <summary>
 		/// Gets the keyboard description for the layout of <paramref name="inputLanguage"/>.
 		/// </summary>
-		private static KeyboardDescription GetKeyboardDescription(IInputLanguage inputLanguage)
+		private static IKeyboardDefinition GetKeyboardDescription(IInputLanguage inputLanguage)
 		{
-			KeyboardDescription sameLayout = null;
-			KeyboardDescription sameCulture = null;
+			IKeyboardDefinition sameLayout = KeyboardDescription.Zero;
+			IKeyboardDefinition sameCulture = KeyboardDescription.Zero;
 			// TODO: write some tests
 			var requestedLayout = GetLayoutNameEx(inputLanguage.Handle).Name;
 			foreach (KeyboardDescription keyboardDescription in Keyboard.Controller.AllAvailableKeyboards)
@@ -590,7 +590,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Windows
 		/// we activated this keyboard (unless we never activated this keyboard since the app
 		/// got started, in which case we use sensible default values).
 		/// </summary>
-		private void RestoreImeConversionStatus(KeyboardDescription keyboard)
+		private void RestoreImeConversionStatus(IKeyboardDefinition keyboard)
 		{
 			var winKeyboard = keyboard as WinKeyboardDescription;
 			if (winKeyboard == null)

--- a/TestApps/TestAppKeyboard/KeyboardForm.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.cs
@@ -85,7 +85,7 @@ namespace TestAppKeyboard
 			Console.WriteLine("TestAppKeyboard.OnLanguageChanged: previous {0}, new {1}",
 				previousKeyboard != null ? previousKeyboard.Layout : "<null>",
 				newKeyboard != null ? newKeyboard.Layout : "<null>");
-			lblCurrentKeyboard.Text = newKeyboard.Layout;
+			lblCurrentKeyboard.Text = newKeyboard != null ? newKeyboard.Layout : "<null>";
 		}
 
 		#endregion


### PR DESCRIPTION
When a user's machine is messed up so that we can't find a keyboard
we shouldn't crash.