### PR TITLE
Skip ByHand tests on Team City

### DIFF
--- a/build/Palaso.proj
+++ b/build/Palaso.proj
@@ -106,7 +106,7 @@
 
 		<NUnitTeamCity
 			Assemblies="@(TestAssemblies)"
-			ExcludeCategory="SkipOnTeamCity$(ExtraExcludeCategories)"
+			ExcludeCategory="SkipOnTeamCity;ByHand$(ExtraExcludeCategories)"
 			NUnitVersion="NUnit-2.6.3" />
 	</Target>
 


### PR DESCRIPTION
These tests, marked "ByHand," are failing most of the time on Team City.