### PR TITLE
Improve NuGet.targets

### DIFF
--- a/build/NuGet.targets
+++ b/build/NuGet.targets
@@ -54,8 +54,14 @@
 			Condition="'$(OS)' != 'Windows_NT'" />
 	</Target>
 
+	<ItemGroup>
+		<PackageConfigs Include="$(SolutionDir)/**/packages.config"/>
+	</ItemGroup>
+
 	<Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
-		<Exec Command='$(NuGetCommand) restore "$(SolutionPath)"'/>
+		<Exec Command='$(NuGetCommand) restore "$(SolutionPath)"' Condition="Exists('$(SolutionPath)')"/>
+		<Exec Command='$(NuGetCommand) restore -SolutionDirectory "$(SolutionDir)" "%(PackageConfigs.FullPath)"'
+			Condition="!Exists('$(SolutionPath)')"/>
 	</Target>
 
 	<UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory"


### PR DESCRIPTION
This change adds the ability to restore packages without having
a solution. This is not needed for libpalaso, but `NuGet.targets`
serves as a template for other projects where this is useful
to have.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/333)
<!-- Reviewable:end -->
