### PR TITLE
Update OfflineSldrAttribute so that it doesn't enable offline mode on every test

### DIFF
--- a/SIL.DictionaryServices.Tests/LexEntryRepositoryCachingTests.cs
+++ b/SIL.DictionaryServices.Tests/LexEntryRepositoryCachingTests.cs
@@ -11,7 +11,6 @@ using SIL.WritingSystems;
 namespace SIL.DictionaryServices.Tests
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class LiftLexEntryRepositoryCachingTests
 	{
 		private TemporaryFolder _tempfolder;

--- a/SIL.DictionaryServices.Tests/LexEntryRepositoryTests.cs
+++ b/SIL.DictionaryServices.Tests/LexEntryRepositoryTests.cs
@@ -12,7 +12,6 @@ using SIL.WritingSystems;
 namespace SIL.DictionaryServices.Tests
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class LiftLexEntryRepositoryTests
 	{
 		private class TestEnvironment : IDisposable

--- a/SIL.DictionaryServices.Tests/Processors/MergeHomographsTests.cs
+++ b/SIL.DictionaryServices.Tests/Processors/MergeHomographsTests.cs
@@ -9,7 +9,6 @@ using SIL.TestUtilities;
 namespace SIL.DictionaryServices.Tests.Processors
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class MergeHomographsTests
 	{
 		private StringBuilderProgress _progress;

--- a/SIL.DictionaryServices.Tests/Properties/AssemblyInfo.cs
+++ b/SIL.DictionaryServices.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using SIL.TestUtilities;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -15,3 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3a622e63-660a-488b-be9c-40575b539a4c")]
+
+[assembly: OfflineSldr]

--- a/SIL.Lexicon.Tests/ProjectLexiconSettingsWritingSystemDataMapperTests.cs
+++ b/SIL.Lexicon.Tests/ProjectLexiconSettingsWritingSystemDataMapperTests.cs
@@ -1,13 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Linq;
 using NUnit.Framework;
-using SIL.TestUtilities;
 using SIL.WritingSystems;
 
 namespace SIL.Lexicon.Tests
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class ProjectLexiconSettingsWritingSystemDataMapperTests
 	{
 		[Test]

--- a/SIL.Lexicon.Tests/Properties/AssemblyInfo.cs
+++ b/SIL.Lexicon.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using SIL.TestUtilities;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -15,3 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("33c83331-9f17-48aa-8f51-77964ce663fb")]
+
+[assembly: OfflineSldr]

--- a/SIL.Lexicon.Tests/UserLexiconSettingsWritingSystemDataMapperTests.cs
+++ b/SIL.Lexicon.Tests/UserLexiconSettingsWritingSystemDataMapperTests.cs
@@ -3,13 +3,11 @@ using System.Linq;
 using System.Xml.Linq;
 using NUnit.Framework;
 using SIL.Keyboarding;
-using SIL.TestUtilities;
 using SIL.WritingSystems;
 
 namespace SIL.Lexicon.Tests
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class UserLexiconSettingsWritingSystemDataMapperTests
 	{
 		[Test]

--- a/SIL.Lift.Tests/Options/WritingSystemsInOptionsListFileHelperTests.cs
+++ b/SIL.Lift.Tests/Options/WritingSystemsInOptionsListFileHelperTests.cs
@@ -10,7 +10,6 @@ using SIL.WritingSystems.Tests;
 namespace SIL.Lift.Tests.Options
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class WritingSystemsInOptionsListFileHelperTests
 	{
 		private class TestEnvironment : IDisposable

--- a/SIL.Lift.Tests/Properties/AssemblyInfo.cs
+++ b/SIL.Lift.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using SIL.TestUtilities;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -15,3 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2fe6d612-e4a3-41cc-bdef-5135701a7208")]
+
+[assembly: OfflineSldr]

--- a/SIL.Lift.Tests/WritingSystemsInLiftFileHelperTests.cs
+++ b/SIL.Lift.Tests/WritingSystemsInLiftFileHelperTests.cs
@@ -10,7 +10,6 @@ using SIL.WritingSystems.Tests;
 namespace SIL.Lift.Tests
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class WritingSystemsInLiftFileHelperTests
 	{
 		private class TestEnvironment : IDisposable

--- a/SIL.TestUtilities/OfflineSldrAttribute.cs
+++ b/SIL.TestUtilities/OfflineSldrAttribute.cs
@@ -11,24 +11,31 @@ namespace SIL.TestUtilities
 	public class OfflineSldrAttribute : Attribute, ITestAction
 	{
 		private OfflineSldr _offlineSldr;
+		private int _refCount;
 
 		public void BeforeTest(TestDetails testDetails)
 		{
-			_offlineSldr = new OfflineSldr();
+			if (_refCount == 0)
+				_offlineSldr = new OfflineSldr();
+			_refCount++;
 		}
 
 		public void AfterTest(TestDetails testDetails)
 		{
-			_offlineSldr.Dispose();
-			_offlineSldr = null;
+			_refCount--;
+			if (_refCount == 0)
+			{
+				_offlineSldr.Dispose();
+				_offlineSldr = null;
+			}
 		}
 
 		/// <summary>
-		/// Provides the target for the action attribute. This action will be run on all tests.
+		/// Provides the target for the action attribute. This action will be run on all tests and suites (fixtures/assemblies).
 		/// </summary>
 		public ActionTargets Targets
 		{
-			get { return ActionTargets.Test; }
+			get { return ActionTargets.Test | ActionTargets.Suite; }
 		}
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupModelTests.cs
@@ -1,11 +1,9 @@
 ﻿using System.Linq;
 using NUnit.Framework;
-using SIL.TestUtilities;
 
 namespace SIL.Windows.Forms.WritingSystems.Tests
 {
 	[TestFixture]
-	[OfflineSldr]
 	public class LanguageLookupModelTests
 	{
 		[Test]

--- a/SIL.WritingSystems.Tests/SldrTests.cs
+++ b/SIL.WritingSystems.Tests/SldrTests.cs
@@ -40,6 +40,14 @@ namespace SIL.WritingSystems.Tests
 			{
 				FolderContainingLdml.Dispose();
 				Sldr.EmbeddedAllTagsTime = Sldr.DefaultEmbeddedAllTagsTime;
+				// The OfflineSldrAttribute has been assigned to the entire test assembly, so we set the offline mode
+				// back to the default value, which is true
+				Sldr.OfflineMode = true;
+				// clear out SLDR cache
+				DirectoryInfo di = new DirectoryInfo(Sldr.SldrCachePath);
+				foreach (FileInfo fi in di.GetFiles())
+					fi.Delete();
+				Sldr.ResetLanguageTags();
 			}
 		}
 
@@ -448,6 +456,7 @@ amo-Latn = amo
 		{
 			using (new TestEnvironment(false))
 			{
+				Sldr.ResetLanguageTags();
 				Sldr.EmbeddedAllTagsTime = new DateTime(2000, 1, 1, 12, 0, 0);
 				string allTagsPath = Path.Combine(Sldr.SldrCachePath, "alltags.txt");
 				Assert.That(File.Exists(allTagsPath), Is.False);
@@ -461,6 +470,7 @@ amo-Latn = amo
 		{
 			using (new TestEnvironment())
 			{
+				Sldr.ResetLanguageTags();
 				string allTagsPath = Path.Combine(Sldr.SldrCachePath, "alltags.txt");
 
 				File.WriteAllText(allTagsPath, "*en-US");
@@ -476,6 +486,7 @@ amo-Latn = amo
 		{
 			using (new TestEnvironment())
 			{
+				Sldr.ResetLanguageTags();
 				string allTagsPath = Path.Combine(Sldr.SldrCachePath, "alltags.txt");
 
 				File.WriteAllText(allTagsPath, "*en-US");
@@ -493,6 +504,7 @@ amo-Latn = amo
 		{
 			using (new TestEnvironment())
 			{
+				Sldr.ResetLanguageTags();
 				string allTagsPath = Path.Combine(Sldr.SldrCachePath, "alltags.txt");
 				Assert.That(File.Exists(allTagsPath), Is.False);
 


### PR DESCRIPTION
* offline mode is enabled only once for a fixture or assembly
* added OfflineSldrAttribute to every assembly that might access SLDR
* removed redundant OfflineSldrAttribute from test fixtures
* fixed online SLDR tests so that SLDR is reset to offline mode

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/328)
<!-- Reviewable:end -->
