### PR TITLE
Use udisks2 if available

### DIFF
--- a/SIL.Core.Tests/UsbDrive/UsbDeviceInfoTests.cs
+++ b/SIL.Core.Tests/UsbDrive/UsbDeviceInfoTests.cs
@@ -1,8 +1,14 @@
-﻿using System;
+﻿// Copyright (c) 2009-2016 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using SIL.UsbDrive;
+#if __MonoCS__
+using SIL.UsbDrive.Linux;
+#endif
 
 namespace SIL.Tests.UsbDrive
 {
@@ -43,6 +49,7 @@ namespace SIL.Tests.UsbDrive
 		[Test]
 		[Category("RequiresUSB")]
 		[Category("SkipOnTeamCity")]
+		[Explicit("Run this test if you have exactly 1 USB drive plugged in")]
 		public void GetDrives_1Drive_DrivesAreReturned()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
@@ -55,7 +62,8 @@ namespace SIL.Tests.UsbDrive
 		public void IsReady_1Drive_True()
 		{
 			var drives = UsbDriveInfo.GetDrives();
-			Assert.That(drives.Count, Is.GreaterThan(0));
+			if (drives.Count < 1)
+				Assert.Ignore("Need at least 1 USB drive plugged in");
 			Assert.That(drives[0].IsReady, Is.True);
 		}
 
@@ -66,7 +74,8 @@ namespace SIL.Tests.UsbDrive
 		{
 			var drives = UsbDriveInfo.GetDrives();
 			// TODO The below is a platform specific expectation.  Fix for windows
-			Assert.That(drives.Count, Is.GreaterThan(0));
+			if (drives.Count < 1)
+				Assert.Ignore("Need at least 1 USB drive plugged in");
 			Assert.That(drives[0].RootDirectory.FullName, Is.StringContaining("/media/"));
 		}
 
@@ -76,13 +85,15 @@ namespace SIL.Tests.UsbDrive
 		public void TotalSize_1Drive_GreaterThan1000()
 		{
 			var drives = UsbDriveInfo.GetDrives();
-			Assert.That(drives.Count, Is.GreaterThan(0));
+			if (drives.Count < 1)
+				Assert.Ignore("Need at least 1 USB drive plugged in");
 			Assert.That(drives[0].TotalSize, Is.GreaterThan(1000));
 		}
 
 		[Test]
 		[Category("RequiresUSB")]
 		[Category("SkipOnTeamCity")]
+		[Explicit("Run this test if you have exactly 2 USB drives plugged in")]
 		public void GetDrives_2DrivesArePluggedIn_DrivesAreReturned()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
@@ -92,6 +103,7 @@ namespace SIL.Tests.UsbDrive
 		[Test]
 		[Category("RequiresUSB")]
 		[Category("SkipOnTeamCity")]
+		[Explicit("Run this test if you have exactly 3 USB drives plugged in")]
 		public void GetDrives_3DrivesArePluggedIn_DrivesAreReturned()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
@@ -104,7 +116,8 @@ namespace SIL.Tests.UsbDrive
 		public void TotalSize_2DrivesArePluggedIn_TheDrivesSizesAreCorrect()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
-			Assert.That(usbDrives.Count, Is.GreaterThan(1));
+			if (usbDrives.Count < 2)
+				Assert.Ignore("Need at least 2 USB drives plugged in");
 			Assert.AreEqual(_drive0.DriveSize, usbDrives[0].TotalSize);
 			Assert.AreEqual(_drive1.DriveSize, usbDrives[1].TotalSize);
 		}
@@ -115,7 +128,8 @@ namespace SIL.Tests.UsbDrive
 		public void RootDirectory_2DrivesArePluggedInAndReady_TheDrivesPathsCorrect()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
-			Assert.That(usbDrives.Count, Is.GreaterThan(1));
+			if (usbDrives.Count < 2)
+				Assert.Ignore("Need at least 2 USB drives plugged in");
 			Assert.AreEqual(_drive0.Path.FullName, usbDrives[0].RootDirectory.FullName);
 			Assert.AreEqual(_drive1.Path.FullName, usbDrives[1].RootDirectory.FullName);
 		}
@@ -126,7 +140,8 @@ namespace SIL.Tests.UsbDrive
 		public void IsReady_2DrivesAreMounted_ReturnsTrue()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
-			Assert.That(usbDrives.Count, Is.GreaterThan(1));
+			if (usbDrives.Count < 2)
+				Assert.Ignore("Need at least 2 USB drives plugged in");
 			Assert.IsTrue(usbDrives[0].IsReady);
 			Assert.IsTrue(usbDrives[1].IsReady);
 		}
@@ -137,7 +152,8 @@ namespace SIL.Tests.UsbDrive
 		public void IsReady_3DrivesAreMounted_ReturnsTrue()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
