### PR TITLE
Changed Palaso solution to allow building a Any-CPU build

### DIFF
--- a/Palaso.sln
+++ b/Palaso.sln
@@ -196,7 +196,8 @@ Global
 		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.Release|Any CPU.ActiveCfg = Release|x86
+		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.Release|Any CPU.Build.0 = Release|x86
 		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.Release|Mixed Platforms.Build.0 = Release|x86
 		{5DE33CD7-60CB-4B9F-A123-A83C1C686E47}.Release|x86.ActiveCfg = Release|x86
@@ -241,6 +242,7 @@ Global
 		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.Release|Mixed Platforms.Build.0 = Release|x86
 		{DB44F49C-D8C6-434F-81ED-28EA5C9E8195}.Release|x86.ActiveCfg = Release|x86
@@ -285,6 +287,7 @@ Global
 		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.Release|Mixed Platforms.Build.0 = Release|x86
 		{3D4F73A8-DB05-4580-98A0-DEE34C010636}.Release|x86.ActiveCfg = Release|x86
@@ -329,6 +332,7 @@ Global
 		{6E16866F-FF8D-4136-AD67-36AFE3626432}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{6E16866F-FF8D-4136-AD67-36AFE3626432}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{6E16866F-FF8D-4136-AD67-36AFE3626432}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E16866F-FF8D-4136-AD67-36AFE3626432}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6E16866F-FF8D-4136-AD67-36AFE3626432}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{6E16866F-FF8D-4136-AD67-36AFE3626432}.Release|Mixed Platforms.Build.0 = Release|x86
 		{6E16866F-FF8D-4136-AD67-36AFE3626432}.Release|x86.ActiveCfg = Release|x86
@@ -413,6 +417,7 @@ Global
 		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.Release|Any CPU.Build.0 = Release|Any CPU
 		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.Release|Mixed Platforms.Build.0 = Release|x86
 		{66B3504A-3B4E-45CB-903A-A9A75B22EF68}.Release|x86.ActiveCfg = Release|x86
@@ -456,7 +461,8 @@ Global
 		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.Release|Any CPU.ActiveCfg = Release|x86
+		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.Release|Any CPU.Build.0 = Release|x86
 		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.Release|Mixed Platforms.Build.0 = Release|x86
 		{CD4AF11C-C214-4D90-8F12-6DA97836B800}.Release|x86.ActiveCfg = Release|x86
@@ -541,6 +547,7 @@ Global
 		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.Release|Mixed Platforms.Build.0 = Release|x86
 		{13B5E313-1B26-4DAE-9E96-133768B62FD2}.Release|x86.ActiveCfg = Release|x86
@@ -625,6 +632,7 @@ Global
 		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.Release|Mixed Platforms.Build.0 = Release|x86
 		{BCE1F124-5479-4B23-90B1-B7A4EBE44FA3}.Release|x86.ActiveCfg = Release|x86
@@ -669,6 +677,7 @@ Global
 		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.Release|Mixed Platforms.Build.0 = Release|x86
 		{892C7F20-FBBB-4AB3-BAC2-E40A135567B6}.Release|x86.ActiveCfg = Release|x86
@@ -793,6 +802,7 @@ Global
 		{776BECCD-102A-4C69-A478-4A4A6F695019}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{776BECCD-102A-4C69-A478-4A4A6F695019}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{776BECCD-102A-4C69-A478-4A4A6F695019}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{776BECCD-102A-4C69-A478-4A4A6F695019}.Release|Any CPU.Build.0 = Release|Any CPU
 		{776BECCD-102A-4C69-A478-4A4A6F695019}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{776BECCD-102A-4C69-A478-4A4A6F695019}.Release|Mixed Platforms.Build.0 = Release|x86
 		{776BECCD-102A-4C69-A478-4A4A6F695019}.Release|x86.ActiveCfg = Release|x86
@@ -837,6 +847,7 @@ Global
 		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.Release|Mixed Platforms.Build.0 = Release|x86
 		{D000879E-9AA6-4811-A6F0-80DF6119FB08}.Release|x86.ActiveCfg = Release|x86
@@ -881,6 +892,7 @@ Global
 		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.Release|Mixed Platforms.Build.0 = Release|x86
 		{6CA85A3E-4AB3-4BBC-861F-0C68F018868B}.Release|x86.ActiveCfg = Release|x86
@@ -925,6 +937,7 @@ Global
 		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.Release|Mixed Platforms.Build.0 = Release|x86
 		{CCF34218-52D9-4092-ADB8-1893BBE5ED31}.Release|x86.ActiveCfg = Release|x86
