### PR TITLE
API: Remove public string-formatting methods from Progress

### DIFF
--- a/Palaso/Progress/Progress.cs
+++ b/Palaso/Progress/Progress.cs
@@ -421,13 +421,8 @@ namespace Palaso.Progress
 		public SynchronizationContext SyncContext { get; set; }
 		public void WriteStatus(string message, params object[] args)
 		{
-#if MONO
-			Console.Write("                          ".Substring(0, indent*2));
-			Console.WriteLine(GenericProgress.SafeFormat(message, args));
-#else
 			Console.Write("                          ".Substring(0, indent * 2));
-			Console.WriteLine(GenericProgress.SafeFormat(message, args));
-#endif
+			Console.WriteLine(message.FormatWithErrorStringInsteadOfException(args));
 		}
 
 		public void WriteMessage(string message, params object[] args)
@@ -474,7 +469,7 @@ namespace Palaso.Progress
 		{
 			if(!_verbose)
 				return;
-			var lines = GenericProgress.SafeFormat(message, args);
+			var lines = message.FormatWithErrorStringInsteadOfException(args);
 			foreach (var line in lines.Split('\n'))
 			{
 				WriteStatus("    " + line);
@@ -558,7 +553,7 @@ public class StringBuilderProgress : GenericProgress
 
 		public  void WriteStatus(string message, params object[] args)
 		{
-			LastStatus = GenericProgress.SafeFormat(message, args);
+			LastStatus = message.FormatWithErrorStringInsteadOfException(args);
 		}
 
 		public void WriteMessageWithColor(string colorName, string message, params object[] args)
@@ -568,7 +563,7 @@ public class StringBuilderProgress : GenericProgress
 
 		public void WriteWarning(string message, params object[] args)
 		{
-			LastWarning = GenericProgress.SafeFormat(message, args);
+			LastWarning = message.FormatWithErrorStringInsteadOfException(args);
 			LastStatus = LastWarning;
 		}
 
@@ -579,7 +574,7 @@ public class StringBuilderProgress : GenericProgress
 
 		public void WriteError(string message, params object[] args)
 		{
-			LastError = GenericProgress.SafeFormat(message, args);
+			LastError = message.FormatWithErrorStringInsteadOfException(args);
 			LastStatus = LastError;
 		}
 
@@ -608,15 +603,7 @@ public class StringBuilderProgress : GenericProgress
 
 		public void Clear()
 		{
-			LastError = LastWarning =LastStatus = string.Empty;
-		}
-	}
-
-	public static class SafeFormatString
-	{
-		public static string EscapeThingsThatLookLikeArguments(this string format, params object[] args)
-		{
-			return format.Replace("{", @"\{");
+			LastError = LastWarning = LastStatus = string.Empty;
 		}
 	}
 
@@ -669,7 +656,7 @@ public class StringBuilderProgress : GenericProgress
 		{
 			if(!_verbose)
 				return;
-			var lines = GenericProgress.SafeFormat(message, args);
+			var lines = message.FormatWithErrorStringInsteadOfException(args);
 			foreach (var line in lines.Split('\n'))
 			{
 
@@ -700,7 +687,7 @@ public class StringBuilderProgress : GenericProgress
 
 		public override void WriteMessage(string message, params object[] args)
 		{
-			File.AppendAllText(_path, GenericProgress.SafeFormat(message + Environment.NewLine, args));
+			File.AppendAllText(_path, message.FormatWithErrorStringInsteadOfException(args) + Environment.NewLine);
 		}
 		public override void WriteMessageWithColor(string colorName, string message, params object[] args)
 		{

--- a/PalasoUIWindowsForms/Progress/LabelProgress.cs
+++ b/PalasoUIWindowsForms/Progress/LabelProgress.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Windows.Forms;
+using Palaso.Extensions;
 using Palaso.Progress;
 
 namespace Palaso.UI.WindowsForms.Progress
@@ -35,11 +36,7 @@ namespace Palaso.UI.WindowsForms.Progress
 		{
 			try
 			{
-				_box.Invoke(new Action(() =>
-										   {
-											   _box.Text = GenericProgress.SafeFormat(message + Environment.NewLine,
-																					  args);
-										   }));
+				_box.Invoke(new Action(() => { _box.Text = message.FormatWithErrorStringInsteadOfException(args) + Environment.NewLine; }));
 			}
 			catch (Exception)
 			{

--- a/PalasoUIWindowsForms/Progress/LogBox.cs
+++ b/PalasoUIWindowsForms/Progress/LogBox.cs
@@ -238,17 +238,17 @@ namespace Palaso.UI.WindowsForms.Progress
 					if (SynchronizationContext.Current == SyncContext) //we're on the UI thread
 					{
 						action();
-				}
-				else
-				{
+					}
+					else
+					{
 						//NB: if you're getting eratic behavior here, make sure there isn't one of those "access to modified closure" situations in your calling method
-						  SyncContext.Post(state =>
-											 {
-												 //assumption is that since this is run on the UI thread, we can't be disposed in between the check of IsDiposed and the action itself
-												 if (!IsDisposed)
-													 action();
-											 }, null);
-				}
+						SyncContext.Post(state =>
+							{
+								//assumption is that since this is run on the UI thread, we can't be disposed in between the check of IsDiposed and the action itself
+								if(!IsDisposed)
+									action();
+							}, null);
+					}
 				}
 			}
 			catch (Exception)
@@ -287,7 +287,7 @@ namespace Palaso.UI.WindowsForms.Progress
 						rtfBoxForDelegate.SelectionColor = color;
 						rtfBoxForDelegate.SelectionFont = fnt;
 #endif
-						rtfBoxForDelegate.AppendText(string.Format(msg + Environment.NewLine, args));
+						rtfBoxForDelegate.AppendText(msg.FormatWithErrorStringInsteadOfException(args) + Environment.NewLine);
 						rtfBoxForDelegate.SelectionStart = rtfBoxForDelegate.Text.Length;
 						rtfBoxForDelegate.ScrollToCaret();
 #if !MONO

--- a/PalasoUIWindowsForms/Progress/SimpleStatusProgress.cs
+++ b/PalasoUIWindowsForms/Progress/SimpleStatusProgress.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Windows.Forms;
+using Palaso.Extensions;
 using Palaso.Progress;
 
 namespace Palaso.UI.WindowsForms.Progress
@@ -9,7 +10,7 @@ namespace Palaso.UI.WindowsForms.Progress
 	{
 		public void WriteStatus(string message, params object[] args)
 		{
-			string theMessage = GenericProgress.SafeFormat(message, args);
+			string theMessage = message.FormatWithErrorStringInsteadOfException(args);
 			LastStatus = theMessage;
 			if (SyncContext != null)
 			{
@@ -32,7 +33,7 @@ namespace Palaso.UI.WindowsForms.Progress
 		public void WriteWarning(string message, params object[] args)
 		{
 			WarningEncountered = true;
-			LastWarning = GenericProgress.SafeFormat(message, args);
+			LastWarning = message.FormatWithErrorStringInsteadOfException(args);
 			LastStatus = LastWarning;
 		}
 		public void WriteException(Exception error)
@@ -43,7 +44,7 @@ namespace Palaso.UI.WindowsForms.Progress
 		public void WriteError(string message, params object[] args)
 		{
 			ErrorEncountered = true;
-			LastError = GenericProgress.SafeFormat(message, args);
+			LastError = message.FormatWithErrorStringInsteadOfException(args);
 			LastStatus = LastError;
 		}
 		public void WriteVerbose(string message, params object[] args) { }

--- a/PalasoUIWindowsForms/Progress/TextBoxProgress.cs
+++ b/PalasoUIWindowsForms/Progress/TextBoxProgress.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using Palaso.Extensions;
 using Palaso.Progress;
 
 namespace Palaso.UI.WindowsForms.Progress
@@ -23,7 +24,7 @@ namespace Palaso.UI.WindowsForms.Progress
 				_box.Invoke(new Action(() =>
 				{
 					_box.Text += "                          ".Substring(0, indent * 2);
-					_box.Text += GenericProgress.SafeFormat(message + Environment.NewLine, args);
+					_box.Text += message.FormatWithErrorStringInsteadOfException(args) + Environment.NewLine;
 				}));
 			}
 			catch (Exception)

--- a/PalasoUIWindowsForms/Reporting/WinFormsErrorReporter.cs
+++ b/PalasoUIWindowsForms/Reporting/WinFormsErrorReporter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Forms;
+using Palaso.Extensions;
 using Palaso.Reporting;
 
 namespace Palaso.UI.WindowsForms.Reporting
@@ -64,7 +65,7 @@ namespace Palaso.UI.WindowsForms.Reporting
 		/// </summary>
 		public void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
 		{
-			var s = string.Format(message, args);
+			var s = message.FormatWithErrorStringInsteadOfException(args);
 			ExceptionReportingDialog.ReportMessage(s, error, false);
 		}
 
@@ -74,14 +75,14 @@ namespace Palaso.UI.WindowsForms.Reporting
 		/// </summary>
 		public void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
 		{
-			var s = string.Format(message, args);
+			var s = message.FormatWithErrorStringInsteadOfException(args);
 			var stack = new System.Diagnostics.StackTrace(true);
 			ExceptionReportingDialog.ReportMessage(s, stack, false);
 		}
 
 		public void ReportFatalMessageWithStackTrace(string message, object[] args)
 		{
-			var s = string.Format(message, args);
+			var s = message.FormatWithErrorStringInsteadOfException(args);
 			var stack = new System.Diagnostics.StackTrace(true);
 			ExceptionReportingDialog.ReportMessage(s, stack, true);
 		}


### PR DESCRIPTION
Use Safe String Formatting when formatting unknown strings