### PR TITLE
Re-add previous dllmaps

### DIFF
--- a/SIL.Windows.Forms/app.config
+++ b/SIL.Windows.Forms/app.config
@@ -1,5 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <dllmap dll="libgdk-x11-2.0" target="libgdk-x11-2.0.so.0"/>
+    <dllmap dll="libgtk-x11-2.0" target="libgtk-x11-2.0.so.0"/>
+    <dllmap dll="libxklavier" target="libxklavier.so.16"/>
+    <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+    <dllmap dll="libdconf.dll" target="libdconf.so.1"/>
+    <!-- Even explicit .so references need a mapping for versioning. -->
+    <!-- (The unversioned links are part of -dev packages usually. -->
+    <dllmap dll="libgio-2.0.so" target="libgio-2.0.so.0"/>
+    <dllmap dll="libglib-2.0.so" target="libglib-2.0.so.0"/>
+    <dllmap dll="libgobject-2.0.so" target="libgobject-2.0.so.0"/>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
             <section name="SIL.Windows.Forms.ImageToolbox.ImageToolboxSettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />


### PR DESCRIPTION
When PalasoUIWindowsForms was changed to SIL.Windows.Forms,
the dllmap entries were removed from the app.config.  At least
the entries for libgtk and libgdk are needed for WeSay packages
for Linux to build.  Why were these removed?