### PR TITLE
Don't crash when language associated with Keyman keyboard changes

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -261,6 +261,11 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Windows
 						// ignore if we can't find a culture (this can happen e.g. when a language gets
 						// removed that was previously assigned to a WS) - see LT-15333
 					}
+					catch (COMException)
+					{
+						// this can happen when the user changes the language associated with a
+						// Keyman keyboard (LT-16172)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When a user opens the Keyman configuration dialog from the Keyboard tab
of the WS properties dialog and changes the language associated with a
Keyman keyboard we used to crash (LT-16172). This fix is similar the the
one for LT-15333 only that we get a different exception in this case.