### PR TITLE
[v2.6] Fix crash from getting active keyboard

### DIFF
--- a/PalasoUIWindowsForms/Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/PalasoUIWindowsForms/Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -770,13 +770,13 @@ namespace Palaso.UI.WindowsForms.Keyboarding.Windows
 				{
 					var profile = ProfileMgr.GetActiveProfile(Guids.TfcatTipKeyboard);
 					return Keyboard.Controller.AllAvailableKeyboards.OfType<WinKeyboardDescription>()
-						.FirstOrDefault(winKeybd => InputProcessorProfilesEqual(profile, winKeybd.InputProcessorProfile));
+						.FirstOrDefault(winKeybd => InputProcessorProfilesEqual(profile, winKeybd.InputProcessorProfile)) ?? KeyboardDescription.Zero;
 				}
 
 				// Probably Windows XP where we don't have ProfileMgr
 				var lang = ProcessorProfiles.GetCurrentLanguage();
 				return Keyboard.Controller.AllAvailableKeyboards.OfType<WinKeyboardDescription>()
-					.FirstOrDefault(winKeybd => winKeybd.InputProcessorProfile.LangId == lang);
+					.FirstOrDefault(winKeybd => winKeybd.InputProcessorProfile.LangId == lang) ?? KeyboardDescription.Zero;
 			}
 		}
 


### PR DESCRIPTION
Under some circumstances ActiveKeyboard can't detect the currently
active keyboard and used to return null which caused a crash. Now
we return KeyboardDescriptionZero instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/324)
<!-- Reviewable:end -->
