### PR TITLE
Filter out dialects from LanguageLookupDialog by default

### DIFF
--- a/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using SIL.TestUtilities;
+using SIL.WritingSystems;
+
+namespace SIL.Windows.Forms.WritingSystems.Tests
+{
+	[TestFixture]
+	public class LanguageLookupModelTests
+	{
+		private class TestEnvironment : IDisposable
+		{
+			private readonly TemporaryFolder _sldrCacheFolder;
+			private readonly LanguageLookupModel _model;
+
+			public TestEnvironment()
+			{
+				Sldr.OfflineMode = true;
+				_sldrCacheFolder = new TemporaryFolder("SldrCache");
+				_model = new LanguageLookupModel();
+				_model.LoadLanguages();
+			}
+
+			public LanguageLookupModel Model
+			{
+				get { return _model; }
+			}
+
+			public void Dispose()
+			{
+				_sldrCacheFolder.Dispose();
+				Sldr.OfflineMode = false;
+			}
+		}
+
+		[Test]
+		public void ShowDialects_SetToFalse_DialectsNotReturned()
+		{
+			using (var env = new TestEnvironment())
+			{
+				env.Model.ShowDialects = false;
+				env.Model.SearchText = "english";
+				Assert.That(env.Model.MatchingLanguages.Select(li => li.LanguageTag), Has.None.EqualTo("en-US"));
+			}
+		}
+
+		[Test]
+		public void ShowDialects_SetToFalseSearchForChinese_ReturnsTaiwanAndMainlandChina()
+		{
+			using (var env = new TestEnvironment())
+			{
+				env.Model.ShowDialects = false;
+				env.Model.SearchText = "chinese";
+				string[] codes = env.Model.MatchingLanguages.Select(li => li.LanguageTag).ToArray();
+				Assert.That(codes, Contains.Item("zh-CN"));
+				Assert.That(codes, Contains.Item("zh-TW"));
+			}
+		}
+
+		[Test]
+		public void ShowDialects_SetToTrue_DialectsReturned()
+		{
+			using (var env = new TestEnvironment())
+			{
+				env.Model.ShowDialects = true;
+				env.Model.SearchText = "english";
+				Assert.That(env.Model.MatchingLanguages.Select(li => li.LanguageTag), Contains.Item("en-US"));
+			}
+		}
+	}
+}

