### PR TITLE
Add properties to get desktop environment to Platform class

### DIFF
--- a/Palaso.Tests/PlatformUtilities/PlatformTests.cs
+++ b/Palaso.Tests/PlatformUtilities/PlatformTests.cs
@@ -124,6 +124,77 @@ namespace Palaso.Tests.PlatformUtilities
 		{
 			Assert.That(Platform.IsUnix, Is.False);
 		}
+
+		[Test]
+		[Platform(Include = "Win", Reason = "Windows specific test")]
+		public void DesktopEnvironment_Windows()
+		{
+			// SUT
+			Assert.That(Platform.DesktopEnvironment, Is.EqualTo("Win32NT"));
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		[TestCase("Unity", null, "ubuntu", Result = "unity", TestName = "Unity")]
+		[TestCase("Unity", "/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/",
+			"ubuntu", Result = "unity", TestName = "Unity with dataDir")]
+		[TestCase("GNOME", null, "gnome-shell", Result = "gnome",
+			TestName = "Gnome shell")]
+		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
+			"kde-plasma", Result = "kde", TestName = "KDE on Ubuntu 12_04")]
+		[TestCase("XFCE", null, "xubuntu", Result = "xfce", TestName = "XFCE")]
+		[TestCase("foo", null, null, Result = "foo", TestName = "Only XDG_CURRENT_DESKTOP set")]
+		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/", null,
+			Result = "kde", TestName = "Only XDG_DATA_DIRS set")]
+		[TestCase(null, null, "something", Result = "something", TestName = "Only GDMSESSION set")]
+		public string DesktopEnvironment_SimulateDesktops(string currDesktop,
+			string dataDirs, string gdmSession)
+		{
+			// See http://askubuntu.com/a/227669 for actual values on different systems
+
+			// Setup
+			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", currDesktop);
+			Environment.SetEnvironmentVariable("XDG_DATA_DIRS", dataDirs);
+			Environment.SetEnvironmentVariable("GDMSESSION", gdmSession);
+
+			// SUT
+			return Platform.DesktopEnvironment;
+		}
+
+		[Test]
+		[Platform(Include = "Win", Reason = "Windows specific test")]
+		public void DesktopEnvironmentInfoString_Windows()
+		{
+			// SUT
+			Assert.That(Platform.DesktopEnvironmentInfoString, Is.Empty);
+		}
+
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		[TestCase("Unity", null, "ubuntu", null, Result = "unity (ubuntu)", TestName = "Unity")]
+		[TestCase("Unity", "/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/",
+			"ubuntu", null, Result = "unity (ubuntu)", TestName = "Unity with dataDir")]
+		[TestCase("Unity", null, "ubuntu", "session-1",
+			Result = "unity (ubuntu [display server: Mir])", TestName = "Unity with Mir")]
+		[TestCase("GNOME", null, "gnome-shell", null, Result = "gnome (gnome-shell)",
+			TestName = "Gnome shell")]
+		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
+			"kde-plasma", null, Result = "kde (kde-plasma)", TestName = "KDE on Ubuntu 12_04")]
+		public string DesktopEnvironmentInfoString_SimulateDesktopEnvironments(string currDesktop,
+			string dataDirs, string gdmSession, string mirServerName)
+		{
+			// See http://askubuntu.com/a/227669 for actual values on different systems
+
+			// Setup
+			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", currDesktop);
+			Environment.SetEnvironmentVariable("XDG_DATA_DIRS", dataDirs);
+			Environment.SetEnvironmentVariable("GDMSESSION", gdmSession);
+			Environment.SetEnvironmentVariable("MIR_SERVER_NAME", mirServerName);
+
+			// SUT
+			return Platform.DesktopEnvironmentInfoString;
+		}
+
 	}
 }
 

--- a/Palaso.Tests/reporting/ErrorReportTests.cs
+++ b/Palaso.Tests/reporting/ErrorReportTests.cs
@@ -77,34 +77,5 @@ namespace Palaso.Tests.reporting
 			// Verify
 			Assert.That(props.Keys, Has.Member("DesktopEnvironment"));
 		}
