### PR TITLE
BL-1141 Fix IComparer in EthnologueLookup so searching doesn't crash

### DIFF
--- a/Palaso.Tests/WritingSystems/EthnologueLookupTests.cs
+++ b/Palaso.Tests/WritingSystems/EthnologueLookupTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
 using NUnit.Framework;
 using Palaso.WritingSystems;
 
@@ -139,6 +136,25 @@ namespace Palaso.Tests.WritingSystems
 			Assert.True(languages.Any(l => l.Names.Contains("Aguanunga")));
 			Assert.True(languages.Any(l => l.Names.Contains("Andaki")));
 			Assert.True(languages.Any(l => l.Names.Contains("Churuba")));
+		}
+
+		[Test]
+		public void SuggestLanguages_Akan_DoesnotCrash()
+		{
+			var languages = _ethnologue.SuggestLanguages("a");
+			Assert.True(languages.Any(l => l.Code == "ak"));
+			Assert.True(languages.Any(l => l.Code == "akq"));
+			Assert.True(languages.Any(l => l.Names.Contains("Akuapem")));
+			Assert.True(languages.Any(l => l.Names.Contains("Ak")));
+			Assert.True(languages.Any(l => l.Names.Contains("Akan")));
+			Assert.True(languages.Any(l => l.Names.Contains("Fanti")));
+			languages = _ethnologue.SuggestLanguages("ak");
+			Assert.True(languages.Any(l => l.Code == "ak"));
+			Assert.True(languages.Any(l => l.Code == "akq"));
+			Assert.True(languages.Any(l => l.Names.Contains("Asante")));
+			Assert.True(languages.Any(l => l.Names.Contains("Ak")));
+			Assert.True(languages.Any(l => l.Names.Contains("Akan")));
+			Assert.True(languages.Any(l => l.Names.Contains("Fanti")));
 		}
 	}
 }

--- a/Palaso/WritingSystems/EthnologueLookup.cs
+++ b/Palaso/WritingSystems/EthnologueLookup.cs
@@ -197,15 +197,15 @@ namespace Palaso.WritingSystems
 			{
 				if (x.Code == y.Code)
 					return 0;
-				if (x.Code == _searchString || x.Names[0].ToLowerInvariant() == _searchString)
-				{
+				// Favor ones where some language matches to solve BL-1141
+				if (x.Names[0].ToLowerInvariant() == _searchString)
 					return -1;
-				}
-				if (y.Code == _searchString || y.Names[0].ToLowerInvariant() == _searchString)
-				{
+				if (y.Names[0].ToLowerInvariant() == _searchString)
 					return 1;
-				}
-				//enhance we could favor ones where some language matches
+				if (x.Code == _searchString)
+					return -1;
+				if (y.Code == _searchString)
+					return 1;
 				return 0;
 			}
 		}

--- a/PalasoUIWindowsForms.Tests/PalasoUIWindowsForms.Tests.csproj
+++ b/PalasoUIWindowsForms.Tests/PalasoUIWindowsForms.Tests.csproj
@@ -208,6 +208,7 @@
     </Compile>
     <Compile Include="UniqueToken\UniqueTokenTests.cs" />
     <Compile Include="Widgets\PromptTests.cs" />
+    <Compile Include="WritingSystems\LookupIsoControlTests.cs" />
     <Compile Include="WritingSystems\LookupIsoCodeModelTests.cs" />
     <Compile Include="WritingSystems\UITests.cs" />
     <Compile Include="WritingSystems\Tree\WritingSystemTreeItemTests.cs" />

--- a/PalasoUIWindowsForms.Tests/WritingSystems/LookupIsoControlTests.cs
+++ b/PalasoUIWindowsForms.Tests/WritingSystems/LookupIsoControlTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading;
+using System.Windows.Forms;
+using NUnit.Framework;
+using Palaso.UI.WindowsForms.WritingSystems;
+
+namespace PalasoUIWindowsForms.Tests.WritingSystems
+{
+	[TestFixture]
+	public class LookupIsoControlTests
+	{
+		private LookupISOControl _control;
+		private bool _ready;
+		private Form _testForm;
+
+		[SetUp]
+		public void Setup()
+		{
+			_ready = false;
+			_control = new LookupISOControl();
+			_control.ReadinessChanged += _control_ReadinessChanged;
+			_testForm = new Form();
+			_testForm.Controls.Add(_control);
+		}
+
+		private void _control_ReadinessChanged(object sender, EventArgs e)
+		{
+			if (_control.LanguageInfo != null)
+				_ready = true;
+		}
+
+		private void WaitForControl()
+		{
+			while (!_ready)
+			{
+				Application.DoEvents();
+			}
+			_ready = false;
+		}
+
+		[Test]
+		public void LookupIsoControl_AkanSearchDoesNotCrash()
+		{
+			_control.ISOCode = "a";
+			_testForm.Show();
+			WaitForControl();
+			_control.ISOCode = "ak";
+			WaitForControl();
+			Assert.AreEqual("akq", _control.ISOCode);
+			Assert.AreEqual("Ak", _control.DesiredLanguageName);
+			_control.ISOCode = "akq";
+			WaitForControl();
+			Assert.AreEqual("akq", _control.ISOCode);
+			Assert.AreEqual("Ak", _control.DesiredLanguageName);
+		}
+	}
+}


### PR DESCRIPTION
* searching for 'ak' crashed because comparing
    'ak' vs 'akq' and
    'akq' vs 'ak'
  both returned -1; an inconsistency