--- a/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
@@ -39,7 +39,7 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		{
 			using (var env = new TestEnvironment())
 			{
-				env.Model.IncludeRegionCodes = false;
+				env.Model.IncludeRegionalDialects = false;
 				env.Model.SearchText = "english";
 				Assert.That(env.Model.MatchingLanguages.Select(li => li.LanguageTag), Has.None.EqualTo("en-US"));
 			}
@@ -50,7 +50,7 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		{
 			using (var env = new TestEnvironment())
 			{
-				env.Model.IncludeRegionCodes = false;
+				env.Model.IncludeRegionalDialects = false;
 				env.Model.SearchText = "chinese";
 				string[] codes = env.Model.MatchingLanguages.Select(li => li.LanguageTag).ToArray();
 				Assert.That(codes, Contains.Item("zh-CN"));
@@ -63,7 +63,7 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		{
 			using (var env = new TestEnvironment())
 			{
-				env.Model.IncludeRegionCodes = true;
+				env.Model.IncludeRegionalDialects = true;
 				env.Model.SearchText = "english";
 				Assert.That(env.Model.MatchingLanguages.Select(li => li.LanguageTag), Contains.Item("en-US"));
 			}

--- a/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
@@ -35,22 +35,22 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		}
 
 		[Test]
-		public void ShowDialects_SetToFalse_DialectsNotReturned()
+		public void IncludeRegionCodes_SetToFalse_DialectsNotReturned()
 		{
 			using (var env = new TestEnvironment())
 			{
-				env.Model.ShowDialects = false;
+				env.Model.IncludeRegionCodes = false;
 				env.Model.SearchText = "english";
 				Assert.That(env.Model.MatchingLanguages.Select(li => li.LanguageTag), Has.None.EqualTo("en-US"));
 			}
 		}
 
 		[Test]
-		public void ShowDialects_SetToFalseSearchForChinese_ReturnsTaiwanAndMainlandChina()
+		public void IncludeRegionCodes_SetToFalseSearchForChinese_ReturnsTaiwanAndMainlandChina()
 		{
 			using (var env = new TestEnvironment())
 			{
-				env.Model.ShowDialects = false;
+				env.Model.IncludeRegionCodes = false;
 				env.Model.SearchText = "chinese";
 				string[] codes = env.Model.MatchingLanguages.Select(li => li.LanguageTag).ToArray();
 				Assert.That(codes, Contains.Item("zh-CN"));
@@ -59,11 +59,11 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		}
 
 		[Test]
-		public void ShowDialects_SetToTrue_DialectsReturned()
+		public void IncludeRegionCodes_SetToTrue_DialectsReturned()
 		{
 			using (var env = new TestEnvironment())
 			{
-				env.Model.ShowDialects = true;
+				env.Model.IncludeRegionCodes = true;
 				env.Model.SearchText = "english";
 				Assert.That(env.Model.MatchingLanguages.Select(li => li.LanguageTag), Contains.Item("en-US"));
 			}

--- a/SIL.Windows.Forms.WritingSystems.Tests/SIL.Windows.Forms.WritingSystems.Tests.csproj
+++ b/SIL.Windows.Forms.WritingSystems.Tests/SIL.Windows.Forms.WritingSystems.Tests.csproj
@@ -188,6 +188,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="LanguageLookupControlTests.cs" />
+    <Compile Include="LanguageLookupModelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tree\WritingSystemTreeItemTests.cs" />
     <Compile Include="Tree\WritingSystemTreeModelTests.cs" />

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
@@ -43,6 +43,7 @@
 			this._desiredLanguageDisplayName = new System.Windows.Forms.TextBox();
 			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
 			this._L10NSharpExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
+			this._showDialectsCheckBox = new System.Windows.Forms.CheckBox();
 			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).BeginInit();
 			this.SuspendLayout();
@@ -187,10 +188,25 @@
 			this._L10NSharpExtender.LocalizationManagerId = "Palaso";
 			this._L10NSharpExtender.PrefixForNewItems = "LanguageLookup";
 			// 
+			// _showDialectsCheckBox
+			// 
+			this._showDialectsCheckBox.AutoSize = true;
+			this._L10NSharpExtender.SetLocalizableToolTip(this._showDialectsCheckBox, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._showDialectsCheckBox, null);
+			this._L10NSharpExtender.SetLocalizingId(this._showDialectsCheckBox, "LanguageLookup.ShowDialectsLabel");
+			this._showDialectsCheckBox.Location = new System.Drawing.Point(235, 5);
+			this._showDialectsCheckBox.Name = "_showDialectsCheckBox";
+			this._showDialectsCheckBox.Size = new System.Drawing.Size(105, 17);
+			this._showDialectsCheckBox.TabIndex = 16;
+			this._showDialectsCheckBox.Text = "Show all dialects";
+			this._showDialectsCheckBox.UseVisualStyleBackColor = true;
+			this._showDialectsCheckBox.CheckedChanged += new System.EventHandler(this._showDialectsCheckBox_CheckedChanged);
+			// 
 			// LanguageLookupControl
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this._showDialectsCheckBox);
 			this.Controls.Add(this._desiredLanguageLabel);
 			this.Controls.Add(this.flowLayoutPanel1);
 			this.Controls.Add(this._desiredLanguageDisplayName);
@@ -226,5 +242,6 @@
 		private System.Windows.Forms.TextBox _desiredLanguageDisplayName;
 		private L10NSharp.UI.L10NSharpExtender _L10NSharpExtender;
 		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+		private System.Windows.Forms.CheckBox _showDialectsCheckBox;
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
@@ -43,7 +43,7 @@
 			this._desiredLanguageDisplayName = new System.Windows.Forms.TextBox();
 			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
 			this._L10NSharpExtender = new L10NSharp.UI.L10NSharpExtender(this.components);
-			this._showDialectsCheckBox = new System.Windows.Forms.CheckBox();
+			this._showRegionalDialectsCheckBox = new System.Windows.Forms.CheckBox();
 			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
 			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).BeginInit();
 			this.SuspendLayout();
@@ -188,25 +188,25 @@
 			this._L10NSharpExtender.LocalizationManagerId = "Palaso";
 			this._L10NSharpExtender.PrefixForNewItems = "LanguageLookup";
 			// 
-			// _showDialectsCheckBox
+			// _showRegionalDialectsCheckBox
 			// 
-			this._showDialectsCheckBox.AutoSize = true;
-			this._L10NSharpExtender.SetLocalizableToolTip(this._showDialectsCheckBox, null);
-			this._L10NSharpExtender.SetLocalizationComment(this._showDialectsCheckBox, null);
-			this._L10NSharpExtender.SetLocalizingId(this._showDialectsCheckBox, "LanguageLookup.ShowDialectsLabel");
-			this._showDialectsCheckBox.Location = new System.Drawing.Point(235, 5);
-			this._showDialectsCheckBox.Name = "_showDialectsCheckBox";
-			this._showDialectsCheckBox.Size = new System.Drawing.Size(105, 17);
-			this._showDialectsCheckBox.TabIndex = 16;
-			this._showDialectsCheckBox.Text = "Show all dialects";
-			this._showDialectsCheckBox.UseVisualStyleBackColor = true;
-			this._showDialectsCheckBox.CheckedChanged += new System.EventHandler(this._showDialectsCheckBox_CheckedChanged);
+			this._showRegionalDialectsCheckBox.AutoSize = true;
+			this._L10NSharpExtender.SetLocalizableToolTip(this._showRegionalDialectsCheckBox, null);
+			this._L10NSharpExtender.SetLocalizationComment(this._showRegionalDialectsCheckBox, null);
+			this._L10NSharpExtender.SetLocalizingId(this._showRegionalDialectsCheckBox, "LanguageLookup.ShowRegionalDialectsLabel");
+			this._showRegionalDialectsCheckBox.Location = new System.Drawing.Point(235, 5);
+			this._showRegionalDialectsCheckBox.Name = "_showRegionalDialectsCheckBox";
+			this._showRegionalDialectsCheckBox.Size = new System.Drawing.Size(132, 17);
+			this._showRegionalDialectsCheckBox.TabIndex = 16;
+			this._showRegionalDialectsCheckBox.Text = "Show regional dialects";
+			this._showRegionalDialectsCheckBox.UseVisualStyleBackColor = true;
+			this._showRegionalDialectsCheckBox.CheckedChanged += new System.EventHandler(this._showRegionalDialectsCheckBox_CheckedChanged);
 			// 
 			// LanguageLookupControl
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this._showDialectsCheckBox);
+			this.Controls.Add(this._showRegionalDialectsCheckBox);
 			this.Controls.Add(this._desiredLanguageLabel);
 			this.Controls.Add(this.flowLayoutPanel1);
 			this.Controls.Add(this._desiredLanguageDisplayName);
@@ -242,6 +242,6 @@
 		private System.Windows.Forms.TextBox _desiredLanguageDisplayName;
 		private L10NSharp.UI.L10NSharpExtender _L10NSharpExtender;
 		private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
-		private System.Windows.Forms.CheckBox _showDialectsCheckBox;
+		private System.Windows.Forms.CheckBox _showRegionalDialectsCheckBox;
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
@@ -48,9 +48,9 @@ namespace SIL.Windows.Forms.WritingSystems
 			set { _desiredLanguageDisplayName.Visible = _desiredLanguageLabel.Visible = value; }
 		}
 
