### PR TITLE
Improve handling of empty or corrupt user.config file

### DIFF
--- a/SIL.Core/Reporting/ErrorReport.cs
+++ b/SIL.Core/Reporting/ErrorReport.cs
@@ -560,7 +560,6 @@ namespace SIL.Reporting
 		/// </summary>
 		public static void ReportFatalMessageWithStackTrace(string message, params object[] args)
 		{
-			s_previousNonFatalMessage = message;
 			_errorReporter.ReportFatalMessageWithStackTrace(message, args);
 		}
 

--- a/SIL.Core/Reporting/ErrorReport.cs
+++ b/SIL.Core/Reporting/ErrorReport.cs
@@ -273,6 +273,36 @@ namespace SIL.Reporting
 		}
 
 		/// <summary>
+		/// use this in unit tests to cleanly check that a message would have been shown.
+		/// E.g.  using (new Palaso.Reporting.ErrorReport.NonFatalErrorReportExpected()) {...}
+		/// </summary>
+		public class NoNonFatalErrorReportExpected : IDisposable
+		{
+			private readonly bool previousJustRecordNonFatalMessagesForTesting;
+			public NoNonFatalErrorReportExpected()
+			{
+				previousJustRecordNonFatalMessagesForTesting = s_justRecordNonFatalMessagesForTesting;
+				s_justRecordNonFatalMessagesForTesting = true;
+				s_previousNonFatalMessage = null;//this is a static, so a previous unit test could have filled it with something (yuck)
+				s_previousNonFatalException = null;
+			}
+			public void Dispose()
+			{
+				s_justRecordNonFatalMessagesForTesting = previousJustRecordNonFatalMessagesForTesting;
+				if (s_previousNonFatalException != null || s_previousNonFatalMessage != null)
+					throw new Exception("Non Fatal Error Report was not expected but was generated: "+Message);
+				s_previousNonFatalMessage = null;
+			}
+			/// <summary>
+			/// use this to check the actual contents of the message that was triggered
+			/// </summary>
+			public string Message
+			{
+				get { return s_previousNonFatalMessage; }
+			}
+		}
+
+		/// <summary>
 		/// set this property if you want the dialog to offer to create an e-mail message.
 		/// </summary>
 		public static string EmailAddress
@@ -511,6 +541,8 @@ namespace SIL.Reporting
 		/// </summary>
 		public static void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args)
 		{
+			s_previousNonFatalMessage = message;
+			s_previousNonFatalException = error;
 			_errorReporter.ReportNonFatalExceptionWithMessage(error, message, args);
 		}
 
@@ -520,6 +552,7 @@ namespace SIL.Reporting
 		/// </summary>
 		public static void ReportNonFatalMessageWithStackTrace(string message, params object[] args)
 		{
+			s_previousNonFatalMessage = message;
 			_errorReporter.ReportNonFatalMessageWithStackTrace(message, args);
 		}
 		/// <summary>
@@ -527,6 +560,7 @@ namespace SIL.Reporting
 		/// </summary>
 		public static void ReportFatalMessageWithStackTrace(string message, params object[] args)
 		{
+			s_previousNonFatalMessage = message;
 			_errorReporter.ReportFatalMessageWithStackTrace(message, args);
 		}
 

--- a/SIL.Core/Settings/CrossPlatformSettingsProvider.cs
+++ b/SIL.Core/Settings/CrossPlatformSettingsProvider.cs
@@ -13,7 +13,7 @@ namespace SIL.Settings
 	/// A custom SettingsProvider implementation functional on both Windows and Linux (the default mono implementation was buggy and incomplete)
 	/// </summary>
 	/// <example>
-	/// var settingsProvider = new TestCrossPlatformSettingsProvider();
+	/// var settingsProvider = new CrossPlatformSettingsProvider();
 	/// //optionally pre-check for problems
 	/// if(settingsProvider.CheckForErrorsInFile()) ...
 	/// </example>
@@ -77,8 +77,8 @@ namespace SIL.Settings
 		/// If you want to control when it does that, and get a message describing the problem
 		/// so that you can tell the user, call this before anything else touches the settings.
 		/// </summary>