-			Assert.That(usbDrives.Count, Is.GreaterThan(2));
+			if (usbDrives.Count < 3)
+				Assert.Ignore("Need at least 3 USB drives plugged in");
 			Assert.IsTrue(usbDrives[0].IsReady);
 			Assert.IsTrue(usbDrives[1].IsReady);
 			Assert.IsTrue(usbDrives[2].IsReady);
@@ -149,7 +165,8 @@ namespace SIL.Tests.UsbDrive
 		public void IsReady_2DrivesAreNotMounted_ReturnsFalse()
 		{
 			List<IUsbDriveInfo> usbDrives = UsbDriveInfo.GetDrives();
-			Assert.That(usbDrives.Count, Is.GreaterThan(1));
+			if (usbDrives.Count < 2)
+				Assert.Ignore("Need at least 2 USB drives plugged in");
 			Assert.IsFalse(usbDrives[0].IsReady);
 			Assert.IsFalse(usbDrives[1].IsReady);
 		}
@@ -157,9 +174,16 @@ namespace SIL.Tests.UsbDrive
 		[Test]
 		[Category("RequiresUSB")]
 		[Category("SkipOnTeamCity")]
-		public void RootDirectory_2DrivesAreNotMounted_Throws()
+		public void RootDirectory_FirstDriveIsNotMounted_Throws()
 		{
 			var usbDrives = UsbDriveInfo.GetDrives();
+			if (usbDrives.Count < 1)
+				Assert.Ignore("Need at least 1 USB drive plugged in");
+#if __MonoCS__
+			if (UsbDriveInfoUDisks2.IsUDisks2Available)
+				Assert.Ignore("With udisks2 GetDrives() only returns mounted drives");
+#endif
+
 			Assert.Throws<ArgumentOutOfRangeException>(
 				() =>
 					{

--- a/SIL.Core/CoreSetup.cs
+++ b/SIL.Core/CoreSetup.cs
@@ -12,14 +12,12 @@ namespace SIL
 	/// }
 	/// </remarks>
 	/// <remarks>
-	/// At the moment, this is needed only if the program implicitly or explicitly
-	/// uses SIL.UsbDrive on Linux/Mono.
+	/// This class was originally created to help close NDesk.DBus on Linux. We keep it around
+	/// for backwards compatibility.
 	/// </remarks>
+	[Obsolete("No longer needed.")]
 	public class CoreSetup : IDisposable
 	{
-		public CoreSetup()
-		{
-		}
 		private bool disposed = false;
 
 		public void Dispose()
@@ -34,14 +32,6 @@ namespace SIL
 				return;
 			if (disposing)
 			{
-#if __MonoCS__
-				// Using Palaso.UsbDrive on Linux/Mono results in NDesk spinning up a thread that
-				// continues until NDesk Bus is closed.  Failure to close the thread results in a
-				// program hang when closing.  Closing the system bus allows the thread to close,
-				// and thus the program to close.  Closing the system bus can happen safely only
-				// at the end of the program.
-				NDesk.DBus.Bus.System.Close();
-#endif
 			}
 			disposed = true;
 		}

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -354,6 +354,7 @@
     <Compile Include="UsbDrive\Linux\UDiskDevice.cs" />
     <Compile Include="UsbDrive\Linux\UDisks.cs" />
     <Compile Include="UsbDrive\Linux\UsbDriveInfoUDisks.cs" />
+    <Compile Include="UsbDrive\Linux\UsbDriveInfoUDisks2.cs" />
     <Compile Include="UsbDrive\Linux\UsbDriveInfoHAL.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SIL.Core/UsbDrive/Linux/UDisks.cs
+++ b/SIL.Core/UsbDrive/Linux/UDisks.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2009-2016 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
 using System.Collections.Generic;
 using SIL.Reporting;
 using NDesk.DBus;
@@ -20,7 +23,8 @@ namespace SIL.UsbDrive.Linux
 		}
 
 		/// <summary>
-		/// Enumerate the devices on the given interface.
+		/// Enumerate the mounted filesystems on the given interface, returning a set of their
+		/// mount points.
 		/// </summary>
 		/// <remarks>
 		/// DBus is a bit flakey and subject to random timing problems.  We need to

--- a/SIL.Core/UsbDrive/Linux/UsbDriveInfoUDisks2.cs
+++ b/SIL.Core/UsbDrive/Linux/UsbDriveInfoUDisks2.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) 2016 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NDesk.DBus;
+using org.freedesktop.DBus;
+
+namespace SIL.UsbDrive.Linux
+{
+	/// <summary>
+	/// Accesses information about a particular filesystem on a USB Flash Drive, using UDisks2.
+	/// </summary>
+	internal class UsbDriveInfoUDisks2 : UsbDriveInfo
+	{
+		/// <summary>
+		/// dbus object path of the block device
+		/// </summary>
+		private readonly string _blockDevicePath;
+
+		private UsbDriveInfoUDisks2(string dbusBlockDevicePath)
+		{
+			_blockDevicePath = dbusBlockDevicePath;
+		}
+
+		/// <summary>
+		/// Get block device object with information, corresponding to _blockDevicePath.
+		/// </summary>
+		private KeyValuePair<ObjectPath, IDictionary<string, IDictionary<string, object>>> BlockDevice
+		{
+			get
+			{
+				var disks = Bus.System.GetObject<ObjectManager>("org.freedesktop.UDisks2",
+					new ObjectPath("/org/freedesktop/UDisks2"));
+				var managedObjects = disks.GetManagedObjects();
+				var blockDevice = managedObjects.First(obj => obj.Key.ToString() == _blockDevicePath);
+				return blockDevice;
+			}
+		}
+
+		public override bool IsReady
+		{
+			get
+			{
+				return !string.IsNullOrEmpty(RootDirectory.FullName);
+			}
+		}
+
+		/// <summary>
+		/// Mount point of USB Flash Drive.
+		/// </summary>
+		public override DirectoryInfo RootDirectory
+		{
+			get
+			{
+				var mountPoints = BlockDevice.Value["org.freedesktop.UDisks2.Filesystem"]["MountPoints"] as byte[][];
+				if (mountPoints.Length == 0)
+					return new DirectoryInfo(string.Empty);
+
+				// The mountPoints byte array contains NULL terminators.
+				var mountPoint = Encoding.UTF8.GetString(mountPoints[0]).TrimEnd('\0');
+
+				return new DirectoryInfo(mountPoint);
+			}
+		}
+
+		public override string VolumeLabel
+		{
+			get
+			{
+				return BlockDevice.Value["org.freedesktop.UDisks2.Block"]["IdLabel"].ToString();
+			}
+		}
+
+		public override ulong TotalSize
+		{
+			get
+			{
+				return (ulong)BlockDevice.Value["org.freedesktop.UDisks2.Block"]["Size"];
+			}
+		}
+
+		public override ulong AvailableFreeSpace
+		{
+			// UDisks2 itself does not appear to provide this information.
+			// Could use another library if need to support this.
+			get
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		/// <summary>
+		/// Checks if UDisks2 is available to be used on this system.
+		/// </summary>
+		public static bool IsUDisks2Available
+		{
+			get
+			{
+				var names = Bus.System.GetObject<IBus>("org.freedesktop.DBus",
+					new ObjectPath("/org/freedesktop/DBus")).ListActivatableNames();
+				return names.Contains("org.freedesktop.UDisks2");
+			}
+		}
+
+		/// <summary>
+		/// Get a set of all mounted filesystems on the system's USB Flash Drives.
+		/// </summary>
+		public new static List<IUsbDriveInfo> GetDrives()
+		{
+			var drives = GetUsbBlockDevices()
+				.Select(device => new UsbDriveInfoUDisks2(device) as IUsbDriveInfo).ToList();
+			return drives;
+		}
+
+		/// <summary>
+		/// Get set of mounted, removable filesystems connected over USB, represented as dbus object paths.
+		/// </summary>
+		private static IEnumerable<string> GetUsbBlockDevices()
+		{
+			var disks = Bus.System.GetObject<ObjectManager>("org.freedesktop.UDisks2",
+				new ObjectPath("/org/freedesktop/UDisks2"));
+			var managedObjects = disks.GetManagedObjects();
+			var blockDevices = managedObjects
+				.Where(obj => obj.Key.ToString().StartsWith("/org/freedesktop/UDisks2/block_devices",
+					StringComparison.Ordinal))
+				.Where(obj => obj.Value != null && obj.Value.ContainsKey("org.freedesktop.UDisks2.Block") &&
+					obj.Value.ContainsKey("org.freedesktop.UDisks2.Filesystem"))
+				.Where(obj => obj.Value["org.freedesktop.UDisks2.Filesystem"].ContainsKey("MountPoints") &&
+					(obj.Value["org.freedesktop.UDisks2.Filesystem"]["MountPoints"] as byte[][]).Length > 0)
+				.Where(obj =>
+					{
+						var drive = (ObjectPath)obj.Value["org.freedesktop.UDisks2.Block"]["Drive"];
+						if (!managedObjects.ContainsKey(drive) ||
+							!managedObjects[drive].ContainsKey("org.freedesktop.UDisks2.Drive"))
+							return false;
+						return (bool)managedObjects[drive]["org.freedesktop.UDisks2.Drive"]["Removable"] &&
+							((string)managedObjects[drive]["org.freedesktop.UDisks2.Drive"]["ConnectionBus"]) == "usb";
+					});
+
+			var objectPaths = blockDevices.Select(device => device.Key.ToString());
+			return objectPaths;
+		}
+	}
+}


### PR DESCRIPTION
This is needed on new systems (such as Ubuntu 16.04) that have
udisks2 but not udisks.

This change is based on a change from MarkS that he made on the
libpalaso-2.6 branch (https://github.com/sillsdev/libpalaso/pull/338).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/341)
<!-- Reviewable:end -->