-		public bool IsShowDialectsCheckBoxVisible
+		public bool IsShowRegionalDialectsCheckBoxVisible
 		{
-			set { _showDialectsCheckBox.Visible = value; }
+			set { _showRegionalDialectsCheckBox.Visible = value; }
 		}
 
 		public Func<LanguageInfo, bool> MatchingLanguageFilter
@@ -252,9 +252,9 @@ namespace SIL.Windows.Forms.WritingSystems
 			_model.SearchText = _searchText.Text;
 		}
 
-		private void _showDialectsCheckBox_CheckedChanged(object sender, EventArgs e)
+		private void _showRegionalDialectsCheckBox_CheckedChanged(object sender, EventArgs e)
 		{
-			_model.IncludeRegionCodes = _showDialectsCheckBox.Checked;
+			_model.IncludeRegionalDialects = _showRegionalDialectsCheckBox.Checked;
 			_lastSearchedForText = null;
 		}
 	}

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
@@ -247,5 +247,11 @@ namespace SIL.Windows.Forms.WritingSystems
 		{
 			_model.SearchText = _searchText.Text;
 		}
+
+		private void _showDialectsCheckBox_CheckedChanged(object sender, EventArgs e)
+		{
+			_model.ShowDialects = _showDialectsCheckBox.Checked;
+			_lastSearchedForText = null;
+		}
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
@@ -30,7 +30,6 @@ namespace SIL.Windows.Forms.WritingSystems
 		public LanguageLookupControl()
 		{
 			InitializeComponent();
-			ShowDesiredLanguageNameField = true;
 			_model = new LanguageLookupModel();
 		}
 
