### PR TITLE
Fix bug where app-specific WS settings can get lost when replacing local WSs with newer global WSs

### DIFF
--- a/SIL.Lexicon/ProjectLexiconSettingsWritingSystemDataMapper.cs
+++ b/SIL.Lexicon/ProjectLexiconSettingsWritingSystemDataMapper.cs
@@ -66,6 +66,7 @@ namespace SIL.Lexicon
 				var scd = new SystemCollationDefinition { LanguageTag = (string) systemCollationElem };
 				ws.DefaultCollation = scd;
 			}
+			ws.AcceptChanges();
 		}
 
 		public virtual void Write(T ws)

--- a/SIL.Lexicon/UserLexiconSettingsWritingSystemDataMapper.cs
+++ b/SIL.Lexicon/UserLexiconSettingsWritingSystemDataMapper.cs
@@ -62,6 +62,7 @@ namespace SIL.Lexicon
 			}
 			ws.DefaultFontSize = (float?) wsElem.Element("DefaultFontSize") ?? 0f;
 			ws.IsGraphiteEnabled = (bool?) wsElem.Element("IsGraphiteEnabled") ?? true;
+			ws.AcceptChanges();
 		}
 
 		public virtual void Write(T ws)

--- a/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
+++ b/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
@@ -227,6 +227,7 @@
     <Compile Include="TestLdmlInXmlWritingSystemRepository.cs" />
     <Compile Include="TestLdmlInFolderWritingSystemFactory.cs" />
     <Compile Include="TestLdmlInFolderWritingSystemRepository.cs" />
+    <Compile Include="TestWritingSystemCustomDataMapper.cs" />
     <Compile Include="TestWritingSystemFactory.cs" />
     <Compile Include="WritingSystemRepositoryTests.cs" />
     <Compile Include="LdmlDataMapperTests.cs" />

