### PR TITLE
Fix PalasoImage tests and preserve b&w color depth of PNGs

### DIFF
--- a/PalasoUIWindowsForms.Tests/ImageToolbox/PalasoImageTests.cs
+++ b/PalasoUIWindowsForms.Tests/ImageToolbox/PalasoImageTests.cs
@@ -133,6 +133,44 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 		//            }
 		//        }
 
+		[Test]
+		public void Save_1BitPng_SavedAs1Bit()
+		{
+			RoundTripImageThenCheckPixelFormat(".png", ImageFormat.Png, PixelFormat.Format1bppIndexed);
+		}
 
+		[Test, Ignore(".net Image.FromFile just can't do this, would take something more complicated to work around")]
+		public void Save_8BitPng_SavedAs8Bit()
+		{
+			//NB: Image.FromFile(some 8 bit or 48 bit png) will always give you a 32 bit image.
+			//See http://stackoverflow.com/questions/7276212/reading-preserving-a-pixelformat-format48bpprgb-png-bitmap-in-net
+			RoundTripImageThenCheckPixelFormat(".png", ImageFormat.Png, PixelFormat.Format8bppIndexed);
+		}
+
+		[Test]
+		public void Save_32BitPngImage_SavedAs32Bit()
+		{
+			RoundTripImageThenCheckPixelFormat(".png", ImageFormat.Png, PixelFormat.Format32bppArgb);
+		}
+
+		private static void RoundTripImageThenCheckPixelFormat(string  extension, ImageFormat imageFormat, PixelFormat pixelFormat)
+		{
+			using (var originalBitmap = new Bitmap(10, 10, pixelFormat))
+			using (var saved = TempFile.WithExtension(extension))
+			{
+				using (var palasoImageToSave = PalasoImage.FromImage(originalBitmap))
+				{
+					palasoImageToSave.Save(saved.Path);
+				}
+                using (var palasoImageToSave = PalasoImage.FromFile(saved.Path))
+				{
+					Assert.AreEqual(pixelFormat, palasoImageToSave.Image.PixelFormat, "Format was lost when loading into palaso image");
+				}
+				using (var loaded = Image.FromFile(saved.Path))
+				{
+					Assert.AreEqual(pixelFormat, loaded.PixelFormat, "Format was lost when loading into plain .net Image");
+                }
+			}
+		}
 	}
 }

--- a/PalasoUIWindowsForms.Tests/ImageToolbox/PalasoImageTests.cs
+++ b/PalasoUIWindowsForms.Tests/ImageToolbox/PalasoImageTests.cs
@@ -1,36 +1,21 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
-using System.Text;
 using NUnit.Framework;
 using Palaso.IO;
-using Palaso.UI.WindowsForms.ClearShare;
 using Palaso.UI.WindowsForms.ImageToolbox;
 
 namespace PalasoUIWindowsForms.Tests.ImageToolbox
 {
-	[TestFixture, Ignore("Needs exiftool in the distfiles")]
+	[TestFixture]
 	public class PalasoImageTests
 	{
 		[Test]
 		public void FileName_CreatedWithImageOnly_Null()
 		{
-			var pi = PalasoImage.FromImage(new Bitmap(10,10));
+			var pi = PalasoImage.FromImage(new Bitmap(10, 10));
 			Assert.IsNull(pi.FileName);
-		}
-
-		[Test, Ignore("by hand only")]
-		public void FromFile_HugeJPEG_DoesNotCrash()
-		{
-			//nb: trying to reproduce a problem that came up in bloom with this very image, but
-			//i never did get this to crash here
-				PalasoImage.FromFile(@"C:\Users\John\Desktop\hugetestimage.jpg");
-				PalasoImage.FromFile(@"C:\Users\John\Desktop\hugetestimage.jpg");
-				PalasoImage.FromFile(@"C:\Users\John\Desktop\hugetestimage.jpg");
-				PalasoImage.FromFile(@"C:\Users\John\Desktop\hugetestimage.jpg");
 		}
 
 		/// <summary>
@@ -48,7 +33,7 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 		[Test]
 		public void Image_FromFile_GivesImage()
 		{
-			using(Bitmap bitmap = new Bitmap(10, 10))
+			using (Bitmap bitmap = new Bitmap(10, 10))
 			using (var temp = TempFile.CreateAndGetPathButDontMakeTheFile())
 			{
 				bitmap.Save(temp.Path);
@@ -70,17 +55,17 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 				using (var pi1 = PalasoImage.FromFile(tf1.Path))
 				using (var pi2 = PalasoImage.FromFile(tf2.Path))
 					Assert.AreNotEqual(pi1.OriginalFilePath, pi2.OriginalFilePath);
-					
+
 			}
 		}
 
 		[Test]
 		public void FromFile_DoesNotLockFile()
 		{
-		   using(Bitmap bitmap = new Bitmap(10, 10))
+			using (var bitmap = new Bitmap(10, 10))
 			using (var temp = TempFile.CreateAndGetPathButDontMakeTheFile())
 			{
-				bitmap.Save(temp.Path);
+				bitmap.Save(temp.Path, ImageFormat.Png);
 				PalasoImage.FromFile(temp.Path);
 				Assert.DoesNotThrow(() => File.Delete(temp.Path));
 			}
@@ -105,7 +90,7 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 		public void LoadAndSave_DeleteAfter_NothingLocked()
 		{
 			var png = new Bitmap(10, 10);
-			using (var temp = new TempFile(false))
+			using (var temp =  TempFile.WithExtension(".png"))
 			{
 				png.Save(temp.Path);
 				var pi = PalasoImage.FromFile(temp.Path);
@@ -126,6 +111,7 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 				Assert.IsFalse(pi.MetadataLocked);
 			}
 		}
+
 		[Test]
 		public void Locked_NewOne_False()
 		{
@@ -133,19 +119,20 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 			Assert.IsFalse(pi.MetadataLocked);
 		}
 
-//        [Test]
-//        public void MetadataLocked_IfLoadedWithIllustrator_True()
-//        {
-//            var png = new Bitmap(10, 10);
-//            using (var temp = new TempFile(false))
-//            {
-//                var pi = PalasoImage.FromImage(png);
-//                pi.Metadata.AttributionName = "me";
-//                pi.Save(temp.Path);
-//                var incoming = PalasoImage.FromFile(temp.Path);
-//                Assert.IsTrue(incoming.MetadataLocked);
-//            }
-//        }
+		//        [Test]
+		//        public void MetadataLocked_IfLoadedWithIllustrator_True()
+		//        {
+		//            var png = new Bitmap(10, 10);
+		//            using (var temp = new TempFile(false))
+		//            {
+		//                var pi = PalasoImage.FromImage(png);
+		//                pi.Metadata.AttributionName = "me";
+		//                pi.Save(temp.Path);
+		//                var incoming = PalasoImage.FromFile(temp.Path);
+		//                Assert.IsTrue(incoming.MetadataLocked);
+		//            }
+		//        }
+
 
 	}
 }

--- a/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
@@ -374,7 +374,10 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 				!Disposed && LicenseManager.UsageMode != LicenseUsageMode.Designtime)//don't know if this will work here
 			{
 				string imageLabel = _image == null ? "no-image" : "with-image";
-				Debug.Assert(Disposed, "PalasoImage wasn't disposed of properly: " + imageLabel);
+#if DEBUG
+				if(!Disposed)
+					throw new ApplicationException("PalasoImage wasn't disposed of properly: " + imageLabel);
+#endif
 			}
 		}
 	}


### PR DESCRIPTION
See commit messages for more info.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/299)
<!-- Reviewable:end -->
