### PR TITLE
Reset writing system properties when reading an LDML file

### DIFF
--- a/SIL.WritingSystems.Tests/Migration/GlobalWritingSystemRepositoryMigratorTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/GlobalWritingSystemRepositoryMigratorTests.cs
@@ -20,7 +20,8 @@ namespace SIL.WritingSystems.Tests.Migration
 
 			public TestEnvironment()
 			{
-				_ldmlFileNames = Directory.GetFiles(GlobalWritingSystemRepositoryMigrator.LdmlPathPre0);
+				_ldmlFileNames = Directory.Exists(GlobalWritingSystemRepositoryMigrator.LdmlPathPre0)
+					? Directory.GetFiles(GlobalWritingSystemRepositoryMigrator.LdmlPathPre0) : new string[0];
 				NamespaceManager = new XmlNamespaceManager(new NameTable());
 				NamespaceManager.AddNamespace("sil", "urn://www.sil.org/ldml/0.1");
 				NamespaceManager.AddNamespace("palaso", "urn://palaso.org/ldmlExtensions/v1");

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -293,6 +293,8 @@ namespace SIL.WritingSystems
 			if (element.Name != "ldml")
 				throw new ApplicationException("Unable to load writing system definition: Missing <ldml> tag.");
 
+			ResetWritingSystemDefinition(ws);
+
 			XElement identityElem = element.Element("identity");
 			if (identityElem != null)
 				ReadIdentityElement(identityElem, ws);
@@ -332,6 +334,28 @@ namespace SIL.WritingSystems
 			}
 			ws.Id = string.Empty;
 			ws.AcceptChanges();
+		}
+
+		/// <summary>
+		/// Resets all of the properties of the writing system definition that might not get set when reading the LDML file.
+		/// </summary>
+		private void ResetWritingSystemDefinition(WritingSystemDefinition ws)
+		{
+			ws.VersionNumber = null;
+			ws.VersionDescription = null;
+			ws.WindowsLcid = null;
+			ws.DefaultRegion = null;
+			ws.CharacterSets.Clear();
+			ws.MatchedPairs.Clear();
+			ws.PunctuationPatterns.Clear();
+			ws.QuotationMarks.Clear();
+			ws.QuotationParagraphContinueType = QuotationParagraphContinueType.None;
+			ws.RightToLeftScript = false;
+			ws.DefaultCollationType = null;
+			ws.Collations.Clear();
+			ws.Fonts.Clear();
+			ws.SpellCheckDictionaries.Clear();
+			ws.KnownKeyboards.Clear();
 		}
 
 		private void CheckVersion(XElement specialElem, WritingSystemDefinition ws)
@@ -659,7 +683,6 @@ namespace SIL.WritingSystems
 
 		private void ReadCollationsElement(XElement collationsElem, WritingSystemDefinition ws)
 		{
-			ws.Collations.Clear();
 			XElement defaultCollationElem = collationsElem.Element("defaultCollation");
 			ws.DefaultCollationType = (string) defaultCollationElem;
 			foreach (XElement collationElem in collationsElem.NonAltElements("collation"))

--- a/SIL.WritingSystems/SIL.WritingSystems.csproj
+++ b/SIL.WritingSystems/SIL.WritingSystems.csproj
@@ -18,7 +18,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\output\Debug</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;STAGING_SLDR</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\output\Debug\SIL.WritingSystems.XML</DocumentationFile>
@@ -31,7 +31,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\output\Release</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;STAGING_SLDR</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -40,7 +40,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugMono|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\output\DebugMono</OutputPath>
-    <DefineConstants>TRACE;DEBUG;MONO</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;MONO;STAGING_SLDR</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -53,7 +53,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseMono|AnyCPU'">
     <OutputPath>..\output\ReleaseMono</OutputPath>
-    <DefineConstants>TRACE;MONO</DefineConstants>
+    <DefineConstants>TRACE;MONO;STAGING_SLDR</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -71,7 +71,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugMonoStrongName|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\output\DebugMonoStrongName\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;MONO;STRONG_NAME</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;MONO;STRONG_NAME;STAGING_SLDR</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
@@ -82,7 +82,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugStrongName|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\output\DebugStrongName\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;STRONG_NAME</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;STRONG_NAME;STAGING_SLDR</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <LangVersion>default</LangVersion>
@@ -93,7 +93,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseMonoStrongName|AnyCPU'">
     <OutputPath>..\output\ReleaseMonoStrongName\</OutputPath>
-    <DefineConstants>TRACE;MONO;STRONG_NAME</DefineConstants>
+    <DefineConstants>TRACE;MONO;STRONG_NAME;STAGING_SLDR</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseStrongName|AnyCPU'">
     <OutputPath>..\output\ReleaseStrongName\</OutputPath>
-    <DefineConstants>TRACE;STRONG_NAME</DefineConstants>
+    <DefineConstants>TRACE;STRONG_NAME;STAGING_SLDR</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
If an existing writing system definition is reused when loading an LDML file, we want to make sure that any properties that are not set during reading are reset to their defaults, otherwise we can run into issues.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/310)
<!-- Reviewable:end -->
