### PR TITLE
Don't set ibus keyboard again when it's already set (LT-16179)

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
@@ -94,19 +94,6 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			}
 		}
 
-		internal override bool IBusKeyboardAlreadySet(IbusKeyboardDescription keyboard)
-		{
-			if (keyboard == null || keyboard.IBusKeyboardEngine == null)
-			{
-				UnsetKeyboard();
-				return true;
-			}
-
-			// Even when GlobalCachedInputContext.Keyboard is already set to keyboard we still
-			// want to set the keyboard again
-			return false;
-		}
-
 		/// <summary>
 		/// Set the XKB layout from the IBus keyboard.
 		/// </summary>


### PR DESCRIPTION
When using the IPA KMFL keyboard we get a commit from IBus after
every character. At least on Wasta 14 this causes a keyboard
activation. The previous code that didn't check if the keyboard
was already set causes the IPA keyboard to lose its context thus
preventing the IPA keyboard from working properly. This change
removes the override of IBusKeyboardAlreadySet() method and uses
the base implementation instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/272)
<!-- Reviewable:end -->