-		/// <returns>and exception or null</returns>
-		public Exception CheckForErrorsInFile()
+		/// <returns>an exception or null</returns>
+		public Exception CheckForErrorsInSettingsFile()
 		{
 			if(!_initialized)
 				throw new ApplicationException("CrossPlatformSettingsProvider: Call Initialize() before CheckForErrorsInFile()");

--- a/SIL.Core/Settings/CrossPlatformSettingsProvider.cs
+++ b/SIL.Core/Settings/CrossPlatformSettingsProvider.cs
@@ -12,6 +12,11 @@ namespace SIL.Settings
 	/// <summary>
 	/// A custom SettingsProvider implementation functional on both Windows and Linux (the default mono implementation was buggy and incomplete)
 	/// </summary>
+	/// <example>
+	/// var settingsProvider = new TestCrossPlatformSettingsProvider();
+	/// //optionally pre-check for problems
+	/// if(settingsProvider.CheckForErrorsInFile()) ...
+	/// </example>
 	public class CrossPlatformSettingsProvider : SettingsProvider, IApplicationSettingsProvider
 	{
 		//Protected only for unit testing. I can't get InternalsVisibleTo to work, possibly because of strong naming.
@@ -22,10 +27,16 @@ namespace SIL.Settings
 		protected string UserLocalLocation = null;
 		private static string CompanyAndProductPath;
 
+		private bool _reportReadingErrorsDirectlyToUser = true;
+
 		// May be overridden in a derived class to control where settings are looked for
 		// when that class is used as the provider. Must do any initialization before calls to GetCompanyAndProductPath,
 		// that is, before trying to use instances of the relevant settings.
-		protected virtual string ProductName {get { return null; }}
+		protected virtual string ProductName
+		{
+			get { return null; }
+		}
+
 		/// <summary>
 		/// Indicates if the settings should be saved in roaming or local location, defaulted to false;
 		/// </summary>
@@ -34,9 +45,12 @@ namespace SIL.Settings
 		/// <summary>
 		/// Where we expect to find the config file. Protected for unit testing.
 		/// </summary>
-		protected string UserConfigLocation { get { return IsRoaming ? UserRoamingLocation : UserLocalLocation; } }
+		protected string UserConfigLocation
+		{
+			get { return IsRoaming ? UserRoamingLocation : UserLocalLocation; }
+		}
 
-		private readonly Dictionary<string, string> _renamedSections; 
+		private readonly Dictionary<string, string> _renamedSections;
 
 		/// <summary>
 		/// Default constructor for this provider class
@@ -44,8 +58,10 @@ namespace SIL.Settings
 		public CrossPlatformSettingsProvider()
 		{
 			_renamedSections = new Dictionary<string, string>();
-			UserRoamingLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), GetFullSettingsPath());
-			UserLocalLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), GetFullSettingsPath());
+			UserRoamingLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+				GetFullSettingsPath());
+			UserLocalLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+				GetFullSettingsPath());
 			// When running multiple builds in parallel we have to use separate directories for
 			// each build, otherwise some unit tests might fail.
 			var buildagentSubdir = Environment.GetEnvironmentVariable("BUILDAGENT_SUBKEY");
@@ -54,6 +70,22 @@ namespace SIL.Settings
 				UserRoamingLocation = Path.Combine(UserRoamingLocation, buildagentSubdir);
 				UserLocalLocation = Path.Combine(UserLocalLocation, buildagentSubdir);
 			}
+		}
+
+		/// <summary>
+		/// This Settings Provider will automatically delete a corrupted settings file, silently.
+		/// If you want to control when it does that, and get a message describing the problem
+		/// so that you can tell the user, call this before anything else touches the settings.
+		/// </summary>
+		/// <returns>and exception or null</returns>
+		public Exception CheckForErrorsInFile()
+		{
+			if(!_initialized)
+				throw new ApplicationException("CrossPlatformSettingsProvider: Call Initialize() before CheckForErrorsInFile()");
+
+			_reportReadingErrorsDirectlyToUser = false;
+			var dummy =SettingsXml;
+			return _lastReadingError;
 		}
 
 		public IDictionary<string, string> RenamedSections
@@ -69,6 +101,7 @@ namespace SIL.Settings
 			{
 				base.Initialize(name, config);
 			}
+			_initialized = true;
 		}
 
 		private string GetFullSettingsPath()
@@ -412,6 +445,8 @@ namespace SIL.Settings
 		}
 
 		private XmlDocument _settingsXml;
+		private bool _initialized;
+		private XmlException _lastReadingError;
 
 		private XmlDocument SettingsXml
 		{
@@ -430,10 +465,39 @@ namespace SIL.Settings
 								_settingsXml.Load(Path.Combine(UserConfigLocation, UserConfigFileName));
 								return _settingsXml;
 							}
-							catch(XmlException e)
+							catch (XmlException e)
 							{
-								ErrorReport.ReportNonFatalExceptionWithMessage(e, "A settings file was corrupted. Some user settings may have been lost.");
-								File.Delete(userConfigFilePath);
+								//a partial reading can leave the _settingsXml in a weird state. Start over:
+								_settingsXml = new XmlDocument();
+
+								Logger.WriteError("Problem with contents of " + userConfigFilePath, e);
+
+								//This ErrorReport was actually keeping Bloom from starting at all.
+								//It now calls CheckForErrorsInFile() which lets it control the messaging;
+								//that also sets this to false.
+
+								if(_reportReadingErrorsDirectlyToUser)
+									ErrorReport.ReportNonFatalExceptionWithMessage(e, "A settings file was corrupted. Some user settings may have been lost.");
+								_lastReadingError = e;
+
+								try
+								{
+									File.Copy(userConfigFilePath, userConfigFilePath + ".bad", true);
+								}
+								catch (Exception)
+								{
+									//not worth dying over
+								}
+								try
+								{
+									File.Delete(userConfigFilePath);
+								}
+								catch (Exception deletionError)
+								{
+									Logger.WriteError("Could not delete " + userConfigFilePath, deletionError);
+									ErrorReport.ReportFatalMessageWithStackTrace("Please delete the configuration file at " + userConfigFilePath + " and then re-run the program.");
+									throw deletionError;
+								}
 							}
 						}
 

--- a/SIL.Windows.Forms.Tests/SettingsProviderTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProviderTests.cs
@@ -238,7 +238,7 @@ namespace SIL.Windows.Forms.Tests
 				{
 					File.WriteAllText(filePath, "hello world");
 
-					Assert.That(settingsProvider.CheckForErrorsInFile(), Is.Not.Null);
+					Assert.That(settingsProvider.CheckForErrorsInSettingsFile(), Is.Not.Null);
 
 					//because we already did the check, we don't expect to see any error now
 					using (new ErrorReport.NoNonFatalErrorReportExpected())


### PR DESCRIPTION
Previously, if the user.config file was corrupt, it would try to put up a UI. However the client may trigger this before UI is even possible. This was killing Bloom silently. This PR adds some unit tests around these situations, verifying that it can self-heal. It also copies corrupt files to ".bad" for debugging purposes. Finally, it adds an optional method a client can use to safely check and heal the settings before UI is possible (Bloom will use this).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/356)
<!-- Reviewable:end -->
