### PR TITLE
Fix a momentary black box artifact when querying  Art Of Reading

### DIFF
--- a/PalasoUIWindowsForms.GeckoFxWebBrowserAdapter/WebThumbnailViewer.cs
+++ b/PalasoUIWindowsForms.GeckoFxWebBrowserAdapter/WebThumbnailViewer.cs
@@ -157,7 +157,16 @@ namespace Palaso.UI.WindowsForms.ImageGallery
 			// What we want to do here is _browser.NavigateToString(sb.ToString()).
 			// But the Windows.Forms WebBrowser class doesn't have that method.
 			File.WriteAllText(_htmlFile.Path, sb.ToString(), Encoding.UTF8);
+
+			// BL-2729: Hiding the viewer during search prevents a momentary black screen on first query (and only the first).
+			// This problem is hard to reproduce from just libpalaso test apps; for a while I was able to
+			// get it to show using the testapp by opening the image toolbox and then closing it, then 
+			// opening it again and doing a query. But after a while, that stopped working.
+			// But on my Windows machine, it was a 100% reproducible inside Bloom, and this change made
+			// that problem go away.
+			_browser.Visible = false;
 			_browser.Navigate(_htmlFile.Path);
+			_browser.Visible = true;
 		}
 
 		//BL-907: Crashes, probably out-of-memory error

--- a/PalasoUIWindowsForms.TestApp/TestAppForm.Designer.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.Designer.cs
@@ -59,7 +59,7 @@ namespace PalasoUIWindowsForms.TestApp
 			this.btnFolderBrowserControl = new System.Windows.Forms.Button();
 			this.btnLookupISOCodeDialog = new System.Windows.Forms.Button();
 			this.btnWritingSystemSetupDialog = new System.Windows.Forms.Button();
-			this.btnArtOfReading = new System.Windows.Forms.Button();
+			this.btnImageToolbox = new System.Windows.Forms.Button();
 			this.btnSilAboutBox = new System.Windows.Forms.Button();
 			this.btnShowReleaseNotes = new System.Windows.Forms.Button();
 			this.superToolTip1 = new Palaso.UI.WindowsForms.SuperToolTip.SuperToolTip(this.components);
@@ -99,15 +99,15 @@ namespace PalasoUIWindowsForms.TestApp
 			this.btnWritingSystemSetupDialog.UseVisualStyleBackColor = true;
 			this.btnWritingSystemSetupDialog.Click += new System.EventHandler(this.OnWritingSystemSetupDialogClicked);
 			// 
-			// btnArtOfReading
+			// btnImageToolbox
 			// 
-			this.btnArtOfReading.Location = new System.Drawing.Point(12, 99);
-			this.btnArtOfReading.Name = "btnArtOfReading";
-			this.btnArtOfReading.Size = new System.Drawing.Size(157, 23);
-			this.btnArtOfReading.TabIndex = 0;
-			this.btnArtOfReading.Text = "ArtOfReading";
-			this.btnArtOfReading.UseVisualStyleBackColor = true;
-			this.btnArtOfReading.Click += new System.EventHandler(this.OnArtOfReadingClicked);
+			this.btnImageToolbox.Location = new System.Drawing.Point(12, 99);
+			this.btnImageToolbox.Name = "btnImageToolbox";
+			this.btnImageToolbox.Size = new System.Drawing.Size(157, 23);
+			this.btnImageToolbox.TabIndex = 0;
+			this.btnImageToolbox.Text = "Image Toolbox";
+			this.btnImageToolbox.UseVisualStyleBackColor = true;
+			this.btnImageToolbox.Click += new System.EventHandler(this.OnImageToolboxClicked);
 			// 
 			// btnSilAboutBox
 			// 
@@ -197,7 +197,7 @@ namespace PalasoUIWindowsForms.TestApp
 			this.Controls.Add(this.btnMetaDataEditor);
 			this.Controls.Add(this.btnShowReleaseNotes);
 			this.Controls.Add(this.btnSilAboutBox);
-			this.Controls.Add(this.btnArtOfReading);
+			this.Controls.Add(this.btnImageToolbox);
 			this.Controls.Add(this.btnWritingSystemSetupDialog);
 			this.Controls.Add(this.btnLookupISOCodeDialog);
 			this.Controls.Add(this.btnFolderBrowserControl);
@@ -213,7 +213,7 @@ namespace PalasoUIWindowsForms.TestApp
 		private System.Windows.Forms.Button btnFolderBrowserControl;
 		private System.Windows.Forms.Button btnLookupISOCodeDialog;
 		private System.Windows.Forms.Button btnWritingSystemSetupDialog;
-		private System.Windows.Forms.Button btnArtOfReading;
+		private System.Windows.Forms.Button btnImageToolbox;
 		private System.Windows.Forms.Button btnSilAboutBox;
 		private System.Windows.Forms.Button btnShowReleaseNotes;
 		private Palaso.UI.WindowsForms.SuperToolTip.SuperToolTip superToolTip1;

--- a/PalasoUIWindowsForms.TestApp/TestAppForm.cs
+++ b/PalasoUIWindowsForms.TestApp/TestAppForm.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -22,6 +23,7 @@ using Palaso.WritingSystems;
 using Palaso.WritingSystems.Migration.WritingSystemsLdmlV0To1Migration;
 using PalasoUIWindowsForms.TestApp.Properties;
 using Palaso.Reporting;
+using Palaso.UI.WindowsForms.ImageToolbox;
 
 namespace PalasoUIWindowsForms.TestApp
 {
@@ -94,10 +96,14 @@ namespace PalasoUIWindowsForms.TestApp
 			}
 		}
 
-		private void OnArtOfReadingClicked(object sender, EventArgs e)
+		private void OnImageToolboxClicked(object sender, EventArgs e)
 		{
-			using (var dlg = new ArtOfReadingTestForm())
+			Application.EnableVisualStyles();
+			ThumbnailViewer.UseWebViewer = true;
+			using (var dlg = new ImageToolboxDialog(new PalasoImage(), null))
+			{
 				dlg.ShowDialog();
+			}
 		}
 
 		private static void onMigration(IEnumerable<LdmlVersion0MigrationStrategy.MigrationInfo> migrationInfo)


### PR DESCRIPTION
Hiding the viewer during search prevents a momentary black screen on first query (and only the first).

The related Bloom issue: https://silbloom.myjetbrains.com/youtrack/issue/BL-2729