### PR TITLE
BL-2966 Make image library handle image orientation

### DIFF
--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageToolboxTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageToolboxTests.cs
@@ -23,7 +23,10 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 				if (DialogResult.OK == dlg.ShowDialog())
 				{
 					// File name ending in .tmp will confuse TagLib#...doesn't know what kind of metadata to write.
-					string path  = Path.ChangeExtension(Path.GetTempFileName(), Path.GetExtension(dlg.ImageInfo.OriginalFilePath));
+					var ext = ".png";
+					if (Path.GetExtension(dlg.ImageInfo.OriginalFilePath) == ".jpg")
+						ext = ".jpg";
+					string path  = Path.ChangeExtension(Path.GetTempFileName(), ext);
 					dlg.ImageInfo.Save(path);
 					Process.Start("explorer.exe", "/select, \"" + path + "\"");
 				}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageToolboxTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageToolboxTests.cs
@@ -23,7 +23,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 				if (DialogResult.OK == dlg.ShowDialog())
 				{
 					// File name ending in .tmp will confuse TagLib#...doesn't know what kind of metadata to write.
-					string path  = Path.ChangeExtension(Path.GetTempFileName(), ".png");
+					string path  = Path.ChangeExtension(Path.GetTempFileName(), Path.GetExtension(dlg.ImageInfo.OriginalFilePath));
 					dlg.ImageInfo.Save(path);
 					Process.Start("explorer.exe", "/select, \"" + path + "\"");
 				}

--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -372,7 +372,9 @@ namespace SIL.Windows.Forms.ClearShare
 		/// </summary>
 		public void NormalizeOrientation()
 		{
-			var ifdTag = _originalTablibMetadata?.GetTag(TagTypes.TiffIFD) as IFDTag;
+			if (_originalTablibMetadata == null)
+				return;
+			var ifdTag = _originalTablibMetadata.GetTag(TagTypes.TiffIFD) as IFDTag;
 			if (ifdTag != null)
 				ifdTag.Orientation = ImageOrientation.TopLeft;
 		}

--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -380,15 +380,17 @@ namespace SIL.Windows.Forms.ClearShare
 		}
 
 		/// <summary>
-		/// Write the metadata to the specified image file. Optionally, if this MetaData was made from a file,
-		/// any other original metadata from that file can be copied to the new one. This can include all kinds
+		/// Write the metadata to the specified image file. By default, if this MetaData was made from a file,
+		/// any other original metadata from that file is copied to the new one. This can include all kinds
 		/// of details like where and when a photo was taken, image size, and so forth, so it should not be
 		/// done except for copies of the image; for example, not when applying the same ClearShare settings
-		/// to a group of images.
+		/// to a group of images. Thought should also be given to copying to a modified version of the image;
+		/// for example, some of the metadata may be incorrect if the image being saved has a different
+		/// size or format from the original file from which the metadata was loaded.
 		/// </summary>
 		/// <param name="path"></param>
 		/// <param name="copyAllMetaDataFromOriginal"></param>
-		public void Write(string path, bool copyAllMetaDataFromOriginal = false)
+		public void Write(string path, bool copyAllMetaDataFromOriginal = true)
 		{
 			// do not attempt to add metadata to a file type that does not support it.
 			if (!FileFormatSupportsMetadata(path))
@@ -410,6 +412,17 @@ namespace SIL.Windows.Forms.ClearShare
 			file.Save();
 			//as of right now, we are clean with respect to what is on disk, no need to save.
 			HasChanges = false;
+		}
+
+		/// <summary>
+		/// Write just the ClearShare License information to the specified image. This is appropriate
+		/// when e.g. duplicating license info to a collection of images (things like the place and time
+		/// where a photo was taken should not be copied to all of them).
+		/// </summary>
+		/// <param name="path"></param>
+		public void WriteLicenseOnly(string path)
+		{
+			Write(path, false);
 		}
 
 		public void SetupReasonableLicenseDefaultBeforeEditing()