@@ -969,6 +982,7 @@ Global
 		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.Release|Mixed Platforms.Build.0 = Release|x86
 		{52A93C63-08F4-4527-8E6E-AC2ADEBA6E2D}.Release|x86.ActiveCfg = Release|x86
@@ -1012,7 +1026,8 @@ Global
 		{641EB241-BF16-4A5F-89BD-54411F9AC973}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{641EB241-BF16-4A5F-89BD-54411F9AC973}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{641EB241-BF16-4A5F-89BD-54411F9AC973}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{641EB241-BF16-4A5F-89BD-54411F9AC973}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{641EB241-BF16-4A5F-89BD-54411F9AC973}.Release|Any CPU.ActiveCfg = Release|x86
+		{641EB241-BF16-4A5F-89BD-54411F9AC973}.Release|Any CPU.Build.0 = Release|x86
 		{641EB241-BF16-4A5F-89BD-54411F9AC973}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{641EB241-BF16-4A5F-89BD-54411F9AC973}.Release|Mixed Platforms.Build.0 = Release|x86
 		{641EB241-BF16-4A5F-89BD-54411F9AC973}.Release|x86.ActiveCfg = Release|x86
@@ -1057,6 +1072,7 @@ Global
 		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.Release|Mixed Platforms.Build.0 = Release|x86
 		{F7DF58E2-5B67-498A-9F64-B5F1584A5AB9}.Release|x86.ActiveCfg = Release|x86
@@ -1100,7 +1116,8 @@ Global
 		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.Release|Any CPU.ActiveCfg = Release|x86
+		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.Release|Any CPU.Build.0 = Release|x86
 		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.Release|Mixed Platforms.Build.0 = Release|x86
 		{24E0B3A0-EE71-48CE-82F9-549F1F47322F}.Release|x86.ActiveCfg = Release|x86
@@ -1145,6 +1162,7 @@ Global
 		{0580ED5F-6274-4928-83EE-175F01AD052D}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{0580ED5F-6274-4928-83EE-175F01AD052D}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
 		{0580ED5F-6274-4928-83EE-175F01AD052D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0580ED5F-6274-4928-83EE-175F01AD052D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0580ED5F-6274-4928-83EE-175F01AD052D}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{0580ED5F-6274-4928-83EE-175F01AD052D}.Release|Mixed Platforms.Build.0 = Release|x86
 		{0580ED5F-6274-4928-83EE-175F01AD052D}.Release|x86.ActiveCfg = Release|x86
@@ -1188,7 +1206,8 @@ Global
 		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.Release|Any CPU.ActiveCfg = Release|x86
+		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.Release|Any CPU.Build.0 = Release|x86
 		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.Release|Mixed Platforms.Build.0 = Release|x86
 		{B732A1A3-5CAF-4BC3-B127-A154F2C7E4FA}.Release|x86.ActiveCfg = Release|x86
@@ -1426,8 +1445,8 @@ Global
 		{CC84BDED-CECD-466A-9397-F5D83527B218}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{CC84BDED-CECD-466A-9397-F5D83527B218}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{CC84BDED-CECD-466A-9397-F5D83527B218}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|Any CPU.ActiveCfg = Release|x86
+		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|Any CPU.Build.0 = Release|x86
 		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|Mixed Platforms.Build.0 = Release|x86
 		{CC84BDED-CECD-466A-9397-F5D83527B218}.Release|x86.ActiveCfg = Release|x86
@@ -1570,8 +1589,8 @@ Global
 		{FE61F837-8EAA-4FD7-824A-9949194430DC}.DebugStrongName|Mixed Platforms.Build.0 = DebugStrongName|x86
 		{FE61F837-8EAA-4FD7-824A-9949194430DC}.DebugStrongName|x86.ActiveCfg = DebugStrongName|x86
 		{FE61F837-8EAA-4FD7-824A-9949194430DC}.DebugStrongName|x86.Build.0 = DebugStrongName|x86
-		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|Any CPU.ActiveCfg = Release|x86
+		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|Any CPU.Build.0 = Release|x86
 		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|Mixed Platforms.Build.0 = Release|x86
 		{FE61F837-8EAA-4FD7-824A-9949194430DC}.Release|x86.ActiveCfg = Release|x86


### PR DESCRIPTION
 Changed Palaso solution to allow building a Any-CPU build for special cases (i.e. Paratext needs it).