### PR TITLE
Fix Platform.DesktopEnvironment property

### DIFF
--- a/Palaso.Tests/PlatformUtilities/PlatformTests.cs
+++ b/Palaso.Tests/PlatformUtilities/PlatformTests.cs
@@ -147,6 +147,7 @@ namespace Palaso.Tests.PlatformUtilities
 		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/", null,
 			Result = "kde", TestName = "Only XDG_DATA_DIRS set")]
 		[TestCase(null, null, "something", Result = "something", TestName = "Only GDMSESSION set")]
+		[TestCase(null, null, null, Result = "", TestName = "Nothing set")]
 		public string DesktopEnvironment_SimulateDesktops(string currDesktop,
 			string dataDirs, string gdmSession)
 		{
@@ -180,6 +181,7 @@ namespace Palaso.Tests.PlatformUtilities
 			TestName = "Gnome shell")]
 		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
 			"kde-plasma", null, Result = "kde (kde-plasma)", TestName = "KDE on Ubuntu 12_04")]
+		[TestCase(null, null, null, null, Result = " (not set)", TestName = "Nothing set")]
 		public string DesktopEnvironmentInfoString_SimulateDesktopEnvironments(string currDesktop,
 			string dataDirs, string gdmSession, string mirServerName)
 		{

--- a/Palaso/PlatformUtilities/Platform.cs
+++ b/Palaso/PlatformUtilities/Platform.cs
@@ -116,7 +116,7 @@ namespace Palaso.PlatformUtilities
 							currentDesktop = "Gnome";
 					}
 					if (string.IsNullOrEmpty(currentDesktop))
-						currentDesktop = Environment.GetEnvironmentVariable("GDMSESSION");
+						currentDesktop = Environment.GetEnvironmentVariable("GDMSESSION") ?? string.Empty;
 				}
 				return currentDesktop.ToLowerInvariant();
 			}
@@ -139,7 +139,7 @@ namespace Palaso.PlatformUtilities
 				var additionalInfo = string.Empty;
 				if (!string.IsNullOrEmpty(mirSession))
 					additionalInfo = " [display server: Mir]";
-				var gdmSession = Environment.GetEnvironmentVariable("GDMSESSION");
+				var gdmSession = Environment.GetEnvironmentVariable("GDMSESSION") ?? "not set";
 				return string.Format("{0} ({1}{2})", currentDesktop, gdmSession, additionalInfo);
 			}
 		}

--- a/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
+++ b/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
@@ -9,6 +9,9 @@ using System.Windows.Forms;
 using Palaso.Reporting;
 using Palaso.WritingSystems;
 using Palaso.UI.WindowsForms.Keyboarding.InternalInterfaces;
+using System.Diagnostics;
+
+
 #if __MonoCS__
 using Palaso.UI.WindowsForms.Keyboarding.Linux;
 #else
@@ -547,8 +550,15 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 				Keyboard.Controller = new KeyboardControllerImpl();
 				Manager.Reset();
 			}
-			catch (Exception)
+			catch (Exception e)
 			{
+				Console.WriteLine("Got exception {0} initalizing keyboard controller", e.GetType());
+				Console.WriteLine(e.StackTrace);
+				Logger.WriteEvent("Got exception {0} initalizing keyboard controller", e.GetType());
+				Logger.WriteEvent(e.StackTrace);
+
+				if (Keyboard.Controller != null)
+					Keyboard.Controller.Dispose();
 				Keyboard.Controller = null;
 				throw;
 			}


### PR DESCRIPTION
When run from a terminal without being attached to an X-server
the environment variables for the desktop environment are not set.
In this case we shouldn't crash but simply return an empty string.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/271)
<!-- Reviewable:end -->
