### PR TITLE
Fixed namespace used to create ResourceManager for ClearShareResource

### DIFF
--- a/SIL.Windows.Forms/ClearShare/ClearShareResources.Designer.cs
+++ b/SIL.Windows.Forms/ClearShare/ClearShareResources.Designer.cs
@@ -36,7 +36,7 @@ namespace SIL.Windows.Forms.ClearShare {
 		internal static global::System.Resources.ResourceManager ResourceManager {
 			get {
 				if (object.ReferenceEquals(resourceMan, null)) {
-					global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Palaso.UI.WindowsForms.ClearShare.ClearShareResources", typeof(ClearShareResources).Assembly);
+					global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("SIL.Windows.Forms.ClearShare.ClearShareResources", typeof(ClearShareResources).Assembly);
 					resourceMan = temp;
 				}
 				return resourceMan;


### PR DESCRIPTION
This was accidentally missed when the namespaces in libpalaso were changed from Palaso... to SIL...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/350)
<!-- Reviewable:end -->
