### PR TITLE
Add label for debugging PalasoImage & make unit tests dispose properly

### DIFF
--- a/PalasoUIWindowsForms.Tests/ImageToolbox/PalasoImageTests.cs
+++ b/PalasoUIWindowsForms.Tests/ImageToolbox/PalasoImageTests.cs
@@ -13,9 +13,11 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 	{
 		[Test]
 		public void FileName_CreatedWithImageOnly_Null()
-		{
-			var pi = PalasoImage.FromImage(new Bitmap(10, 10));
-			Assert.IsNull(pi.FileName);
+		{ 
+			using (var pi = PalasoImage.FromImage(new Bitmap(10, 10)))
+			{
+				Assert.IsNull(pi.FileName);
+			}
 		}
 
 		/// <summary>
@@ -26,8 +28,10 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 		public void Image_CreatedWithImageOnly_GivesSameImage()
 		{
 			Bitmap bitmap = new Bitmap(10, 10);
-			var pi = new PalasoImage(bitmap);
-			Assert.AreEqual(bitmap, pi.Image);
+			using (var pi = new PalasoImage(bitmap))
+			{
+				Assert.AreEqual(bitmap, pi.Image);
+			}
 		}
 
 		[Test]
@@ -37,8 +41,10 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 			using (var temp = TempFile.CreateAndGetPathButDontMakeTheFile())
 			{
 				bitmap.Save(temp.Path);
-				var pi = PalasoImage.FromFile(temp.Path);
-				Assert.AreEqual(10, pi.Image.Width);
+				using (var pi = PalasoImage.FromFile(temp.Path))
+				{
+					Assert.AreEqual(10, pi.Image.Width);
+				}
 			}
 		}
 
@@ -66,8 +72,10 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 			using (var temp = TempFile.CreateAndGetPathButDontMakeTheFile())
 			{
 				bitmap.Save(temp.Path, ImageFormat.Png);
-				PalasoImage.FromFile(temp.Path);
-				Assert.DoesNotThrow(() => File.Delete(temp.Path));
+				using (PalasoImage.FromFile(temp.Path))
+				{
+					Assert.DoesNotThrow(() => File.Delete(temp.Path));
+				}
 			}
 		}
 
@@ -93,10 +101,12 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 			using (var temp =  TempFile.WithExtension(".png"))
 			{
 				png.Save(temp.Path);
-				var pi = PalasoImage.FromFile(temp.Path);
-				pi.Metadata.CopyrightNotice = "Copyright 2011 me";
-				Assert.DoesNotThrow(() => pi.Save(temp.Path));
-				Assert.DoesNotThrow(() => File.Delete(temp.Path));
+				using (var pi = PalasoImage.FromFile(temp.Path))
+				{
+					pi.Metadata.CopyrightNotice = "Copyright 2011 me";
+					Assert.DoesNotThrow(() => pi.Save(temp.Path));
+					Assert.DoesNotThrow(() => File.Delete(temp.Path));
+				}
 			}
 		}
 
@@ -107,16 +117,20 @@ namespace PalasoUIWindowsForms.Tests.ImageToolbox
 			using (var temp = new TempFile(false))
 			{
 				png.Save(temp.Path);
-				var pi = PalasoImage.FromFile(temp.Path);
-				Assert.IsFalse(pi.MetadataLocked);
+				using (var pi = PalasoImage.FromFile(temp.Path))
+				{
+					Assert.IsFalse(pi.MetadataLocked);
+				}
 			}
 		}
 
 		[Test]
 		public void Locked_NewOne_False()
 		{
-			var pi = new PalasoImage();
-			Assert.IsFalse(pi.MetadataLocked);
+			using (var pi = new PalasoImage())
+			{
+				Assert.IsFalse(pi.MetadataLocked);
+			}
 		}
 
 		//        [Test]

--- a/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
+++ b/PalasoUIWindowsForms/ImageToolbox/PalasoImage.cs
@@ -28,6 +28,18 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 
 		private string _originalFilePath;
 
+		
+		/// <summary>
+		/// If false, you get a debug.Fail(). If true, you get a throw.
+		/// </summary>
+		public static bool ThrowOnFailureToDisposeAnyPalasoImage = false;
+
+		/// <summary>
+		/// If the object isn't disposed, the resulting message will give this label. 
+		/// This can help trace where it was created.
+		/// </summary>
+		public string LabelForDebugging = "unlabeled";
+		
 		/// <summary>
 		/// Generally, when we load an image, we can happily forget where it came from, because
 		/// the nature of the palaso image system is to deliver images, not file paths, to documents
@@ -68,6 +80,7 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 
 
 		private Image _image;
+
 		public Image Image
 		{
 			get
@@ -392,13 +405,26 @@ namespace Palaso.UI.WindowsForms.ImageToolbox
 				!Disposed && LicenseManager.UsageMode != LicenseUsageMode.Designtime)//don't know if this will work here
 			{
 				string imageLabel = _image == null ? "no-image" : "with-image";
-#if DEBUG
-				if(!Disposed)
-					throw new ApplicationException("PalasoImage wasn't disposed of properly: " + imageLabel);
-#endif
+
+				if (!Disposed)
+				{
+					var message = "PalasoImage wasn't disposed of properly: " + imageLabel + ". LabelForDebugging=" + LabelForDebugging;
+					if (ThrowOnFailureToDisposeAnyPalasoImage)
+					{
+						throw new PalsoImageNotDisposed(message);
+					}
+					else
+					{
+						Debug.Fail(message);
+					}
+				}
 			}
 		}
 	}
-
-
+	public class PalsoImageNotDisposed : ApplicationException
+	{
+		public PalsoImageNotDisposed(string message) : base(message)
+		{
+		}
+	}
 }


### PR DESCRIPTION
Also make the new throw-instead-of-Assert behavior opt-in and introduce an exception class just for it. It would now be possible to throw even in non-DEBUG builds, if desired. Otherwise, the behavior is now the same as it was for years, prior to my recent commit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/301)
<!-- Reviewable:end -->