-
-		[Test]
-		[Platform(Include = "Linux", Reason = "Linux specific test")]
-		[TestCase("Unity", null, "ubuntu", null, Result = "Unity (ubuntu)", TestName = "Unity")]
-		[TestCase("Unity", "/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/",
-			"ubuntu", null, Result = "Unity (ubuntu)", TestName = "Unity with dataDir")]
-		[TestCase("Unity", null, "ubuntu", "session-1",
-			Result = "Unity (ubuntu [display server: Mir])", TestName = "Unity with Mir")]
-		[TestCase("GNOME", null, "gnome-shell", null, Result = "GNOME (gnome-shell)"
-			, TestName = "Gnome shell")]
-		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
-			"kde-plasma", null, Result = "KDE (kde-plasma)", TestName = "KDE on Ubuntu 12_04")]
-		public string GetStandardProperties_SimulateDesktopEnvironments(string currDesktop,
-			string dataDirs, string gdmSession, string mirServerName)
-		{
-			// See http://askubuntu.com/a/227669 for actual values on different systems
-
-			// Setup
-			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", currDesktop);
-			Environment.SetEnvironmentVariable("XDG_DATA_DIRS", dataDirs);
-			Environment.SetEnvironmentVariable("GDMSESSION", gdmSession);
-			Environment.SetEnvironmentVariable("MIR_SERVER_NAME", mirServerName);
-
-			// SUT
-			var props = ErrorReport.GetStandardProperties();
-
-			// Verify
-			return props["DesktopEnvironment"];
-		}
 	}
 }

--- a/Palaso/PlatformUtilities/Platform.cs
+++ b/Palaso/PlatformUtilities/Platform.cs
@@ -88,6 +88,62 @@ namespace Palaso.PlatformUtilities
 			get { return IsUnix && SessionManager.StartsWith("/usr/bin/cinnamon-session"); }
 		}
 
+		/// <summary>
+		/// On a Unix machine this gets the current desktop environment (gnome/xfce/...), on
+		/// non-Unix machines the platform name.
+		/// </summary>
+		public static string DesktopEnvironment
+		{
+			get
+			{
+				if (!Platform.IsUnix)
+					return Environment.OSVersion.Platform.ToString();
+
+				// see http://unix.stackexchange.com/a/116694
+				// and http://askubuntu.com/a/227669
+				var currentDesktop = Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP");
+				if (string.IsNullOrEmpty(currentDesktop))
+				{
+					var dataDirs = Environment.GetEnvironmentVariable("XDG_DATA_DIRS");
+					if (dataDirs != null)
+					{
+						dataDirs = dataDirs.ToLowerInvariant();
+						if (dataDirs.Contains("xfce"))
+							currentDesktop = "XFCE";
+						else if (dataDirs.Contains("kde"))
+							currentDesktop = "KDE";
+						else if (dataDirs.Contains("gnome"))
+							currentDesktop = "Gnome";
+					}
+					if (string.IsNullOrEmpty(currentDesktop))
+						currentDesktop = Environment.GetEnvironmentVariable("GDMSESSION");
+				}
+				return currentDesktop.ToLowerInvariant();
+			}
+		}
+
+		/// <summary>
+		/// Get the currently running desktop environment (like Unity, Gnome shell etc)
+		/// </summary>
+		public static string DesktopEnvironmentInfoString
+		{
+			get
+			{
+				if (!Platform.IsUnix)
+					return string.Empty;
+
+				// see http://unix.stackexchange.com/a/116694
+				// and http://askubuntu.com/a/227669
+				var currentDesktop = Platform.DesktopEnvironment;
+				var mirSession = Environment.GetEnvironmentVariable("MIR_SERVER_NAME");
+				var additionalInfo = string.Empty;
+				if (!string.IsNullOrEmpty(mirSession))
+					additionalInfo = " [display server: Mir]";
+				var gdmSession = Environment.GetEnvironmentVariable("GDMSESSION");
+				return string.Format("{0} ({1}{2})", currentDesktop, gdmSession, additionalInfo);
+			}
+		}
+
 		private static string SessionManager
 		{
 			get

--- a/Palaso/Reporting/ErrorReport.cs
+++ b/Palaso/Reporting/ErrorReport.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using Palaso.Reporting;
+using Palaso.PlatformUtilities;
 
 
 namespace Palaso.Reporting
@@ -346,8 +347,8 @@ namespace Palaso.Reporting
 			AddProperty("CurrentDirectory", Environment.CurrentDirectory);
 			AddProperty("MachineName", Environment.MachineName);
 			AddProperty("OSVersion", GetOperatingSystemLabel());
-			if (Palaso.PlatformUtilities.Platform.IsUnix)
-				AddProperty("DesktopEnvironment", GetDesktopEnvironment());
+			if (Platform.IsUnix)
+				AddProperty("DesktopEnvironment", Platform.DesktopEnvironmentInfoString);
 			AddProperty("DotNetVersion", Environment.Version.ToString());
 			AddProperty("WorkingSet", Environment.WorkingSet.ToString());
 			AddProperty("UserDomainName", Environment.UserDomainName);
@@ -367,8 +368,8 @@ namespace Palaso.Reporting
 			props.Add("CurrentDirectory", Environment.CurrentDirectory);
 			props.Add("MachineName", Environment.MachineName);
 			props.Add("OSVersion", GetOperatingSystemLabel());
-			if (Palaso.PlatformUtilities.Platform.IsUnix)
-				props.Add("DesktopEnvironment", GetDesktopEnvironment());
+			if (Platform.IsUnix)
+				props.Add("DesktopEnvironment", Platform.DesktopEnvironmentInfoString);
 			props.Add("DotNetVersion", Environment.Version.ToString());
 			props.Add("WorkingSet", Environment.WorkingSet.ToString());
 			props.Add("UserDomainName", Environment.UserDomainName);
@@ -447,41 +448,6 @@ namespace Palaso.Reporting
 				}
 			}
 			return Environment.OSVersion.VersionString;
