### PR TITLE
Update SimpleFileLock to generate lock files that can be read by older versions of Palaso

### DIFF
--- a/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
+++ b/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using NUnit.Framework;
+using SIL.IO.FileLock;
+using SIL.IO.FileLock.FileSys;
+
+namespace SIL.Tests.IO.FileLock
+{
+	[TestFixture]
+	public class SimpleFileLockTests
+	{
+		private static readonly string LockPath = Path.Combine(Path.GetTempPath(), "SimpleFileLockTests");
+
+		[SetUp]
+		public void SetUp()
+		{
+			CleanupLockFile();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			CleanupLockFile();
+		}
+
+		private static void CleanupLockFile()
+		{
+			if (File.Exists(LockPath))
+				File.Delete(LockPath);
+		}
+
+		[Test]
+		public void TryAcquireLock_Unlocked_ReturnsTrue()
+		{
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+			fileLock.ReleaseLock();
+		}
+
+		[Test]
+		public void TryAcquireLock_LockedByActiveProcess_ReturnsFalse()
+		{
+			LockIO.WriteLock(LockPath, new FileLockContent
+			{
+				PID = 0,
+				ProcessName = Process.GetProcessById(0).ProcessName,
+				Timestamp = DateTime.Now.Ticks
+			});
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			Assert.That(fileLock.TryAcquireLock(), Is.False);
+		}
+
+		[Test]
+		public void TryAcquireLock_LockedByDeadProcess_ReturnsTrue()
+		{
+			LockIO.WriteLock(LockPath, new FileLockContent
+			{
+				PID = 9999,
+				ProcessName = "Stuff",
+				Timestamp = DateTime.Now.Ticks
+			});
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+			fileLock.ReleaseLock();
+		}
+
+		[Test]
+		public void TryAcquireLock_HasLock_ReturnsTrue()
+		{
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+			fileLock.ReleaseLock();
+		}
+
+		[Test]
+		public void TryAcquireLock_FileOpen_ReturnsFalse()
+		{
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			using (File.Open(LockPath, FileMode.Create))
+			{
+				Assert.That(fileLock.TryAcquireLock(), Is.False);
+			}
+		}
+
+		[Test]
+		public void TryAcquireLock_OldEmptyFileLock_ReturnsTrue()
+		{
+			File.WriteAllText(LockPath, "");
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+			fileLock.ReleaseLock();
+		}
+
+		[Test]
+		public void TryAcquireLock_LockedByActiveProcessTimedOut_ReturnsTrue()
+		{
+			LockIO.WriteLock(LockPath, new FileLockContent
+			{
+				PID = 0,
+				ProcessName = Process.GetProcessById(0).ProcessName,
+				Timestamp = (DateTime.Now - TimeSpan.FromHours(2)).Ticks
+			});
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests", TimeSpan.FromHours(1));
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+		}
+
+		[Test]
+		public void TryAcquireLock_LockedByActiveProcessNotTimedOut_ReturnsFalse()
+		{
+			LockIO.WriteLock(LockPath, new FileLockContent
+			{
+				PID = 0,
+				ProcessName = Process.GetProcessById(0).ProcessName,
+				Timestamp = DateTime.Now.Ticks
+			});
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests", TimeSpan.FromHours(1));
+			Assert.That(fileLock.TryAcquireLock(), Is.False);
+		}
+
+		[Test]
+		public void ReleaseLock_HasLock_LockFileDoesNotExist()
+		{
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			Assert.That(fileLock.TryAcquireLock(), Is.True);
+			fileLock.ReleaseLock();
+			Assert.That(File.Exists(LockPath), Is.False);
+		}
+
+		[Test]
+		public void ReleaseLock_Unlocked_LockFileDoesNotExist()
+		{
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			fileLock.ReleaseLock();
+			Assert.That(File.Exists(LockPath), Is.False);
+		}
+
+		[Test]
+		public void ReleaseLock_LockedByActiveProcess_LockFileExists()
+		{
+			LockIO.WriteLock(LockPath, new FileLockContent
+			{
+				PID = 0,
+				ProcessName = Process.GetProcessById(0).ProcessName,
+				Timestamp = DateTime.Now.Ticks
+			});
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			fileLock.ReleaseLock();
+			Assert.That(File.Exists(LockPath), Is.True);
+		}
+
+		[Test]
+		public void ReleaseLock_FileOpen_LockFileExists()
+		{
+			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
+			using (File.Open(LockPath, FileMode.Create))
+			{
+				fileLock.ReleaseLock();
+			}
+			Assert.That(File.Exists(LockPath), Is.True);
+		}
+	}
+}

