### PR TITLE
Fix problem with keyboard setup link in Wasta 14

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -272,9 +272,9 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			if (File.Exists("/usr/lib/cinnamon-settings/cinnamon-settings.py") && File.Exists("/usr/bin/python"))
 			{
 				arguments = "/usr/lib/cinnamon-settings/cinnamon-settings.py " +
-					Platform.DesktopEnvironment == "cinnamon"
+					(Platform.DesktopEnvironment == "cinnamon"
 						? "region layouts" // Wasta 12
-						: "keyboard"; // Wasta 14;
+						: "keyboard"); // Wasta 14;
 				return "/usr/bin/python";
 			}
 			// GNOME


### PR DESCRIPTION
On Wasta 14 without the parens we returned "keyboard" as arguments
which broke the keyboard setup link.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/282)
<!-- Reviewable:end -->