-		}
-
-		/// <summary>
-		/// Get the currently running desktop environment (like Unity, Gnome shell etc)
-		/// </summary>
-		private static string GetDesktopEnvironment()
-		{
-			if (!Palaso.PlatformUtilities.Platform.IsUnix)
-				return string.Empty;
-
-			// see http://unix.stackexchange.com/a/116694
-			// and http://askubuntu.com/a/227669
-			var currentDesktop = Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP");
-			if (string.IsNullOrEmpty(currentDesktop))
-			{
-				var dataDirs = Environment.GetEnvironmentVariable("XDG_DATA_DIRS");
-				if (dataDirs != null)
-				{
-					dataDirs = dataDirs.ToLowerInvariant();
-					if (dataDirs.Contains("xfce"))
-						currentDesktop = "XFCE";
-					else if (dataDirs.Contains("kde"))
-						currentDesktop = "KDE";
-					else if (dataDirs.Contains("gnome"))
-						currentDesktop = "Gnome";
-				}
-				if (string.IsNullOrEmpty(currentDesktop))
-					return string.Empty;
-			}
-			var mirSession = Environment.GetEnvironmentVariable("MIR_SERVER_NAME");
-			var additionalInfo = string.Empty;
-			if (!string.IsNullOrEmpty(mirSession))
-				additionalInfo = " [display server: Mir]";
-			var gdmSession = Environment.GetEnvironmentVariable("GDMSESSION");
-			return string.Format("{0} ({1}{2})", currentDesktop, gdmSession, additionalInfo);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/PalasoUIWindowsForms.TestApp/TestAppForm.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.cs
@@ -41,6 +41,7 @@ namespace PalasoUIWindowsForms.TestApp
 		public TestAppForm()
 		{
 			InitializeComponent();
+			Text = Palaso.PlatformUtilities.Platform.DesktopEnvironmentInfoString;
 		}
 
 		private void OnFolderBrowserControlClicked(object sender, EventArgs e)


### PR DESCRIPTION
- Platform.DesktopEnvironment returns the name of the desktop
  environment, e.g. xfce or unity
- Platform.DesktopEnvironmentInfoString returns more info based on
  the environment varibles set, e.g. "xfce (xubuntu)"
- Display the current desktop environment as title in the test app

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/265)
<!-- Reviewable:end -->
