### PR TITLE
BL-2901 fix background of AOR search which turned black

### DIFF
--- a/SIL.Windows.Forms/ImageGallery/ThumbnailViewer.cs
+++ b/SIL.Windows.Forms/ImageGallery/ThumbnailViewer.cs
@@ -34,6 +34,7 @@ namespace SIL.Windows.Forms.ImageGallery
 			};
 			_thumbnailViewer.TheControl.Dock = DockStyle.Fill;
 			Controls.Add(_thumbnailViewer.TheControl);
+			Clear(); // BL-2901 prevents thumbnail viewer from having a black background when displayed
 		}
 
 		public IThumbnailViewer CreateViewer()

--- a/SIL.Windows.Forms/ImageToolbox/ArtOfReadingChooser.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ArtOfReadingChooser.cs
@@ -223,12 +223,14 @@ namespace SIL.Windows.Forms.ImageToolbox
 			_messageLabel.Font = new Font(SystemFonts.DialogFont.FontFamily, 10);
 
 #if DEBUG
-			if (!HaveImageCollectionOnThisComputer)
-				return;
+			//if (!HaveImageCollectionOnThisComputer)
+			//	return;
 			//when just testing, I just want to see some choices.
-		   // _searchTermsBox.Text = @"flower";
-			_searchButton_Click(this,null);
+			// _searchTermsBox.Text = @"flower";
 #endif
+			// The following line was traced to be the cause of BL-2901 that only appeared in release versions
+			//   so let's keep it outside of the ifdef.
+			_searchButton_Click(this,null);
 		}
 
 		private void SetMessageLabelText()

--- a/SIL.Windows.Forms/ImageToolbox/ArtOfReadingChooser.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ArtOfReadingChooser.cs
@@ -227,10 +227,8 @@ namespace SIL.Windows.Forms.ImageToolbox
 			//	return;
 			//when just testing, I just want to see some choices.
 			// _searchTermsBox.Text = @"flower";
+			//_searchButton_Click(this,null);
 #endif
-			// The following line was traced to be the cause of BL-2901 that only appeared in release versions
-			//   so let's keep it outside of the ifdef.
-			_searchButton_Click(this,null);
 		}
 
 		private void SetMessageLabelText()


### PR DESCRIPTION
Wasn't sure why doing a search button click when loading keeps the background from turning black. It turned out what was needed was a Clear() of the thumbnailviewer. Still not sure why, though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/311)
<!-- Reviewable:end -->