@@ -44,9 +43,14 @@ namespace SIL.Windows.Forms.WritingSystems
 			get { return _model.AreLanguagesLoaded; }
 		}
 
-		public bool ShowDesiredLanguageNameField
+		public bool IsDesiredLanguageNameFieldVisible
 		{
 			set { _desiredLanguageDisplayName.Visible = _desiredLanguageLabel.Visible = value; }
+		}
+
+		public bool IsShowDialectsCheckBoxVisible
+		{
+			set { _showDialectsCheckBox.Visible = value; }
 		}
 
 		public Func<LanguageInfo, bool> MatchingLanguageFilter
@@ -250,7 +254,7 @@ namespace SIL.Windows.Forms.WritingSystems
 
 		private void _showDialectsCheckBox_CheckedChanged(object sender, EventArgs e)
 		{
-			_model.ShowDialects = _showDialectsCheckBox.Checked;
+			_model.IncludeRegionCodes = _showDialectsCheckBox.Checked;
 			_lastSearchedForText = null;
 		}
 	}

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.resx
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.resx
@@ -126,16 +126,18 @@
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAABHNCSVQICAgIfAhkiAAAAAFzUkdCAK7O
-        HOkAAAAEZ0FNQQAAsY8L/GEFAAAACXBIWXMAAA90AAAPdAHMkdJVAAAAGXRFWHRTb2Z0d2FyZQB3d3cu
-        aW5rc2NhcGUub3Jnm+48GgAAAZRJREFUOE+N071LQlEYBnCzIBFyr0mKCFxcsoigD5IoGoIWg6YGlVqa
-        rLAlqH/AoSGXFq9BJdEHzZVDREtBEVhRZi0OIqWWpNyeF86J18NVG36iPs951KuadF2vqtsb6YAwPMEL
-        PMMeTEEz71YclKgEW1ACvYoHcMgzdGMTWkg2923rm4vG+CGXT0v2+rV4j1+7wuMyyz7HArFxnLPSUEBY
-        JMFw/EQW++e3Cxv711qpVF5GtkQSqcy6Z/X4TnaGF3YyH/niyt/HkRAmRIleeUDJG8jm4Y3Z5YsciZ6O
-        dxvkJRpxyhDOeKZC7mDdUzUcZGGIZ0bQKYruoxrQ1y2HdnmmQm6FL9FNq6EFciKkkp3nHLIZ0SOaUWGN
-        FS6g1aBD1zIrOmSyoiBKbfDDSmkIwTR4IQI8p1+6WR3pgldR+I9zsNBZPtIJ76Ig3cOb8hyh39osNMnz
-        cqQdUsDLeXCKnK6JB9zifqMckKhkhyTwkQKMqOVaaOiADRD62t1G5VpoSP635MioUbEeGpqAW7iEIaNS
-        fbrpF329JbOrt7zmAAAAAElFTkSuQmCC
+        iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAP
+        dAAAD3QBzJHSVQAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAGUSURBVDhPjdO9
+        S0JRGAZwsyARcq9JighcXLKIoA+SKBqCFoOmBpVamqywJah/wKEhlxavQSXRB82VQ0RLQRFYUWYtDiKl
+        lqTcnhfOidfDVRt+oj7PedSrmnRdr6rbG+mAMDzBCzzDHkxBM+9WHJSoBFtQAr2KB3DIM3RjE1pINvdt
+        65uLxvghl09L9vq1eI9fu8LjMss+xwKxcZyz0lBAWCTBcPxEFvvntwsb+9daqVReRrZEEqnMumf1+E52
+        hhd2Mh/54srfx5EQJkSJXnlAyRvI5uGN2eWLHImejncb5CUaccoQznimQu5g3VM1HGRhiGdG0CmK7qMa
+        0Ncth3Z5pkJuhS/RTauhBXIipJKd5xyyGdEjmlFhjRUuoNWgQ9cyKzpksqIgSm3ww0ppCME0eCECPKdf
+        ulkd6YJXUfiPc7DQWT7SCe+iIN3Dm/Icod/aLDTJ83KkHVLAy3lwipyuiQfc4n6jHJCoZIck8JECjKjl
+        WmjogA0Q+trdRuVaaEj+t+TIqFGxHhqagFu4hCGjUn266Rd9vSWzq7e85gAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="_L10NSharpExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>181, 17</value>
+  </metadata>
 </root>

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.resx
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.resx
@@ -137,7 +137,4 @@
         WmjogA0Q+trdRuVaaEj+t+TIqFGxHhqagFu4hCGjUn266Rd9vSWzq7e85gAAAABJRU5ErkJggg==
 </value>
   </data>
