### PR TITLE
[Keyboarding] Fix keyboard switching in WS setup dialog in test app

### DIFF
--- a/PalasoUIWindowsForms.TestApp/TestAppForm.Designer.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.Designer.cs
@@ -1,4 +1,7 @@
 // ---------------------------------------------------------------------------------------------
+using Palaso.UI.WindowsForms.Keyboarding;
+
+
 #region // Copyright (c) 2013, SIL International. All Rights Reserved.
 // <copyright from='2013' to='2013' company='SIL International'>
 //		Copyright (c) 2013, SIL International. All Rights Reserved.
@@ -28,9 +31,16 @@ namespace PalasoUIWindowsForms.TestApp
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				if (_KeyboardControllerInitialized)
+				{
+					KeyboardController.Shutdown();
+					_KeyboardControllerInitialized = false;
+				}
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/PalasoUIWindowsForms.TestApp/TestAppForm.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.cs
@@ -31,6 +31,8 @@ namespace PalasoUIWindowsForms.TestApp
 	/// ----------------------------------------------------------------------------------------
 	public partial class TestAppForm : Form
 	{
+		private bool _KeyboardControllerInitialized;
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Default c'tor
@@ -72,25 +74,18 @@ namespace PalasoUIWindowsForms.TestApp
 		{
 			string tempPath = Path.GetTempPath() + "WS-Test";
 			Directory.CreateDirectory(tempPath);
-			KeyboardController.Initialize();
-			try
+			if (!_KeyboardControllerInitialized)
 			{
-				var wsRepo = LdmlInFolderWritingSystemRepository.Initialize(tempPath, onMigration, onLoadProblem);
-				using (var dialog = new WritingSystemSetupDialog(wsRepo))
-				{
-					dialog.WritingSystems.LocalKeyboardSettings = Settings.Default.LocalKeyboards;
-					dialog.ShowDialog();
-					Settings.Default.LocalKeyboards = dialog.WritingSystems.LocalKeyboardSettings;
-					Settings.Default.Save();
-				}
+				KeyboardController.Initialize();
+				_KeyboardControllerInitialized = true;
 			}
-			catch (Exception)
+			var wsRepo = LdmlInFolderWritingSystemRepository.Initialize(tempPath, onMigration, onLoadProblem);
+			using (var dialog = new WritingSystemSetupDialog(wsRepo))
 			{
-				throw;
-			}
-			finally
-			{
-				KeyboardController.Shutdown();
+				dialog.WritingSystems.LocalKeyboardSettings = Settings.Default.LocalKeyboards;
+				dialog.ShowDialog();
+				Settings.Default.LocalKeyboards = dialog.WritingSystems.LocalKeyboardSettings;
+				Settings.Default.Save();
 			}
 		}
 


### PR DESCRIPTION
After closing the WS setup dialog we shouldn't shutdown the
keyboard controller until we exit the app. Otherwise automatic
keyboard switching will stop working when the WS setup dialog is
opened anew.

NOTE: when running the test app on Trusty you'll have to manually
copy the icu.net.dlls for ICU52 from TC - the build currently copies
the ICU48 dlls which cause an immediate crash trying to open the
ws setup dialog.
Change-Id: Ib325f464841695c17aa7593dc080f12d9b0e3d07