--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -63,7 +63,7 @@ namespace SIL.Windows.Forms.ClearShare
 		/// If the MetaData was loaded from a file, this stores all the other metadata from that file,
 		/// which will typically be useful to write to a file derived from it.
 		/// </summary>
-		TagLib.Image.File _originalTablibMetadata;
+		TagLib.Image.File _originalTaglibMetadata;
 
 		/// <summary>
 		/// NB: this is used in 2 places; one is loading from the image we are linked to, the other from a sample image we are copying metadata from
@@ -74,7 +74,7 @@ namespace SIL.Windows.Forms.ClearShare
 		{
 			try
 			{
-				destinationMetadata._originalTablibMetadata = TagLib.File.Create(path) as TagLib.Image.File;
+				destinationMetadata._originalTaglibMetadata = TagLib.File.Create(path) as TagLib.Image.File;
 			}
 			catch (TagLib.UnsupportedFormatException)
 			{
@@ -84,7 +84,7 @@ namespace SIL.Windows.Forms.ClearShare
 				// even in DEBUG mode, because else a lot of simple image tests fail
 				return;
 			}
-			LoadProperties(destinationMetadata._originalTablibMetadata.ImageTag, destinationMetadata);
+			LoadProperties(destinationMetadata._originalTaglibMetadata.ImageTag, destinationMetadata);
 		}
 
 		/// <summary>
@@ -372,9 +372,9 @@ namespace SIL.Windows.Forms.ClearShare
 		/// </summary>
 		public void NormalizeOrientation()
 		{
-			if (_originalTablibMetadata == null)
+			if (_originalTaglibMetadata == null)
 				return;
-			var ifdTag = _originalTablibMetadata.GetTag(TagTypes.TiffIFD) as IFDTag;
+			var ifdTag = _originalTaglibMetadata.GetTag(TagTypes.TiffIFD) as IFDTag;
 			if (ifdTag != null)
 				ifdTag.Orientation = ImageOrientation.TopLeft;
 		}
@@ -402,9 +402,9 @@ namespace SIL.Windows.Forms.ClearShare
 			// of this library and its clients) won't see our copyright notice and creator, at least.
 			file.GetTag(TagTypes.Png, true);
 			// If we know where the image came from, copy as much metadata as we can to the new image.
-			if (copyAllMetaDataFromOriginal && _originalTablibMetadata != null)
+			if (copyAllMetaDataFromOriginal && _originalTaglibMetadata != null)
 			{
-				file.CopyFrom(_originalTablibMetadata);
+				file.CopyFrom(_originalTaglibMetadata);
 			}
 			SaveInImageTag(file.ImageTag);
 			file.Save();

--- a/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
+++ b/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
@@ -288,8 +288,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 				Metadata = Metadata.FromFile(path),
 				_tempFilePath = tempPath
 			};
-			NormalizeImageOrientation(i.Image);
-			i.Metadata.NormalizeOrientation();
+			NormalizeImageOrientation(i);
 			return i;
 		}
 
@@ -297,9 +296,10 @@ namespace SIL.Windows.Forms.ImageToolbox
 		/// If the image contains metadata indicating that it is mirrored or rotated,
 		/// convert it to normal orientation (and remove the metadata).
 		/// </summary>
-		/// <param name="img"></param>
-		private static void NormalizeImageOrientation(Image img)
+		/// <param name="i"></param>
+		private static void NormalizeImageOrientation(PalasoImage i)
 		{
+			var img = i.Image;
 			if (Array.IndexOf(img.PropertyIdList, 274) > -1)
 			{
 				var orientation = (int)img.GetPropertyItem(274).Value[0];
@@ -333,6 +333,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 				// This EXIF data is now invalid and should be removed.
 				img.RemovePropertyItem(274);
 			}
+			i.Metadata.NormalizeOrientation(); // remove it from metadata too.
 		}
 
 		/// <summary>

