### PR TITLE
Fix BL-3222 TempFileForSafeWriting  fails on JAARS network drives

### DIFF
--- a/SIL.Core.Tests/IO/TempFileForSafeWritingTests.cs
+++ b/SIL.Core.Tests/IO/TempFileForSafeWritingTests.cs
@@ -11,8 +11,21 @@ namespace SIL.Tests.IO
 		[Test]
 		public void WriteWasSuccessful_TargetDidNotExist_TargetHasContents()
 		{
+			_WriteWasSuccessful_TargetDidNotExist_TargetHasContents(false);
+		}
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_TargetDidNotExist_TargetHasContents()
+		{
+			_WriteWasSuccessful_TargetDidNotExist_TargetHasContents(true);
+		}
+
+		private static void _WriteWasSuccessful_TargetDidNotExist_TargetHasContents(bool simulateVolumeThatCannotHandleFileReplace)
+		{
 			var targetPath = Path.GetTempFileName();
 			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = simulateVolumeThatCannotHandleFileReplace;
 			File.WriteAllText(f.TempFilePath, "hello");
 			f.WriteWasSuccessful();
 			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("hello"));
@@ -22,21 +35,48 @@ namespace SIL.Tests.IO
 		[Test]
 		public void WriteWasSuccessful_TargetDidExist_TargetHasContents()
 		{
+			_WriteWasSuccessful_TargetDidExist_TargetHasContents(false);
+		}
+
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_TargetDidExist_TargetHasContents()
+		{
+			_WriteWasSuccessful_TargetDidExist_TargetHasContents(true);
+		}
+
+		private static void _WriteWasSuccessful_TargetDidExist_TargetHasContents(bool simulateVolumeThatCannotHandleFileReplace)
+		{
 			var targetPath = Path.GetTempFileName();
 			File.WriteAllText(targetPath, "old");
 			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = simulateVolumeThatCannotHandleFileReplace;
 			File.WriteAllText(f.TempFilePath, "new");
 			f.WriteWasSuccessful();
 			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
 		}
 
-		[Test]
+
 		public void WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist()
+		{
+			_WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist(false);
+		}
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist()
+		{
+			_WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist(true);
+		}
+
+		private static void _WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist(bool simulateVolumeThatCannotHandleFileReplace)
 		{
 			var targetPath = Path.GetTempFileName();
 			File.Delete(targetPath);
 			var backup = targetPath + ".bak";
 			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = simulateVolumeThatCannotHandleFileReplace;
 			File.WriteAllText(f.TempFilePath, "new");
 			f.WriteWasSuccessful();
 			Assert.That(File.Exists(backup), Is.False);
@@ -46,124 +86,77 @@ namespace SIL.Tests.IO
 		[Test]
 		public void WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile()
 		{
-			var targetPath = Path.GetTempFileName();
-			var backup = targetPath + ".bak";
-			File.WriteAllText(targetPath, "old");
-			var f = new TempFileForSafeWriting(targetPath);
-			File.WriteAllText(f.TempFilePath, "new");
-			f.WriteWasSuccessful();
-			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
-			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
-		}
-		[Test]
-		public void WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone()
-		{
-			var targetPath = Path.GetTempFileName();
-			var backup = targetPath + ".bak";
-			File.WriteAllText(backup, "old bak");
-			var f = new TempFileForSafeWriting(targetPath);
-			File.WriteAllText(f.TempFilePath, "new");
-			f.WriteWasSuccessful();
-			Assert.That(File.ReadAllText(backup), Is.EqualTo(""));
-			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
-		}
-		[Test]
-		public void WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile()
-		{
-			var targetPath = Path.GetTempFileName();
-			var backup = targetPath + ".bak";
-			File.WriteAllText(backup, "ancient");
-			File.WriteAllText(targetPath, "old");
-			var f = new TempFileForSafeWriting(targetPath);
-			File.WriteAllText(f.TempFilePath, "new");
-			f.WriteWasSuccessful();
-
-			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
-			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
-		}
-
-
-		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
-		[Test]
-		public void ReplaceFails_WriteWasSuccessful_TargetDidNotExist_TargetHasContents()
-		{
-			var targetPath = Path.GetTempFileName();
-			var f = new TempFileForSafeWriting(targetPath);
-			f.SimulateVolumeThatCannotHandleFileReplace = true;
-			File.WriteAllText(f.TempFilePath, "hello");
-			f.WriteWasSuccessful();
-			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("hello"));
-		}
-
-
-		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
-		[Test]
-		public void ReplaceFails_WriteWasSuccessful_TargetDidExist_TargetHasContents()
-		{
-			var targetPath = Path.GetTempFileName();
-			File.WriteAllText(targetPath, "old");
-			var f = new TempFileForSafeWriting(targetPath);
-			f.SimulateVolumeThatCannotHandleFileReplace = true;
-			File.WriteAllText(f.TempFilePath, "new");
-			f.WriteWasSuccessful();
-			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
-		}
-
-		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
-		[Test]
-		public void ReplaceFails_WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist()
-		{
-			var targetPath = Path.GetTempFileName();
-			File.Delete(targetPath);
-			var backup = targetPath + ".bak";
-			var f = new TempFileForSafeWriting(targetPath);
-			f.SimulateVolumeThatCannotHandleFileReplace = true;
-			File.WriteAllText(f.TempFilePath, "new");
-			f.WriteWasSuccessful();
-			Assert.That(File.Exists(backup), Is.False);
-			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+			_WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile(false);
 		}
 
 		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
 		[Test]
 		public void ReplaceFails_WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile()
 		{
+			_WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile(true);
+		}
+
+		private static void _WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile(bool simulateVolumeThatCannotHandleFileReplace)
+		{
 			var targetPath = Path.GetTempFileName();
 			var backup = targetPath + ".bak";
 			File.WriteAllText(targetPath, "old");
 			var f = new TempFileForSafeWriting(targetPath);
-			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			f.SimulateVolumeThatCannotHandleFileReplace = simulateVolumeThatCannotHandleFileReplace;
 			File.WriteAllText(f.TempFilePath, "new");
 			f.WriteWasSuccessful();
 			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
 			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
 		}
 
