### PR TITLE
Fix failing tests

### DIFF
--- a/SIL.Archiving/Generic/ArchivingFileSystem.cs
+++ b/SIL.Archiving/Generic/ArchivingFileSystem.cs
@@ -48,11 +48,11 @@ namespace SIL.Archiving.Generic
 				{
 					if (Platform.IsLinux)
 					{
-						if (folderName.StartsWith("/var/lib/SIL/"))
+						if (folderName.StartsWith("/var/lib/SIL"))
 						{
 							// by default /var/lib isn't writable on Linux, so we can't create a new
 							// directory. Create a folder in the user's home directory instead.
-							var endFolder = folderName.Substring("/var/lib/SIL/".Length);
+							var endFolder = folderName.Substring("/var/lib/SIL".Length).TrimStart('/');
 							folderName = Path.Combine(
 								Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
 								"SIL", endFolder);

--- a/SIL.Core.Tests/CommandLineProcessing/CommandLineRunnerTests.cs
+++ b/SIL.Core.Tests/CommandLineProcessing/CommandLineRunnerTests.cs
@@ -31,6 +31,7 @@ namespace SIL.Tests.CommandLineProcessing
 		}
 
 		[Test, Category("ByHand")]
+		[Platform(Exclude = "Linux", Reason = "See comment in test")]
 		public void CommandWith10Line_CallbackOption_Get10LinesAsynchronously()
 		{
 			var progress = new StringBuilderProgress();

--- a/SIL.Core.Tests/UsbDrive/UsbDeviceInfoTests.cs
+++ b/SIL.Core.Tests/UsbDrive/UsbDeviceInfoTests.cs
@@ -21,7 +21,13 @@ namespace SIL.Tests.UsbDrive
 		[TestFixtureSetUp]
 		public void TestFixtureSetup()
 		{
-#if MONO
+			var usbDrives = UsbDriveInfo.GetDrives();
+			if (usbDrives == null || usbDrives.Count < 1)
+			{
+				Assert.Ignore("Tests require USB drive");
+				return;
+			}
+#if __MonoCS__
 			_drive0.DriveSize = 256850432;
 			_drive0.Path = new DirectoryInfo("/media/Kingston");
 			_drive1.DriveSize = 1032724480;

--- a/SIL.Media.Tests/AudioRecorderTests.cs
+++ b/SIL.Media.Tests/AudioRecorderTests.cs
@@ -17,7 +17,7 @@ namespace SIL.Media.Tests
 		[Test]
 		public void Construct_FileDoesNotExist_OK()
 		{
-			var x = AudioFactory.AudioSession(Path.GetRandomFileName());
+			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
 		}
 
 		[Test]
@@ -25,7 +25,7 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.AudioSession(f.Path);
+				var x = AudioFactory.CreateAudioSession(f.Path);
 			}
 		}
 
@@ -34,14 +34,14 @@ namespace SIL.Media.Tests
 		public void Construct_FileDoesNotExist_DoesNotCreateFile()
 		{
 			var path = Path.GetRandomFileName();
-			var x = AudioFactory.AudioSession(path);
+			var x = AudioFactory.CreateAudioSession(path);
 			Assert.IsFalse(File.Exists(path));
 		}
 
 		[Test]
 		public void StopRecording_NotRecording_Throws()
 		{
-			var x = AudioFactory.AudioSession(Path.GetRandomFileName());
+			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
 			Assert.Throws<ApplicationException>(() => x.StopRecordingAndSaveAsWav());
 		}
 
@@ -79,14 +79,14 @@ namespace SIL.Media.Tests
 		[Test]
 		public void CanRecord_FileDoesNotExist_True()
 		{
-			var x = AudioFactory.AudioSession(Path.GetRandomFileName());
+			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
 			Assert.IsTrue(x.CanRecord);
 		}
 
 		[Test]
 		public void CanStop_NonExistantFile_False()
 		{
-			var x = AudioFactory.AudioSession(Path.GetRandomFileName());
+			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
 			Assert.IsFalse(x.CanStop);
 		}
 
@@ -95,18 +95,18 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.AudioSession(f.Path);
+				var x = AudioFactory.CreateAudioSession(f.Path);
 				Assert.IsTrue(x.CanRecord);
 			}
 		}
 
 		[Test]
-		[Platform(Include="Linux", Reason="IrrKlang doesn't throw, so we don't really know")]
+		[Platform(Exclude ="Windows", Reason="IrrKlang doesn't throw, so we don't really know")]
 		public void Play_FileEmpty_Throws()
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.AudioSession(f.Path);
+				var x = AudioFactory.CreateAudioSession(f.Path);
 				Assert.Throws<Exception>(() => x.Play());
 			}
 		}
