### PR TITLE
Fix crash from getting active keyboard

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -492,7 +492,7 @@ namespace SIL.Windows.Forms.Keyboarding
 				if (_activeKeyboard == null)
 				{
 					_activeKeyboard = Adaptors[KeyboardAdaptorType.System].SwitchingAdaptor.ActiveKeyboard;
-					if (_activeKeyboard == null)
+					if (_activeKeyboard == null || _activeKeyboard == NullKeyboard)
 					{
 						try
 						{

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -858,13 +858,15 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 				{
 					var profile = ProfileMgr.GetActiveProfile(Guids.TfcatTipKeyboard);
 					return Keyboard.Controller.AvailableKeyboards.OfType<WinKeyboardDescription>()
-						.FirstOrDefault(winKeybd => InputProcessorProfilesEqual(profile, winKeybd.InputProcessorProfile));
+						.FirstOrDefault(winKeybd => InputProcessorProfilesEqual(profile, winKeybd.InputProcessorProfile)) ??
+						KeyboardController.NullKeyboard;
 				}
 
 				// Probably Windows XP where we don't have ProfileMgr
 				var lang = ProcessorProfiles.GetCurrentLanguage();
 				return Keyboard.Controller.AvailableKeyboards.OfType<WinKeyboardDescription>()
-					.FirstOrDefault(winKeybd => winKeybd.InputProcessorProfile.LangId == lang);
+					.FirstOrDefault(winKeybd => winKeybd.InputProcessorProfile.LangId == lang) ??
+					KeyboardController.NullKeyboard;
 			}
 		}
 


### PR DESCRIPTION
Under some circumstances ActiveKeyboard can't detect the currently
active keyboard and used to return null which caused a crash. Now
we return KeyboardController.NullKeyboard instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/325)
<!-- Reviewable:end -->
