### PR TITLE
BL-2415: Use ProductName setting from config file, if present

### DIFF
--- a/PalasoUIWindowsForms/SettingProtection/SettingProtectionDialog.cs
+++ b/PalasoUIWindowsForms/SettingProtection/SettingProtectionDialog.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace Palaso.UI.WindowsForms.SettingProtection
@@ -22,7 +16,7 @@ namespace Palaso.UI.WindowsForms.SettingProtection
 			_didHavePasswordSet = SettingsProtectionSingleton.Settings.RequirePassword;
 
 			_passwordNotice.Text = string.Format(_passwordNotice.Text, SettingsProtectionSingleton.FactoryPassword,
-												 Application.ProductName);
+												 SettingsProtectionSingleton.CoreProductName);
 		}
 
 		private void OnNormallHidden_CheckedChanged(object sender, EventArgs e)

--- a/PalasoUIWindowsForms/SettingProtection/SettingsProtection.cs
+++ b/PalasoUIWindowsForms/SettingProtection/SettingsProtection.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using System.Configuration;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace Palaso.UI.WindowsForms.SettingProtection
@@ -62,8 +63,27 @@ namespace Palaso.UI.WindowsForms.SettingProtection
 
 		public static string FactoryPassword
 		{
-			get { return  (Application.ProductName.Substring(0, 1) + "7" + Application.ProductName.Substring(1, Application.ProductName.Length-1)).ToLower(); }
+			get
+			{
+				var productName = CoreProductName;
+				return productName.Insert(1, "7").ToLower();
+			}
 
+		}
+
+		/// <summary>
+		/// Use the CoreProductName value from the AppSettings in the application config file, if present
+		/// </summary>
+		internal static string CoreProductName
+		{
+			get
+			{
+				var productName = ConfigurationManager.AppSettings["CoreProductName"];
+				if (string.IsNullOrEmpty(productName))
+					productName = Application.ProductName;
+
+				return productName;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added CoreProductName to SettingsProtectionSingleton so the
Application.ProductName can be overridden. The specific example that
prompted this change is Bloom, where the Application.ProductName for
is 'BloomAlpha' for alpha releases and 'BloomBeta' for beta releases,
but we wish to display just 'Bloom' to the user in the
SettingsProtectionDialog.