### PR TITLE
Add desktop environment to error report

### DIFF
--- a/Palaso.Tests/reporting/ErrorReportTests.cs
+++ b/Palaso.Tests/reporting/ErrorReportTests.cs
@@ -1,11 +1,11 @@
-﻿
+﻿// Copyright (c) 2015 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using NUnit.Framework;
+#if !__MonoCS__
 using Palaso.Email;
+#endif
 using Palaso.Reporting;
 
 namespace Palaso.Tests.reporting
@@ -13,14 +13,17 @@ namespace Palaso.Tests.reporting
 	[TestFixture]
 	public class ErrorReportTests
 	{
-		[Test, Ignore("by hand only")]
-		public void Test()
+		[Test]
+		[Ignore("by hand only")]
+		public void ReportNonFatalException()
 		{
 			ErrorReport.EmailAddress = "pretend@8ksdfj83jls8.com";
 			ErrorReport.ReportNonFatalException(new ApplicationException("testing"));
 		}
-#if !MONO
-		[Test, Ignore("by hand only")]
+
+#if !__MonoCS__
+		[Test]
+		[Ignore("by hand only")]
 		public void TestSendEmail()
 		{
 			MAPI x = new MAPI();
@@ -28,5 +31,80 @@ namespace Palaso.Tests.reporting
 			x.SendMailDirect("test", "testbody");
 		}
 #endif
+
+		[Test]
+		[Platform(Include = "Windows", Reason = "Windows specific test")]
+		public void Properties_WindowsDoesNotContainDesktopEnvironment()
+		{
+			// SUT
+			ErrorReport.AddStandardProperties();
+
+			// Verify
+			// (ErrorReport.Properties is a string dictionary which converts all keys to lowercase)
+			Assert.That(ErrorReport.Properties.Keys, Has.No.Member("desktopenvironment"));
+		}
+
+		[Test]
+		[Platform(Include = "Windows", Reason = "Windows specific test")]
+		public void GetStandardProperties_WindowsDoesNotContainDesktopEnvironment()
+		{
+			// SUT
+			var props = ErrorReport.GetStandardProperties();
+
+			// Verify
+			Assert.That(props.Keys, Has.No.Member("DesktopEnvironment"));
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		public void Properties_ContainDesktopEnvironment()
+		{
+			// SUT
+			ErrorReport.AddStandardProperties();
+
+			// Verify
+			// (ErrorReport.Properties is a string dictionary which converts all keys to lowercase)
+			Assert.That(ErrorReport.Properties.Keys, Has.Member("desktopenvironment"));
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		public void GetStandardProperties_ContainDesktopEnvironment()
+		{
+			// SUT
+			var props = ErrorReport.GetStandardProperties();
+
+			// Verify
+			Assert.That(props.Keys, Has.Member("DesktopEnvironment"));
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		[TestCase("Unity", null, "ubuntu", null, Result = "Unity (ubuntu)", TestName = "Unity")]
+		[TestCase("Unity", "/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/",
+			"ubuntu", null, Result = "Unity (ubuntu)", TestName = "Unity with dataDir")]
+		[TestCase("Unity", null, "ubuntu", "session-1",
+			Result = "Unity (ubuntu [display server: Mir])", TestName = "Unity with Mir")]
+		[TestCase("GNOME", null, "gnome-shell", null, Result = "GNOME (gnome-shell)"
+			, TestName = "Gnome shell")]
+		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
+			"kde-plasma", null, Result = "KDE (kde-plasma)", TestName = "KDE on Ubuntu 12_04")]
+		public string GetStandardProperties_SimulateDesktopEnvironments(string currDesktop,
+			string dataDirs, string gdmSession, string mirServerName)
+		{
+			// See http://askubuntu.com/a/227669 for actual values on different systems
+
+			// Setup
+			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", currDesktop);
+			Environment.SetEnvironmentVariable("XDG_DATA_DIRS", dataDirs);
+			Environment.SetEnvironmentVariable("GDMSESSION", gdmSession);
+			Environment.SetEnvironmentVariable("MIR_SERVER_NAME", mirServerName);
+
+			// SUT
+			var props = ErrorReport.GetStandardProperties();
+
+			// Verify
+			return props["DesktopEnvironment"];
+		}
 	}
 }

--- a/Palaso/Reporting/ErrorReport.cs
+++ b/Palaso/Reporting/ErrorReport.cs
@@ -384,7 +384,7 @@ namespace Palaso.Reporting
 			private readonly int _minor;
 			public string Label { get; private set; }
 
-			public Version(PlatformID platform, int minor, int major,  string label)
+			public Version(PlatformID platform, int major, int minor, string label)
 			{
 				_platform = platform;
 				_major = major;
@@ -426,15 +426,23 @@ namespace Palaso.Reporting
 			}
 			else
 			{
+				// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832%28v=vs.85%29.aspx
 				var list = new List<Version>();
-				list.Add(new Version(PlatformID.Win32NT,0,5, "Windows 2000"));
-				list.Add(new Version(PlatformID.Win32NT, 1, 5, "Windows XP"));
-				list.Add(new Version(PlatformID.Win32NT, 0, 6, "Vista"));
-				list.Add(new Version(PlatformID.Win32NT, 1, 6, "Windows 7"));
-				list.Add(new Version(PlatformID.Win32NT, 2, 6, "Windows 8"));
+				list.Add(new Version(PlatformID.Win32NT, 5, 0, "Windows 2000"));
+				list.Add(new Version(PlatformID.Win32NT, 5, 1, "Windows XP"));
+				list.Add(new Version(PlatformID.Win32NT, 6, 0, "Vista"));
+				list.Add(new Version(PlatformID.Win32NT, 6, 1, "Windows 7"));
+				list.Add(new Version(PlatformID.Win32NT, 6, 2, "Windows 8"));
+
+				// Note: Windows might not report Windows 8.1 or 10 unless the app has
+				// "...been manifested for Windows 8.1 or Windows 10" (see remark in
+				// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832%28v=vs.85%29.aspx)
+				list.Add(new Version(PlatformID.Win32NT, 6, 3, "Windows 8.1"));
+				list.Add(new Version(PlatformID.Win32NT, 10, 0, "Windows 10"));
+
 				foreach (var version in list)
 				{
-					if(version.Match(Environment.OSVersion))
+					if (version.Match(Environment.OSVersion))
 						return version.Label + " " + Environment.OSVersion.ServicePack;
 				}
 			}

