### PR TITLE
Add multilingual search index to ArtOfReadingImageCollection

### DIFF
--- a/PalasoUIWindowsForms/ImageToolbox/AcquireImageControl.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/AcquireImageControl.cs
@@ -266,6 +266,15 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 			_galleryControl.SetIntialSearchTerm(searchTerm);
 		}
 
+		/// <summary>
+		/// Gets or sets the language used in searching for an image by words.
+		/// </summary>
+		public string SearchLanguage
+		{
+			get { return _galleryControl.SearchLanguage; }
+			set { _galleryControl.SearchLanguage = value; }
+		}
+
 		/*
 		/// <summary>
 		/// Bitmaps --> PNG, JPEGs stay as jpegs.

--- a/PalasoUIWindowsForms/ImageToolbox/ArtOfReadingChooser.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ArtOfReadingChooser.cs
@@ -31,6 +31,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 				this.betterLinkLabel1.URL = null;
 				this.betterLinkLabel1.LinkClicked += InstallLinkClicked;
 			}
+			SearchLanguage = "en";	// until/unless the owner specifies otherwise explicitly
 		}
 
 		public void Dispose()
@@ -46,6 +47,11 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 		{
 			_searchTermsBox.Text = searchTerm;
 		}
+
+		/// <summary>
+		/// Gets or sets the language used in searching for an image by words.
+		/// </summary>
+		public string SearchLanguage { internal get; set; }
 
 		void _thumbnailViewer_SelectedIndexChanged(object sender, EventArgs e)
 		{
@@ -178,7 +184,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 			if (DesignMode)
 				return;
 
-			_imageCollection = ArtOfReadingImageCollection.FromStandardLocations();
+			_imageCollection = ArtOfReadingImageCollection.FromStandardLocations(SearchLanguage);
 			if (_imageCollection == null)
 			{
 				//label1.Visible = _searchTermsBox.Visible = _searchButton.Visible = _thumbnailViewer.Visible = false;

--- a/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ImageToolboxControl.cs
@@ -28,6 +28,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 			_toolImages = new ImageList();
 			ImageInfo = new PalasoImage();
 			_copyExemplarMetadata.Font = _editMetadataLink.Font;
+			SearchLanguage = "en";	// unless/until the owner specifies otherwise explicitly
 		}
 
 		/// <summary>
@@ -109,6 +110,11 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 				}
 			}
 		}
+
+		/// <summary>
+		/// Gets or sets the language used in searching for an image by words.
+		/// </summary>
+		public string SearchLanguage { protected get; set; }
 
 		private void SetCurrentImageToolTip(PalasoImage image)
 		{
@@ -335,6 +341,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 			{
 				var c = new AcquireImageControl();
 				c.SetIntialSearchString(InitialSearchString);
+				c.SearchLanguage = SearchLanguage;
 				return c;
 			});
 			_cropToolListItem = AddControl("Crop".Localize("ImageToolbox.Crop"), ImageToolboxButtons.crop, "crop", (x) => new ImageCropper());

--- a/PalasoUIWindowsForms/ImageToolbox/ImageToolboxDialog.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/ImageToolboxDialog.cs
@@ -16,8 +16,14 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 			 InitializeComponent();
 			imageToolboxControl1.ImageInfo = imageInfo;
 			imageToolboxControl1.InitialSearchString = initialSearchString;
+			SearchLanguage = "en";	// unless the caller specifies otherwise explicitly
 		}
 		public PalasoImage ImageInfo { get { return imageToolboxControl1.ImageInfo; } }
+
+		/// <summary>
+		/// Sets the language used in searching for an image by words.
+		/// </summary>
+		public string SearchLanguage { set { imageToolboxControl1.SearchLanguage = value; } }
 
 		private void _okButton_Click(object sender, EventArgs e)
 		{


### PR DESCRIPTION
This does not change the GUI at all, and does not require a change to calling ImageToolboxDialog if you're happy with English lookup or don't have access to the new Art of Reading multilingual index.  It does provide a way to pass in the language code of the language you'd like to use for image searches in Art of Reading.