-  <metadata name="_L10NSharpExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>181, 17</value>
-  </metadata>
 </root>

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupDialog.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupDialog.cs
@@ -9,16 +9,20 @@ namespace SIL.Windows.Forms.WritingSystems
 		public LanguageLookupDialog()
 		{
 			InitializeComponent();
-			ShowDesiredLanguageNameField = true;
 		}
 
 		/// <summary>
 		/// If you wouldn't be paying attention to their requested name, and are only going to look at the code, then
 		/// set this to default so that they aren't fooled into thinking they can modify the name they'll see in your application.
 		/// </summary>
-		public bool ShowDesiredLanguageNameField
+		public bool IsDesiredLanguageNameFieldVisible
 		{
-			set { _languageLookupControl.ShowDesiredLanguageNameField = value; }
+			set { _languageLookupControl.IsDesiredLanguageNameFieldVisible = value; }
+		}
+
+		public bool IsShowDialectsCheckBoxVisible
+		{
+			set { _languageLookupControl.IsShowDialectsCheckBoxVisible = value; }
 		}
 
 		public Func<LanguageInfo, bool> MatchingLanguageFilter

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupDialog.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupDialog.cs
@@ -20,9 +20,9 @@ namespace SIL.Windows.Forms.WritingSystems
 			set { _languageLookupControl.IsDesiredLanguageNameFieldVisible = value; }
 		}
 
-		public bool IsShowDialectsCheckBoxVisible
+		public bool IsShowRegionalDialectsCheckBoxVisible
 		{
-			set { _languageLookupControl.IsShowDialectsCheckBoxVisible = value; }
+			set { _languageLookupControl.IsShowRegionalDialectsCheckBoxVisible = value; }
 		}
 
 		public Func<LanguageInfo, bool> MatchingLanguageFilter

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
@@ -67,9 +67,21 @@ namespace SIL.Windows.Forms.WritingSystems
 					yield break;
 				}
 
-				foreach (LanguageInfo li in _languageLookup.SuggestLanguages(_searchText).Where(li => MatchingLanguageFilter == null || MatchingLanguageFilter(li)))
+				foreach (LanguageInfo li in _languageLookup.SuggestLanguages(_searchText).Where(li => (MatchingLanguageFilter == null || MatchingLanguageFilter(li)) && ShowDialectsFilter(li)))
 					yield return li;
 			}
+		}
+
+		private bool ShowDialectsFilter(LanguageInfo li)
+		{
+			if (ShowDialects)
+				return true;
+
+			// always include Chinese langauges with region codes
+			if (li.LanguageTag.IsOneOf("zh-CN", "zh-TW"))
+				return true;
+
+			return string.IsNullOrEmpty(IetfLanguageTag.GetRegionPart(li.LanguageTag));
 		}
 
 		public LanguageInfo SelectedLanguage
