### PR TITLE
Made OK button on LanguageLookupDialog disabled by default

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupDialog.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupDialog.Designer.cs
@@ -39,6 +39,7 @@ namespace SIL.Windows.Forms.WritingSystems
 			// _okButton
 			//
 			this._okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this._okButton.Enabled = false;
 			this._L10NSharpExtender.SetLocalizableToolTip(this._okButton, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._okButton, null);
 			this._L10NSharpExtender.SetLocalizingId(this._okButton, "Common.OKButton");


### PR DESCRIPTION
The code that normally determines whether it is enabled is only executed when the language control registers a change, but initially _languageLookupControl.HaveSufficientInformation is false because that control does not have anything set.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/323)
<!-- Reviewable:end -->
