### PR TITLE
Protect against event handlers being null

### DIFF
--- a/SIL.Core/ObjectModel/ObservableDictionary.cs
+++ b/SIL.Core/ObjectModel/ObservableDictionary.cs
@@ -217,14 +217,16 @@ namespace SIL.ObjectModel
 
 		protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
-			if (CollectionChanged != null)
-				CollectionChanged(this, args);
+			NotifyCollectionChangedEventHandler handler = CollectionChanged;
+			if (handler != null)
+				handler(this, args);
 		}
 
 		protected virtual void OnPropertyChanged(string name)
 		{
-			if (PropertyChanged != null)
-				PropertyChanged(this, new PropertyChangedEventArgs(name));
+			PropertyChangedEventHandler handler = PropertyChanged;
+			if (handler != null)
+				handler(this, new PropertyChangedEventArgs(name));
 		}
 
 		protected virtual bool RemoveEntry(TKey key)

--- a/SIL.Core/ObjectModel/ObservableHashSet.cs
+++ b/SIL.Core/ObjectModel/ObservableHashSet.cs
@@ -21,7 +21,7 @@ namespace SIL.ObjectModel
 
 		private readonly SimpleMonitor _reentrancyMonitor = new SimpleMonitor();
 		private readonly HashSet<T> _set;
- 
+
 		public ObservableHashSet()
 		{
 			_set = new HashSet<T>();
@@ -210,19 +210,21 @@ namespace SIL.ObjectModel
 
 		protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 		{
-			if (CollectionChanged != null)
+			NotifyCollectionChangedEventHandler handler = CollectionChanged;
+			if (handler != null)
 			{
 				using (_reentrancyMonitor.Enter())
-					CollectionChanged(this, e);
+					handler(this, e);
 			}
 		}
 
 		protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
 		{
-			if (PropertyChanged != null)
+			PropertyChangedEventHandler handler = PropertyChanged;
+			if (handler != null)
 			{
 				using (_reentrancyMonitor.Enter())
-					PropertyChanged(this, e);
+					handler(this, e);
 			}
 		}
 

--- a/SIL.Core/ObjectModel/ObservableObject.cs
+++ b/SIL.Core/ObjectModel/ObservableObject.cs
@@ -72,14 +72,16 @@ namespace SIL.ObjectModel
 
 		protected virtual void OnPropertyChanging(PropertyChangingEventArgs e)
 		{
-			if (PropertyChanging != null)
-				PropertyChanging(this, e);
+			PropertyChangingEventHandler handler = PropertyChanging;
+			if (handler != null)
+				handler(this, e);
 		}
 
 		protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
 		{
-			if (PropertyChanged != null)
-				PropertyChanged(this, e);
+			PropertyChangedEventHandler handler = PropertyChanged;
+			if (handler != null)
+				handler(this, e);
 		}
 
 		/// <summary>

--- a/SIL.Core/ObjectModel/ReadOnlyObservableCollection.cs
+++ b/SIL.Core/ObjectModel/ReadOnlyObservableCollection.cs
@@ -33,14 +33,16 @@ namespace SIL.ObjectModel
 
 		protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 		{
-			if (CollectionChanged != null)
-				CollectionChanged(this, e);
+			NotifyCollectionChangedEventHandler handler = CollectionChanged;
+			if (handler != null)
+				handler(this, e);
 		}
 
 		protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
 		{
-			if (PropertyChanged != null)
-				PropertyChanged(this, e);
+			PropertyChangedEventHandler handler = PropertyChanged;
+			if (handler != null)
+				handler(this, e);
 		}
 	}
 }

--- a/SIL.Core/ObjectModel/ReadOnlyObservableList.cs
+++ b/SIL.Core/ObjectModel/ReadOnlyObservableList.cs
@@ -33,14 +33,16 @@ namespace SIL.ObjectModel
 
 		protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
 		{
-			if (CollectionChanged != null)
-				CollectionChanged(this, e);
+			NotifyCollectionChangedEventHandler handler = CollectionChanged;
+			if (handler != null)
+				handler(this, e);
 		}
 
 		protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
 		{
-			if (PropertyChanged != null)
-				PropertyChanged(this, e);
+			PropertyChangedEventHandler handler = PropertyChanged;
+			if (handler != null)
+				handler(this, e);
 		}
 	}
 }


### PR DESCRIPTION
Although the event handlers are checked for null before being called, this is not thread-safe. If another thread removed the last event handler in between the check and the call, a NullReferenceException could still happen.

Note: the ?. operator in C# 6.0 will make this commit obsolete. See https://github.com/dotnet/roslyn/wiki/New-Language-Features-in-C%23-6#null-conditional-operators (especially the last paragraph giving the `PropertyChanged?.Invoke(this, args);` example) for more details.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/337)
<!-- Reviewable:end -->
