### PR TITLE
Improve performance of Detect.Reentry

### DIFF
--- a/SIL.Core/Code/Detect.cs
+++ b/SIL.Core/Code/Detect.cs
@@ -13,7 +13,7 @@ namespace SIL.Code
 
 	public class ReentryDetecter : IDisposable
 	{
-		private static List<string> _currentlyInScope = new List<string>();
+		private static HashSet<string> _currentlyInScope = new HashSet<string>();
 		private readonly string _name;
 		private bool _didReenter;
 


### PR DESCRIPTION
We don't need a List here when we're never storing more than a single object. Use a HashSet instead for O(1) lookup.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/336)
<!-- Reviewable:end -->
