### PR TITLE
Properly dispose the SLDR cache mutex

### DIFF
--- a/SIL.Core.Tests/Threading/GlobalMutexTests.cs
+++ b/SIL.Core.Tests/Threading/GlobalMutexTests.cs
@@ -13,7 +13,6 @@ namespace SIL.Tests.Threading
 			{
 				mutex.Unlink();
 				Assert.That(mutex.Initialize(), Is.True);
-				mutex.Unlink();
 			}
 		}
 
@@ -25,7 +24,6 @@ namespace SIL.Tests.Threading
 				mutex1.Initialize();
 				using (var mutex2 = new GlobalMutex("test"))
 					Assert.That(mutex2.Initialize(), Is.False);
-				mutex1.Unlink();
 			}
 		}
 
@@ -38,7 +36,6 @@ namespace SIL.Tests.Threading
 				bool createdNew;
 				using (mutex.InitializeAndLock(out createdNew)) {}
 				Assert.That(createdNew, Is.True);
-				mutex.Unlink();
 			}
 		}
 
@@ -54,7 +51,6 @@ namespace SIL.Tests.Threading
 					using (mutex2.InitializeAndLock(out createdNew)) {}
 					Assert.That(createdNew, Is.False);
 				}
-				mutex1.Unlink();
 			}
 		}
 
@@ -67,7 +63,6 @@ namespace SIL.Tests.Threading
 				{
 					using (mutex.Lock()) {}
 				}
-				mutex.Unlink();
 			}
 		}
 
@@ -81,7 +76,6 @@ namespace SIL.Tests.Threading
 				{
 					using (mutex.Lock()) {}
 				}
-				mutex.Unlink();
 			}
 		}
 	}

--- a/SIL.Core/Threading/GlobalMutex.cs
+++ b/SIL.Core/Threading/GlobalMutex.cs
@@ -238,6 +238,7 @@ namespace SIL.Threading
 
 			protected override void DisposeUnmanagedResources()
 			{
+				Unlink();
 				Syscall.close(_handle);
 			}
 		}

--- a/SIL.Core/Threading/GlobalMutex.cs
+++ b/SIL.Core/Threading/GlobalMutex.cs
@@ -131,7 +131,7 @@ namespace SIL.Threading
 
 		[SuppressMessage("Gendarme.Rules.Correctness", "DisposableFieldsShouldBeDisposedRule",
 			Justification="m_adapter is a reference.")]
-		private sealed class ReleaseDisposable : IDisposable
+		private sealed class ReleaseDisposable : DisposableBase
 		{
 			private readonly IGlobalMutexAdapter _adapter;
 
@@ -140,7 +140,7 @@ namespace SIL.Threading
 				_adapter = adapter;
 			}
 
-			public void Dispose()
+			protected override void DisposeManagedResources()
 			{
 				_adapter.Release();
 			}
@@ -236,9 +236,13 @@ namespace SIL.Threading
 				}
 			}
 
-			protected override void DisposeUnmanagedResources()
+			protected override void DisposeManagedResources()
 			{
 				Unlink();
+			}
+
+			protected override void DisposeUnmanagedResources()
+			{
 				Syscall.close(_handle);
 			}
 		}

--- a/SIL.TestUtilities/OfflineSldr.cs
+++ b/SIL.TestUtilities/OfflineSldr.cs
@@ -16,17 +16,13 @@ namespace SIL.TestUtilities
 		public OfflineSldr()
 		{
 			_sldrCacheFolder = new TemporaryFolder("SldrCacheTest");
-			Sldr.SldrCachePath = _sldrCacheFolder.Path;
-			Sldr.OfflineMode = true;
-			Sldr.ResetLanguageTags();
+			Sldr.Initialize(true, _sldrCacheFolder.Path);
 		}
 
 		protected override void DisposeManagedResources()
 		{
-			Sldr.OfflineMode = false;
-			Sldr.ResetLanguageTags();
+			Sldr.Cleanup();
 			_sldrCacheFolder.Dispose();
-			Sldr.SldrCachePath = Sldr.DefaultSldrCachePath;
 		}
 	}
 }

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -67,7 +67,7 @@ namespace SIL.WritingSystems
 		private const string UserAgent = "SIL.WritingSystems Library";
 
 		// Mode to test when the SLDR is unavailable.  Default to false