--- a/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
+++ b/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
@@ -63,7 +63,7 @@ namespace SIL.Tests.IO.FileLock
 			LockIO.WriteLock(LockPath, new FileLockContent
 			{
 				PID = 9999,
-				ProcessName = "Stuff",
+				ProcessName = Path.GetRandomFileName(),
 				Timestamp = DateTime.Now.Ticks
 			});
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
@@ -81,7 +81,7 @@ namespace SIL.Tests.IO.FileLock
 		}
 
 		[Test]
-		public void TryAcquireLock_FileOpen_ReturnsFalse()
+		public void TryAcquireLock_LockFileCurrentlyOpen_ReturnsFalse()
 		{
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
 			using (File.Open(LockPath, FileMode.Create))
@@ -157,7 +157,7 @@ namespace SIL.Tests.IO.FileLock
 		}
 
 		[Test]
-		public void ReleaseLock_FileOpen_LockFileExists()
+		public void ReleaseLock_LockFileCurrentlyOpen_LockFileExists()
 		{
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
 			using (File.Open(LockPath, FileMode.Create))

--- a/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
+++ b/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using NUnit.Framework;
 using SIL.IO.FileLock;
 using SIL.IO.FileLock.FileSys;
+using SIL.PlatformUtilities;
 
 namespace SIL.Tests.IO.FileLock
 {
@@ -11,6 +12,11 @@ namespace SIL.Tests.IO.FileLock
 	public class SimpleFileLockTests
 	{
 		private static readonly string LockPath = Path.Combine(Path.GetTempPath(), "SimpleFileLockTests");
+		// some tests require the Id of an active process.
+		// on Windows, we use 0, which is the system idle process.
+		// on Linux, we use 1, which is the init process.
+		// we know that these will always be active.
+		private static readonly int ActiveProcessId = Platform.IsLinux ? 1 : 0;
 
 		[SetUp]
 		public void SetUp()
@@ -43,8 +49,8 @@ namespace SIL.Tests.IO.FileLock
 		{
 			LockIO.WriteLock(LockPath, new FileLockContent
 			{
-				PID = 0,
-				ProcessName = Process.GetProcessById(0).ProcessName,
+				PID = ActiveProcessId,
+				ProcessName = Process.GetProcessById(ActiveProcessId).ProcessName,
 				Timestamp = DateTime.Now.Ticks
 			});
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");
@@ -98,8 +104,8 @@ namespace SIL.Tests.IO.FileLock
 		{
 			LockIO.WriteLock(LockPath, new FileLockContent
 			{
-				PID = 0,
-				ProcessName = Process.GetProcessById(0).ProcessName,
+				PID = ActiveProcessId,
+				ProcessName = Process.GetProcessById(ActiveProcessId).ProcessName,
 				Timestamp = (DateTime.Now - TimeSpan.FromHours(2)).Ticks
 			});
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests", TimeSpan.FromHours(1));
@@ -111,8 +117,8 @@ namespace SIL.Tests.IO.FileLock
 		{
 			LockIO.WriteLock(LockPath, new FileLockContent
 			{
-				PID = 0,
-				ProcessName = Process.GetProcessById(0).ProcessName,
+				PID = ActiveProcessId,
+				ProcessName = Process.GetProcessById(ActiveProcessId).ProcessName,
 				Timestamp = DateTime.Now.Ticks
 			});
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests", TimeSpan.FromHours(1));
@@ -141,8 +147,8 @@ namespace SIL.Tests.IO.FileLock
 		{
 			LockIO.WriteLock(LockPath, new FileLockContent
 			{
-				PID = 0,
-				ProcessName = Process.GetProcessById(0).ProcessName,
+				PID = ActiveProcessId,
+				ProcessName = Process.GetProcessById(ActiveProcessId).ProcessName,
 				Timestamp = DateTime.Now.Ticks
 			});
 			SimpleFileLock fileLock = SimpleFileLock.Create("SimpleFileLockTests");

--- a/SIL.Core.Tests/SIL.Core.Tests.csproj
+++ b/SIL.Core.Tests/SIL.Core.Tests.csproj
@@ -237,6 +237,7 @@
     <Compile Include="i18n\StringCatalogTests.cs" />
     <Compile Include="IO\DirectoryUtilitiesTests.cs" />
     <Compile Include="IO\FileLocatorTests.cs" />
+    <Compile Include="IO\FileLock\SimpleFileLockTests.cs" />
     <Compile Include="IO\FileUtilsTests.cs" />
     <Compile Include="IO\TempFileTests.cs" />
     <Compile Include="Migration\DefaultVersionTests.cs" />

--- a/SIL.Core/IO/FileLock/FileLockContent.cs
+++ b/SIL.Core/IO/FileLock/FileLockContent.cs
@@ -1,30 +1,24 @@
-﻿using System.Runtime.Serialization;
-
-namespace SIL.IO.FileLock
+﻿namespace SIL.IO.FileLock
 {
 	/// <summary>
 	/// Class which gets serialized into the file lock - responsible for letting conflicting
 	/// processes know which process owns this lock, when the lock was acquired, and the process name.
 	/// </summary>
-	[DataContract]
 	public class FileLockContent
 	{
 		/// <summary>
 		/// The process ID
 		/// </summary>
-		[DataMember]
 		public long PID { get; set; }
 
 		/// <summary>
 		/// The timestamp (DateTime.Now.Ticks)
 		/// </summary>
-		[DataMember]
 		public long Timestamp { get; set; }
 
 		/// <summary>
 		/// The name of the process
 		/// </summary>
-		[DataMember]
 		public string ProcessName { get; set; }
 	}
 

--- a/SIL.Core/IO/FileLock/FileSys/LockIO.cs
+++ b/SIL.Core/IO/FileLock/FileSys/LockIO.cs
@@ -51,7 +51,10 @@ namespace SIL.IO.FileLock.FileSys
 			try
 			{
 				var obj = new JObject();
-				// type is only required for forward compatibility
+				// type is only required for forward compatibility.
+				// older versions of this library used DataContractJsonSerializer to read/write the lock file contents.
+				// by writing out the old type value, it allows older versions of this library to continue to be able
+				// to read the lock files correctly.
 				obj["__type"] = "FileLockContent:#Palaso.IO.FileLock";
 				obj["PID"] = lockContent.PID;
 				obj["ProcessName"] = lockContent.ProcessName;

--- a/SIL.Core/IO/FileLock/FileSys/LockIO.cs
+++ b/SIL.Core/IO/FileLock/FileSys/LockIO.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.Serialization.Json;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace SIL.IO.FileLock.FileSys
 {
 	internal static class LockIO
 	{
-		private static readonly DataContractJsonSerializer JsonSerializer;
-
-		static LockIO()
-		{
-			JsonSerializer = new DataContractJsonSerializer(typeof(FileLockContent), new[] { typeof(FileLockContent) }, int.MaxValue, true, null, true);
-		}
-
 		public static string GetFilePath(string lockName)
 		{
 			return Path.Combine(Path.GetTempPath(), lockName);
@@ -27,10 +21,15 @@ namespace SIL.IO.FileLock.FileSys
 		{
 			try
 			{
-				using (var stream = File.OpenRead(lockFilePath))
+				using (var streamReader = new StreamReader(File.OpenRead(lockFilePath)))
 				{
-					var obj = JsonSerializer.ReadObject(stream);
-					return (FileLockContent) obj ?? new MissingFileLockContent();
+					JObject obj = JObject.Load(new JsonTextReader(streamReader));
+					return new FileLockContent
+					{
+						PID = obj["PID"].ToObject<long>(),
+						ProcessName = obj["ProcessName"].ToString(),
+						Timestamp = obj["Timestamp"].ToObject<long>()
+					};
 				}
 			}
 			catch (FileNotFoundException)
@@ -51,9 +50,15 @@ namespace SIL.IO.FileLock.FileSys
 		{
 			try
 			{
-				using (var stream = File.Create(lockFilePath))
+				var obj = new JObject();
+				// type is only required for forward compatibility
+				obj["__type"] = "FileLockContent:#Palaso.IO.FileLock";
+				obj["PID"] = lockContent.PID;
+				obj["ProcessName"] = lockContent.ProcessName;
+				obj["Timestamp"] = lockContent.Timestamp;
+				using (StreamWriter streamWriter = new StreamWriter(File.Create(lockFilePath)))
 				{
-					JsonSerializer.WriteObject(stream, lockContent);
+					obj.WriteTo(new JsonTextWriter(streamWriter));
 				}
 				return true;
 			}

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -137,8 +137,11 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\Ionic.Zip.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -149,6 +152,7 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Xml" />
     <None Include="app.config" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SIL.Core/packages.config
+++ b/SIL.Core/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
* generate lock file contents using JSON.NET instead of object serialization
* add unit tests for SimpleFileLock

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/322)
<!-- Reviewable:end -->
