### PR TITLE
On Linux, remove lock file when mutex goes away

### DIFF
--- a/SIL.Core/Threading/GlobalMutex.cs
+++ b/SIL.Core/Threading/GlobalMutex.cs
@@ -236,6 +236,11 @@ namespace SIL.Threading
 				}
 			}
 
+			protected override void DisposeManagedResources()
+			{
+				Unlink();
+			}
+
 			protected override void DisposeUnmanagedResources()
 			{
 				Syscall.close(_handle);


### PR DESCRIPTION
Without this change, classes like Sldr will create a lock file in `/var/lock` and never remove it, leading to problems if a different user later runs Fieldworks on the same computer.

Note that I have not yet tested this; I'll be able to test it tomorrow.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/352)
<!-- Reviewable:end -->
