### PR TITLE
Exclude Microsoft.VisualBasic.Devices on Linux

### DIFF
--- a/PalasoUIWindowsForms/PalasoUIWindowsForms.csproj
+++ b/PalasoUIWindowsForms/PalasoUIWindowsForms.csproj
@@ -287,7 +287,7 @@
     <None Include="..\lib\common\Enchant.Net.dll.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <Reference Include="Microsoft.VisualBasic" />
+    <Reference Include="Microsoft.VisualBasic" Condition="'$(OS)'=='Windows_NT'"/>
     <Reference Include="sysglobl" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/PalasoUIWindowsForms/Reporting/MemoryManagement.cs
+++ b/PalasoUIWindowsForms/Reporting/MemoryManagement.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) 2014 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using L10NSharp;
-using Microsoft.VisualBasic.Devices;
 using Palaso.PlatformUtilities;
 using Palaso.Reporting;
+#if !__MonoCS__ // This is not needed on Linux, and can causes extra dependancy trouble if it is compiled in
+using Microsoft.VisualBasic.Devices;
+#else
+using System.IO;
+using System.Text.RegularExpressions;
+#endif
 
 namespace Palaso.UI.WindowsForms.Reporting
 {
@@ -43,14 +44,12 @@ namespace Palaso.UI.WindowsForms.Reporting
 			string message;
 			ulong totalPhysicalMemory = 0;
 			string totalVirtualMemory = "unknown";
-			if (Platform.IsWindows)
-			{
+
+#if !__MonoCS__ // There are completely different dependencies and code per platform for finding the memory information
 				var computerInfo = new Computer().Info;
 				totalPhysicalMemory = computerInfo.TotalPhysicalMemory;
 				totalVirtualMemory = (computerInfo.TotalVirtualMemory / 1024).ToString("N0");
-			}
-			else if (Platform.IsLinux)
-			{
+#else
 				var meminfo = File.ReadAllText("/proc/meminfo");
 				var match = new Regex(@"MemTotal:\s+(\d+) kB").Match(meminfo);
 				if (match.Success)
@@ -72,7 +71,7 @@ namespace Palaso.UI.WindowsForms.Reporting
 					ulong twoGB = 2147483648L;
 					totalVirtualMemory = ((availableMemory > twoGB ? twoGB : availableMemory) / 1024).ToString("N0");
 				}
-			}
+#endif
 			using (var proc = Process.GetCurrentProcess())
 			{
 				memorySize64 = proc.PrivateMemorySize64;


### PR DESCRIPTION
* Add copyright notice
* Remove unused usings
* Exclude the Microsoft.VisualBasic.Devices using on Linux because
  Mono aggressively pursues every using at runtime and has problems
  if it can't find them, even if the code doesn't need them. Excluding
  avoids the need for every Linux package using palaso to have access
  to it.