--- a/SIL.WritingSystems.Tests/TestLdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems.Tests/TestLdmlInFolderWritingSystemRepository.cs
@@ -1,9 +1,17 @@
-﻿namespace SIL.WritingSystems.Tests
+﻿using System.Collections.Generic;
+
+namespace SIL.WritingSystems.Tests
 {
 	public class TestLdmlInFolderWritingSystemRepository : LdmlInFolderWritingSystemRepository
 	{
 		public TestLdmlInFolderWritingSystemRepository(string basePath, GlobalWritingSystemRepository globalRepository = null)
 			: base(basePath, globalRepository)
+		{
+		}
+
+		public TestLdmlInFolderWritingSystemRepository(string basePath, IEnumerable<ICustomDataMapper<WritingSystemDefinition>> customDataMappers,
+			GlobalWritingSystemRepository globalRepository = null)
+			: base(basePath, customDataMappers, globalRepository)
 		{
 		}
 

--- a/SIL.WritingSystems.Tests/TestWritingSystemCustomDataMapper.cs
+++ b/SIL.WritingSystems.Tests/TestWritingSystemCustomDataMapper.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections.Generic;
+
+namespace SIL.WritingSystems.Tests
+{
+	public class TestWritingSystemCustomDataMapper : ICustomDataMapper<WritingSystemDefinition>
+	{
+		private readonly Dictionary<string, Dictionary<string, string>> _writingSystems = new Dictionary<string, Dictionary<string, string>>();
+
+		public void Read(WritingSystemDefinition ws)
+		{
+			Dictionary<string, string> properties;
+			if (_writingSystems.TryGetValue(ws.LanguageTag, out properties))
+			{
+				string abbreviation;
+				if (properties.TryGetValue("Abbreviation", out abbreviation))
+					ws.Abbreviation = abbreviation;
+
+				string languageName;
+				if (properties.TryGetValue("LanguageName", out languageName) && ws.Language != null && ws.Language.IsPrivateUse)
+					ws.Language = new LanguageSubtag(ws.Language, languageName);
+
+				string scriptName;
+				if (properties.TryGetValue("ScriptName", out scriptName) && ws.Script != null && ws.Script.IsPrivateUse)
+					ws.Script = new ScriptSubtag(ws.Script, scriptName);
+
+				string regionName;
+				if (properties.TryGetValue("RegionName", out regionName) && ws.Region != null && ws.Region.IsPrivateUse)
+					ws.Region = new RegionSubtag(ws.Region, regionName);
+
+				string spellCheckingId;
+				if (properties.TryGetValue("SpellCheckingId", out spellCheckingId))
+					ws.SpellCheckingId = spellCheckingId;
+
+				string legacyMapping;
+				if (properties.TryGetValue("LegacyMapping", out legacyMapping))
+					ws.LegacyMapping = legacyMapping;
+
+				string keyboard;
+				if (properties.TryGetValue("Keyboard", out keyboard))
+					ws.Keyboard = keyboard;
+
+				string systemCollation;
+				if (properties.TryGetValue("SystemCollation", out systemCollation))
+					ws.DefaultCollation = new SystemCollationDefinition {LanguageTag = systemCollation};
+				ws.AcceptChanges();
+			}
+		}
+
+		public void Write(WritingSystemDefinition ws)
+		{
+			var properties = new Dictionary<string, string>();
+			if (!string.IsNullOrEmpty(ws.Abbreviation))
+				properties["Abbreviation"] = ws.Abbreviation;
+			if (ws.Language != null && ws.Language.IsPrivateUse && !string.IsNullOrEmpty(ws.Language.Name))
+				properties["LanguageName"] = ws.Language.Name;
+			if (ws.Script != null && ws.Script.IsPrivateUse && !string.IsNullOrEmpty(ws.Script.Name))
+				properties["ScriptName"] = ws.Script.Name;
+			if (ws.Region != null && ws.Region.IsPrivateUse && !string.IsNullOrEmpty(ws.Region.Name))
+				properties["RegionName"] = ws.Region.Name;
+			if (!string.IsNullOrEmpty(ws.SpellCheckingId))
+				properties["SpellCheckingId"] = ws.SpellCheckingId;
+			if (!string.IsNullOrEmpty(ws.LegacyMapping))
+				properties["LegacyMapping"] = ws.LegacyMapping;
+			if (!string.IsNullOrEmpty(ws.Keyboard))
+				properties["Keyboard"] = ws.Keyboard;
+			var sysCollation = ws.DefaultCollation as SystemCollationDefinition;
+			if (sysCollation != null)
+				properties["SystemCollation"] = sysCollation.LanguageTag;
+			_writingSystems[ws.LanguageTag] = properties;
+		}
+
+		public void Remove(string wsId)
+		{
+			_writingSystems.Remove(wsId);
+		}
+	}
+}

--- a/SIL.WritingSystems/ILocalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/ILocalWritingSystemRepository.cs
@@ -9,7 +9,8 @@ namespace SIL.WritingSystems
 	public interface ILocalWritingSystemRepository : IWritingSystemRepository
 	{
 		/// <summary>
-		/// Gets all newer shared writing systems.
+		/// Returns copies of all of the global writing systems that are newer than their corresponding local writing systems. These
+		/// writing systems can be used to replace the existing local writing systems.
 		/// </summary>
 		IEnumerable<WritingSystemDefinition> CheckForNewerGlobalWritingSystems();
 

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -515,5 +515,17 @@ namespace SIL.WritingSystems
 				WritingSystemsToIgnore[(string)wsElem.Attribute("id")] = dateModified;
 			}
 		}
+
+		public override IEnumerable<T> CheckForNewerGlobalWritingSystems()
+		{
+			foreach (T ws in base.CheckForNewerGlobalWritingSystems())
+			{
+				// load local settings using custom data mappers, so these settings won't be lost if these writing systems are used to
+				// replace the existing local writing systems
+				foreach (ICustomDataMapper<T> customDataMapper in _customDataMappers)
+					customDataMapper.Read(ws);
+				yield return ws;
+			}
+		}
 	}
 }

--- a/SIL.WritingSystems/LocalWritingSystemRepositoryBase.cs
+++ b/SIL.WritingSystems/LocalWritingSystemRepositoryBase.cs
@@ -84,7 +84,7 @@ namespace SIL.WritingSystems
 			}
 		}
 
-		public IEnumerable<T> CheckForNewerGlobalWritingSystems()
+		public virtual IEnumerable<T> CheckForNewerGlobalWritingSystems()
 		{
 			if (_globalRepository != null)
 			{


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/312)
<!-- Reviewable:end -->