--- a/Palaso/Reporting/ErrorReport.cs
+++ b/Palaso/Reporting/ErrorReport.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -91,28 +90,29 @@ namespace Palaso.Reporting
 		/// ------------------------------------------------------------------------------------
 		public static string GetExceptionText(Exception error)
 		{
-			StringBuilder subject = new StringBuilder();
+			var subject = new StringBuilder();
 			subject.AppendFormat("Exception: {0}", error.Message);
 
-			StringBuilder txt = new StringBuilder();
+			var txt = new StringBuilder();
 
 			txt.Append("Msg: ");
-			txt.Append(error.Message);
+			txt.AppendLine(error.Message);
 
 			try
 			{
-				if (error is COMException)
+				var cOMException = error as COMException;
+				if (cOMException != null)
 				{
-					txt.Append("\r\nCOM message: ");
-					txt.Append(new Win32Exception(((COMException) error).ErrorCode).Message);
+					txt.Append("COM message: ");
+					txt.AppendLine(new Win32Exception(cOMException.ErrorCode).Message);
 				}
 			}
 			catch {}
 
 			try
 			{
-				txt.Append("\r\nSource: ");
-				txt.Append(error.Source);
+				txt.Append("Source: ");
+				txt.AppendLine(error.Source);
 				subject.AppendFormat(" in {0}", error.Source);
 			}
 			catch {}
@@ -121,22 +121,21 @@ namespace Palaso.Reporting
 			{
 				if (error.TargetSite != null)
 				{
-					txt.Append("\r\nAssembly: ");
-					txt.Append(error.TargetSite.DeclaringType.Assembly.FullName);
+					txt.Append("Assembly: ");
+					txt.AppendLine(error.TargetSite.DeclaringType.Assembly.FullName);
 				}
 			}
 			catch {}
 
 			try
 			{
-				txt.Append("\r\nStack: ");
-				txt.Append(error.StackTrace);
+				txt.Append("Stack: ");
+				txt.AppendLine(error.StackTrace);
 			}
 			catch {}
 
 			s_emailSubject = subject.ToString();
 
-			txt.Append("\r\n");
 			return txt.ToString();
 		}
 
@@ -398,7 +397,7 @@ namespace Palaso.Reporting
 
 		public static string GetOperatingSystemLabel()
 		{
-			if(Environment.OSVersion.Platform == PlatformID.Unix)
+			if (Environment.OSVersion.Platform == PlatformID.Unix)
 			{
 				var startInfo = new ProcessStartInfo("lsb_release", "-si -sr -sc");
 				startInfo.RedirectStandardOutput = true;
@@ -416,22 +415,28 @@ namespace Palaso.Reporting
 						return String.Format("{0} {1} {2}", si, sr, sc);
 					}
 				}
-				catch(Exception)
-				{ /*lsb_release should work on all supported versions but fall back to the OSVersion.VersionString */ }
+				catch (Exception)
+				{
+					/*lsb_release should work on all supported versions but fall back to the OSVersion.VersionString */
+				}
 			}
 			else
 			{
-			var list = new List<Version>();
-			list.Add(new Version(System.PlatformID.Win32NT,0,5, "Windows 2000"));
-			list.Add(new Version(System.PlatformID.Win32NT, 1, 5, "Windows XP"));
-			list.Add(new Version(System.PlatformID.Win32NT, 0, 6, "Vista"));
-			list.Add(new Version(System.PlatformID.Win32NT, 1, 6, "Windows 7"));
-			list.Add(new Version(System.PlatformID.Win32NT, 2, 6, "Windows 8"));
-			foreach (var version in list)
-			{
-				if(version.Match(System.Environment.OSVersion))
-					return version.Label + " " + Environment.OSVersion.ServicePack;
+				var list = new List<Version>();
+				list.Add(new Version(PlatformID.Win32NT,0,5, "Windows 2000"));
+				list.Add(new Version(PlatformID.Win32NT, 1, 5, "Windows XP"));
+				list.Add(new Version(PlatformID.Win32NT, 0, 6, "Vista"));
+				list.Add(new Version(PlatformID.Win32NT, 1, 6, "Windows 7"));
+				list.Add(new Version(PlatformID.Win32NT, 2, 6, "Windows 8"));
+				foreach (var version in list)
+				{
+					if(version.Match(Environment.OSVersion))
+						return version.Label + " " + Environment.OSVersion.ServicePack;
+				}
 			}
+			return Environment.OSVersion.VersionString;
+		}
+
 			}
 			return System.Environment.OSVersion.VersionString;
 		}
@@ -450,7 +455,7 @@ namespace Palaso.Reporting
 			{
 				innerMostException = error.InnerException;
 
-				x += "**Inner Exception:\r\n";
+				x += "**Inner Exception:" + Environment.NewLine;
 				x += GetHiearchicalExceptionInfo(error.InnerException, ref innerMostException);
 			}
 			return x;


### PR DESCRIPTION
On Linux this change adds the currently running desktop environment (Unity, gnome shell etc) to the error report.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/263)
<!-- Reviewable:end -->
