### PR TITLE
Fix a memory leak in ImageToolboxControl

### DIFF
--- a/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.Designer.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.Designer.cs
@@ -10,29 +10,6 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
-		/// <summary>
-		/// Clean up any resources being used.
-		/// </summary>
-		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing)
-			{
-				_toolImages.Dispose();
-				if (ImageInfo!=null)
-				{
-					ImageInfo.Disposed = true;
-					ImageInfo.Dispose();
-				}
-				if (components != null)
-				{
-
-					components.Dispose();
-				}
-			}
-			base.Dispose(disposing);
-		}
-
 		#region Component Designer generated code
 
 		/// <summary>

--- a/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.cs
@@ -31,6 +31,29 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 		}
 
 		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				_toolImages.Dispose();
+				if (_imageInfo!=null)
+				{
+					_imageInfo.Dispose();
+					_imageInfo = null;
+				}
+				if (components != null)
+				{
+					components.Dispose();
+					components = null;
+				}
+			}
+			base.Dispose(disposing);
+		}
+
+		/// <summary>
 		/// This is the main input/output of this dialog
 		/// </summary>
 		public PalasoImage ImageInfo


### PR DESCRIPTION
Note that setting ImageInfo.Disposed causes ImageInfo.Dispose() to return
immediately without freeing its resources.  Dispose() sets Disposed
when it is finished freeing everything.