+		[Test]
+		public void WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone()
+		{
+			_WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone(false);
+		}
+
 		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
 		[Test]
 		public void ReplaceFails_WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone()
 		{
+			_WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone(true);
+		}
+
+		private static void _WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone(bool simulateVolumeThatCannotHandleFileReplace)
+		{
 			var targetPath = Path.GetTempFileName();
+			File.Delete(targetPath);
 			var backup = targetPath + ".bak";
 			File.WriteAllText(backup, "old bak");
 			var f = new TempFileForSafeWriting(targetPath);
-			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			f.SimulateVolumeThatCannotHandleFileReplace = simulateVolumeThatCannotHandleFileReplace;
 			File.WriteAllText(f.TempFilePath, "new");
 			f.WriteWasSuccessful();
-			Assert.That(File.ReadAllText(backup), Is.EqualTo(""));
+			Assert.That(File.ReadAllText(backup), Is.EqualTo("old bak"));
 			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		[Test]
+		public void WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile()
+		{
+			_WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile(false);
 		}
 
 		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
 		[Test]
 		public void ReplaceFails_WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile()
 		{
+			_WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile(true);
+		}
+
+		private static void _WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile(bool simulateVolumeThatCannotHandleFileReplace)
+		{
 			var targetPath = Path.GetTempFileName();
 			var backup = targetPath + ".bak";
 			File.WriteAllText(backup, "ancient");
 			File.WriteAllText(targetPath, "old");
 			var f = new TempFileForSafeWriting(targetPath);
-			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			f.SimulateVolumeThatCannotHandleFileReplace = simulateVolumeThatCannotHandleFileReplace;
 			File.WriteAllText(f.TempFilePath, "new");
 			f.WriteWasSuccessful();
 

--- a/SIL.Core.Tests/IO/TempFileForSafeWritingTests.cs
+++ b/SIL.Core.Tests/IO/TempFileForSafeWritingTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using SIL.IO;
+
+namespace SIL.Tests.IO
+{
+	[TestFixture]
+	public class TempFileForSafeWritingTests
+	{
+		[Test]
+		public void WriteWasSuccessful_TargetDidNotExist_TargetHasContents()
+		{
+			var targetPath = Path.GetTempFileName();
+			var f = new TempFileForSafeWriting(targetPath);
+			File.WriteAllText(f.TempFilePath, "hello");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("hello"));
+		}
+
+
+		[Test]
+		public void WriteWasSuccessful_TargetDidExist_TargetHasContents()
+		{
+			var targetPath = Path.GetTempFileName();
+			File.WriteAllText(targetPath, "old");
+			var f = new TempFileForSafeWriting(targetPath);
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		[Test]
+		public void WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist()
+		{
+			var targetPath = Path.GetTempFileName();
+			File.Delete(targetPath);
+			var backup = targetPath + ".bak";
+			var f = new TempFileForSafeWriting(targetPath);
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.Exists(backup), Is.False);
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		[Test]
+		public void WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile()
+		{
+			var targetPath = Path.GetTempFileName();
+			var backup = targetPath + ".bak";
+			File.WriteAllText(targetPath, "old");
+			var f = new TempFileForSafeWriting(targetPath);
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+		[Test]
+		public void WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone()
+		{
+			var targetPath = Path.GetTempFileName();
+			var backup = targetPath + ".bak";
+			File.WriteAllText(backup, "old bak");
+			var f = new TempFileForSafeWriting(targetPath);
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(backup), Is.EqualTo(""));
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+		[Test]
+		public void WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile()
+		{
+			var targetPath = Path.GetTempFileName();
+			var backup = targetPath + ".bak";
+			File.WriteAllText(backup, "ancient");
+			File.WriteAllText(targetPath, "old");
+			var f = new TempFileForSafeWriting(targetPath);
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+
+			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_TargetDidNotExist_TargetHasContents()
+		{
+			var targetPath = Path.GetTempFileName();
+			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			File.WriteAllText(f.TempFilePath, "hello");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("hello"));
+		}
+
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_TargetDidExist_TargetHasContents()
+		{
+			var targetPath = Path.GetTempFileName();
+			File.WriteAllText(targetPath, "old");
+			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_TargetAndBakcupDidNotExist_BackupFileStillDoesNotExist()
+		{
+			var targetPath = Path.GetTempFileName();
+			File.Delete(targetPath);
+			var backup = targetPath + ".bak";
+			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.Exists(backup), Is.False);
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_BackupDidNotExist_HasContentsOfReplacedFile()
+		{
+			var targetPath = Path.GetTempFileName();
+			var backup = targetPath + ".bak";
+			File.WriteAllText(targetPath, "old");
+			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_BackupExistedButTargetDidNot_BackupLeftAlone()
+		{
+			var targetPath = Path.GetTempFileName();
+			var backup = targetPath + ".bak";
+			File.WriteAllText(backup, "old bak");
+			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+			Assert.That(File.ReadAllText(backup), Is.EqualTo(""));
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+
+		// Simulate situation on the JAARS network in 2016, .net's built-in File.Replace fails on the network drives.
+		[Test]
+		public void ReplaceFails_WriteWasSuccessful_BackupDidExist_HasContentsOfReplacedFile()
+		{
+			var targetPath = Path.GetTempFileName();
+			var backup = targetPath + ".bak";
+			File.WriteAllText(backup, "ancient");
+			File.WriteAllText(targetPath, "old");
+			var f = new TempFileForSafeWriting(targetPath);
+			f.SimulateVolumeThatCannotHandleFileReplace = true;
+			File.WriteAllText(f.TempFilePath, "new");
+			f.WriteWasSuccessful();
+
+			Assert.That(File.ReadAllText(backup), Is.EqualTo("old"));
+			Assert.That(File.ReadAllText(targetPath), Is.EqualTo("new"));
+		}
+	}
+}

--- a/SIL.Core.Tests/SIL.Core.Tests.csproj
+++ b/SIL.Core.Tests/SIL.Core.Tests.csproj
@@ -239,6 +239,7 @@
     <Compile Include="IO\FileLocatorTests.cs" />
     <Compile Include="IO\FileLock\SimpleFileLockTests.cs" />
     <Compile Include="IO\FileUtilsTests.cs" />
+    <Compile Include="IO\TempFileForSafeWritingTests.cs" />
     <Compile Include="IO\TempFileTests.cs" />
     <Compile Include="Migration\DefaultVersionTests.cs" />
     <Compile Include="Migration\FileMigratorTests.cs" />


### PR DESCRIPTION
Underlying problem is that File.Replace(), fails on JAARS network drives, so this has a fall-back to do the same thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/370)
<!-- Reviewable:end -->
