### PR TITLE
Retrieve Windows version information from a different api

### DIFF
--- a/TestApps/ReportingTest/Program.cs
+++ b/TestApps/ReportingTest/Program.cs
@@ -13,6 +13,9 @@ namespace TestApp
 		[STAThread]
 		static void Main()
 		{
+			Application.EnableVisualStyles();
+			Application.SetCompatibleTextRenderingDefault(false);
+
 			if(Settings.Default.NeedsUpgrade)
 			{
 				Settings.Default.Upgrade();
@@ -25,9 +28,6 @@ namespace TestApp
 				Settings.Default.Save();
 			}
 			SetupErrorHandling();
-
-			Application.EnableVisualStyles();
-			Application.SetCompatibleTextRenderingDefault(false);
 			//Application.Run(new FastXmlSplitterTestForm());
 			Application.Run(new Form1());
 		}


### PR DESCRIPTION
* Uses the version information from a network api when Windows
  reports that it is "Windows 8"
* This will allow applications to report useful version information
  on versions of windows which are released after the application is built.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/295)
<!-- Reviewable:end -->
