### PR TITLE
Some refactoring of CommandLineRunnerTests

### DIFF
--- a/Palaso.Tests/CommandLineProcessing/CommandLineRunnerTests.cs
+++ b/Palaso.Tests/CommandLineProcessing/CommandLineRunnerTests.cs
@@ -4,20 +4,19 @@ using Palaso.CommandLineProcessing;
 using Palaso.Progress;
 
 
-namespace Palaso.Tests.Progress
+namespace Palaso.Tests.CommandLineProcessing
 {
 	[TestFixture]
 	public class CommandLineRunnerTests
 	{
+		private const string App = "PalasoUIWindowsForms.TestApp.exe";
 
-		[Test, Category("KnownMonoIssue")]
-		[Platform(Exclude="Linux", Reason = "Test has problems on Mono")]
+		[Test]
 		public void CommandWith10Line_NoCallbackOption_Get10LinesSynchronously()
 		{
-			var app = "PalasoUIWindowsForms.TestApp.exe";// FileLocator.GetFileDistributedWithApplication("PalasoUIWindowsForms.TestApp.exe");
 			var progress = new StringBuilderProgress();
-			int linesReceivedAsynchronously = 0;
-			var result = CommandLineRunner.Run(app, "CommandLineRunnerTest", null, string.Empty, 100, progress, null);
+			var result = CommandLineRunner.Run(App, "CommandLineRunnerTest", null, string.Empty, 100,
+				progress, null);
 			Assert.IsTrue(result.StandardOutput.Contains("0"));
 			Assert.IsTrue(result.StandardOutput.Contains("9"));
 		}
@@ -26,10 +25,12 @@ namespace Palaso.Tests.Progress
 		[Platform(Exclude="Linux", Reason = "Test has problems on Mono")]
 		public void CommandWith10Line_CallbackOption_Get10LinesAsynchronously()
 		{
-			var app = "PalasoUIWindowsForms.TestApp.exe";// FileLocator.GetFileDistributedWithApplication("PalasoUIWindowsForms.TestApp.exe");
 			var progress = new StringBuilderProgress();
 			int linesReceivedAsynchronously = 0;
-			CommandLineRunner.Run(app, "CommandLineRunnerTest", null, string.Empty, 100, progress, s => { ++linesReceivedAsynchronously; });
+			CommandLineRunner.Run(App, "CommandLineRunnerTest", null, string.Empty, 100,
+				progress, s => ++linesReceivedAsynchronously);
+			// The test fails on Linux because progress gets called 10x for StdOutput plus
+			// 1x for StdError (probably on the closing of the stream), so linesReceivedAsync is 11.
 			Assert.AreEqual(10, linesReceivedAsynchronously);
 		}
 	}

--- a/Palaso.Tests/CommandLineProcessing/CommandLineRunnerTests.cs
+++ b/Palaso.Tests/CommandLineProcessing/CommandLineRunnerTests.cs
@@ -21,6 +21,17 @@ namespace Palaso.Tests.CommandLineProcessing
 			Assert.IsTrue(result.StandardOutput.Contains("9"));
 		}
 
+		[Test]
+		public void CommandWith10Line_NoCallbackOption_TimeoutAfter3s()
+		{
+			var progress = new StringBuilderProgress();
+			var result = CommandLineRunner.Run(App, "CommandLineRunnerTest", null, string.Empty, 3,
+				progress, null);
+			Assert.That(result.DidTimeOut, Is.True);
+			Assert.That(result.StandardOutput, Is.Null);
+			Assert.That(result.StandardError, Contains.Substring("Timed Out after waiting 3 seconds."));
+		}
+
 		[Test, Category("KnownMonoIssue")]
 		[Platform(Exclude="Linux", Reason = "Test has problems on Mono")]
 		public void CommandWith10Line_CallbackOption_Get10LinesAsynchronously()
@@ -32,6 +43,18 @@ namespace Palaso.Tests.CommandLineProcessing
 			// The test fails on Linux because progress gets called 10x for StdOutput plus
 			// 1x for StdError (probably on the closing of the stream), so linesReceivedAsync is 11.
 			Assert.AreEqual(10, linesReceivedAsynchronously);
+		}
+
+		[Test]
+		public void CommandWith10Line_CallbackOption_TimeoutAfter3s()
+		{
+			var progress = new StringBuilderProgress();
+			int linesReceivedAsynchronously = 0;
+			var result = CommandLineRunner.Run(App, "CommandLineRunnerTest", null, string.Empty, 3,
+				progress, s => ++linesReceivedAsynchronously);
+			Assert.That(result.DidTimeOut, Is.True);
+			Assert.That(result.StandardOutput, Is.Null);
+			Assert.That(result.StandardError, Contains.Substring("Timed Out after waiting 3 seconds."));
 		}
 	}
 }

--- a/Palaso.Tests/Palaso.Tests.csproj
+++ b/Palaso.Tests/Palaso.Tests.csproj
@@ -244,7 +244,6 @@
     <Compile Include="Migration\XslMigratorTests.cs" />
     <Compile Include="Misc\GuardAgainstReentry.cs" />
     <Compile Include="Network\RobustNetworkOperation.Tests.cs" />
-    <Compile Include="Progress\CommandLineRunnerTests.cs" />
     <Compile Include="Progress\MultiProgressTests.cs" />
     <Compile Include="Progress\Commands\CommandTests.cs" />
     <Compile Include="Progress\ConsoleProgressTests.cs" />
@@ -314,6 +313,7 @@
     <Compile Include="PlatformUtilities\PlatformTests.cs" />
     <Compile Include="IO\PathUtilitiesTests.cs" />
     <Compile Include="SetupFixture.cs" />
+    <Compile Include="CommandLineProcessing\CommandLineRunnerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Palaso\Palaso.csproj">
@@ -358,5 +358,8 @@
   <ItemGroup />
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="CommandLineProcessing\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- move to correct location and namespace
- add tests for timeout
- enable test that is working on Linux
- add comment why the other existing test fails on Linux