@@ -114,7 +114,7 @@ namespace SIL.Media.Tests
 		[Test]
 		public void Play_FileDoesNotExist_Throws()
 		{
-			var x = AudioFactory.AudioSession(Path.GetRandomFileName());
+			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
 			Assert.Throws<FileNotFoundException>(() => x.Play());
 		}
 
@@ -140,7 +140,7 @@ namespace SIL.Media.Tests
 				var oldLength = oldInfo.Length;
 				Assert.AreEqual(0, oldLength);
 				var oldTimestamp = oldInfo.LastWriteTimeUtc;
-				var x = AudioFactory.AudioSession(f.Path);
+				var x = AudioFactory.CreateAudioSession(f.Path);
 				x.StartRecording();
 				Thread.Sleep(1000);
 				x.StopRecordingAndSaveAsWav();
@@ -155,7 +155,7 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.AudioSession(f.Path);
+				var x = AudioFactory.CreateAudioSession(f.Path);
 				x.StartRecording();
 				Thread.Sleep(100);
 				Assert.IsTrue(x.IsRecording);
@@ -171,7 +171,7 @@ namespace SIL.Media.Tests
 				var w = new BackgroundWorker();
 				w.DoWork+=new DoWorkEventHandler((o,args)=> SystemSounds.Exclamation.Play());
 
-				var x = AudioFactory.AudioSession(f.Path);
+				var x = AudioFactory.CreateAudioSession(f.Path);
 				x.StartRecording();
 				w.RunWorkerAsync();
 				Thread.Sleep(1000);
@@ -194,13 +194,13 @@ namespace SIL.Media.Tests
 					var w = new BackgroundWorker();
 					w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
 
-					var x = AudioFactory.AudioSession(f.Path);
+					var x = AudioFactory.CreateAudioSession(f.Path);
 					x.StartRecording();
 					w.RunWorkerAsync();
 					Thread.Sleep(1000);
 					x.StopRecordingAndSaveAsWav();
 
-					var y = AudioFactory.AudioSession(f.Path);
+					var y = AudioFactory.CreateAudioSession(f.Path);
 					y.Play();
 					Thread.Sleep(1000);
 					y.StopPlaying();
@@ -220,7 +220,7 @@ namespace SIL.Media.Tests
 			public RecordingSession()
 			{
 				_tempFile = new TempFile();
-				_recorder = AudioFactory.AudioSession(_tempFile.Path);
+				_recorder = AudioFactory.CreateAudioSession(_tempFile.Path);
 				_recorder.StartRecording();
 				Thread.Sleep(100);
 			}
@@ -344,7 +344,7 @@ namespace SIL.Media.Tests
 
 		private ISimpleAudioSession RecordSomething(TempFile f)
 		{
-			var x = AudioFactory.AudioSession(f.Path);
+			var x = AudioFactory.CreateAudioSession(f.Path);
 			x.StartRecording();
 			Thread.Sleep(100);
 			x.StopRecordingAndSaveAsWav();

--- a/SIL.Media.Tests/FFmpegRunnerTests.cs
+++ b/SIL.Media.Tests/FFmpegRunnerTests.cs
@@ -9,6 +9,13 @@ namespace SIL.Media.Tests
 	[TestFixture]
 	public class FFmpegRunnerTests
 	{
+		[TestFixtureSetUp]
+		public void CheckRequirements()
+		{
+			if (!MediaInfo.HaveNecessaryComponents)
+				Assert.Ignore("These tests require ffmpeg to be installed.");
+		}
+
 		[Test]
 		[Category("RequiresFfmpeg")]
 		public void HaveNecessaryComponents_ReturnsTrue()

--- a/SIL.Media.Tests/MediaInfoTests.cs
+++ b/SIL.Media.Tests/MediaInfoTests.cs
@@ -7,6 +7,13 @@ namespace SIL.Media.Tests
 	[TestFixture]
 	public class MediaInfoTests
 	{
+		[TestFixtureSetUp]
+		public void CheckRequirements()
+		{
+			if (!MediaInfo.HaveNecessaryComponents)
+				Assert.Ignore("These tests require ffmpeg to be installed.");
+		}
+
 		[Test]
 		[Category("RequiresFfmpeg")]
 		public void HaveNecessaryComponents_ReturnsTrue()
@@ -36,7 +43,6 @@ namespace SIL.Media.Tests
 				Assert.AreEqual("mpeg4", info.Video.Encoding);
 			}
 		}
-
 
 		[Test]
 		[Category("RequiresFfmpeg")]

--- a/SIL.Media/MediaInfo.cs
+++ b/SIL.Media/MediaInfo.cs
@@ -22,10 +22,7 @@ namespace SIL.Media
 			{
 				Video = new VideoInfo(ffmpegOutput);
 			}
-
 		}