-		internal static bool OfflineMode { get; set; }
+		private static bool _offlineMode;
 
 		// If the user wants to request a new UID, you use "uid=unknown" and that will create a new random identifier
 		public const string DefaultUserId = "unknown";
@@ -75,7 +75,7 @@ namespace SIL.WritingSystems
 		// in order to avoid deadlocks, SyncRoot should always be acquired first and then SldrCacheMutex
 		private static readonly object SyncRoot = new object();
 		// multiple applications could read/write to the SLDR cache at the same time, so synchronize access
-		private static readonly GlobalMutex SldrCacheMutex;
+		private static GlobalMutex _sldrCacheMutex;
 
 		private static IReadOnlyKeyedCollection<string, SldrLanguageTagInfo> _languageTags;
 
@@ -90,19 +90,60 @@ namespace SIL.WritingSystems
 		}
 
 		/// <summary>
-		/// Gets the SLDR cache path. The setter should only be used for testing purposes.
+		/// Gets the SLDR cache path.
 		/// </summary>
-		public static string SldrCachePath { get; internal set; }
+		public static string SldrCachePath { get; private set; }
 
-		internal static readonly DateTime DefaultEmbeddedAllTagsTime = DateTime.Parse(LanguageRegistryResources.AllTagsTime, CultureInfo.InvariantCulture);
-		internal static DateTime EmbeddedAllTagsTime { get; set; }
+		private static readonly DateTime DefaultEmbeddedAllTagsTime = DateTime.Parse(LanguageRegistryResources.AllTagsTime, CultureInfo.InvariantCulture);
+		private static DateTime _embeddedAllTagsTime;
 
-		static Sldr()
+		/// <summary>
+		/// Initializes the SLDR. This should be called before calling other methods or properties.
+		/// </summary>
+		public static void Initialize()
 		{
-			SldrCacheMutex = new GlobalMutex("SldrCache");
-			SldrCacheMutex.Initialize();
-			SldrCachePath = DefaultSldrCachePath;
-			EmbeddedAllTagsTime = DefaultEmbeddedAllTagsTime;
+			Initialize(false, DefaultSldrCachePath);
+		}
+
+		/// <summary>
+		/// This method is used for testing purposes.
+		/// </summary>
+		internal static void Initialize(bool offlineMode, string sldrCachePath)
+		{
+			Initialize(offlineMode, sldrCachePath, DefaultEmbeddedAllTagsTime);
+		}
+
+		/// <summary>
+		/// This method is used for testing purposes.
+		/// </summary>
+		internal static void Initialize(bool offlineMode, string sldrCachePath, DateTime embeddedAllTagsTime)
+		{
+			if (_sldrCacheMutex != null)
+				throw new InvalidOperationException("The SLDR has already been initialized.");
+
+			_sldrCacheMutex = new GlobalMutex("SldrCache");
+			_sldrCacheMutex.Initialize();
+			_offlineMode = offlineMode;
+			SldrCachePath = sldrCachePath;
+			_embeddedAllTagsTime = embeddedAllTagsTime;
+		}
+
+		/// <summary>
+		/// Cleans up the SLDR. This should be called to properly clean up SLDR resources.
+		/// </summary>
+		public static void Cleanup()
+		{
+			CheckInitialized();
+
+			_sldrCacheMutex.Dispose();
+			_sldrCacheMutex = null;
+			_languageTags = null;
+		}
+
+		private static void CheckInitialized()
+		{
+			if (_sldrCacheMutex == null)
+				throw new InvalidOperationException("The SLDR has not been initialized.");
 		}
 
 		/// <summary>