@@ -126,5 +138,7 @@ namespace SIL.Windows.Forms.WritingSystems
 				return _selectedLanguage.LanguageTag;
 			}
 		}
+
+		public bool ShowDialects { get; set; }
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
@@ -67,17 +67,17 @@ namespace SIL.Windows.Forms.WritingSystems
 					yield break;
 				}
 
-				foreach (LanguageInfo li in _languageLookup.SuggestLanguages(_searchText).Where(li => (MatchingLanguageFilter == null || MatchingLanguageFilter(li)) && ShowDialectsFilter(li)))
+				foreach (LanguageInfo li in _languageLookup.SuggestLanguages(_searchText).Where(li => (MatchingLanguageFilter == null || MatchingLanguageFilter(li)) && RegionCodesFilter(li)))
 					yield return li;
 			}
 		}
 
-		private bool ShowDialectsFilter(LanguageInfo li)
+		private bool RegionCodesFilter(LanguageInfo li)
 		{
-			if (ShowDialects)
+			if (IncludeRegionCodes)
 				return true;
 
-			// always include Chinese langauges with region codes
+			// always include Chinese languages with region codes
 			if (li.LanguageTag.IsOneOf("zh-CN", "zh-TW"))
 				return true;
 
@@ -139,6 +139,6 @@ namespace SIL.Windows.Forms.WritingSystems
 			}
 		}
 
-		public bool ShowDialects { get; set; }
+		public bool IncludeRegionCodes { get; set; }
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
@@ -67,14 +67,14 @@ namespace SIL.Windows.Forms.WritingSystems
 					yield break;
 				}
 
-				foreach (LanguageInfo li in _languageLookup.SuggestLanguages(_searchText).Where(li => (MatchingLanguageFilter == null || MatchingLanguageFilter(li)) && RegionCodesFilter(li)))
+				foreach (LanguageInfo li in _languageLookup.SuggestLanguages(_searchText).Where(li => (MatchingLanguageFilter == null || MatchingLanguageFilter(li)) && RegionalDialectsFilter(li)))
 					yield return li;
 			}
 		}
 
-		private bool RegionCodesFilter(LanguageInfo li)
+		private bool RegionalDialectsFilter(LanguageInfo li)
 		{
-			if (IncludeRegionCodes)
+			if (IncludeRegionalDialects)
 				return true;
 
 			// always include Chinese languages with region codes
@@ -139,6 +139,6 @@ namespace SIL.Windows.Forms.WritingSystems
 			}
 		}
 
-		public bool IncludeRegionCodes { get; set; }
+		public bool IncludeRegionalDialects { get; set; }
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/WritingSystemSetupView.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemSetupView.cs
@@ -129,7 +129,7 @@ namespace SIL.Windows.Forms.WritingSystems
 
 		private WritingSystemDefinition ShowCreateNewWritingSystemDialog()
 		{
-			using (var dlg = new LanguageLookupDialog {ShowDesiredLanguageNameField = false})
+			using (var dlg = new LanguageLookupDialog {IsDesiredLanguageNameFieldVisible = false, IsShowDialectsCheckBoxVisible = false})
 			{
 				WaitCursor.Show();
 				try

--- a/SIL.Windows.Forms.WritingSystems/WritingSystemSetupView.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemSetupView.cs
@@ -129,7 +129,7 @@ namespace SIL.Windows.Forms.WritingSystems
 
 		private WritingSystemDefinition ShowCreateNewWritingSystemDialog()
 		{
-			using (var dlg = new LanguageLookupDialog {IsDesiredLanguageNameFieldVisible = false, IsShowDialectsCheckBoxVisible = false})
+			using (var dlg = new LanguageLookupDialog {IsDesiredLanguageNameFieldVisible = false, IsShowRegionalDialectsCheckBoxVisible = false})
 			{
 				WaitCursor.Show();
 				try


### PR DESCRIPTION
* add "Show all dialects" checkbox to dialog
* filter out all languages with regions specified if not checked
* closes #315

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/317)
<!-- Reviewable:end -->