-
-
 
 		///<summary>
 		/// Returns false if it can't find ffmpeg
@@ -90,7 +87,6 @@ namespace SIL.Media
 				return default(TimeSpan);
 		}
 
-
 		public class AudioInfo
 		{
 
@@ -115,9 +111,10 @@ namespace SIL.Media
 
 			private void ExtractChannels(string ffmpegOutput)
 			{
-				var match = Regex.Match(ffmpegOutput, ", ([^,]*) channels");
-				if (match.Groups.Count == 2)
+				var regex = new Regex(", ([^,]*) channels");
+				if (regex.IsMatch(ffmpegOutput))
 				{
+					var match = regex.Match(ffmpegOutput);
 					var value = match.Groups[1].Value;
 
 					int channelCount;
@@ -125,6 +122,57 @@ namespace SIL.Media
 					if (int.TryParse(value, out channelCount))
 					{
 						this.ChannelCount = channelCount;
+					}
+					return;
+				}
+				// older versions (i.e. 9.18 which comes with trusty) have a slightly different
+				// output format
+				regex = new Regex(", (mono|stereo|quad|hexagonal|octagonal|downmix|[2-7].[0-1](\\(.\\))?),");
+				if (regex.IsMatch(ffmpegOutput))
+				{
+					var match = regex.Match(ffmpegOutput);
+					var value = match.Groups[1].Value;
+					switch (value)
+					{
+						case "mono":
+							this.ChannelCount = 1;
+							break;
+						case "stereo":
+						case "downmix":
+							this.ChannelCount = 2;
+							break;
+						case "2.1":
+						case "3.0":
+						case "3.0(back)":
+							this.ChannelCount = 3;
+							break;
+						case "3.1":
+						case "4.0":
+						case "quad":
+						case "quad(side)":
+							this.ChannelCount = 4;
+							break;
+						case "4.1":
+						case "5.0":
+							this.ChannelCount = 5;
+							break;
+						case "5.1":
+						case "6.0":
+						case "6.0(front)":
+						case "hexagonal":
+							this.ChannelCount = 6;
+							break;
+						case "6.1":
+						case "6.1(front)":
+						case "7.0":
+						case "7.0(front)":
+							this.ChannelCount = 7;
+							break;
+						case "7.1":
+						case "7.1(wide)":
+						case "octagonal":
+							this.ChannelCount = 8;
+							break;
 					}
 				}
 			}

--- a/SIL.Windows.Forms.Keyboarding.Tests/WinKeyboardAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/WinKeyboardAdaptorTests.cs
@@ -32,7 +32,12 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 				if (!lcids.Contains(lang.Culture.LCID))
 					lcids.Add(lang.Culture.LCID);
 			}
-			Assert.That(adaptor.GetLanguages(), Is.EquivalentTo(lcids));
+			// This test can fail if a Keyman keyboard is installed but
+			// keyman is not running
+			Assert.That(adaptor.GetLanguages(), Is.EquivalentTo(lcids),
+				"WinKeyboardAdaptor.GetLanguages returned a different set of languages from what " +
+				"we get from Windows. This can happen if a Keyman keyboard is installed in the " +
+				"system but Keyman is not running.");
 		}
 	}
 }

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -275,7 +275,7 @@ namespace SIL.WritingSystems
 							JArray commits = JArray.Load(new JsonTextReader(responseReader));
 							foreach (JObject commit in commits.Children<JObject>())
 							{
-								DateTime time = DateTime.Parse((string) commit["commit"]["author"]["date"]);
+								var time = commit["commit"]["author"]["date"].ToObject<DateTime>();
 								if (time > latestCommitTime)
 									latestCommitTime = time;
 							}


### PR DESCRIPTION
Fix (or explicitly ignore) several tests that failed on my machine, mostly on Linux.

Also fix Sldr.GetAvailableLanguageTags() which failed when using a non-US culture, and MediaInfo channel info on Trusty which comes with a different ffmpeg version that produces a slightly different output.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/306)
<!-- Reviewable:end -->
