### PR TITLE
App color palette extender

### DIFF
--- a/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
+++ b/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
@@ -6,40 +6,94 @@ using System.Windows.Forms;
 
 namespace SIL.Windows.Forms.AppColorPalette
 {
+	[ProvideProperty("UsePaletteColors", typeof(IComponent))]
 	[ProvideProperty("ForeColor", typeof(IComponent))]
-	public class AppColorPaletteExtender : Component, IExtenderProvider, ISupportInitialize
+	[ProvideProperty("BackColor", typeof(IComponent))]
+	[ProvideProperty("LinkColor", typeof(LinkLabel))]
+	[ProvideProperty("ActiveLinkColor", typeof(LinkLabel))]
+	[ProvideProperty("DisabledLinkColor", typeof(LinkLabel))]
+	[ProvideProperty("VisitedLinkColor", typeof(LinkLabel))]
+	public abstract class AppColorPaletteExtender<TPaletteColors> : Component, IExtenderProvider, ISupportInitialize where TPaletteColors : struct, IConvertible
 	{
+		public enum ColorProperties
+		{
+			ForeColor,
+			BackColor,
+			LinkColor,
+			ActiveLinkColor, 
+			DisabledLinkColor,
+			VisitedLinkColor,
+		}
+
 		private Container _components = null;
 		private readonly Dictionary<object, ColorOverrideInfo> _extendedCtrls;
-		private readonly Dictionary<PaletteColors, Color> _appColorPalette = new Dictionary<PaletteColors, Color> {{PaletteColors.Color1, Color.AliceBlue}, {PaletteColors.Color2, Color.BlueViolet}};
-
-		public enum PaletteColors
-		{
-			Color1,
-			Color2,
-		}
 
 		private class ColorOverrideInfo
 		{
-			public PaletteColors ForeColor { get; set; }
+			public ColorOverrideInfo(bool usePaletteColors)
+			{
+				UsePaletteColors = usePaletteColors;
+			}
+
+			public bool UsePaletteColors { get; set; }
+			public TPaletteColors ForeColor { get; set; }
+			public TPaletteColors BackColor { get; set; }
+			public TPaletteColors LinkColor { get; set; }
+			public TPaletteColors ActiveLinkColor { get; set; }
+			public TPaletteColors DisabledLinkColor { get; set; }
+			public TPaletteColors VisitedLinkColor { get; set; }
 		}
 
-		public virtual Dictionary<PaletteColors, Color> AppColorPalette
+		public abstract Color GetColor(TPaletteColors paletteColor);
+
+		protected virtual bool UsePaletteColorsForComponent(IComponent component)
 		{
-			get { return _appColorPalette; }
+			return true;
 		}
 
-		public AppColorPaletteExtender()
+		protected virtual TPaletteColors GetDefaultPaletteColor(ColorProperties colorProperty)
+		{
+			return default(TPaletteColors);
+		}
+
+		protected AppColorPaletteExtender()
 		{
 			// Required for Windows.Forms Class Composition Designer support
 			_components = new Container();
-
 			_extendedCtrls = new Dictionary<object, ColorOverrideInfo>();
 		}
 
-		public AppColorPaletteExtender(IContainer container) : this()
+		protected AppColorPaletteExtender(IContainer container) : this()
 		{
 			container.Add(this);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets a value indicating whether to use colors from the application color palette for
+		/// the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		[DefaultValue(true)]
+		public bool GetUsePaletteColors(IComponent component)
+		{
+			var overrideInfo = GetComponentInfo(component);
+			return overrideInfo.UsePaletteColors;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets a value indicating whether to use colors from the application color palette for
+		/// the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetUsePaletteColors(IComponent component, bool usePaletteColors)
+		{
+			var overrideInfo = GetComponentInfo(component);
+			overrideInfo.UsePaletteColors = usePaletteColors;
+			ApplyColorChange(component, overrideInfo);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -49,10 +103,14 @@ namespace SIL.Windows.Forms.AppColorPalette
 		/// ------------------------------------------------------------------------------------
 		[Localizable(false)]
 		[Category("App Palette Properties")]
-		[DefaultValue(PaletteColors.Color1)]
-		public PaletteColors GetForeColor(IComponent component)
+		public TPaletteColors GetForeColor(IComponent component)
 		{
-			return GetComponentInfo(component).ForeColor;
+			var overrideInfo = GetComponentInfo(component);
+			// By default, we do not override the fore color for forms because it will affect the
+			// fore color of buttons or other controls that are using visual styles.
+			if (overrideInfo.ForeColor.Equals(default(TPaletteColors)) && !(component is ScrollableControl))
+				overrideInfo.ForeColor = GetDefaultPaletteColor(ColorProperties.ForeColor);
+			return overrideInfo.ForeColor;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -60,9 +118,146 @@ namespace SIL.Windows.Forms.AppColorPalette
 		/// Sets the fore color of the specified component.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public void SetForeColor(IComponent component, PaletteColors color)
+		public void SetForeColor(IComponent component, TPaletteColors color)
 		{
-			GetComponentInfo(component).ForeColor = color;
+			var overrideInfo = GetComponentInfo(component);
+			overrideInfo.ForeColor = color;
+			ApplyColorChange(component, overrideInfo);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the back color of the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		public TPaletteColors GetBackColor(IComponent component)
+		{
+			var overrideInfo = GetComponentInfo(component);
+			if (overrideInfo.BackColor.Equals(default(TPaletteColors)))
+				overrideInfo.BackColor = GetDefaultPaletteColor(ColorProperties.BackColor);
+			return overrideInfo.BackColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the back color of the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetBackColor(IComponent component, TPaletteColors color)
+		{
+			var overrideInfo = GetComponentInfo(component);
+			overrideInfo.BackColor = color;
+			ApplyColorChange(component, overrideInfo);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		public TPaletteColors GetLinkColor(LinkLabel label)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			if (overrideInfo.LinkColor.Equals(default(TPaletteColors)))
+				overrideInfo.LinkColor = GetDefaultPaletteColor(ColorProperties.LinkColor);
+			return overrideInfo.LinkColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetLinkColor(LinkLabel label, TPaletteColors color)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			overrideInfo.LinkColor = color;
+			ApplyColorChange(label, overrideInfo);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the active link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		public TPaletteColors GetActiveLinkColor(LinkLabel label)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			if (overrideInfo.ActiveLinkColor.Equals(default(TPaletteColors)))
+				overrideInfo.ActiveLinkColor = GetDefaultPaletteColor(ColorProperties.ActiveLinkColor);
+			return overrideInfo.ActiveLinkColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the active link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetActiveLinkColor(LinkLabel label, TPaletteColors color)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			overrideInfo.ActiveLinkColor = color;
+			ApplyColorChange(label, overrideInfo);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the disabled link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		public TPaletteColors GetDisabledLinkColor(LinkLabel label)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			if (overrideInfo.DisabledLinkColor.Equals(default(TPaletteColors)))
+				overrideInfo.DisabledLinkColor = GetDefaultPaletteColor(ColorProperties.DisabledLinkColor);
+			return overrideInfo.DisabledLinkColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the disabled link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetDisabledLinkColor(LinkLabel label, TPaletteColors color)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			overrideInfo.DisabledLinkColor = color;
+			ApplyColorChange(label, overrideInfo);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the visited link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		public TPaletteColors GetVisitedLinkColor(LinkLabel label)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			if (overrideInfo.VisitedLinkColor.Equals(default(TPaletteColors)))
+				overrideInfo.VisitedLinkColor = GetDefaultPaletteColor(ColorProperties.VisitedLinkColor);
+			return overrideInfo.VisitedLinkColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the visited link color of the specified link label.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetVisitedLinkColor(LinkLabel label, TPaletteColors color)
+		{
+			var overrideInfo = GetComponentInfo(label);
+			overrideInfo.VisitedLinkColor = color;
+			ApplyColorChange(label, overrideInfo);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -73,11 +268,8 @@ namespace SIL.Windows.Forms.AppColorPalette
 		private ColorOverrideInfo GetComponentInfo(IComponent component)
 		{
 			ColorOverrideInfo coi;
-			if (_extendedCtrls.TryGetValue(component, out coi))
-				return coi;
-
-			coi = new ColorOverrideInfo();
-			_extendedCtrls[component] = coi;
+			if (!_extendedCtrls.TryGetValue(component, out coi))
+				_extendedCtrls[component] = coi = new ColorOverrideInfo(UsePaletteColorsForComponent(component));
 			return coi;
 		}
 
@@ -92,31 +284,88 @@ namespace SIL.Windows.Forms.AppColorPalette
 
 		public void EndInit()
 		{
-			try
+			foreach (var componentOverrideInfo in _extendedCtrls)
 			{
-				foreach (var colorOverrideInfo in _extendedCtrls)
+				ApplyColorChange(componentOverrideInfo.Key, componentOverrideInfo.Value);
+			}
+		}
+
+		private void ApplyColorChange(object component, ColorOverrideInfo info)
+		{
+			var control = component as Control;
+			if (control != null)
+			{
+				bool resetUseVisualStyleBackColor = false;
+				try
 				{
-					var control = colorOverrideInfo.Key as Control;
-					if (control != null)
+					var useVisualStyleBackColorProperty = ReflectionHelper.GetProperty(control, "UseVisualStyleBackColor");
+					if (useVisualStyleBackColorProperty != null)
+						resetUseVisualStyleBackColor = (bool)useVisualStyleBackColorProperty;
+				}
+				catch (InvalidCastException)
+				{
+				}
+				catch (MissingMethodException)
+				{
+				}
+				var linkLabel = control as LinkLabel;
+				if (info.UsePaletteColors)
+				{
+					if (!info.ForeColor.Equals(default(TPaletteColors)))
+						control.ForeColor = GetColor(info.ForeColor);
+					if (!info.BackColor.Equals(default(TPaletteColors)))
+						control.BackColor = GetColor(info.BackColor);
+					if (linkLabel != null)
 					{
-						control.ForeColor = AppColorPalette[colorOverrideInfo.Value.ForeColor];
+						if (!info.LinkColor.Equals(default(TPaletteColors)))
+							linkLabel.LinkColor = GetColor(info.LinkColor);
+						if (!info.ActiveLinkColor.Equals(default(TPaletteColors)))
+							linkLabel.ActiveLinkColor = GetColor(info.ActiveLinkColor);
+						if (!info.DisabledLinkColor.Equals(default(TPaletteColors)))
+							linkLabel.DisabledLinkColor = GetColor(info.DisabledLinkColor);
+						if (!info.VisitedLinkColor.Equals(default(TPaletteColors)))
+							linkLabel.VisitedLinkColor = GetColor(info.VisitedLinkColor);
+					}
+				}
+				else
+				{
+					control.ResetForeColor();
+					control.ResetBackColor();
+					if (linkLabel != null)
+					{
+						linkLabel.LinkColor = Color.Empty;
+						linkLabel.ActiveLinkColor = Color.Empty;
+						linkLabel.DisabledLinkColor = Color.Empty;
+						linkLabel.VisitedLinkColor = Color.Empty;
+					}
+				}
+				if (resetUseVisualStyleBackColor)
+					ReflectionHelper.SetProperty(control, "UseVisualStyleBackColor",  true);
+			}
+			else
+			{
+				var item = component as ToolStripItem;
+				if (item != null)
+				{
+					if (info.UsePaletteColors)
+					{
+						if (!info.ForeColor.Equals(default(TPaletteColors)))
+							item.ForeColor = GetColor(info.ForeColor);
+						if (!info.BackColor.Equals(default(TPaletteColors)))
+							item.BackColor = GetColor(info.BackColor);
 					}
 					else
 					{
-						var item = colorOverrideInfo.Key as ToolStripItem;
-						if (item != null)
-						{
-							item.ForeColor = AppColorPalette[colorOverrideInfo.Value.ForeColor];
-						}
+						item.ResetForeColor();
+						item.ResetBackColor();
 					}
 				}
 			}
-			catch (Exception)
-			{
-#if DEBUG
-				throw;
-#endif
-			}
+		}
+
+		private void InitializeComponent()
+		{
+
 		}
 	}
 }

--- a/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
+++ b/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
@@ -13,6 +13,9 @@ namespace SIL.Windows.Forms.AppColorPalette
 	[ProvideProperty("ActiveLinkColor", typeof(LinkLabel))]
 	[ProvideProperty("DisabledLinkColor", typeof(LinkLabel))]
 	[ProvideProperty("VisitedLinkColor", typeof(LinkLabel))]
+	[ProvideProperty("FlatAppearanceBorderColor", typeof(ButtonBase))]
+	[ProvideProperty("FlatAppearanceMouseDownBackColor", typeof(ButtonBase))]
+	[ProvideProperty("FlatAppearanceMouseOverBackColor", typeof(ButtonBase))]
 	public abstract class AppColorPaletteExtender<TPaletteColors> : Component, IExtenderProvider, ISupportInitialize where TPaletteColors : struct, IConvertible
 	{
 		public enum ColorProperties
@@ -23,6 +26,9 @@ namespace SIL.Windows.Forms.AppColorPalette
 			ActiveLinkColor, 
 			DisabledLinkColor,
 			VisitedLinkColor,
+			BorderColor,
+			MouseDownBackColor,
+			MouseOverBackColor,
 		}
 
 		private Container _components = null;
@@ -43,6 +49,9 @@ namespace SIL.Windows.Forms.AppColorPalette
 			public TPaletteColors ActiveLinkColor { get; set; }
 			public TPaletteColors DisabledLinkColor { get; set; }
 			public TPaletteColors VisitedLinkColor { get; set; }
+			public TPaletteColors FlatAppearanceBorderColor { get; set; }
+			public TPaletteColors FlatAppearanceMouseDownBackColor { get; set; }
+			public TPaletteColors FlatAppearanceMouseOverBackColor { get; set; }
 		}
 
 		public abstract Color GetColor(TPaletteColors paletteColor);
@@ -77,7 +86,6 @@ namespace SIL.Windows.Forms.AppColorPalette
 		/// ------------------------------------------------------------------------------------
 		[Localizable(false)]
 		[Category("App Palette Properties")]
-		[DefaultValue(true)]
 		public bool GetUsePaletteColors(IComponent component)
 		{
 			var overrideInfo = GetComponentInfo(component);
@@ -112,6 +120,16 @@ namespace SIL.Windows.Forms.AppColorPalette
 							linkLabel.ActiveLinkColor = Color.Empty;
 							linkLabel.DisabledLinkColor = Color.Empty;
 							linkLabel.VisitedLinkColor = Color.Empty;
+						}
+						else
+						{
+							var button = control as ButtonBase;
+							if (button != null)
+							{
+								button.FlatAppearance.BorderColor = Color.Empty;
+								button.FlatAppearance.MouseDownBackColor = Color.Empty;
+								button.FlatAppearance.MouseOverBackColor = Color.Empty;
+							}
 						}
 					}
 					else
@@ -299,6 +317,36 @@ namespace SIL.Windows.Forms.AppColorPalette
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
+		/// Gets the border color of a button that uses "flat" appearance (ignored if button
+		/// uses "VisualStyles").
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		public TPaletteColors GetFlatAppearanceBorderColor(ButtonBase button)
+		{
+			var overrideInfo = GetComponentInfo(button);
+			if (overrideInfo.FlatAppearanceBorderColor.Equals(default(TPaletteColors)))
+				overrideInfo.FlatAppearanceBorderColor = GetDefaultPaletteColor(ColorProperties.BorderColor);
+			return overrideInfo.FlatAppearanceBorderColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the border color of a button that uses "flat" appearance (ignored if button
+		/// uses "VisualStyles").
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetFlatAppearanceBorderColor(ButtonBase button, TPaletteColors color)
+		{
+			var overrideInfo = GetComponentInfo(button);
+			overrideInfo.FlatAppearanceBorderColor = color;
+			if (_initialized)
+				ApplyColorChange(button, overrideInfo);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
 		/// Gets the color object information for the specified component.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -347,13 +395,13 @@ namespace SIL.Windows.Forms.AppColorPalette
 				catch (MissingMethodException)
 				{
 				}
-				var linkLabel = control as LinkLabel;
 				if (info.UsePaletteColors)
 				{
 					if (!info.ForeColor.Equals(default(TPaletteColors)))
 						control.ForeColor = GetColor(info.ForeColor);
 					if (!info.BackColor.Equals(default(TPaletteColors)))
 						control.BackColor = GetColor(info.BackColor);
+					var linkLabel = control as LinkLabel;
 					if (linkLabel != null)
 					{
 						if (!info.LinkColor.Equals(default(TPaletteColors)))
@@ -364,6 +412,19 @@ namespace SIL.Windows.Forms.AppColorPalette
 							linkLabel.DisabledLinkColor = GetColor(info.DisabledLinkColor);
 						if (!info.VisitedLinkColor.Equals(default(TPaletteColors)))
 							linkLabel.VisitedLinkColor = GetColor(info.VisitedLinkColor);
+					}
+					else
+					{
+						var button = control as ButtonBase;
+						if (button != null)
+						{
+							if (!info.FlatAppearanceBorderColor.Equals(default(TPaletteColors)))
+								button.FlatAppearance.BorderColor = GetColor(info.FlatAppearanceBorderColor);
+							if (!info.FlatAppearanceMouseDownBackColor.Equals(default(TPaletteColors)))
+								button.FlatAppearance.MouseDownBackColor = GetColor(info.FlatAppearanceMouseDownBackColor);
+							if (!info.FlatAppearanceMouseOverBackColor.Equals(default(TPaletteColors)))
+								button.FlatAppearance.MouseOverBackColor = GetColor(info.FlatAppearanceMouseOverBackColor);
+						}
 					}
 				}
 				if (resetUseVisualStyleBackColor)

--- a/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
+++ b/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace SIL.Windows.Forms.AppColorPalette
+{
+	[ProvideProperty("ForeColor", typeof(IComponent))]
+	public class AppColorPaletteExtender : Component, IExtenderProvider, ISupportInitialize
+	{
+		private Container _components = null;
+		private readonly Dictionary<object, ColorOverrideInfo> _extendedCtrls;
+		private readonly Dictionary<PaletteColors, Color> _appColorPalette = new Dictionary<PaletteColors, Color> {{PaletteColors.Color1, Color.AliceBlue}, {PaletteColors.Color2, Color.BlueViolet}};
+
+		public enum PaletteColors
+		{
+			Color1,
+			Color2,
+		}
+
+		private class ColorOverrideInfo
+		{
+			public PaletteColors ForeColor { get; set; }
+		}
+
+		public virtual Dictionary<PaletteColors, Color> AppColorPalette
+		{
+			get { return _appColorPalette; }
+		}
+
+		public AppColorPaletteExtender()
+		{
+			// Required for Windows.Forms Class Composition Designer support
+			_components = new Container();
+
+			_extendedCtrls = new Dictionary<object, ColorOverrideInfo>();
+		}
+
+		public AppColorPaletteExtender(IContainer container) : this()
+		{
+			container.Add(this);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the fore color of the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Localizable(false)]
+		[Category("App Palette Properties")]
+		[DefaultValue(PaletteColors.Color1)]
+		public PaletteColors GetForeColor(IComponent component)
+		{
+			return GetComponentInfo(component).ForeColor;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Sets the fore color of the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		public void SetForeColor(IComponent component, PaletteColors color)
+		{
+			GetComponentInfo(component).ForeColor = color;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Gets the color object information for the specified component.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		private ColorOverrideInfo GetComponentInfo(IComponent component)
+		{
+			ColorOverrideInfo coi;
+			if (_extendedCtrls.TryGetValue(component, out coi))
+				return coi;
+
+			coi = new ColorOverrideInfo();
+			_extendedCtrls[component] = coi;
+			return coi;
+		}
+
+		public bool CanExtend(object extendee)
+		{
+			return (extendee is Control || extendee is ToolStripItem);
+		}
+
+		public void BeginInit()
+		{
+		}
+
+		public void EndInit()
+		{
+			try
+			{
+				foreach (var colorOverrideInfo in _extendedCtrls)
+				{
+					var control = colorOverrideInfo.Key as Control;
+					if (control != null)
+					{
+						control.ForeColor = AppColorPalette[colorOverrideInfo.Value.ForeColor];
+					}
+					else
+					{
+						var item = colorOverrideInfo.Key as ToolStripItem;
+						if (item != null)
+						{
+							item.ForeColor = AppColorPalette[colorOverrideInfo.Value.ForeColor];
+						}
+					}
+				}
+			}
+			catch (Exception)
+			{
+#if DEBUG
+				throw;
+#endif
+			}
+		}
+	}
+}

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -311,6 +311,9 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AbstractControlDescriptionProvider.cs" />
+    <Compile Include="AppColorPalette\AppColorPaletteExtender.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="ClearShare\ClearShareResources.Designer.cs" />
     <Compile Include="ClearShare\Contribution.cs" />
     <Compile Include="ClearShare\ContributionCollection.cs" />


### PR DESCRIPTION
Added an extender to enable applications to use custom color palettes and have the default color scheme apply in Designer.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/346)
<!-- Reviewable:end -->
