### PR TITLE
Prevent overwriting an existing LDML file with an empty one

### DIFF
--- a/Palaso/WritingSystems/LdmlDataMapper.cs
+++ b/Palaso/WritingSystems/LdmlDataMapper.cs
@@ -493,11 +493,33 @@ namespace Palaso.WritingSystems
 					readerSettings.ProhibitDtd = false;
 					reader = XmlReader.Create(oldFile, readerSettings);
 				}
-				using (var writer = XmlWriter.Create(filePath, CanonicalXmlSettings.CreateXmlWriterSettings()))
+				
+				string backupFilePath = null;
+				if (File.Exists(filePath))
 				{
-					writer.WriteStartDocument();
-					WriteLdml(writer, reader, ws);
-					writer.Close();
+					try
+					{
+						backupFilePath = Path.ChangeExtension(Path.GetTempFileName(), Path.GetExtension(filePath));
+						File.Copy(filePath, backupFilePath);
+					}
+					catch (Exception)
+					{
+						backupFilePath = null;
+					}
+				}
+				try
+				{
+					using (var writer = XmlWriter.Create(filePath, CanonicalXmlSettings.CreateXmlWriterSettings()))
+					{
+						writer.WriteStartDocument();
+						WriteLdml(writer, reader, ws);
+					}
+				}
+				catch (Exception)
+				{
+					if (backupFilePath != null)
+						File.Copy(backupFilePath, filePath);
+					throw;
 				}
 			}
 			finally

--- a/Palaso/WritingSystems/LdmlDataMapper.cs
+++ b/Palaso/WritingSystems/LdmlDataMapper.cs
@@ -518,7 +518,7 @@ namespace Palaso.WritingSystems
 				catch (Exception)
 				{
 					if (backupFilePath != null)
-						File.Copy(backupFilePath, filePath);
+						File.Copy(backupFilePath, filePath, true);
 					throw;
 				}
 

--- a/Palaso/WritingSystems/LdmlDataMapper.cs
+++ b/Palaso/WritingSystems/LdmlDataMapper.cs
@@ -521,6 +521,9 @@ namespace Palaso.WritingSystems
 						File.Copy(backupFilePath, filePath);
 					throw;
 				}
+
+				if (backupFilePath != null)
+					File.Delete(backupFilePath);
 			}
 			finally
 			{


### PR DESCRIPTION
To prevent overwriting of an existing LDML file with an empty one in the event event of a failed write, make a backup first and put it back if the write fails.