### PR TITLE
Add keyboard adaptor information to ErrorReport properties

### DIFF
--- a/PalasoUIWindowsForms.TestApp/TestAppForm.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.cs
@@ -21,6 +21,7 @@ using Palaso.UI.WindowsForms.WritingSystems;
 using Palaso.WritingSystems;
 using Palaso.WritingSystems.Migration.WritingSystemsLdmlV0To1Migration;
 using PalasoUIWindowsForms.TestApp.Properties;
+using Palaso.Reporting;
 
 namespace PalasoUIWindowsForms.TestApp
 {
@@ -79,6 +80,9 @@ namespace PalasoUIWindowsForms.TestApp
 			{
 				KeyboardController.Initialize();
 				_KeyboardControllerInitialized = true;
+
+				foreach (string key in ErrorReport.Properties.Keys)
+					Console.WriteLine("{0}: {1}", key, ErrorReport.Properties[key]);
 			}
 			var wsRepo = LdmlInFolderWritingSystemRepository.Initialize(tempPath, onMigration, onLoadProblem);
 			using (var dialog = new WritingSystemSetupDialog(wsRepo))

--- a/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
+++ b/PalasoUIWindowsForms/Keyboarding/KeyboardController.cs
@@ -10,6 +10,7 @@ using Palaso.Reporting;
 using Palaso.WritingSystems;
 using Palaso.UI.WindowsForms.Keyboarding.InternalInterfaces;
 using System.Diagnostics;
+using System.Text;
 
 
 #if __MonoCS__
@@ -103,12 +104,19 @@ namespace Palaso.UI.WindowsForms.Keyboarding
 				}
 
 				// Now that we know who can deal with the keyboards we can retrieve all available
-				// keyboards
+				// keyboards, as well as add the used keyboard adaptors as error report property.
+				var bldr = new StringBuilder();
 				foreach (var retriever in KeyboardRetrievers.Values)
 				{
 					retriever.Initialize();
 					retriever.RegisterAvailableKeyboards();
+
+					if (bldr.Length > 0)
+						bldr.Append(", ");
+					bldr.Append(retriever.GetType().Name);
 				}
+				ErrorReport.AddProperty("KeyboardAdaptors", bldr.ToString());
+				Logger.WriteEvent("Keyboard adaptors in use: {0}", bldr.ToString());
 			}
 
 			/// <summary>

--- a/PalasoUIWindowsForms/Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -177,12 +177,25 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 			// We want to create a new switching adaptor only the first time otherwise we're
 			// getting into trouble
 			if (_adaptor == null)
+			{
 				_adaptor = new CombinedIbusKeyboardSwitchingAdaptor(_IBusCommunicator);
+				KeyboardRetrievingHelper.AddIbusVersionAsErrorReportProperty();
+			}
 		}
 
 		public override IKeyboardDefinition CreateKeyboardDefinition(string layout, string locale)
 		{
 			return XkbKeyboardRetrievingAdaptor.CreateKeyboardDefinition(layout, locale, _adaptor);
+		}
+
+		public override void Close()
+		{
+			if (_settingsGeneral != IntPtr.Zero)
+			{
+				Unmanaged.g_object_unref(_settingsGeneral);
+				_settingsGeneral = IntPtr.Zero;
+			}
+			base.Close();
 		}
 		#endregion
 

--- a/PalasoUIWindowsForms/Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Palaso.Reporting;
 using Palaso.UI.WindowsForms.Keyboarding.Types;
 
 namespace Palaso.UI.WindowsForms.Keyboarding.Linux
@@ -26,6 +27,31 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 		{
 			return Unmanaged.g_settings_schema_source_lookup(Unmanaged.g_settings_schema_source_get_default(),
 				schema, recursive: true) != IntPtr.Zero;
+		}
+
+		public static void AddIbusVersionAsErrorReportProperty()
+		{
+			var settingsGeneral = IntPtr.Zero;
+			try
+			{
+				const string ibusSchema = "org.freedesktop.ibus.general";
+				if (!SchemaIsInstalled(ibusSchema))
+					return;
+				settingsGeneral = Unmanaged.g_settings_new(ibusSchema);
+				if (settingsGeneral == IntPtr.Zero)
+					return;
+				var version = Unmanaged.g_settings_get_string(settingsGeneral, "version");
+				ErrorReport.AddProperty("IbusVersion", version);
+			}
+			catch
+			{
+				// Ignore any error we might get
+			}
+			finally
+			{
+				if (settingsGeneral != IntPtr.Zero)
+					Unmanaged.g_object_unref(settingsGeneral);
+			}
 		}
 
 		/// <summary>

--- a/PalasoUIWindowsForms/Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -31,6 +31,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 		public override void Initialize()
 		{
 			_adaptor = new UnityIbusKeyboardSwitchingAdaptor(_IBusCommunicator);
+			KeyboardRetrievingHelper.AddIbusVersionAsErrorReportProperty();
 		}
 
 		public override string GetKeyboardSetupApplication(out string arguments)

--- a/PalasoUIWindowsForms/Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
@@ -75,6 +75,7 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Linux
 				return null;
 			var list = KeyboardRetrievingHelper.GetStringArrayFromGVariantListArray(sources);
 			Unmanaged.g_variant_unref(sources);
+			Unmanaged.g_object_unref(settings);
 
 			return list;
 		}

--- a/PalasoUIWindowsForms/Keyboarding/Types/Unmanaged.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Types/Unmanaged.cs
@@ -39,6 +39,9 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Types
 		internal extern static bool g_settings_get_boolean(IntPtr settings, string key);
 
 		[DllImport("libgio-2.0.so")]
+		internal extern static string g_settings_get_string(IntPtr settings, string key);
+
+		[DllImport("libgio-2.0.so")]
 		internal extern static bool g_settings_set_uint(IntPtr settings, string key, uint value);
 
 		[DllImport("libglib-2.0.so")]


### PR DESCRIPTION
Add the keyboard adaptors in use as well as the IBus version to
the properties of the ErrorReport dialog so that we get this
information if the user submits an error report.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/284)
<!-- Reviewable:end -->
