### PR TITLE
Use Dictionary<string,string> for ErrorReport properties

### DIFF
--- a/Palaso/Reporting/ErrorReport.cs
+++ b/Palaso/Reporting/ErrorReport.cs
@@ -68,8 +68,8 @@ namespace Palaso.Reporting
 		/// <summary>
 		/// a list of name, string value pairs that will be included in the details of the error report.
 		/// </summary>
-		private static StringDictionary s_properties =
-			new StringDictionary();
+		private static Dictionary<string, string> s_properties =
+			new Dictionary<string, string>();
 
 		private static bool s_isOkToInteractWithUser = true;
 		private static bool s_justRecordNonFatalMessagesForTesting=false;
@@ -299,7 +299,7 @@ namespace Palaso.Reporting
 		/// <summary>
 		/// a list of name, string value pairs that will be included in the details of the error report.
 		/// </summary>
-		public static StringDictionary Properties
+		public static Dictionary<string, string> Properties
 		{
 			get
 			{


### PR DESCRIPTION
Using Dictionary<string,string> instead of StringDictionary
preserves the case of the dictionary keys which makes them easier
to read in an error report.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/286)
<!-- Reviewable:end -->