--- a/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
+++ b/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
@@ -145,7 +145,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 		{
 			ThrowIfDisposedOfAlready();
 			SaveImageSafely(path, format);
-			Metadata.Write(path, OriginalFilePath);
+			Metadata.Write(path, true);
 		}
 
 		private void SaveImageSafely(string path, ImageFormat format)
@@ -289,6 +289,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 				_tempFilePath = tempPath
 			};
 			NormalizeImageOrientation(i.Image);
+			i.Metadata.NormalizeOrientation();
 			return i;
 		}
 

--- a/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
+++ b/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
@@ -145,7 +145,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 		{
 			ThrowIfDisposedOfAlready();
 			SaveImageSafely(path, format);
-			Metadata.Write(path, true);
+			Metadata.Write(path);
 		}
 
 		private void SaveImageSafely(string path, ImageFormat format)
@@ -216,9 +216,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 		/// If you edit the metadata, call this. If it happens to have an actual file associated, it will save it.
 		/// If not (e.g. the image came from a scanner), it won't do anything.
 		/// 
-		/// Warning. Don't use this on original books. See https://jira.sil.org/browse/BL-1001. Bloom uses it to 
-		/// update its own copies of books, when the user edits the metadata without opening the libpalaso
-		/// image toolbox.
+		/// Warning. Don't use this on original images. See https://jira.sil.org/browse/BL-1001.
 		/// </summary>
 		public void SaveUpdatedMetadataIfItMakesSense()
 		{

--- a/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
+++ b/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
@@ -145,7 +145,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 		{
 			ThrowIfDisposedOfAlready();
 			SaveImageSafely(path, format);
-			Metadata.Write(path);
+			Metadata.Write(path, OriginalFilePath);
 		}
 
 		private void SaveImageSafely(string path, ImageFormat format)
@@ -288,7 +288,50 @@ namespace SIL.Windows.Forms.ImageToolbox
 				Metadata = Metadata.FromFile(path),
 				_tempFilePath = tempPath
 			};
+			NormalizeImageOrientation(i.Image);
 			return i;
+		}
+
+		/// <summary>
+		/// If the image contains metadata indicating that it is mirrored or rotated,
+		/// convert it to normal orientation (and remove the metadata).
+		/// </summary>
+		/// <param name="img"></param>
+		private static void NormalizeImageOrientation(Image img)
+		{
+			if (Array.IndexOf(img.PropertyIdList, 274) > -1)
+			{
+				var orientation = (int)img.GetPropertyItem(274).Value[0];
+				switch (orientation)
+				{
+					case 1:
+						// No rotation required.
+						break;
+					case 2:
+						img.RotateFlip(RotateFlipType.RotateNoneFlipX);
+						break;
+					case 3:
+						img.RotateFlip(RotateFlipType.Rotate180FlipNone);
+						break;
+					case 4:
+						img.RotateFlip(RotateFlipType.Rotate180FlipX);
+						break;
+					case 5:
+						img.RotateFlip(RotateFlipType.Rotate90FlipX);
+						break;
+					case 6:
+						img.RotateFlip(RotateFlipType.Rotate90FlipNone);
+						break;
+					case 7:
+						img.RotateFlip(RotateFlipType.Rotate270FlipX);
+						break;
+					case 8:
+						img.RotateFlip(RotateFlipType.Rotate270FlipNone);
+						break;
+				}
+				// This EXIF data is now invalid and should be removed.
+				img.RemovePropertyItem(274);
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Image metadata can contain an Orientation field which
indicates how it needs to be flipped and/or rotated to
look right. The image library was ignoring this, which
caused images to look wrong in the toolbox, and was not
copying the metadata to new image files, which caused
them to look wrong elsewhere.
This patch fixes both these problems, though fixing
the first made it unnecessary to fix the second at least
to solve THIS issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/340)
<!-- Reviewable:end -->