@@ -116,6 +157,8 @@ namespace SIL.WritingSystems
 		/// <returns>Enum status SldrStatus if file could be retrieved and the source</returns>
 		public static SldrStatus GetLdmlFile(string destinationPath, string languageTag, IEnumerable<string> topLevelElements, out string filename)
 		{
+			CheckInitialized();
+
 			if (String.IsNullOrEmpty(destinationPath))
 				throw new ArgumentException("destinationPath");
 			if (!Directory.Exists(destinationPath))
@@ -131,7 +174,7 @@ namespace SIL.WritingSystems
 				sldrLanguageTag = langTagInfo.SldrLanguageTag;
 			string[] topLevelElementsArray = topLevelElements.ToArray();
 
-			using (SldrCacheMutex.Lock())
+			using (_sldrCacheMutex.Lock())
 			{
 				var status = SldrStatus.NotFound;
 				CreateSldrCacheDirectory();
@@ -181,7 +224,7 @@ namespace SIL.WritingSystems
 
 					try
 					{
-						if (OfflineMode)
+						if (_offlineMode)
 							throw new WebException("Test mode: SLDR offline so accessing cache", WebExceptionStatus.ConnectFailure);
 
 						// Check the response header to see if the requested LDML file got redirected
@@ -274,18 +317,14 @@ namespace SIL.WritingSystems
 		{
 			get
 			{
+				CheckInitialized();
+
 				lock (SyncRoot)
 				{
 					LoadLanguageTagsIfNecessary();
 					return _languageTags;
 				}
 			}
-		}
-
-		public static void ResetLanguageTags()
-		{
-			lock (SyncRoot)
-				_languageTags = null;
 		}
 
 		/// <summary>
@@ -297,13 +336,13 @@ namespace SIL.WritingSystems
 				return;
 
 			string allTagsContent;
-			using (SldrCacheMutex.Lock())
+			using (_sldrCacheMutex.Lock())
 			{
 				CreateSldrCacheDirectory();
 
 				string cachedAllTagsPath = Path.Combine(SldrCachePath, "alltags.txt");
 				DateTime latestCommitTime = DateTime.MinValue;
-				DateTime sinceTime = EmbeddedAllTagsTime;
+				DateTime sinceTime = _embeddedAllTagsTime;
 				if (File.Exists(cachedAllTagsPath))
 				{
 					DateTime fileTime = File.GetLastWriteTime(cachedAllTagsPath);
@@ -318,7 +357,7 @@ namespace SIL.WritingSystems
 				sinceTime += TimeSpan.FromSeconds(1);
 				try
 				{
-					if (OfflineMode)
+					if (_offlineMode)
 						throw new WebException("Test mode: SLDR offline so accessing cache", WebExceptionStatus.ConnectFailure);
 
 					// query the SLDR Git repo to see if there is an updated version of alltags.txt

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -118,7 +118,7 @@ namespace SIL.WritingSystems
 		/// </summary>
 		internal static void Initialize(bool offlineMode, string sldrCachePath, DateTime embeddedAllTagsTime)
 		{
-			if (_sldrCacheMutex != null)
+			if (IsInitialized)
 				throw new InvalidOperationException("The SLDR has already been initialized.");
 
 			_sldrCacheMutex = new GlobalMutex("SldrCache");
@@ -126,6 +126,11 @@ namespace SIL.WritingSystems
 			_offlineMode = offlineMode;
 			SldrCachePath = sldrCachePath;
 			_embeddedAllTagsTime = embeddedAllTagsTime;
+		}
+
+		public static bool IsInitialized
+		{
+			get { return _sldrCacheMutex != null; }
 		}
 
 		/// <summary>
@@ -142,7 +147,7 @@ namespace SIL.WritingSystems
 
 		private static void CheckInitialized()
 		{
-			if (_sldrCacheMutex == null)
+			if (!IsInitialized)
 				throw new InvalidOperationException("The SLDR has not been initialized.");
 		}
 

--- a/TestApps/SIL.Windows.Forms.TestApp/Program.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Windows.Forms;
+using SIL.WritingSystems;
 
 namespace SIL.Windows.Forms.TestApp
 {
@@ -14,6 +15,7 @@ namespace SIL.Windows.Forms.TestApp
 		{
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
+			Sldr.Initialize();
 
 			if(args.Length>0) //for testing commandlinerunner
 			{
@@ -27,6 +29,7 @@ namespace SIL.Windows.Forms.TestApp
 
 			Application.Run(new TestAppForm());
 
+			Sldr.Cleanup();
 	   }
 
 


### PR DESCRIPTION
The static Sldr class uses a global mutex to synchronize access to the SLDR cache folder. Unfortunately, this mutex was not being disposed of properly. In order to fix this issue, I added Initialize() and Cleanup() methods to the Sldr class that must be called by any applications that use the writing systems classes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/357)
<!-- Reviewable:end -->
