### PR TITLE
Don't execute IbusKeyboardSwitchingAdaptor.HandleGotFocus twice

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardSwitchingAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/IbusKeyboardSwitchingAdaptor.cs
@@ -259,6 +259,14 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			if (!IBusCommunicator.Connected)
 				return;
 
+			// On FieldWorks we get here twice: once because we intercept the WM_SETFOCUS message
+			// and the other time because we have to call the original window proc. However, only
+			// the second time will the control report as being focused (or when we not intercept
+			// the message then the first time) (see SimpleRootSite.OriginalWndProc).
+			var control = sender as Control;
+			if (control == null || !control.Focused)
+				return;
+
 			IBusCommunicator.FocusIn();
 			m_needIMELocation = true;
 		}


### PR DESCRIPTION
When using the keyboarding code in FW HandleGotFocus got called
twice because of some specific requirements of FW on Linux. This
change checks the control.Focus state and returns if this doesn't
tell us that we have focus.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/275)
<!-- Reviewable:end -->
