### PR TITLE
Update language data files

### DIFF
--- a/SIL.WritingSystems.Tests/LanguageLookupTests.cs
+++ b/SIL.WritingSystems.Tests/LanguageLookupTests.cs
@@ -142,25 +142,5 @@ namespace SIL.WritingSystems.Tests
 			Assert.True(languages.Any(l => l.Names.Contains("Andaki")));
 			Assert.True(languages.Any(l => l.Names.Contains("Churuba")));
 		}
-
-		[Test]
-		public void SuggestLanguages_Akan_DoesnotCrash()
-		{
-			var lookup = new LanguageLookup();
-			LanguageInfo[] languages = lookup.SuggestLanguages("a").ToArray();
-			Assert.True(languages.Any(l => l.LanguageTag == "ak"));
-			Assert.True(languages.Any(l => l.LanguageTag == "akq"));
-			Assert.True(languages.Any(l => l.Names.Contains("Akuapem")));
-			Assert.True(languages.Any(l => l.Names.Contains("Ak")));
-			Assert.True(languages.Any(l => l.Names.Contains("Akan")));
-			Assert.True(languages.Any(l => l.Names.Contains("Fanti")));
-			languages = lookup.SuggestLanguages("ak").ToArray();
-			Assert.True(languages.Any(l => l.LanguageTag == "ak"));
-			Assert.True(languages.Any(l => l.LanguageTag == "akq"));
-			Assert.True(languages.Any(l => l.Names.Contains("Asante")));
-			Assert.True(languages.Any(l => l.Names.Contains("Ak")));
-			Assert.True(languages.Any(l => l.Names.Contains("Akan")));
-			Assert.True(languages.Any(l => l.Names.Contains("Fanti")));
-		}
 	}
 }

--- a/SIL.WritingSystems/Resources/LanguageCodes.txt
+++ b/SIL.WritingSystems/Resources/LanguageCodes.txt
@@ -63,7 +63,7 @@ acq	YE	L	Arabic, Ta’izzi-Adeni Spoken
 acr	GT	L	Achi
 acs	BR	X	Acroá
 act	NL	L	Achterhoeks
-acu	PE	L	Achuar-Shiwiar
+acu	EC	L	Achuar-Shiwiar
 acv	US	L	Achumawi
 acw	SA	L	Arabic, Hijazi Spoken
 acx	OM	L	Arabic, Omani Spoken
@@ -135,7 +135,7 @@ agm	PG	L	Angaataha
 agn	PH	L	Agutaynen
 ago	PG	L	Tainae
 agq	CM	L	Aghem
-agr	PE	L	Aguaruna
+agr	PE	L	Awajún
 ags	CM	L	Esimbi
 agt	PH	L	Agta, Central Cagayan
 agu	GT	L	Awakateko
@@ -190,7 +190,6 @@ ajt	IL	L	Arabic, Judeo-Tunisian
 aju	IL	L	Arabic, Judeo-Moroccan
 ajw	NG	X	Ajawa
 ajz	IN	L	Amri Karbi
-aka	GH	L	Akan
 akb	ID	L	Batak Angkola
 akc	ID	L	Mpur
 akd	NG	L	Ukpet-Ehom
@@ -225,7 +224,7 @@ alj	PH	L	Alangan
 alk	LA	L	Alak
 all	IN	L	Allar
 alm	VU	L	Amblong
-aln	RS	L	Albanian, Gheg
+aln	AL	L	Albanian, Gheg
 alo	ID	L	Larike-Wakasihu
 alp	ID	L	Alune
 alq	CA	L	Algonquin
@@ -366,7 +365,7 @@ asd	PG	L	Asas
 ase	US	L	American Sign Language
 asf	AU	L	Australian Sign Language
 asg	NG	L	Cishingini
-ash	PE	X	Abishira
+ash	PE	X	Awishira
 asi	ID	L	Buruwai
 asj	CM	L	Sari
 ask	AF	L	Ashkun
@@ -549,7 +548,7 @@ bcc	PK	L	Balochi, Southern
 bcd	ID	L	Babar, North
 bce	CM	L	Bamenyam
 bcf	PG	L	Bamu
-bcg	GN	L	Baga Binari
+bcg	GN	L	Baga Pokur
 bch	PG	L	Bariai
 bci	CI	L	Baoulé
 bcj	AU	L	Bardi
@@ -655,7 +654,6 @@ bgi	PH	L	Giangan
 bgj	CM	L	Bangolan
 bgk	LA	L	Bit
 bgl	LA	L	Bo
-bgm	GN	L	Baga Mboteni
 bgn	PK	L	Balochi, Western
 bgo	GN	L	Baga Koga
 bgp	PK	L	Balochi, Eastern
@@ -969,7 +967,6 @@ btg	CI	L	Bété, Gagnoa
 bth	MY	L	Bidayuh, Biatah
 bti	ID	L	Burate
 btj	ID	L	Malay, Bacanese
-btl	IN	L	Bhatola
 btm	ID	L	Batak Mandailing
 btn	PH	L	Ratagnon
 bto	PH	L	Bikol, Rinconada
@@ -1040,7 +1037,7 @@ bwe	MM	L	Karen, Bwe
 bwf	PG	L	Boselewa
 bwg	MZ	L	Barwe
 bwh	CM	X	Bishuo
-bwi	BR	L	Baniwa
+bwi	VE	L	Baniwa
 bwj	BF	L	Bwamu, Láá Láá
 bwk	PG	L	Bauwaki
 bwl	CD	L	Bwela
@@ -1070,7 +1067,7 @@ bxj	AU	L	Bayungu
 bxk	KE	L	Lubukusu
 bxl	BF	L	Jalkunan
 bxm	MN	L	Buriat, Mongolia
-bxn	AU	L	Burduna
+bxn	AU	X	Burduna
 bxo	NG	L	Barikanchi
 bxp	CM	L	Bebil
 bxq	NG	L	Beele
@@ -1155,9 +1152,7 @@ caz	BO	L	Canichana
 cbb	CO	L	Cabiyarí
 cbc	CO	L	Carapana
 cbd	CO	L	Carijona
-cbe	CO	X	Chipiajes
 cbg	CO	L	Chimila
-cbh	CO	X	Cagua
 cbi	EC	L	Chachi
 cbj	BJ	L	Ede Cabe
 cbk	PH	L	Chavacano
@@ -1165,10 +1160,10 @@ cbl	MM	L	Chin, Bualkhaw
 cbn	TH	L	Nyahkur
 cbo	NG	L	Izora
 cbq	NG	L	Tsucuba
-cbr	PE	L	Cashibo-Cacataibo
+cbr	PE	L	Kakataibo-Kashibo
 cbs	PE	L	Kashinawa
-cbt	PE	L	Chayahuita
-cbu	PE	L	Candoshi-Shapra
+cbt	PE	L	Shawi
+cbu	PE	L	Kandozi-Chapra
 cbv	CO	L	Cacua
 cbw	PH	L	Kinabalian
 cby	CO	L	Carabayo
@@ -1223,7 +1218,7 @@ chh	US	L	Chinook
 chj	MX	L	Chinantec, Ojitlán
 chk	FM	L	Chuukese
 chl	US	L	Cahuilla
-chn	CA	L	Chinook Wawa
+chn	US	L	Chinook Wawa
 cho	US	L	Choctaw
 chp	CA	L	Dene
 chq	MX	L	Chinantec, Quiotepec
@@ -1255,13 +1250,13 @@ cji	RU	L	Chamalal
 cjk	AO	L	Cokwe
 cjm	VN	L	Cham, Eastern
 cjn	PG	L	Chenapian
-cjo	PE	L	Ashéninka Pajonal
+cjo	PE	L	Ashéninka, Pajonal
 cjp	CR	L	Cabécar
 cjs	RU	L	Shor
 cjv	PG	L	Chuave
 cjy	CN	L	Chinese, Jinyu
 ckb	IQ	L	Kurdish, Central
-ckh	MM	L	Chak
+ckh	BD	L	Chak
 ckl	NG	L	Kibaku
 ckn	MM	L	Chin, Kaang
 cko	GH	L	Anufo
@@ -1295,13 +1290,13 @@ cmi	CO	L	Emberá-Chamí
 cml	ID	L	Campalagian
 cmn	CN	L	Chinese, Mandarin
 cmo	VN	L	Mnong, Central
-cmr	MM	L	Chin, Mro-Khimi
+cmr	MM	L	Mro-Khimi
 cmt	ZA	L	Camtho
 cna	IN	L	Changthang
 cnb	MM	L	Chin, Chinbon
 cnc	VN	L	Côông
 cng	CN	L	Qiang, Northern
-cnh	MM	L	Chin, Haka
+cnh	MM	L	Chin, Hakha
 cni	PE	L	Asháninka
 cnk	MM	L	Chin, Khumi
 cnl	MX	L	Chinantec, Lalana
@@ -1310,10 +1305,10 @@ cns	ID	L	Asmat, Central
 cnt	MX	L	Chinantec, Tepetotutla
 cnu	DZ	L	Chenoua
 cnw	MM	L	Chin, Ngawn
-coa	MY	L	Malay, Cocos Islands
+coa	AU	L	Malay, Cocos Islands
 cob	MX	L	Chicomuceltec
 coc	MX	L	Cocopa
-cod	PE	L	Cocama-Cocamilla
+cod	PE	L	Kukama-Kukamiria
 coe	CO	L	Koreguaje
 cof	EC	L	Colorado
 cog	TH	L	Chong
@@ -1333,7 +1328,6 @@ cou	SN	L	Wamey
 cov	CN	L	Cao Miao
 cow	US	L	Cowlitz
 cox	PE	L	Nanti
-coy	CO	X	Coyaima
 coz	MX	L	Chocholtec
 cpa	MX	L	Chinantec, Palantla
 cpb	PE	L	Ashéninka, Ucayali-Yurúa
@@ -1347,7 +1341,6 @@ cpu	PE	L	Ashéninka, Pichis
 cpx	CN	L	Chinese, Pu-Xian
 cpy	PE	L	Ashéninka, South Ucayali
 cqd	CN	L	Miao, Chuanqiandian Cluster
-cqu	CL	L	Quechua, Chilean
 cra	ET	L	Chara
 crc	VU	L	Lonwolwol
 crd	US	L	Coeur d’Alene
@@ -1410,13 +1403,12 @@ ctz	MX	L	Chatino, Zacatepec
 cua	VN	L	Cua
 cub	CO	L	Cubeo
 cuc	MX	L	Chinantec, Usila
-cug	CM	L	Cung
+cug	CM	L	Chungmboko
 cuh	KE	L	Gichuka
 cui	CO	L	Cuiba
 cuj	PE	L	Mashco Piro
 cuk	PA	L	Kuna, San Blas
 cul	BR	L	Kulina
-cum	CO	X	Cumeral
 cuo	VE	L	Cumanagoto
 cup	US	L	Cupeño
 cuq	CN	L	Cun
@@ -1531,7 +1523,7 @@ dgw	AU	L	Daungwurrung
 dgx	PG	L	Doghoro
 dgz	PG	L	Daga
 dhd	IN	L	Dhundari
-dhg	AU	L	Djangu
+dhg	AU	L	Dhangu-Djangu
 dhi	NP	L	Dhimal
 dhl	AU	L	Dhalandji
 dhm	AO	L	Dhimba
@@ -1672,8 +1664,9 @@ dth	AU	X	Adithinngithigh
 dti	ML	L	Dogon, Ana Tinga
 dtk	ML	L	Dogon, Tene Kan
 dtm	ML	L	Dogon, Tomo Kan
+dtn	ET	L	Daatsʼíin
 dto	ML	L	Dogon, Tommo So
-dtp	MY	L	Dusun, Central
+dtp	MY	L	Dusun, Kadazan
 dtr	MY	L	Lotud
 dts	ML	L	Dogon, Toro So
 dtt	ML	L	Dogon, Toro Tegu
@@ -1688,7 +1681,6 @@ duf	NC	L	Drubea
 dug	KE	L	Chiduruma
 duh	IN	L	Dungra Bhil
 dui	PG	L	Dumun
-duj	AU	L	Dhuwal
 duk	PG	L	Uyajitaya
 dul	PH	L	Agta, Alabat Island
 dun	ID	L	Dusun Deyah
@@ -1702,11 +1694,13 @@ duv	ID	L	Duvle
 duw	ID	L	Dusun Witu
 dux	ML	L	Duungooma
 duy	PH	X	Agta, Dicamay
-duz	CM	X	Duli
+duz	CM	L	Duli-Gey
 dva	PG	L	Duau
 dwa	NG	L	Diri
 dwr	ET	L	Dawro
+dwu	AU	L	Dhuwal
 dww	PG	L	Dawawa
+dwy	AU	L	Dhuwaya
 dya	BF	L	Dyan
 dyb	AU	X	Dyaberdyaber
 dyd	AU	X	Dyugun
@@ -1804,6 +1798,7 @@ ers	CN	L	Ersu
 ert	ID	L	Eritai
 erw	ID	L	Erokwanas
 ese	BO	L	Ese Ejja
+esg	IN	L	Gondi, Aheri
 esh	IR	L	Eshtehardi
 esi	US	L	Inupiatun, North Alaskan
 esk	US	L	Inupiatun, Northwest Alaska
@@ -1813,6 +1808,7 @@ eso	EE	L	Estonian Sign Language
 esq	US	L	Esselen
 ess	US	L	Yupik, Central Siberian
 esu	US	L	Yupik, Central
+esy	PH	L	Eskayan
 etb	NG	L	Etebi
 eth	ET	L	Ethiopian Sign Language
 etn	VU	L	Eton
@@ -1845,9 +1841,10 @@ fak	CM	L	Fang
 fal	CM	L	Fali, South
 fam	NG	L	Fam
 fan	GQ	L	Fang
-fao	DK	L	Faroese
+fao	FO	L	Faroese
 fap	SN	L	Palor
 far	SB	L	Fataleka
+fat	GH	L	Fanti
 fau	ID	L	Fayu
 fax	ES	L	Fala
 fay	IR	L	Fars, Southwestern
@@ -1878,6 +1875,7 @@ flr	CD	L	Fuliiru
 fly	ZA	L	Flaaitaal
 fmp	CM	L	Fe’fe’
 fmu	IN	L	Muria, Far Western
+fnb	VU	L	Fanbak
 fng	ZA	L	Pidgin Bantu
 fni	TD	L	Fania
 fod	BJ	L	Foodo
@@ -2021,8 +2019,6 @@ gge	AU	L	Guragone
 ggg	PK	L	Gurgula
 ggk	AU	X	Kungarakany
 ggl	PG	L	Ganglau
-ggn	NP	L	Gurung, Eastern
-ggo	IN	L	Gondi, Southern
 ggt	PG	L	Gitua
 ggu	CI	L	Gban
 ggw	PG	L	Gogodala
@@ -2053,12 +2049,13 @@ git	CA	L	Gitxsan
 giu	CN	L	Mulao
 giw	CN	L	Duoluo
 gix	CD	L	Gilima
-giy	AU	L	Giyug
+giy	AU	X	Giyug
 giz	CM	L	Giziga, South
 gji	NG	L	Geji
 gjk	PK	L	Koli, Kachi
 gjm	AU	X	Gunditjmara
 gjn	GH	L	Gonja
+gjr	AU	L	Gurindji Kriol
 gju	IN	L	Gujari
 gka	PG	L	Guya
 gke	CM	L	Ndai
@@ -2066,7 +2063,7 @@ gkn	NG	L	Gokana
 gko	AU	X	Kok-Nar
 gkp	GN	L	Kpelle, Guinea
 gku	ZA	X	‡Ungkue
-gla	GB	L	Gaelic, Scottish
+gla	GB	L	Scottish Gaelic
 glc	TD	L	Bon Gula
 gld	RU	L	Nanai
 gle	IE	L	Irish
@@ -2158,12 +2155,12 @@ grv	LR	L	Grebo, Central
 grw	PG	L	Gweda
 grx	PG	L	Guriaso
 gry	LR	L	Grebo, Barclayville
-grz	PG	L	Guramalum
+grz	PG	X	Guramalum
 gse	GH	L	Ghanaian Sign Language
 gsg	DE	L	German Sign Language
 gsl	SN	L	Gusilay
 gsm	GT	L	Guatemalan Sign Language
-gsn	PG	L	Gusan
+gsn	PG	L	Nema
 gso	CF	L	Gbaya, Southwest
 gsp	PG	L	Wasembo
 gss	GR	L	Greek Sign Language
@@ -2191,7 +2188,6 @@ gur	GH	L	Farefare
 gus	GN	L	Guinean Sign Language
 gut	CR	L	Maléku Jaíka
 guu	VE	L	Yanomamö
-guv	CM	L	Gey
 guw	BJ	L	Gun
 gux	BF	L	Gourmanchéma
 guz	KE	L	Ekegusii
@@ -2205,7 +2201,7 @@ gvm	NG	L	Gurmana
 gvn	AU	L	Kuku-Yalanji
 gvo	BR	L	Gavião do Jiparaná
 gvp	BR	L	Gavião, Pará
-gvr	NP	L	Gurung, Western
+gvr	NP	L	Gurung
 gvs	PG	L	Gumawana
 gvy	AU	X	Guyani
 gwa	CI	L	Mbato
@@ -2258,7 +2254,7 @@ hap	ID	L	Hupla
 haq	TZ	L	Ha
 har	ET	L	Harari
 has	CA	L	Haisla
-hat	HT	L	Haitian
+hat	HT	L	Haitian Creole
 hau	NG	L	Hausa
 hav	CD	L	Havu
 haw	US	L	Hawaiian
@@ -2389,7 +2385,7 @@ hti	ID	X	Hoti
 hto	CO	L	Huitoto, Minica
 hts	TZ	L	Hadza
 htu	ID	L	Hitu
-hub	PE	L	Huambisa
+hub	PE	L	Wampís
 huc	BW	L	‡Hua
 hud	ID	L	Huaulu
 hue	MX	L	Huave, San Francisco del Mar
@@ -2411,7 +2407,7 @@ hut	NP	L	Humla
 huu	PE	L	Huitoto, Murui
 huv	MX	L	Huave, San Mateo del Mar
 huw	ID	X	Hukumina
-hux	PE	L	Huitoto, Nüpode
+hux	PE	L	Witoto, Muinani
 huy	IL	L	Hulaulá
 huz	RU	L	Hunzib
 hvc	HT	L	Haitian Vodoun Culture Language
@@ -2426,7 +2422,6 @@ hya	CM	L	Hya
 hye	AM	L	Armenian
 iai	NC	L	Iaai
 ian	PG	L	Iatmul
-iap	BR	X	Iapama
 iar	PG	L	Purari
 iba	MY	L	Iban
 ibb	NG	L	Ibibio
@@ -2498,8 +2493,9 @@ ilb	ZM	L	Ila
 ilg	AU	X	Garig-Ilgar
 ili	CN	L	Ili Turki
 ilk	PH	L	Ilongot
-ill	PH	L	Iranun
+ilm	MY	L	Iranun
 ilo	PH	L	Ilocano
+ilp	PH	L	Iranun
 ils	IT	L	International Sign
 ilu	ID	L	Ili’uun
 ilv	NG	L	Ilue
@@ -2525,7 +2521,7 @@ iou	PG	L	Tuma-Irumu
 iow	US	L	Iowa-Oto
 ipi	PG	L	Ipili
 ipo	PG	L	Ipiko
-iqu	PE	L	Iquito
+iqu	PE	L	Iquitu
 iqw	NG	L	Ikwo
 ire	ID	L	Yeresiam
 irh	ID	L	Irarutu
@@ -2553,6 +2549,7 @@ ist	HR	L	Istriot
 isu	CM	L	Isu
 ita	IT	L	Italian
 itb	PH	L	Itneg, Binongan
+itd	ID	L	Tidung, Southern
 ite	BO	L	Itene
 iti	PH	L	Itneg, Inlaod
 itk	IT	L	Judeo-Italian
@@ -2597,6 +2594,7 @@ jan	AU	X	Jandai
 jao	AU	L	Yanyuwa
 jaq	ID	L	Yaqay
 jas	NC	L	Javanese, New Caledonian
+jat	AF	L	Inku
 jau	ID	L	Yaur
 jav	ID	L	Javanese
 jax	ID	L	Malay, Jambi
@@ -2651,6 +2649,7 @@ jiv	EC	L	Shuar
 jiy	CN	L	Jinuo, Buyuan
 jje	KR	L	Jejueo
 jjr	NG	L	Bankal
+jka	ID	L	Kaera
 jkm	MM	L	Karen, Mobwa
 jko	PG	L	Kubo
 jkp	MM	L	Karen, Paku
@@ -2678,6 +2677,7 @@ jnl	IN	L	Rawat
 jns	IN	L	Jaunsari
 job	CD	L	Joba
 jod	CI	L	Wojenaka
+jog	PK	L	Jogi
 jor	BO	X	Jorá
 jos	JO	L	Jordanian Sign Language
 jow	ML	L	Jowulu
@@ -2702,7 +2702,6 @@ juo	NG	L	Jiba
 jup	BR	L	Hupdë
 jur	BR	L	Jurúna
 jus	NP	L	Jumla Sign Language
-jut	DK	L	Jutish
 juu	NG	L	Ju
 juw	NG	L	Wãpha
 juy	IN	L	Juray
@@ -2722,8 +2721,8 @@ kag	MY	L	Kajaman
 kah	CF	L	Kara
 kai	NG	L	Karekare
 kaj	NG	L	Jju
-kak	PH	L	Kallahan, Kayapa
-kal	GL	L	Inuktitut, Greenlandic
+kak	PH	L	Kalanguya
+kal	GL	L	Greenlandic
 kam	KE	L	Kamba
 kan	IN	L	Kannada
 kao	ML	L	Xaasongaxango
@@ -2851,7 +2850,7 @@ kfn	CM	L	Kuk
 kfo	CI	L	Koro
 kfp	IN	L	Korwa
 kfq	IN	L	Korku
-kfr	IN	L	Kachchi
+kfr	IN	L	Kacchi
 kfs	IN	L	Bilaspuri
 kft	IN	L	Kanjari
 kfu	IN	L	Katkari
@@ -2862,7 +2861,6 @@ kfy	IN	L	Kumaoni
 kfz	BF	L	Koromfé
 kga	CI	L	Koyaga
 kgb	ID	L	Kawe
-kgc	LA	L	Kasseng
 kgd	LA	L	Kataang
 kge	ID	L	Komering
 kgf	PG	L	Kube
@@ -2921,7 +2919,7 @@ kij	PG	L	Kilivila
 kik	KE	L	Gikuyu
 kil	NG	L	Kariya
 kim	RU	L	Karagas
-kin	RW	L	Rwanda
+kin	RW	L	Kinyarwanda
 kio	US	L	Kiowa
 kip	NP	L	Kham, Sheshi
 kiq	ID	L	Kosare
@@ -3078,7 +3076,6 @@ kot	CM	L	Lagwan
 kou	TD	L	Koke
 kov	NG	L	Kudu-Camo
 kow	NG	L	Kugama
-kox	CO	X	Coxima
 koy	US	L	Koyukon
 koz	PG	L	Korak
 kpa	NG	L	Kutto
@@ -3196,7 +3193,6 @@ ktn	BR	L	Karitiâna
 kto	PG	L	Kuot
 ktp	CN	L	Kaduo
 ktq	PH	X	Katabaga
-ktr	MY	L	Kota Marudu Tinagas
 kts	ID	L	Muyu, South
 ktt	ID	L	Ketum
 ktu	CD	L	Kituba
@@ -3204,7 +3200,7 @@ ktv	VN	L	Katu, Eastern
 ktw	US	L	Kato
 ktx	BR	L	Kaxararí
 kty	CD	L	Kango
-ktz	BW	L	Ju|’hoan
+ktz	NA	L	Ju|’hoan
 kua	AO	L	Oshiwambo
 kub	NG	L	Kutep
 kuc	ID	L	Kwinsu
@@ -3248,7 +3244,6 @@ kvo	ID	L	Dobel
 kvp	ID	L	Kompane
 kvq	MM	L	Karen, Geba
 kvr	ID	L	Kerinci
-kvs	AU	L	Kunggara
 kvt	MM	L	Lahta
 kvu	MM	L	Yinbaw
 kvv	ID	L	Kola
@@ -3285,9 +3280,9 @@ kxa	PG	L	Kairiru
 kxb	CI	L	Krobu
 kxc	ET	L	Konso
 kxd	BN	L	Brunei
-kxf	MM	L	Manumanaw
+kxf	MM	L	Kawyaw
 kxh	ET	L	Karo
-kxi	MY	L	Keningau Murut
+kxi	MY	L	Murut, Keningau
 kxj	TD	L	Kulfa
 kxk	MM	L	Zayein
 kxl	NP	L	Kurux, Nepali
@@ -3339,7 +3334,6 @@ kze	PG	L	Kosena
 kzf	ID	L	Kaili, Da’a
 kzg	JP	L	Kikai
 kzi	MY	L	Kelabit
-kzj	MY	L	Kadazan, Coastal
 kzk	SB	X	Kazukuru
 kzl	ID	L	Kayeli
 kzm	ID	L	Kais
@@ -3349,7 +3343,6 @@ kzp	ID	L	Kaidipang
 kzq	NP	L	Kaike
 kzr	CM	L	Karang
 kzs	MY	L	Dusun, Sugut
-kzt	MY	L	Dusun, Tambunan
 kzu	ID	L	Kayupulau
 kzv	ID	L	Komyandaret
 kzw	BR	L	Karirí-Xocó
@@ -3529,7 +3522,7 @@ llb	MZ	L	Lolo
 llc	GN	L	Lele
 lld	IT	L	Ladin
 lle	PG	L	Lele
-llf	PG	X	Hermit
+llf	PG	L	Hermit
 llg	ID	L	Lole
 llh	CN	L	Lamu
 lli	CG	L	Teke-Laali
@@ -3629,7 +3622,7 @@ lsd	IL	L	Lishana Deni
 lse	CD	L	Lusengo
 lsg	FR	L	Lyons Sign Language
 lsh	IN	L	Lish
-lsi	MM	L	Lashi
+lsi	MM	L	Lacid
 lsl	LV	L	Latvian Sign Language
 lsm	UG	L	Saamia
 lso	LA	L	Laos Sign Language
@@ -3735,7 +3728,7 @@ mbx	PG	L	Mari
 mby	PK	L	Memoni
 mbz	MX	L	Mixtec, Amoltepec
 mca	PY	L	Maka
-mcb	PE	L	Machiguenga
+mcb	PE	L	Matsigenka
 mcc	PG	L	Bitur
 mcd	PE	L	Sharanahua
 mce	MX	L	Mixtec, Itundujia
@@ -3865,7 +3858,7 @@ mhc	MX	L	Mocho
 mhd	TZ	L	Mbugu
 mhe	MY	L	Mah Meri
 mhf	PG	L	Mamaa
-mhg	AU	L	Margu
+mhg	AU	X	Margu
 mhi	UG	L	Ma’di
 mhj	AF	L	Mogholi
 mhk	CM	L	Mungaka
@@ -3907,6 +3900,7 @@ miw	PG	L	Akoye
 mix	MX	L	Mixtec, Mixtepec
 miy	MX	L	Mixtec, Ayutla
 miz	MX	L	Mixtec, Coatzospan
+mjb	TL	L	Makalero
 mjc	MX	L	Mixtec, San Juan Colorado
 mjd	US	L	Maidu, Northwest
 mje	TD	X	Muskum
@@ -4210,7 +4204,7 @@ mvr	ID	L	Marau
 mvs	ID	L	Massep
 mvt	VU	L	Mpotovoro
 mvu	TD	L	Marfa
-mvv	MY	L	Tagal Murut
+mvv	MY	L	Tahol
 mvw	TZ	L	Machinga
 mvx	ID	L	Meoswar
 mvy	PK	L	Kohistani, Indus
@@ -4313,7 +4307,6 @@ mzz	PG	L	Maiadomu
 naa	ID	L	Namla
 nab	BR	L	Nambikuára, Southern
 nac	PG	L	Narak
-nad	AU	L	Nijadali
 nae	ID	X	Naka’ela
 naf	PG	L	Nabak
 nag	IN	L	Naga Pidgin
@@ -4506,7 +4499,7 @@ nja	NG	L	Nzanyi
 njb	IN	L	Naga, Nocte
 njd	TZ	L	Ndonde Hamba
 njh	IN	L	Naga, Lotha
-nji	AU	L	Gudanji
+nji	AU	X	Gudanji
 njj	CM	L	Njen
 njl	SS	L	Njalgulgule
 njm	IN	L	Naga, Angami
@@ -4553,7 +4546,6 @@ nlk	ID	L	Yali, Ninia
 nll	IN	L	Nihali
 nlo	CD	L	Ngul
 nlq	MM	L	Naga, Lao
-nlr	AU	L	Ngarla
 nlu	GH	L	Nchumbulu
 nlv	MX	L	Nahuatl, Orizaba
 nlw	AU	X	Walangama
@@ -4600,6 +4592,7 @@ nnk	PG	L	Nankina
 nnl	IN	L	Naga, Northern Rengma
 nnm	PG	L	Namia
 nnn	TD	L	Ngete
+nno	NO	L	Norwegian Nynorsk
 nnp	IN	L	Naga, Wancho
 nnq	TZ	L	Ngindo
 nnr	AU	L	Narungga
@@ -4611,6 +4604,7 @@ nnw	BF	L	Nuni, Southern
 nny	AU	X	Nyangga
 nnz	CM	L	Nda’nda’
 noa	CO	L	Woun Meu
+nob	NO	L	Norwegian Bokmål
 noc	PG	L	Nuk
 nod	TH	L	Thai, Northern
 noe	IN	L	Nimadi
@@ -4623,9 +4617,8 @@ nok	US	L	Nooksack
 nol	US	L	Nomlaki
 nop	PG	L	Numanggang
 noq	CD	L	Ngongo
-nor	NO	L	Norwegian
 nos	CN	L	Nisu, Eastern
-not	PE	L	Nomatsiguenga
+not	PE	L	Nomatsigenga
 nou	PG	L	Ewage-Notu
 now	TZ	L	Nyambo
 noy	TD	L	Noy
@@ -4654,6 +4647,7 @@ nre	IN	L	Naga, Southern Rengma
 nrf	JE	L	Jèrriais
 nrg	VU	L	Narango
 nri	IN	L	Naga, Chokri
+nrk	AU	L	Ngarla
 nrl	AU	L	Ngarluma
 nrm	MY	L	Narom
 nrr	IN	X	Nora
@@ -4684,6 +4678,7 @@ nsw	VU	L	Navut
 nsx	AO	L	Songo
 nsy	ID	L	Nasal
 nsz	US	L	Nisenan
+ntd	MY	L	Tidung, Northern
 nte	MZ	L	Nathembo
 ntg	AU	X	Ngantangarra
 nti	BF	L	Natioro
@@ -4693,7 +4688,6 @@ ntm	BJ	L	Nateni
 nto	CD	L	Ntomba
 ntp	MX	L	Tepehuan, Northern
 ntr	GH	L	Delo
-nts	CO	X	Natagaimas
 ntu	SB	L	Natügu
 ntw	US	L	Nottoway
 ntx	MM	L	Naga, Tangkhul
@@ -4715,7 +4709,7 @@ nun	MM	L	Anong
 nuo	VN	L	Nguôn
 nup	NG	L	Nupe-Nupe-Tako
 nuq	PG	L	Nukumanu
-nur	PG	L	Nukuria
+nur	PG	L	Nukeria
 nus	SS	L	Nuer
 nut	VN	L	Nung
 nuu	CD	L	Ngbundu
@@ -4739,10 +4733,10 @@ nxd	CD	L	Ngando
 nxe	ID	L	Nage
 nxg	ID	L	Ngad’a
 nxi	TZ	L	Nindi
-nxk	MM	L	Naga, Koki
+nxk	MM	L	Kokak
 nxl	ID	L	Nuaulu, South
 nxn	AU	X	Ngawun
-nxo	GA	L	Ndambono
+nxo	GA	L	Ndambomo
 nxq	CN	L	Naxi
 nxr	PG	L	Ninggerum
 nxx	ID	L	Nafri
@@ -4829,9 +4823,9 @@ olk	AU	L	Olkol
 olm	NG	L	Oloma
 olo	RU	L	Livvi-Karelian
 olr	VU	L	Olrat
+olu	AO	L	Kuvale
 oma	US	L	Omaha-Ponca
 omb	VU	L	Ambae, East
-ome	CO	X	Omejes
 omg	PE	L	Omagua
 omi	CD	L	Omi
 oml	CD	L	Ombo
@@ -4866,7 +4860,7 @@ opt	MX	X	Opata
 opy	BR	L	Ofayé
 ora	SB	L	Oroha
 orc	KE	L	Orma
-ore	PE	L	Orejón
+ore	PE	L	Maijuna
 org	NG	L	Oring
 orh	CN	L	Oroqen
 orn	MY	L	Orang Kanaq
@@ -4877,7 +4871,7 @@ ort	IN	L	Oriya, Adivasi
 oru	PK	L	Ormuri
 orw	BR	L	Oro Win
 orx	NG	L	Oro
-ory	IN	L	Oriya
+ory	IN	L	Odia
 orz	ID	L	Ormu
 osa	US	L	Osage
 osi	ID	L	Osing
@@ -4893,7 +4887,7 @@ otm	MX	L	Otomi, Eastern Highland
 otn	MX	L	Otomi, Tenango
 otq	MX	L	Otomi, Querétaro
 otr	SD	L	Otoro
-ots	MX	L	Otomi, Estado de México
+ots	MX	L	Otomí, Estado de México
 ott	MX	L	Otomi, Temoaya
 otu	BR	X	Otuke
 otw	CA	L	Ottawa
@@ -5000,6 +4994,7 @@ pgi	PG	L	Pagi
 pgk	VU	L	Rerep
 pgs	NG	L	Pangseng
 pgu	ID	L	Pagu
+pgz	PG	L	Papua New Guinean Sign Language
 pha	CN	L	Pa-Hng
 phd	IN	L	Phudagi
 phg	VN	L	Phuong
@@ -5072,7 +5067,6 @@ ply	CN	L	Bolyu
 plz	MY	L	Paluan
 pma	VU	L	Paama
 pmb	CD	L	Pambia
-pmc	ID	X	Palumata
 pmd	AU	X	Pallanganmiddang
 pme	NC	L	Pwaamei
 pmf	ID	L	Pamona
@@ -5115,7 +5109,6 @@ pnx	LA	L	Phong-Kniang
 pny	CM	L	Pinyin
 pnz	CF	L	Pana
 poc	GT	L	Poqomam
-pod	CO	X	Ponares
 poe	MX	L	Popoloca, San Juan Atzingo
 pof	CD	L	Poke
 pog	BR	L	Potiguára
@@ -5134,11 +5127,10 @@ pot	US	L	Potawatomi
 pov	GW	L	Crioulo, Upper Guinea
 pow	MX	L	Popoloca, San Felipe Otlaltepec
 poy	TZ	L	Pogolo
-ppa	IN	L	Pao
 ppe	PG	L	Papi
 ppi	MX	L	Paipai
 ppk	ID	L	Uma
-ppl	SV	L	Pipil
+ppl	SV	L	Nahuat
 ppm	ID	L	Papuma
 ppn	PG	L	Papapana
 ppo	PG	L	Folopa
@@ -5162,14 +5154,13 @@ prl	PE	L	Peruvian Sign Language
 prm	PG	L	Kibiri
 prn	AF	L	Prasuni
 prp	IN	L	Parsi
-prq	PE	L	Ashéninka Perené
+prq	PE	L	Ashéninka, Perené
 prr	BR	X	Puri
 prs	AF	L	Dari
 prt	TH	L	Prai
 pru	ID	L	Puragi
 prw	PG	L	Parawen
 prx	IN	L	Purik
-pry	TH	L	Pray 3
 prz	CO	L	Providencia Sign Language
 psa	ID	L	Awyu, Asue
 psc	IR	L	Persian Sign Language
@@ -5182,7 +5173,7 @@ psl	PR	L	Puerto Rican Sign Language
 psm	BO	L	Pauserna
 psn	ID	L	Panasuan
 pso	PL	L	Polish Sign Language
-psp	PH	L	Philippine Sign Language
+psp	PH	L	Filipino Sign Language
 psq	PG	L	Pasi
 psr	PT	L	Portuguese Sign Language
 pss	PG	L	Kaulong
@@ -5195,6 +5186,7 @@ pti	AU	L	Pintiini
 ptn	ID	L	Patani
 pto	BR	L	Zo’é
 ptp	PG	L	Patep
+ptq	IN	L	Pattapu
 ptr	VU	L	Piamatsina
 ptt	ID	L	Enrekang
 ptu	ID	L	Bambam
@@ -5235,9 +5227,9 @@ pyn	BR	L	Poyanáwa
 pys	PY	L	Paraguayan Sign Language
 pyu	TW	L	Puyuma
 pyy	MM	L	Pyen
-pzn	MM	L	Naga, Para
+pzn	MM	L	Naga, Jejara
 qua	US	L	Quapaw
-qub	PE	L	Quechua, Huallaga Huánuco
+qub	PE	L	Quechua, Huallaga
 quc	GT	L	K’iche’
 qud	EC	L	Quichua, Calderón Highland
 quf	PE	L	Quechua, Lambayeque
@@ -5266,7 +5258,7 @@ qvj	EC	L	Quichua, Loja Highland
 qvl	PE	L	Quechua, Cajatambo North Lima
 qvm	PE	L	Quechua, Margos-Yarowilca-Lauricocha
 qvn	PE	L	Quechua, North Junín
-qvo	PE	L	Quechua, Napo Lowland
+qvo	PE	L	Quichua, Napo
 qvp	PE	L	Quechua, Pacaraos
 qvs	PE	L	Quechua, San Martín
 qvw	PE	L	Quechua, Huaylla Wanca
@@ -5275,12 +5267,12 @@ qvz	EC	L	Quichua, Northern Pastaza
 qwa	PE	L	Quechua, Corongo Ancash
 qwh	PE	L	Quechua, Huaylas Ancash
 qws	PE	L	Quechua, Sihuas Ancash
-qxa	PE	L	Quechua, Chiquián Ancash
+qxa	PE	L	Quechua, Chiquián
 qxc	PE	L	Quechua, Chincha
-qxh	PE	L	Quechua, Panao Huánuco
+qxh	PE	L	Quechua, Panao
 qxl	EC	L	Quichua, Salasaca Highland
 qxn	PE	L	Quechua, Northern Conchucos Ancash
-qxo	PE	L	Quechua, Southern Conchucos Ancash
+qxo	PE	L	Quechua, Southern Conchucos
 qxp	PE	L	Quechua, Puno
 qxq	IR	L	Kashkay
 qxr	EC	L	Quichua, Cañar Highland
@@ -5303,7 +5295,7 @@ ran	ID	L	Riantana
 rao	PG	L	Rao
 rap	CL	L	Rapa Nui
 raq	NP	L	Saam
-rar	CK	L	Rarotongan
+rar	CK	L	Cook Islands Maori
 ras	SD	L	Tegali
 rat	IR	L	Razajerdi
 rau	NP	L	Raute
@@ -5343,7 +5335,7 @@ rhp	PG	L	Yahang
 ria	IN	L	Riang
 rie	LA	L	Rien
 rif	MA	L	Tarifit
-ril	MM	L	Riang
+ril	MM	L	Riang Lang
 rim	TZ	L	Nyaturu
 rin	NG	L	Nungu
 rir	ID	L	Ribun
@@ -5361,7 +5353,7 @@ rkt	BD	L	Rangpuri
 rkw	AU	X	Arakwal
 rma	NI	L	Rama
 rmb	AU	L	Rembarunga
-rmc	CZ	L	Romani, Carpathian
+rmc	SK	L	Romani, Carpathian
 rmd	DK	X	Traveller Danish
 rme	GB	L	Angloromani
 rmf	FI	L	Romani, Kalo Finnish
@@ -5372,17 +5364,16 @@ rmk	PG	L	Romkun
 rml	PL	L	Romani, Baltic
 rmm	ID	L	Roma
 rmn	RS	L	Romani, Balkan
-rmo	RS	L	Romani, Sinte
+rmo	DE	L	Romani, Sinte
 rmp	PG	L	Rempi
 rmq	ES	L	Caló
 rms	RO	L	Romanian Sign Language
-rmt	IR	L	Domari
+rmt	EG	L	Domari
 rmu	SE	L	Romani, Tavringer
 rmw	GB	L	Romani, Welsh
 rmx	VN	L	Romam
 rmy	RO	L	Romani, Vlax
 rmz	BD	L	Marma
-rna	CO	X	Runa
 rnd	CD	L	Ruund
 rng	MZ	L	Ronga
 rnl	IN	L	Ranglong
@@ -5411,6 +5402,7 @@ rro	PG	L	Waima
 rsb	RS	L	Romano-Serbian
 rsi	SB	X	Rennellese Sign Language
 rsl	RU	L	Russian Sign Language
+rsm	AU	L	Miriwoong Sign Language
 rtc	MM	L	Chin, Rungtu
 rth	ID	L	Ratahan
 rtm	FJ	L	Rotuman
@@ -5442,6 +5434,7 @@ rxw	AU	L	Karuwali
 ryn	JP	L	Amami-Oshima, Northern
 rys	JP	L	Yaeyama
 ryu	JP	L	Okinawan, Central
+rzh	YE	L	Rāziḥī
 saa	TD	L	Saba
 sab	PA	L	Buglere
 sac	US	L	Meskwaki
@@ -5482,7 +5475,7 @@ sbn	PK	L	Sindhi Bhil
 sbo	MY	L	Sabüm
 sbp	TZ	L	Sangu
 sbq	PG	L	Sileibi
-sbr	ID	L	Sembakung Murut
+sbr	ID	L	Murut, Sembakung
 sbs	NA	L	Kuhane
 sbt	ID	L	Kimki
 sbu	IN	L	Stod Bhoti
@@ -5567,6 +5560,7 @@ sgk	CN	L	Sangkong
 sgm	KE	X	Singa
 sgp	IN	L	Singpho
 sgr	IR	L	Sangisari
+sgs	LT	L	Samogitian
 sgt	BT	L	Brokpake
 sgu	ID	L	Salas
 sgw	ET	L	Sebat Bet Gurage
@@ -5664,7 +5658,7 @@ slc	CO	L	Sáliba
 sld	BF	L	Sissala
 sle	IN	L	Sholaga
 slf	CH	L	Swiss-Italian Sign Language
-slg	ID	L	Selungai Murut
+slg	ID	L	Murut, Selungai
 slh	US	L	Salish, Southern Puget Sound
 sli	PL	L	Silesian, Lower
 slj	BR	L	Salumá
@@ -5750,7 +5744,7 @@ sor	TD	L	Somrai
 sos	BF	L	Seeku
 sot	LS	L	Sotho, Southern
 sou	TH	L	Thai, Southern
-sov	PW	L	Sonsorol
+sov	PW	L	Sonsorolese
 sow	PG	L	Sowanda
 sox	CM	L	Swo
 soy	BJ	L	Miyobe
@@ -5768,7 +5762,7 @@ spm	PG	L	Akukem
 spn	PY	L	Sanapaná
 spo	US	L	Spokane
 spp	ML	L	Sénoufo, Supyire
-spq	PE	L	Spanish, Loreto-Ucayali
+spq	PE	L	Spanish, Charapa
 spr	ID	L	Saparua
 sps	PG	L	Saposa
 spt	IN	L	Spiti Bhoti
@@ -5792,7 +5786,7 @@ srf	PG	L	Nafi
 srg	PH	L	Sulod
 srh	CN	L	Sarikoli
 sri	CO	L	Siriano
-srk	MY	L	Serudung Murut
+srk	MY	L	Murut, Serudung
 srl	ID	L	Isirawa
 srm	SR	L	Saramaccan
 srn	SR	L	Sranan
@@ -5879,7 +5873,6 @@ svc	VC	L	Vincentian Creole English
 sve	ID	L	Serili
 svk	SK	L	Slovakian Sign Language
 svm	IT	L	Slavomolisano
-svr	IN	L	Savara
 svs	SB	L	Savosavo
 swb	YT	L	Comorian, Maore
 swc	CD	L	Swahili, Congo
@@ -6022,13 +6015,13 @@ tdi	ID	L	Tomadino
 tdj	ID	L	Tajio
 tdk	NG	L	Tambas
 tdl	NG	L	Sur
+tdm	GY	L	Taruma
 tdn	ID	L	Tondano
 tdo	NG	L	Teme
 tdq	NG	L	Tita
 tdr	VN	L	Todrah
 tds	ID	L	Doutai
 tdt	TL	L	Tetun Dili
-tdu	MY	L	Dusun, Tempasuk
 tdv	NG	L	Toro
 tdx	MG	L	Malagasy, Tandroy-Mahafaly
 tdy	PH	L	Tadyawan
@@ -6086,7 +6079,6 @@ tgx	CA	L	Tagish
 tgy	SS	X	Togoyo
 tgz	AU	L	Tagalaka
 tha	TH	L	Thai
-thc	VN	L	Tai Hang Tong
 thd	AU	L	Thayore
 the	NP	L	Tharu, Chitwania
 thf	NP	L	Thangmi
@@ -6108,10 +6100,9 @@ thy	NG	L	Tha
 thz	NE	L	Tamajeq, Tayart
 tia	DZ	L	Tamazight, Tidikelt
 tic	SD	L	Tira
-tid	ID	L	Tidong
 tif	PG	L	Tifal
 tig	ER	L	Tigré
-tih	MY	L	Timugon Murut
+tih	MY	L	Murut, Timugon
 tii	CD	L	Tiene
 tij	NP	L	Tilung
 tik	CM	L	Tikar
@@ -6174,7 +6165,7 @@ tlp	MX	L	Totonac, Filomena Mata-Coahuitlán
 tlq	MM	L	Tai Loi
 tlr	SB	L	Talise
 tls	VU	L	Tambotalo
-tlt	ID	L	Teluti
+tlt	ID	L	Sou Nama
 tlu	ID	L	Tulehu
 tlv	ID	L	Taliabu
 tlx	PG	L	Khehek
@@ -6193,7 +6184,6 @@ tml	ID	L	Citak, Tamnim
 tmm	VN	L	Tai Thanh
 tmn	ID	L	Taman
 tmo	MY	L	Temoq
-tmp	LA	L	Tai Mène
 tmq	PG	L	Tumleo
 tmr	IL	L	Jewish Babylonian Aramaic
 tms	SD	L	Tima
@@ -6207,7 +6197,6 @@ tna	BO	L	Tacana
 tnb	CO	L	Tunebo, Western
 tnc	CO	L	Tanimuca-Retuarã
 tnd	CO	L	Tunebo, Angosturas
-tne	PH	L	Kallahan, Tinoc
 tng	TD	L	Tobanga
 tnh	PG	L	Maiani
 tni	ID	L	Tandia
@@ -6226,11 +6215,10 @@ tnv	BD	L	Tangchangya
 tnw	ID	L	Tonsawang
 tnx	SB	L	Tanema
 tny	TZ	L	Tongwe
-tnz	TH	L	Tonga
+tnz	TH	L	Ten’edn
 tob	AR	L	Toba
 toc	MX	L	Totonac, Coyutla
 tod	GN	L	Toma
-toe	CO	X	Tomedes
 tof	PG	L	Gizrra
 tog	MW	L	Tonga
 toh	MZ	L	Tonga
@@ -6278,7 +6266,7 @@ tqo	PG	L	Toaripi
 tqp	PG	L	Tomoip
 tqq	SO	L	Tunni
 tqr	SD	L	Torona
-tqt	MX	L	Totonac, Ozumatlán
+tqt	MX	L	Totonaco del cerro Xinolatépetl
 tqu	SB	L	Touo
 tqw	US	L	Tonkawa
 tra	AF	L	Tirahi
@@ -6398,6 +6386,7 @@ twe	ID	L	Teiwa
 twf	US	L	Tiwa, Northern
 twg	ID	L	Tereweng
 twh	VN	L	Tai Dón
+twi	GH	L	Twi
 twl	MZ	L	Tawara
 twm	IN	L	Monpa, Tawang
 twn	CM	L	Twendi
@@ -6427,7 +6416,7 @@ tya	PG	L	Tauya
 tye	NG	L	Kyanga
 tyh	VN	L	O’du
 tyi	CG	L	Teke-Tsaayi
-tyj	VN	L	Tai Do
+tyj	VN	L	Tai Yo
 tyl	VN	L	Thu Lao
 tyn	ID	L	Kombai
 typ	AU	X	Thaypan
@@ -6556,7 +6545,7 @@ utp	SB	L	Amba
 utr	NG	L	Etulo
 utu	PG	L	Utu
 uum	GE	L	Urum
-uun	TW	X	Kulon-Pazeh
+uun	TW	L	Kulon-Pazeh
 uur	VU	L	Ura
 uuu	CN	L	U
 uve	NC	L	Fagauvea
@@ -6727,8 +6716,8 @@ wgg	AU	X	Wangganguru
 wgi	PG	L	Wahgi
 wgo	ID	L	Waigeo
 wgu	AU	L	Wirangu
-wgy	AU	L	Warrgamay
-wha	ID	L	Manusela
+wgy	AU	X	Warrgamay
+wha	ID	L	Sou Upaa
 whg	PG	L	Wahgi, North
 whk	ID	L	Kenyah, Wahau
 whu	ID	L	Kayan, Wahau
@@ -6776,7 +6765,7 @@ wly	NP	X	Waling
 wma	NG	X	Mawa
 wmb	AU	L	Wambaya
 wmc	PG	L	Wamas
-wmd	BR	L	Mamaindé
+wmd	BR	L	Mamaindê
 wme	NP	L	Wambule
 wmh	TL	L	Waima’a
 wmi	AU	X	Wamin
@@ -6840,6 +6829,7 @@ wrx	ID	L	Wae Rana
 wry	IN	L	Merwari
 wrz	AU	X	Waray
 wsa	ID	L	Warembori
+wsg	IN	L	Gondi, Adilabad
 wsi	VU	L	Wusi
 wsk	PG	L	Waskia
 wsr	PG	L	Owenia
@@ -6863,7 +6853,7 @@ wur	AU	X	Wurrugu
 wut	PG	L	Wutung
 wuu	CN	L	Chinese, Wu
 wuv	PG	L	Wuvulu-Aua
-wux	AU	L	Wulna
+wux	AU	X	Wulna
 wuy	ID	L	Wauyai
 wwa	BJ	L	Waama
 wwb	AU	X	Wakabunga
@@ -6882,6 +6872,7 @@ xab	NG	L	Sambe
 xac	IN	L	Kachari
 xai	BR	L	Kaimbé
 xaj	BR	X	Ararandewára
+xak	VE	X	Máku
 xal	RU	L	Kalmyk-Oirat
 xam	ZA	X	|Xam
 xan	ET	L	Xamtanga
@@ -6893,7 +6884,6 @@ xau	ID	L	Kauwera
 xav	BR	L	Xavánte
 xaw	US	L	Kawaiisu
 xay	ID	L	Kayan Mahakam
-xba	BR	L	Kamba
 xbd	AU	X	Bindal
 xbe	AU	X	Bigambal
 xbg	AU	X	Bunganditj
@@ -6902,7 +6892,6 @@ xbj	AU	X	Birrpayi
 xbp	AU	X	Bibbulman
 xbr	ID	L	Kambera
 xbw	BR	L	Kambiwá
-xbx	BR	X	Kabixí
 xby	AU	L	Batyala
 xda	AU	L	Darkinyung
 xdk	AU	X	Dharuk
@@ -6926,7 +6915,6 @@ xho	ZA	L	Xhosa
 xhv	VN	L	Khua
 xii	ZA	L	Xiri
 xin	GT	X	Xinca
-xip	BR	X	Xipináwa
 xir	BR	L	Xiriâna
 xis	IN	L	Kisan
 xiy	BR	L	Xipaya
@@ -6939,7 +6927,6 @@ xkd	ID	L	Kayan, Mendalam
 xke	ID	L	Kereho
 xkf	BT	L	Khengkha
 xkg	ML	L	Kagoro
-xkh	BR	L	Karahawyana
 xki	KE	L	Kenyan Sign Language
 xkj	IR	L	Kajali
 xkk	KH	L	Kaco’
@@ -7120,7 +7107,7 @@ ycl	CN	L	Lolopo
 ycn	CO	L	Yucuna
 ycp	LA	L	Chepya
 yda	AU	L	Yanda
-ydd	IL	L	Yiddish, Eastern
+ydd	UA	L	Yiddish, Eastern
 yde	PG	L	Yangum Dey
 ydg	PK	L	Yidgha
 ydk	PG	L	Yoidik
@@ -7148,6 +7135,7 @@ ygw	PG	L	Yagwoia
 yha	CN	L	Buyang, Baha
 yhd	IL	L	Arabic, Judeo-Iraqi
 yhl	CN	L	Phowa, Hlepho
+yhs	AU	L	Yan-nhangu Sign Language
 yia	AU	L	Yinggarda
 yif	CN	L	Ache
 yig	CN	L	Nasu, Wusa
@@ -7157,7 +7145,7 @@ yij	AU	L	Yindjibarndi
 yik	CN	L	Lalo, Dongshanba
 yil	AU	X	Yindjilandji
 yim	IN	L	Naga, Yimchungru
-yin	MM	L	Yinchia
+yin	MM	L	Riang Lai
 yip	CN	L	Pholo
 yiq	CN	L	Miqie
 yir	ID	L	Awyu, North
@@ -7166,7 +7154,6 @@ yit	CN	L	Lalu, Eastern
 yiu	CN	L	Awu
 yiv	CN	L	Nisu, Northern
 yix	CN	L	Axi
-yiy	AU	L	Yir Yoront
 yiz	CN	L	Azhe
 yka	PH	L	Yakan
 ykg	RU	L	Yukaghir, Northern
@@ -7241,10 +7228,11 @@ ypz	CN	L	Phuza
 yra	PG	L	Yerakai
 yrb	PG	L	Yareba
 yre	CI	L	Yaouré
-yri	CO	L	Yarí
 yrk	RU	L	Nenets
 yrl	BR	L	Nhengatu
+yrm	AU	L	Yirrk-Mel
 yrn	CN	L	Yerong
+yro	BR	L	Yaroamë
 yrs	ID	L	Yarsun
 yrw	PG	L	Yarawata
 yry	AU	L	Yarluyandi
@@ -7286,7 +7274,7 @@ yuz	BO	L	Yuracare
 yva	ID	L	Yawa
 yvt	VE	L	Yavitero
 ywa	PG	L	Kalou
-ywg	AU	L	Yinhawangka
+ywg	AU	X	Yinhawangka
 ywl	CN	L	Lalu, Western
 ywn	BR	L	Yawanawa
 ywq	CN	L	Yi, Wuding-Luquan
@@ -7300,12 +7288,13 @@ yxl	AU	L	Yardliyawarra
 yxm	AU	L	Yinwum
 yxu	AU	L	Yuyu
 yxy	AU	X	Yabula Yabula
+yyr	AU	L	Yir-Yoront
 yyu	PG	L	Yau
 yyz	CN	L	Ayizi
 yzg	CN	L	Buyang, E’ma
 yzk	CN	L	Zokhuo
 zaa	MX	L	Zapotec, Sierra de Juárez
-zab	MX	L	Zapotec, San Juan Guelavía
+zab	MX	L	Zapotec, Western Tlacolula Valley
 zac	MX	L	Zapotec, Ocotlán
 zad	MX	L	Zapotec, Cajonos
 zae	MX	L	Zapotec, Yareni
@@ -7364,6 +7353,7 @@ zkd	MM	L	Kadu
 zkn	MM	L	Kanan
 zkp	BR	X	Kaingáng, São Paulo
 zkr	CN	L	Zakhring
+zku	AU	L	Kaurna
 zlj	CN	L	Zhuang, Liujiang
 zlm	MY	L	Malay
 zln	CN	L	Zhuang, Lianshan
@@ -7460,7 +7450,7 @@ zuh	PG	L	Tokano
 zul	ZA	L	Zulu
 zum	OM	L	Kumzari
 zun	US	L	Zuni
-zuy	CM	L	Zumaya
+zuy	CM	X	Zumaya
 zwa	ET	L	Zay
 zyb	CN	L	Zhuang, Yongbei
 zyg	CN	L	Zhuang, Yang

--- a/SIL.WritingSystems/Resources/LanguageIndex.txt
+++ b/SIL.WritingSystems/Resources/LanguageIndex.txt
@@ -25,6 +25,7 @@ aaf	IN	LA	Eranadans
 aag	PG	L	Ambrak
 aah	PG	D	Matapau
 aah	PG	L	Arapesh, Abu’
+aah	PG	LA	Abu’
 aah	PG	LA	Ua
 aai	PG	D	Arifama
 aai	PG	D	Miniafia
@@ -81,6 +82,7 @@ aar	ET	L	Afar
 aar	ET	LA	Adal
 aar	ET	LA	’Afar Af
 aar	ET	LA	Afaraf
+aar	ET	LA	Affarigna
 aar	ET	LA	Qafar
 aar	ET	LP	Danakil
 aar	ET	LP	Denkel
@@ -160,7 +162,9 @@ abg	PG	L	Abaga
 abg	PG	LA	Wagaba
 abh	AF	D	Balkh Arabic
 abh	AF	L	Arabic, Tajiki Spoken
+abh	AF	LA	Arabi
 abh	TJ	L	Arabic, Tajiki Spoken
+abh	TJ	LA	Arabi
 abh	TJ	LA	Arabic
 abh	TJ	LA	Bukhara Arabic
 abh	TJ	LA	Buxara Arabic
@@ -263,6 +267,9 @@ abu	CI	LA	Abonwa
 abu	CI	LA	Abouré
 abu	CI	LA	Abule
 abu	CI	LA	Akaplass
+abu	CI	LA	Ehie
+abu	CI	LA	Eyive
+abu	CI	LA	Ossouon
 abv	BH	L	Arabic, Baharna Spoken
 abv	BH	LA	Baharna
 abv	BH	LA	Baharnah
@@ -298,6 +305,8 @@ aca	CO	LA	Xagua
 acb	NG	L	Áncá
 acb	NG	LA	Bunta
 acd	GH	L	Gikyode
+acd	GH	LA	Achode
+acd	GH	LA	Akyode
 acd	GH	LA	Chode
 acd	GH	LA	Gichode
 acd	GH	LA	Kyode
@@ -370,6 +379,7 @@ acm	IQ	D	Anatolian Cluster
 acm	IQ	D	Euphrates Cluster
 acm	IQ	D	Tigris Cluster
 acm	IQ	L	Arabic, Mesopotamian Spoken
+acm	IQ	LA	’Arabi
 acm	IQ	LA	Arabic
 acm	IQ	LA	Baghdadi
 acm	IQ	LA	Furati
@@ -378,14 +388,17 @@ acm	IQ	LA	Mesopotamian Gelet Arabic
 acm	IQ	LA	Mesopotamian Qeltu Arabic
 acm	IR	L	Arabic, Mesopotamian Spoken
 acm	IR	LA	Arabi
+acm	IR	LA	’Arabi
 acm	IR	LA	Mesopotamian Gelet Arabic
 acm	SY	D	Euphrates Cluster
 acm	SY	L	Arabic, Mesopotamian Spoken
+acm	SY	LA	’Arabi
 acm	SY	LA	Furati
 acm	SY	LA	Mesopotamian Gelet Arabic
 acm	SY	LA	North Syrian Arabic
 acm	TR	D	Anatolian Cluster
 acm	TR	L	Arabic, Mesopotamian Spoken
+acm	TR	LA	’Arabi
 acn	CN	D	Husa
 acn	CN	D	Lianghe
 acn	CN	D	Longchuan
@@ -408,8 +421,9 @@ acn	CN	LA	Ngo Chang
 acn	CN	LA	Ngochang
 acn	CN	LA	Xiandao
 acn	MM	D	Maingtha
-acn	MM	L	Achang
+acn	MM	L	Ngochang
 acn	MM	LA	Acang
+acn	MM	LA	Achang
 acn	MM	LA	Anchan
 acn	MM	LA	Atsang
 acn	MM	LA	Chung
@@ -417,7 +431,6 @@ acn	MM	LA	Manmaw
 acn	MM	LA	Mönghsa
 acn	MM	LA	Ngac’ang
 acn	MM	LA	Ngachang
-acn	MM	LA	Ngochang
 acn	MM	LA	Tai Sa’
 acp	NG	D	Bobi
 acp	NG	D	Boroma
@@ -435,8 +448,10 @@ acq	YE	D	Ta’izzi
 acq	YE	L	Arabic, Ta’izzi-Adeni Spoken
 acq	YE	LA	Southern Yemeni Spoken Arabic
 acr	GT	D	Cubulco Achi
-acr	GT	D	Rabinal Achi
+acr	GT	D	Maya Achi
+acr	GT	DA	Rabinal Achi
 acr	GT	L	Achi
+acr	GT	LA	Qach’a’teem
 acs	BR	L	Acroá
 acs	BR	LA	Coroá
 act	NL	L	Achterhoeks
@@ -446,14 +461,18 @@ acu	EC	L	Achuar-Shiwiar
 acu	EC	LA	Achual
 acu	EC	LA	Achuale
 acu	EC	LA	Achuar
+acu	EC	LA	Achuar Chicham
 acu	EC	LA	Achuara
 acu	EC	LA	Jivaro
 acu	EC	LA	Maina
 acu	EC	LA	Mayna
+acu	PE	D	Achuar
+acu	PE	D	Shiwiar
 acu	PE	L	Achuar-Shiwiar
 acu	PE	LA	Achual
 acu	PE	LA	Achuale
 acu	PE	LA	Achuar
+acu	PE	LA	Achuar Chicham
 acu	PE	LA	Achuara
 acu	PE	LA	Jivaro
 acu	PE	LA	Maina
@@ -520,6 +539,7 @@ ade	GH	D	Lower Adele
 ade	GH	D	Upper Adele
 ade	GH	L	Adele
 ade	GH	LA	Bidire
+ade	GH	LA	Gidire
 ade	TG	D	Lower Adele
 ade	TG	D	Upper Adele
 ade	TG	L	Adele
@@ -535,7 +555,9 @@ adg	AU	L	Andegerebinha
 adg	AU	LA	Andigibinha
 adg	AU	LA	Antekerrepinhe
 adh	UG	L	Adhola
+adh	UG	LA	Badama
 adh	UG	LA	Dhopadhola
+adh	UG	LA	Jopadhola
 adh	UG	LA	Ludama
 adi	CN	L	Luoba, Boga’er
 adi	CN	LA	Abor
@@ -658,15 +680,19 @@ adx	CN	LA	Ngambo
 adx	CN	LA	Panang
 ady	IL	L	Adyghe
 ady	IL	LA	Adygey
+ady	IL	LA	Circassian
 ady	IL	LA	West Circassian
 ady	IQ	L	Adyghe
 ady	IQ	LA	Adygey
+ady	IQ	LA	Circassian
 ady	IQ	LA	West Circassian
 ady	JO	L	Adyghe
 ady	JO	LA	Adygey
+ady	JO	LA	Circassian
 ady	JO	LA	West Circassian
 ady	MK	L	Adyghe
 ady	MK	LA	Adygey
+ady	MK	LA	Circassian
 ady	MK	LA	West Circassian
 ady	RU	D	Abadzex
 ady	RU	D	Bezhedukh
@@ -691,6 +717,7 @@ ady	RU	LA	Lower Circassian
 ady	RU	LA	West Circassian
 ady	SY	L	Adyghe
 ady	SY	LA	Adygey
+ady	SY	LA	Circassian
 ady	SY	LA	West Circassian
 ady	TR	L	Adyghe
 ady	TR	LA	Adygey
@@ -753,6 +780,7 @@ aem	VN	L	Arem
 aem	VN	LA	A-Rem
 aem	VN	LA	Chombrau
 aem	VN	LA	Chomrau
+aem	VN	LA	Kri
 aem	VN	LA	Umo
 aen	AM	L	Armenian Sign Language
 aeq	PK	D	Jamesabad Aer
@@ -794,26 +822,34 @@ aey	PG	LA	Amale
 aez	PG	L	Aeka
 aez	PG	LA	Ajeka
 afb	AE	L	Arabic, Gulf Spoken
+afb	AE	LA	’Arabi
 afb	AE	LA	Gulf Arabic
 afb	AE	LA	Khaliji
 afb	BH	D	Bahraini Gulf Arabic
 afb	BH	L	Arabic, Gulf Spoken
+afb	BH	LA	’Arabi
 afb	BH	LA	Gulf Arabic
 afb	BH	LA	Khaliji
+afb	EG	L	Arabic, Gulf Spoken
+afb	EG	LA	’Arabi
 afb	IQ	D	Zubair-Faau Arabic
 afb	IQ	L	Arabic, Gulf Spoken
+afb	IQ	LA	’Arabi
 afb	IQ	LA	Gulf Arabic
 afb	IQ	LA	Khaliji
 afb	IR	D	Al-Hasâ
 afb	IR	D	Khamseh
 afb	IR	L	Arabic, Gulf Spoken
+afb	IR	LA	’Arabi
 afb	IR	LA	Gulf Arabic
 afb	IR	LA	Khaliji
 afb	KW	D	Kuwaiti Bedouin Arabic
 afb	KW	D	Kuwaiti Hadari Arabic
 afb	KW	L	Arabic, Gulf Spoken
+afb	KW	LA	’Arabi
 afb	KW	LA	Khaliji
 afb	OM	L	Arabic, Gulf Spoken
+afb	OM	LA	’Arabi
 afb	OM	LA	Bedawi
 afb	OM	LA	Gulf Arabic
 afb	OM	LA	Khaliji
@@ -821,13 +857,16 @@ afb	OM	LA	Omani Bedawi Arabic
 afb	QA	D	North Qatari Arabic
 afb	QA	D	South Qatari Arabic
 afb	QA	L	Arabic, Gulf Spoken
+afb	QA	LA	’Arabi
 afb	QA	LA	Gulf Arabic
 afb	QA	LA	Khaliji
 afb	QA	LA	Qatari
 afb	SA	D	Al-Hasaa
 afb	SA	L	Arabic, Gulf Spoken
+afb	SA	LA	’Arabi
 afb	SA	LA	Gulf Spoken
 afb	YE	L	Arabic, Gulf Spoken
+afb	YE	LA	’Arabi
 afd	PG	L	Andai
 afd	PG	LA	Pundungum
 afd	PG	LA	Wangkai
@@ -890,6 +929,7 @@ afs	MX	D	Mexico Afro-Seminole
 afs	MX	L	Afro-Seminole Creole
 afs	MX	LA	Afro-Seminol Criollo
 afs	MX	LA	Afro-Seminole
+afs	MX	LA	Mascogos
 afs	US	D	Mexico Afro-Seminole
 afs	US	D	Texas Afro-Seminole
 afs	US	L	Afro-Seminole Creole
@@ -977,10 +1017,10 @@ ago	PG	LA	Ivori
 agq	CM	L	Aghem
 agq	CM	LA	Wum
 agq	CM	LA	Yum
-agr	PE	L	Aguaruna
+agr	PE	L	Awajún
 agr	PE	LA	Aguajún
+agr	PE	LA	Aguaruna
 agr	PE	LA	Ahuajún
-agr	PE	LA	Awajún
 agr	PE	LA	Awajunt
 ags	CM	D	Lower Esimbi
 ags	CM	D	Upper Esimbi
@@ -998,12 +1038,15 @@ ags	NG	L	Esimbi
 ags	NG	LA	Aage
 ags	NG	LA	Age
 ags	NG	LA	Bogue
+ags	NG	LA	Eshimbi
 ags	NG	LA	Essimbi
 ags	NG	LA	Isimbi
 ags	NG	LA	Mburugam
 ags	NG	LA	Simpi
 agt	PH	L	Agta, Central Cagayan
 agt	PH	LA	Labin Agta
+agu	GT	D	Chalchiteko
+agu	GT	DA	Chalchitec
 agu	GT	L	Awakateko
 agu	GT	LA	Aguacatec
 agu	GT	LA	Aguacateco
@@ -1027,9 +1070,11 @@ agx	RU	DA	Burkikhan
 agx	RU	DA	Q’ushan
 agx	RU	L	Aghul
 agx	RU	LA	Aghul-ch’al
+agx	RU	LA	Agiul Shui
 agx	RU	LA	Agul
 agy	PH	L	Alta, Southern
 agy	PH	LA	Ita
+agy	PH	LA	Kaboloan
 agy	PH	LA	Kabulowan
 agy	PH	LA	Kabuluen
 agy	PH	LA	Kabuluwan
@@ -1071,8 +1116,13 @@ ahh	ID	LA	Djair
 ahh	ID	LA	Dyair
 ahi	CI	L	Aizi, Tiagbamrin
 ahi	CI	LA	Ahizi
+ahi	CI	LA	Ed-eyng
+ahi	CI	LA	Ezibo
+ahi	CI	LA	Kropko
 ahi	CI	LA	Lélémrin
+ahi	CI	LA	Prokpo
 ahi	CI	LA	Tiagba
+ahi	CI	LA	Tiagbamrin
 ahk	CN	L	Akha
 ahk	CN	LA	Ahka
 ahk	CN	LA	Aini
@@ -1150,14 +1200,20 @@ ahl	TG	LA	Ahlon
 ahl	TG	LA	Ahlon-Bogo
 ahl	TG	LA	Ahonlan
 ahl	TG	LA	Anlo
+ahl	TG	LA	Bogo
 ahm	CI	L	Aizi, Mobumrin
 ahm	CI	LA	Ahizi
+ahm	CI	LA	Ed-eyng
+ahm	CI	LA	Ezibo
+ahm	CI	LA	Frukpu
+ahm	CI	LA	Mouin
 ahn	NG	L	Àhàn
 ahn	NG	LA	Ahaan
 aho	IN	L	Ahom
 aho	IN	LA	Tai Ahom
 ahp	CI	L	Aizi, Aproumu
 ahp	CI	LA	Ahizi
+ahp	CI	LA	Aproin
 ahp	CI	LA	Aprou
 ahp	CI	LA	Aproumu
 ahp	CI	LA	Aprwe
@@ -1355,6 +1411,7 @@ ais	TW	LA	Nataoran
 ais	TW	LA	Natawran
 ais	TW	LA	Tauran
 ait	BR	L	Arikem
+ait	BR	LA	Ahopovo
 ait	BR	LA	Ariken
 aiw	ET	D	Bako
 aiw	ET	D	Biyo
@@ -1385,7 +1442,9 @@ aix	PG	DA	Psokok
 aix	PG	DA	Sokhok
 aix	PG	L	Aighon
 aix	PG	LA	Aigon
+aix	PG	LA	Apsokok
 aix	PG	LA	Bao
+aix	PG	LA	Eighon
 aix	PG	LA	Psohoh
 aiy	CF	L	Ali
 aja	SS	L	Aja
@@ -1461,7 +1520,6 @@ aka	GH	D	Asante
 aka	GH	D	Asen
 aka	GH	D	Bono
 aka	GH	D	Dankyira
-aka	GH	D	Fante
 aka	GH	D	Gomua
 aka	GH	D	Kwawu
 aka	GH	DA	Achanti
@@ -1471,10 +1529,7 @@ aka	GH	DA	Akwapi
 aka	GH	DA	Akyem Bosome
 aka	GH	DA	Asanti
 aka	GH	DA	Ashante Twi
-aka	GH	DA	Fanti
 aka	GH	DA	Kwahu
-aka	GH	DA	Mfantse
-aka	GH	DA	Twi
 aka	GH	L	Akan
 akb	ID	L	Batak Angkola
 akb	ID	LA	Anakola
@@ -1499,6 +1554,7 @@ ake	BR	LA	Acewaio
 ake	BR	LA	Akawai
 ake	BR	LA	Akawaio
 ake	BR	LA	Akwaio
+ake	BR	LA	Kapon
 ake	BR	LA	Kapóng
 ake	BR	LA	Patamona
 ake	GY	L	Akawaio
@@ -1506,11 +1562,13 @@ ake	GY	LA	Acahuayo
 ake	GY	LA	Acewaio
 ake	GY	LA	Akawai
 ake	GY	LA	Ingariko
+ake	GY	LA	Kapon
 ake	VE	L	Akawaio
 ake	VE	LA	Acahuayo
 ake	VE	LA	Acawayo
 ake	VE	LA	Acewaio
 ake	VE	LA	Akawai
+ake	VE	LA	Kapon
 ake	VE	LA	Waicá
 ake	VE	LA	Waika
 akf	NG	L	Akpa
@@ -1559,6 +1617,7 @@ akp	GH	D	Lolobi
 akp	GH	L	Siwu
 akp	GH	LA	Akpafu-Lolobi
 akp	GH	LA	Lolobi-Akpafu
+akp	GH	LA	Mawu
 akp	GH	LA	Siwusi
 akq	PG	L	Ak
 akr	VU	L	Araki
@@ -1605,8 +1664,22 @@ ala	NG	LA	Idoma Nokwu
 alc	CL	D	Aksanás
 alc	CL	DA	Aksana
 alc	CL	L	Qawasqar
+alc	CL	LA	Alacalouf
 alc	CL	LA	Alacaluf
 alc	CL	LA	Alacalufe
+alc	CL	LA	Alaculoof
+alc	CL	LA	Alaculuf
+alc	CL	LA	Alakaluf
+alc	CL	LA	Alikaluf
+alc	CL	LA	Alikhoolip
+alc	CL	LA	Alikuluf
+alc	CL	LA	Alilkoolif
+alc	CL	LA	Alokolup
+alc	CL	LA	Alooculoof
+alc	CL	LA	Alookooloop
+alc	CL	LA	Alucaluf
+alc	CL	LA	Alukoeluf
+alc	CL	LA	Alukulup
 alc	CL	LA	Halakwulup
 alc	CL	LA	Kaweskar
 alc	CL	LA	Kawesqar
@@ -1618,6 +1691,7 @@ ale	RU	D	Beringov
 ale	RU	DA	Atkan
 ale	RU	DA	Bering
 ale	RU	L	Aleut
+ale	RU	LA	Unangam tunnu
 ale	RU	LA	Unangan
 ale	RU	LA	Unangany
 ale	RU	LA	Unanghan
@@ -1632,6 +1706,7 @@ ale	US	DA	Unangan
 ale	US	DA	Unangany
 ale	US	L	Aleut
 ale	US	LA	Anangax
+ale	US	LA	Unangam tunnu
 alf	NG	L	Alege
 alf	NG	LA	Alegi
 alf	NG	LA	Ugbe
@@ -1662,14 +1737,18 @@ aln	AL	LA	Gheg
 aln	AL	LA	Guegue
 aln	AL	LA	Shopni
 aln	AL	LA	Shqip
+aln	AL	LA	Shqyp
 aln	ME	D	Northwest Gheg
 aln	ME	L	Albanian, Gheg
 aln	ME	LA	Geg
 aln	ME	LA	Shqip
+aln	ME	LA	Shqyp
 aln	MK	L	Albanian, Gheg
 aln	MK	LA	Geg
 aln	MK	LA	Shqip
+aln	MK	LA	Shqyp
 aln	RO	L	Albanian, Gheg
+aln	RO	LA	Shqyp
 aln	RS	D	Northeast Gheg
 aln	RS	D	Northwest Gheg
 aln	RS	L	Albanian, Gheg
@@ -1677,6 +1756,10 @@ aln	RS	LA	Geg
 aln	RS	LA	Shqip
 aln	RS	LA	Shqyp
 aln	SI	L	Albanian, Gheg
+aln	SI	LA	Shqyp
+aln	TR	D	Samsun Albanian
+aln	TR	L	Albanian, Gheg
+aln	TR	LA	Shqyp
 alo	ID	D	Allang
 alo	ID	D	Larike
 alo	ID	D	Wakasihu
@@ -1751,8 +1834,10 @@ alw	ET	L	Alaba-K’abeena
 alw	ET	LA	Alaaba
 alw	ET	LA	Allaaba
 alw	ET	LA	Halaba
+alw	ET	LA	K’abeena
 alw	ET	LA	K’abena
 alw	ET	LA	Qebena
+alw	ET	LA	Wanbasana
 alx	PG	D	Alang Mol
 alx	PG	D	Arang Mol
 alx	PG	L	Amol
@@ -1792,12 +1877,18 @@ alz	UG	LA	Luri
 ama	BR	L	Amanayé
 ama	BR	LA	Amanage
 ama	BR	LA	Amanajé
+ama	BR	LA	Amanajó
 ama	BR	LA	Amanyé
-ama	BR	LA	Manajo
-ama	BR	LA	Manaxo
+ama	BR	LA	Manajó
+ama	BR	LA	Mananyé
+ama	BR	LA	Manaxó
+ama	BR	LA	Manayé
 ama	BR	LA	Manaze
+ama	BR	LA	Manazewá
 ama	BR	LA	Manazo
+ama	BR	LA	Turiwa
 amb	NG	L	Ambo
+amb	NG	LA	Timap
 amc	BR	D	Inuvaken
 amc	BR	D	Viwivakeu
 amc	BR	L	Amahuaca
@@ -1807,22 +1898,27 @@ amc	BR	LA	Amenguaca
 amc	BR	LA	Sayacu
 amc	PE	L	Amahuaca
 amc	PE	LA	Amaguaco
+amc	PE	LA	Amahuaka
+amc	PE	LA	Amajuaca
 amc	PE	LA	Amawaka
 amc	PE	LA	Ameuhaque
 amc	PE	LA	Ipitineri
+amc	PE	LA	Ipitnere
 amc	PE	LA	Sayaco
+amc	PE	LA	Yora
 ame	PE	L	Yanesha’
-ame	PE	LA	Amage
+ame	PE	LA	Amagé
 ame	PE	LA	Amagues
-ame	PE	LA	Amaje
-ame	PE	LA	Amajo
+ame	PE	LA	Amajé
+ame	PE	LA	Amajó
 ame	PE	LA	Amoishe
 ame	PE	LA	Amueixa
 ame	PE	LA	Amuese
 ame	PE	LA	Amuesha
+ame	PE	LA	Amueshua
 ame	PE	LA	Amuetamo
 ame	PE	LA	Lorenzo
-ame	PE	LA	Omage
+ame	PE	LA	Omagé
 amf	ET	L	Hamer-Banna
 amf	ET	LA	Amar
 amf	ET	LA	Amarcocche
@@ -1866,8 +1962,10 @@ amh	ET	LA	Abyssinian
 amh	ET	LA	Amarigna
 amh	ET	LA	Amarinya
 amh	ET	LA	Amhara
+amh	ET	LA	Beta Israel
 amh	ET	LA	Ethiopian
 amh	IL	L	Amharic
+amh	IL	LA	Beta Israel
 amh	IL	LP	Falasha
 ami	TW	D	Central Amis
 ami	TW	D	Chengkung-Kwangshan
@@ -1894,6 +1992,7 @@ ami	TW	LA	Pangtsah
 ami	TW	LA	Sabari
 ami	TW	LA	Tanah
 amj	TD	L	Amdang
+amj	TD	LA	Andang
 amj	TD	LA	Andangti
 amj	TD	LA	Biltine
 amj	TD	LA	Mima
@@ -1909,17 +2008,21 @@ amk	ID	LA	Ambai-Menawi
 aml	BD	D	War-Jaintia
 aml	BD	D	War-Khasi
 aml	BD	L	War-Jaintia
+aml	BD	LA	War-Khasi
 aml	IN	L	War-Jaintia
 aml	IN	LA	Amwi
 aml	IN	LA	Khasi
 aml	IN	LA	War
+aml	IN	LA	War-Khasi
 amm	PG	L	Ama
 amm	PG	LA	Sawiyanu
 amn	PG	L	Amanab
 amo	NG	L	Amo
+amo	NG	LA	Amap
 amo	NG	LA	Amon
 amo	NG	LA	Among
 amo	NG	LA	Ba
+amo	NG	LA	Timap
 amp	PG	D	Karawari
 amp	PG	D	Kuvenmas
 amp	PG	L	Alamblak
@@ -1932,6 +2035,11 @@ amr	PE	D	Kisambaeri
 amr	PE	L	Amarakaeri
 amr	PE	LA	Amaracaire
 amr	PE	LA	Amarakaire
+amr	PE	LA	Kareneri
+amr	PE	LA	Kochimberi
+amr	PE	LA	Küpondirideri
+amr	PE	LA	Wakitaneri
+amr	PE	LA	Wintaperi
 amr	PE	LP	Mashco
 ams	JP	L	Amami-Oshima, Southern
 ams	JP	LA	Southern Amami-Osima
@@ -1941,8 +2049,10 @@ amt	PG	L	Amto
 amu	MX	D	Amuzgo del Norte
 amu	MX	D	Amuzgo del Sur
 amu	MX	L	Amuzgo, Guerrero
+amu	MX	LA	Jñom’ndaa
 amu	MX	LA	Nomndaa
 amu	MX	LA	Ñomndaa
+amu	MX	LA	Ñonda
 amv	ID	L	Ambelau
 amv	ID	LA	Amblau
 amw	SY	D	Bakh’a
@@ -1973,6 +2083,7 @@ amz	AU	L	Atampaya
 ana	CO	L	Andaqui
 ana	CO	LA	Aguanunga
 ana	CO	LA	Andaki
+ana	CO	LA	Andaquí
 ana	CO	LA	Churuba
 anb	PE	L	Andoa
 anb	PE	LA	Gae
@@ -2015,6 +2126,7 @@ ani	RU	DA	Zilo
 ani	RU	L	Andi
 ani	RU	LA	Andii
 ani	RU	LA	Andiy
+ani	RU	LA	Khivannal
 ani	RU	LA	Qandisel
 ani	RU	LA	Qwannab
 anj	PG	L	Anor
@@ -2055,6 +2167,8 @@ ano	CO	LA	Businka
 ano	CO	LA	Cha’oie
 ano	CO	LA	Paasi-ahá
 ano	CO	LA	Paasiaja
+ano	CO	LA	Paatsiaja
+ano	CO	LA	Poosioho
 anp	IN	L	Angika
 anp	IN	LA	Anga
 anp	IN	LA	Angikar
@@ -2158,11 +2272,14 @@ aoc	BR	DA	Aricuna
 aoc	BR	DA	Ingaricó
 aoc	BR	DA	Ipuricoto
 aoc	BR	DA	Jaricuna
+aoc	BR	DA	Taurepa
 aoc	BR	DA	Taurepan
 aoc	BR	DA	Taurepang
 aoc	BR	L	Pemon
+aoc	BR	LA	Kamarakotos
 aoc	BR	LA	Pemong
 aoc	BR	LA	Taulipáng
+aoc	BR	LA	Taurepáng
 aoc	GY	D	Arecuna
 aoc	GY	D	Camaracoto
 aoc	GY	D	Taurepan
@@ -2170,7 +2287,10 @@ aoc	GY	DA	Arekuna
 aoc	GY	DA	Aricuna
 aoc	GY	DA	Jaricuna
 aoc	GY	DA	Taulipang
+aoc	GY	DA	Taurepa
+aoc	GY	DA	Taurepang
 aoc	GY	L	Pemon
+aoc	GY	LA	Kamarakotos
 aoc	GY	LA	Pemong
 aoc	VE	D	Arecuna
 aoc	VE	D	Camaracoto
@@ -2178,14 +2298,19 @@ aoc	VE	D	Taurepan
 aoc	VE	DA	Arekuna
 aoc	VE	DA	Aricuna
 aoc	VE	DA	Daigok
+aoc	VE	DA	Jarecouna
 aoc	VE	DA	Jaricuna
 aoc	VE	DA	Kamaragakok
 aoc	VE	DA	Pemon
+aoc	VE	DA	Pemóng
 aoc	VE	DA	Pishauco
 aoc	VE	DA	Potsawugok
 aoc	VE	DA	Purucoto
 aoc	VE	DA	Taulipang
+aoc	VE	DA	Taurepa
+aoc	VE	DA	Taurepang
 aoc	VE	L	Pemon
+aoc	VE	LA	Kamarakotos
 aoc	VE	LA	Pemong
 aod	PG	L	Andarum
 aoe	PG	D	Megi
@@ -2346,11 +2471,14 @@ ape	PG	L	Bukiyip
 ape	PG	LA	Bukiyúp
 ape	PG	LA	Mountain Arapesh
 apf	PH	L	Agta, Pahanan
+apf	PH	LA	Pahanan
 apf	PH	LA	Palanan Agta
 apg	ID	L	Ampanang
 aph	NP	L	Athpariya
 aph	NP	LA	Arthare
+aph	NP	LA	Athaphre
 aph	NP	LA	Athapre
+aph	NP	LA	Athpahariya
 aph	NP	LA	Athpare
 aph	NP	LA	Athpre
 aph	NP	LA	Sanango Ring
@@ -2358,6 +2486,7 @@ api	BR	L	Apiaká
 api	BR	LA	Apiacá
 api	BR	LA	Apiake
 apj	US	L	Apache, Jicarilla
+apj	US	LA	Abáachi, Jicarilla
 apk	US	L	Apache, Kiowa
 apl	US	L	Apache, Lipan
 apl	US	LA	Lipan
@@ -2365,8 +2494,17 @@ apm	US	D	Chiricahua
 apm	US	D	Mescalero
 apm	US	L	Apache, Mescalero-Chiricahua
 apn	BR	L	Apinayé
+apn	BR	LA	Afotigé
+apn	BR	LA	Aogé
 apn	BR	LA	Apinagé
 apn	BR	LA	Apinajé
+apn	BR	LA	Otogé
+apn	BR	LA	Oupinagee
+apn	BR	LA	Pinagé
+apn	BR	LA	Pinaré
+apn	BR	LA	Uhitische
+apn	BR	LA	Utinsche
+apn	BR	LA	Western Timbira
 apo	PG	L	Ambul
 apo	PG	LA	Apalik
 apo	PG	LA	Palik
@@ -2402,6 +2540,7 @@ aps	PG	LA	Arop
 apt	IN	L	Apatani
 apt	IN	LA	Apa
 apu	BR	L	Apurinã
+apu	BR	LA	Ipurinã
 apu	BR	LA	Ipurinãn
 apu	BR	LA	Kangite
 apu	BR	LA	Popengare
@@ -2420,7 +2559,8 @@ apx	ID	LA	Opotai
 apx	ID	LA	Tutunohan
 apy	BR	L	Apalaí
 apy	BR	LA	Apalay
-apy	BR	LA	Aparai
+apy	BR	LA	Aparaí
+apy	BR	LA	Arakwayu
 apz	PG	D	Aiewomba
 apz	PG	D	Wajakes
 apz	PG	DA	Wocokeso
@@ -2474,6 +2614,7 @@ aqn	PH	LA	Edimala
 aqr	NC	L	Arhâ
 aqr	NC	LA	Ara
 aqt	PY	L	Angaité
+aqt	PY	LA	Enenlhet
 aqt	PY	LA	Kovalhvok
 aqt	PY	LA	Koyaqteves
 aqz	BR	L	Akuntsu
@@ -2549,16 +2690,23 @@ arg	ES	LA	Fabla Aragonesa
 arg	ES	LA	High Aragonese
 arg	ES	LA	Patués
 arh	CO	L	Arhuaco
+arh	CO	LA	Arauco
+arh	CO	LA	Arhuac
+arh	CO	LA	Aruac
 arh	CO	LA	Aruaco
+arh	CO	LA	Auroguac
 arh	CO	LA	Bintucua
 arh	CO	LA	Bintuk
+arh	CO	LA	Bíntuka
 arh	CO	LA	Bíntukua
+arh	CO	LA	Bítuncua
 arh	CO	LA	Ica
 arh	CO	LA	Ijca
 arh	CO	LA	Ijka
 arh	CO	LA	Ika
 arh	CO	LA	Ikan
 arh	CO	LA	Ike
+arh	CO	LA	Iku
 ari	US	L	Arikara
 ari	US	LA	Arikaree
 ari	US	LA	Arikari
@@ -2575,6 +2723,7 @@ ark	BR	LA	Maxubí
 arl	PE	L	Arabela
 arl	PE	LA	Chiripuno
 arl	PE	LA	Chiripunu
+arl	PE	LA	Tapueyocaca
 arn	AR	D	Pehuenche
 arn	AR	L	Mapudungun
 arn	AR	LA	Araucano
@@ -2595,6 +2744,7 @@ arn	CL	L	Mapudungun
 arn	CL	LA	Araucana
 arn	CL	LA	Mapuche
 arn	CL	LA	Mapudungu
+arn	CL	LA	Mapuzungun
 arn	CL	LP	Araucano
 aro	BO	L	Araona
 aro	BO	LA	Cavina
@@ -2605,6 +2755,7 @@ arq	DZ	D	Constantine
 arq	DZ	D	Oran
 arq	DZ	L	Arabic, Algerian Spoken
 arq	DZ	LA	Algerian
+arq	EG	L	Arabic, Algerian Spoken
 arr	BR	D	Arara
 arr	BR	D	Uruku
 arr	BR	L	Karo
@@ -2665,10 +2816,15 @@ arw	SR	LA	Lokono
 arw	VE	L	Arawak
 arw	VE	LA	Arowak
 arw	VE	LA	Lokono
-arx	BR	D	Aruáshi
+arx	BR	D	Aruashí
 arx	BR	DA	Aruachi
 arx	BR	L	Aruá
+arx	BR	LA	Arouá
+arx	BR	LA	Arouén
+ary	EG	L	Arabic, Moroccan Spoken
+ary	EG	LA	Darija
 ary	EH	L	Arabic, Moroccan Spoken
+ary	EH	LA	Darija
 ary	MA	D	Fez
 ary	MA	D	Jebli
 ary	MA	D	Marrakech
@@ -2681,6 +2837,7 @@ ary	MA	DA	Jbala
 ary	MA	DA	Jebelia
 ary	MA	L	Arabic, Moroccan Spoken
 ary	MA	LA	Colloquial Arabic
+ary	MA	LA	Darija
 ary	MA	LA	Maghrebi Arabic
 ary	MA	LA	Maghribi
 ary	MA	LA	Moroccan Arabic
@@ -2721,7 +2878,9 @@ asc	ID	LA	Kaweinag
 asd	PG	L	Asas
 asd	PG	LA	Kow
 ase	BB	L	American Sign Language
+ase	BB	LA	ASL
 ase	BJ	L	American Sign Language
+ase	BJ	LA	ASL
 ase	BJ	LA	Benin Sign Language
 ase	BJ	LA	Langue des signes de l’Afrique francophone
 ase	BJ	LA	LSAF
@@ -2741,23 +2900,41 @@ ase	CI	LA	LSAF
 ase	CI	LA	LSAF Ivoirienne
 ase	CI	LA	LSCI
 ase	GD	L	American Sign Language
+ase	GD	LA	ASL
+ase	HT	L	American Sign Language
+ase	HT	LA	ASL
+ase	HT	LA	Haitian Sign Language
+ase	HT	LA	Langue des signes haïtienne
+ase	HT	LA	LSH
 ase	KN	L	American Sign Language
+ase	KN	LA	ASL
 ase	ML	L	American Sign Language
+ase	ML	LA	ASL
 ase	ML	LA	Langue des signes de l’Afrique francophone
 ase	ML	LA	LSAF
 ase	PH	L	American Sign Language
+ase	PH	LA	ASL
 ase	TG	L	American Sign Language
 ase	TG	LA	Langue des signes de l’Afrique francophone
 ase	TG	LA	LSAF
 ase	TG	LA	Togo Sign Language
 ase	TT	L	American Sign Language
+ase	TT	LA	ASL
+ase	TT	LA	Trinidad and Tobago Sign Language
+ase	TT	LA	TTSL
 ase	US	D	Black American Sign Language
-ase	US	D	Tactile ASL
+ase	US	D	Tactile American Sign Language
+ase	US	DA	Black ASL
+ase	US	DA	Tactile ASL
 ase	US	DA	TASL
 ase	US	L	American Sign Language
+ase	US	LA	Ameslan
 ase	US	LA	ASL
+ase	US	LA	SIGN AMERICA
 ase	VC	L	American Sign Language
+ase	VC	LA	ASL
 ase	VI	L	American Sign Language
+ase	VI	LA	ASL
 asf	AU	L	Australian Sign Language
 asf	AU	LA	Auslan
 asg	NG	D	Rofia
@@ -2773,14 +2950,16 @@ asg	NG	LA	Kamberri
 asg	NG	LA	Yauri
 asg	NG	LP	Maunchi
 asg	NG	LP	Mawanchi
-ash	PE	L	Abishira
+ash	PE	L	Awishira
 ash	PE	LA	Abigira
 ash	PE	LA	Abiquira
+ash	PE	LA	Abishira
 ash	PE	LA	Agouisiri
 ash	PE	LA	Auishiri
 ash	PE	LA	Avirxiri
 ash	PE	LA	Ixignor
-ash	PE	LA	Tequraca
+ash	PE	LA	Tekiraka
+ash	PE	LA	Tequiraca
 ash	PE	LA	Vacacocha
 asi	ID	L	Buruwai
 asi	ID	LA	Asianara
@@ -2804,6 +2983,7 @@ ask	AF	DA	Wamai
 ask	AF	L	Ashkun
 ask	AF	LA	Ashkund
 ask	AF	LA	Ashkuni
+ask	AF	LA	Ashkunu viri
 ask	AF	LA	Wamais
 ask	AF	LA	Wamayi
 asl	ID	D	Asilulu
@@ -2823,10 +3003,13 @@ asm	IN	LA	Asambe
 asm	IN	LA	Asami
 asm	IN	LA	Asamiya
 asn	BR	L	Asurini of Xingú
+asn	BR	LA	Assuriní
+asn	BR	LA	Assurinikin
 asn	BR	LA	Asuriní de Koatinema
 asn	BR	LA	Asurini do Xingú
 asn	BR	LA	Awaeté
 asn	BR	LA	Awaté
+asn	BR	LA	Kuben-Kamrektí
 aso	PG	D	Amaizuho
 aso	PG	D	Bohena
 aso	PG	D	Kongi
@@ -2880,6 +3063,7 @@ ast	PT	DA	Bable
 ast	PT	L	Asturian
 ast	PT	LA	Asturian-Leonese
 asu	BR	L	Asurini, Tocantins
+asu	BR	LA	Akwawa-Asuriní
 asu	BR	LA	Akwaya
 asu	BR	LA	Assuriní
 asu	BR	LA	Asuriní
@@ -2917,6 +3101,7 @@ atb	CN	LA	Atsi-Maru
 atb	CN	LA	Atzi
 atb	CN	LA	Azi
 atb	CN	LA	Szi
+atb	CN	LA	Tsaiva
 atb	CN	LA	Tsaiwa
 atb	CN	LA	Xiaoshanhua
 atb	MM	L	Zaiwa
@@ -2925,6 +3110,7 @@ atb	MM	LA	Atshi
 atb	MM	LA	Atsi
 atb	MM	LA	Atzi
 atb	MM	LA	Azi
+atb	MM	LA	Tsaiva
 atb	MM	LA	Zi
 atd	PH	L	Manobo, Ata
 atd	PH	LA	Ata of Davao
@@ -2987,6 +3173,7 @@ atr	BR	DA	Uaimirí
 atr	BR	DA	Wahmirí
 atr	BR	DA	Yauaperi
 atr	BR	L	Waimiri-Atroarí
+atr	BR	LA	Atroahí
 atr	BR	LA	Atroahy
 atr	BR	LA	Atroaí
 atr	BR	LA	Atroarí
@@ -3002,10 +3189,12 @@ ats	US	LA	Fall Indians
 ats	US	LA	Gros Ventres
 ats	US	LA	White Clay People
 att	PH	L	Atta, Pamplona
+att	PH	LA	Atta
 att	PH	LA	Northern Cagayan Negrito
 atu	SS	D	Cieng Luai
 atu	SS	D	Cieng Nhyam
 atu	SS	L	Reel
+atu	SS	LA	Atuot
 atu	SS	LA	Atwot
 atu	SS	LA	Thok Cieng Reel
 atu	SS	LA	Thok Reel
@@ -3018,22 +3207,24 @@ atv	RU	LA	Telengut
 atv	RU	LA	Teleut
 atw	US	L	Atsugewi
 atx	BR	L	Arutani
+atx	BR	LA	Anake
 atx	BR	LA	Aoaqui
-atx	BR	LA	Auake
+atx	BR	LA	Auakê
 atx	BR	LA	Auaqué
+atx	BR	LA	Awaikê
 atx	BR	LA	Awake
 atx	BR	LA	Oewaku
 atx	BR	LA	Orotani
 atx	BR	LA	Uruak
-atx	BR	LA	Urutani
+atx	BR	LA	Urutaní
 atx	VE	L	Arutani
 atx	VE	LA	Aoaqui
-atx	VE	LA	Auake
+atx	VE	LA	Auakê
 atx	VE	LA	Auaqué
 atx	VE	LA	Awaké
 atx	VE	LA	Oewaku
 atx	VE	LA	Uruak
-atx	VE	LA	Urutani
+atx	VE	LA	Urutaní
 aty	VU	L	Aneityum
 aty	VU	LA	Aneiteum
 aty	VU	LA	Aneiteumese
@@ -3049,7 +3240,10 @@ aub	CN	LA	Phupha
 auc	EC	L	Waorani
 auc	EC	LA	Huaorani
 auc	EC	LA	Sabela
-auc	EC	LA	Waodani
+auc	EC	LA	Wao Tededö
+auc	EC	LA	Waodäni
+auc	EC	LA	Waodäni Tededö
+auc	EC	LA	Waos
 auc	EC	LP	Auca
 aud	SB	L	Anuta
 aug	BJ	L	Aguna
@@ -3086,6 +3280,7 @@ auk	PG	LA	Arinwa
 auk	PG	LA	Lolopani
 auk	PG	LA	Ruruhip
 auk	PG	LA	Wan Wan
+auk	PG	LA	Wanib
 aul	VU	D	Boinelang
 aul	VU	D	Onesso
 aul	VU	L	Aulua
@@ -3099,6 +3294,7 @@ aun	PG	D	South Aunalei
 aun	PG	L	One, Molmo
 aun	PG	LA	Aunalei
 aun	PG	LA	Molmo
+aun	PG	LA	One
 aun	PG	LA	Onele
 aun	PG	LA	Oni
 aup	PG	D	Giribam
@@ -3305,9 +3501,10 @@ awc	NG	LA	Western Acipa
 awe	BR	L	Awetí
 awe	BR	LA	Arauine
 awe	BR	LA	Arauite
-awe	BR	LA	Aueti
-awe	BR	LA	Aueto
-awe	BR	LA	Auiti
+awe	BR	LA	Auetí
+awe	BR	LA	Auetó
+awe	BR	LA	Auití
+awe	BR	LA	Autl
 awe	BR	LA	Awetö
 awg	AU	D	Mpakwithi
 awg	AU	L	Anguthimri
@@ -3376,6 +3573,7 @@ aws	ID	LA	Sjiagha
 aws	ID	LA	Syiagha
 aws	ID	LA	Yenimu
 awt	BR	L	Araweté
+awt	BR	LA	Arawine
 awt	BR	LA	Bïde
 awu	ID	L	Awyu, Central
 awu	ID	LA	Ajau
@@ -3459,6 +3657,7 @@ axl	AU	LA	Arunta Bu
 axl	AU	LA	Arunta Ulpma
 axl	AU	LA	Eastern Aranda
 axl	AU	LA	Lower Aranda
+axl	AU	LA	Pertame
 axl	AU	LA	Southern Aranda
 axl	AU	LA	Western Aranda
 axx	NC	L	Xârâgurè
@@ -3478,6 +3677,7 @@ ayb	BJ	D	Ayizo-Seto
 ayb	BJ	D	Ayizo-Tori
 ayb	BJ	D	Kadagbe
 ayb	BJ	DA	Kada-Gbe
+ayb	BJ	DA	Sèto
 ayb	BJ	L	Gbe, Ayizo
 ayb	BJ	LA	Ayizo
 ayb	BJ	LA	Ayizo-Gbe
@@ -3545,21 +3745,41 @@ ayo	PY	LA	Sirákua
 ayo	PY	LA	Takrat
 ayo	PY	LA	Totobiegosode
 ayo	PY	LA	Yanaigua
+ayp	IQ	D	Mardini Aramaic
+ayp	IQ	DA	Abdul-Massih
+ayp	IQ	DA	Jesrawi
+ayp	IQ	DA	Mardilli
+ayp	IQ	DA	Mardini
 ayp	IQ	L	Arabic, North Mesopotamian Spoken
 ayp	IQ	LA	Mesopotamian Qeltu Arabic
 ayp	IQ	LA	Moslawi
 ayp	IQ	LA	Syro-Mesopotamian Vernacular Arabic
+ayp	SY	D	Mardini Aramaic
+ayp	SY	DA	Abdul-Massih
+ayp	SY	DA	Jesrawi
+ayp	SY	DA	Mardilli
+ayp	SY	DA	Mardini
 ayp	SY	L	Arabic, North Mesopotamian Spoken
 ayp	SY	LA	Mesopotamian Qeltu Arabic
 ayp	SY	LA	Moslawi
 ayp	SY	LA	Syro-Mesopotamian Arabic
+ayp	TR	D	Mardini Aramaic
+ayp	TR	DA	Abdul-Massih
+ayp	TR	DA	Jesrawi
+ayp	TR	DA	Mardilli
+ayp	TR	DA	Mardini
 ayp	TR	L	Arabic, North Mesopotamian Spoken
 ayp	TR	LA	Syro-Mesopotamian Vernacular Arabic
 ayq	PG	L	Ayi
 ayr	AR	L	Aymara, Central
+ayr	AR	LA	Aimara
 ayr	BO	L	Aymara, Central
+ayr	BO	LA	Aimara
 ayr	CL	L	Aymara, Central
+ayr	CL	LA	Aimara
 ayr	PE	L	Aymara, Central
+ayr	PE	LA	Aimara
+ayr	PE	LA	Aymara
 ays	PH	L	Ayta, Sorsogon
 ayt	PH	L	Ayta, Magbukun
 ayt	PH	LA	Bataan Ayta
@@ -3603,8 +3823,13 @@ aza	CN	LA	Phula
 aza	CN	LA	Phuphje
 aza	CN	LA	Shaoji Phula
 aza	CN	LA	Sifter Basket Phula
+azb	AZ	L	Azerbaijani, South
+azb	AZ	LA	Azeri
 azb	IQ	D	Kirkuk
 azb	IQ	L	Azerbaijani, South
+azb	IQ	LA	Azeri
+azb	IQ	LA	Turk
+azb	IQ	LA	Turkmen
 azb	IR	D	Afshari
 azb	IR	D	Aynallu
 azb	IR	D	Baharlu
@@ -3624,13 +3849,18 @@ azb	IR	DA	Inanlu
 azb	IR	DA	Kamesh
 azb	IR	DA	Shahseven
 azb	IR	L	Azerbaijani, South
+azb	IR	LA	Azeri
 azb	IR	LA	Torki
 azb	SY	L	Azerbaijani, South
+azb	SY	LA	Azeri
+azb	SY	LA	Turkmen
+azb	SY	LA	Turkomen
 azb	TR	D	Kars
 azb	TR	L	Azerbaijani, South
 azb	TR	LA	Azeri
 azd	MX	L	Nahuatl, Eastern Durango
 azd	MX	LA	Eastern Durango Aztec
+azd	MX	LA	Meshikan de San Pedro Shikora
 azd	MX	LA	Meshikan del Este
 azd	MX	LA	Mexicanero del Este
 azd	MX	LA	Nahuat del Este de Durango
@@ -3638,6 +3868,8 @@ aze	IR	L	Azerbaijani
 azg	MX	L	Amuzgo, San Pedro Amuzgos
 azg	MX	LA	Amuzgo Bajo del Este
 azg	MX	LA	Amuzgo de San Pedro Amuzgos
+azg	MX	LA	Jñon’ndaa
+azg	MX	LA	Ñonda
 azg	MX	LA	Oaxaca Amuzgo
 azj	AM	D	Airym
 azj	AM	D	Baku
@@ -3696,7 +3928,9 @@ azj	RU	L	Azerbaijani, North
 azm	MX	L	Amuzgo, Ipalapa
 azm	MX	LA	Amuzgo Bajo del Este
 azm	MX	LA	Jñunda
+azm	MX	LA	Ts’unuma
 azn	MX	L	Nahuatl, Western Durango
+azn	MX	LA	Meshikan de San Agustin Buenaventura y de Santa Cruz
 azn	MX	LA	Meshikan del occidente
 azn	MX	LA	Mexicanero del occidente
 azn	MX	LA	Nahuat del Occidente en Durango y Nayarit
@@ -3711,6 +3945,7 @@ azz	MX	L	Nahuatl, Highland Puebla
 azz	MX	LA	Mejicano de Zacapoaxtla
 azz	MX	LA	Náhuat de la Sierra de Puebla
 azz	MX	LA	Sierra Aztec
+azz	MX	LA	Sierra de Zacapoaxtla Nahuatl
 azz	MX	LA	Sierra Puebla Náhuatl
 azz	MX	LA	Zacapoaxtla Náhuat
 baa	SB	D	Avasö
@@ -3832,6 +4067,7 @@ bam	ML	D	Sikasso
 bam	ML	D	Somono
 bam	ML	D	Standard Bambara
 bam	ML	D	Wasulunkakan
+bam	ML	DA	Kombye
 bam	ML	DA	Maninkakan, Eastern
 bam	ML	DA	Wassulu
 bam	ML	DA	Wassulunka
@@ -3865,8 +4101,10 @@ bao	CO	L	Waimaha
 bao	CO	LA	Barasano
 bao	CO	LA	Bará-Tuyuka
 bao	CO	LA	Northern Barasano
+bao	CO	LA	Waimaja
 bao	CO	LP	Bará
 bap	IN	L	Bantawa
+bap	IN	LA	An Yüng
 bap	IN	LA	Bantaba
 bap	IN	LA	Bantawa Dum
 bap	IN	LA	Bantawa Rai
@@ -3875,6 +4113,7 @@ bap	IN	LA	Bantawa Yüng
 bap	IN	LA	Bontawa
 bap	IN	LA	Kirat Khambu
 bap	IN	LA	Kirat Khambu Rai
+bap	IN	LA	Kirawa Yüng
 bap	IN	LA	Rai
 bap	NP	D	Amchoke
 bap	NP	D	Dhankuta
@@ -3885,12 +4124,14 @@ bap	NP	DA	Northern Bantawa
 bap	NP	DA	Southern Bantawa
 bap	NP	DA	Western Bantawa
 bap	NP	L	Bantawa
+bap	NP	LA	An Yüng
 bap	NP	LA	Bantaba
 bap	NP	LA	Bantawa Dum
 bap	NP	LA	Bantawa Rai
 bap	NP	LA	Bantawa Yong
 bap	NP	LA	Bantawa Yüng
 bap	NP	LA	Bontawa
+bap	NP	LA	Kirawa Yüng
 bar	AT	D	Central Bavarian
 bar	AT	D	North Bavarian
 bar	AT	D	Salzburgish
@@ -4038,6 +4279,7 @@ bbh	CN	LA	Bengan
 bbh	CN	LA	Bogan
 bbh	CN	LA	Bugeng
 bbh	CN	LA	Hualo
+bbh	CN	LA	Hualuo
 bbh	CN	LA	Huazu
 bbh	CN	LA	Pukan
 bbh	CN	LA	Puqeng
@@ -4102,6 +4344,7 @@ bbm	CD	LA	Southwest Bwa
 bbn	PG	L	Uneapa
 bbn	PG	LA	Bali
 bbn	PG	LA	Bali-Vitu
+bbn	PG	LA	Unea
 bbo	BF	D	Jèrè
 bbo	BF	D	Kukoma
 bbo	BF	D	Kure
@@ -4114,8 +4357,9 @@ bbo	BF	L	Konabéré
 bbo	BF	LA	Black Bobo
 bbo	BF	LA	Bobo
 bbo	BF	LA	Bobo Fi
-bbo	BF	LA	Bobo Fign
 bbo	BF	LA	Bobo Fing
+bbo	BF	LA	Bobo Madaré
+bbo	BF	LA	Boboda
 bbo	BF	LA	Northern Bobo Madaré
 bbo	ML	D	San
 bbo	ML	D	Tankire
@@ -4126,6 +4370,8 @@ bbo	ML	LA	Bobo
 bbo	ML	LA	Bobo Da
 bbo	ML	LA	Bobo Fi
 bbo	ML	LA	Bobo Fing
+bbo	ML	LA	Boboda
+bbo	ML	LA	Konakuma
 bbp	CF	D	Dakpa
 bbp	CF	D	Gbaga-Nord
 bbp	CF	D	Gbi
@@ -4175,6 +4421,7 @@ bbw	CM	LA	Bapa
 bbw	CM	LA	Bapakum
 bbw	CM	LA	Papia
 bbw	CM	LA	Papiakum
+bbw	CM	LA	Supapya
 bbw	CM	LA	Supapya’
 bbx	CM	L	Bubia
 bbx	CM	LA	Bobe
@@ -4275,7 +4522,9 @@ bcf	PG	D	Upper Bamu
 bcf	PG	DA	Middle Bamu
 bcf	PG	L	Bamu
 bcf	PG	LA	Bamu Kiwai
-bcg	GN	L	Baga Binari
+bcg	GN	L	Baga Pokur
+bcg	GN	LA	Baga Binari
+bcg	GN	LA	Baga Mboteni
 bcg	GN	LA	Baka
 bcg	GN	LA	Binari
 bcg	GN	LA	Kalum
@@ -4309,6 +4558,7 @@ bcm	PG	L	Bannoni
 bcm	PG	LA	Banoni
 bcm	PG	LA	Tsunari
 bcn	NG	L	Bali
+bcn	NG	LA	Abaali
 bcn	NG	LA	Bibaali
 bcn	NG	LA	Ekpali
 bcn	NG	LA	Ibaali
@@ -4325,6 +4575,7 @@ bcp	CD	D	Bekeni
 bcp	CD	D	Bemili
 bcp	CD	L	Bali
 bcp	CD	LA	Baali
+bcp	CD	LA	Dhibali
 bcp	CD	LA	Kibaali
 bcp	CD	LA	Kibala
 bcp	CD	LA	Kibali
@@ -4345,11 +4596,16 @@ bcq	ET	LA	Gimarra
 bcq	ET	LA	Gimira
 bcr	CA	D	Babine Proper
 bcr	CA	D	Wetsuset’en
+bcr	CA	DA	Babine-Witsuwit’en
+bcr	CA	DA	Bulkley Lakes
+bcr	CA	DA	Witsuwit’en
 bcr	CA	L	Babine
 bcr	CA	LA	Babine Carrier
+bcr	CA	LA	Lake Babine
+bcr	CA	LA	Nadot’en
+bcr	CA	LA	Nat’oot’en
 bcr	CA	LA	Nedut’en
 bcr	CA	LA	Northern Carrier
-bcr	CA	LA	Witsuwit’en
 bcs	NG	L	Kohumono
 bcs	NG	LA	Bahumono
 bcs	NG	LA	Ediba
@@ -4379,6 +4635,7 @@ bcv	NG	DA	Bandawa
 bcv	NG	DA	Jinleri
 bcv	NG	DA	Kunini
 bcv	NG	L	Shoo-Minda-Nye
+bcv	NG	LA	Bakula
 bcw	CM	D	Gamboura
 bcw	CM	D	Gili
 bcw	CM	DA	Guili
@@ -4441,6 +4698,9 @@ bdb	ID	LA	Bosap
 bdc	CO	L	Emberá-Baudó
 bdc	CO	LA	Baudó
 bdc	CO	LA	Catrú
+bdc	CO	LA	Embena
+bdc	CO	LA	Embera
+bdc	CO	LA	Epena
 bdd	PG	D	Barabara
 bdd	PG	D	Bunama
 bdd	PG	D	Kasikasi
@@ -4470,8 +4730,8 @@ bde	NG	LA	Gidgid
 bdf	PG	L	Biage
 bdg	MY	L	Bonggi
 bdg	MY	LA	Bangay
-bdg	MY	LA	Banggi
-bdg	MY	LA	Banggi Dusun
+bdg	MY	LP	Banggi
+bdg	MY	LP	Banggi Dusun
 bdh	CD	L	Baka
 bdh	CD	LA	Tara Baaka
 bdh	SS	L	Baka
@@ -4556,6 +4816,7 @@ bdo	TD	L	Morom
 bdo	TD	LA	Bernde
 bdo	TD	LA	Tar Murba
 bdp	TZ	L	Bende
+bdp	TZ	LA	Babende
 bdp	TZ	LA	Kibende
 bdp	TZ	LA	Si’bende
 bdq	VN	D	Alakong
@@ -4575,16 +4836,21 @@ bdr	MY	D	Banggi
 bdr	MY	D	Kawang
 bdr	MY	D	Kota Belud
 bdr	MY	D	Papar
-bdr	MY	D	Pitas Bajau
+bdr	MY	D	Pitas
 bdr	MY	D	Putatan
-bdr	MY	D	Sandakan Bajau
+bdr	MY	D	Sandakan
 bdr	MY	L	Bajau, West Coast
+bdr	MY	LA	Bajau
+bdr	MY	LA	Bajau Sama
 bdr	MY	LA	Land Bajaw
+bdr	MY	LA	Sama
 bdr	MY	LA	West Coast Bajao
 bdr	MY	LA	West Coast Bajaw
 bds	TZ	L	Burunge
 bds	TZ	LA	Bulunge
 bds	TZ	LA	Burunga Iso
+bds	TZ	LA	Burungaisoo
+bds	TZ	LA	Burungee
 bds	TZ	LA	Burungi
 bds	TZ	LA	Kiburunge
 bds	TZ	LA	Mbulungi
@@ -4668,6 +4934,8 @@ bdz	PK	L	Badeshi
 bdz	PK	LA	Badakhshi
 bea	CA	L	Beaver
 bea	CA	LA	Dane-Zaa
+bea	CA	LA	Dane-zaa Záágé
+bea	CA	LA	Dunne-za
 beb	CM	D	Eki
 beb	CM	D	Manyok
 beb	CM	L	Bebele
@@ -4768,6 +5036,7 @@ beh	BJ	D	Tangeta
 beh	BJ	D	Tihoun
 beh	BJ	L	Biali
 beh	BJ	LA	Berba
+beh	BJ	LA	Bialaba
 beh	BJ	LA	Bieri
 beh	BJ	LA	Bjerb
 beh	BJ	LA	Bjeri
@@ -4780,7 +5049,9 @@ bei	ID	LA	Bakatiq
 bei	ID	LA	Bekati
 bej	EG	L	Bedawiyet
 bej	EG	LA	Bedawi
+bej	EG	LA	Bedàwie
 bej	EG	LA	Beja
+bej	EG	LA	Tu Bdhaawi
 bej	ER	D	Ababda
 bej	ER	D	Amara
 bej	ER	D	Beni-Amir
@@ -4794,6 +5065,7 @@ bej	ER	DA	Hadendowa
 bej	ER	L	Bedawiyet
 bej	ER	LA	Bedauye
 bej	ER	LA	Bedawi
+bej	ER	LA	Bedàwie
 bej	ER	LA	Bedawiye
 bej	ER	LA	Bedawye
 bej	ER	LA	Bedja
@@ -4802,6 +5074,7 @@ bej	ER	LA	Bedya
 bej	ER	LA	Beja
 bej	ER	LA	Bidhaaweet
 bej	ER	LA	Lobat
+bej	ER	LA	Tu Bdhaawi
 bej	SD	D	Beni-Amir
 bej	SD	D	Bisharin
 bej	SD	D	Hadareb
@@ -4813,6 +5086,7 @@ bej	SD	DA	Hadendowa
 bej	SD	L	Bedawiyet
 bej	SD	LA	Bedauye
 bej	SD	LA	Bedawi
+bej	SD	LA	Bedàwie
 bej	SD	LA	Bedawiye
 bej	SD	LA	Bedja
 bej	SD	LA	Beja
@@ -4914,6 +5188,7 @@ ben	NP	LA	Bangala
 ben	NP	LA	Bangla
 ben	NP	LA	Bangla-Bhasa
 ben	SG	L	Bengali
+ben	SG	LA	Bangla
 beo	PG	D	Komofio
 beo	PG	D	North Beami
 beo	PG	L	Beami
@@ -5014,6 +5289,7 @@ bfa	SS	DA	Nypho
 bfa	SS	DA	Pajulu
 bfa	SS	L	Bari
 bfa	SS	LA	Beri
+bfa	SS	LA	Kuku
 bfa	UG	D	Kuku
 bfa	UG	D	Mondari
 bfa	UG	D	Nyangbara
@@ -5033,6 +5309,7 @@ bfa	UG	DA	Nypho
 bfa	UG	DA	Pajulu
 bfa	UG	L	Bari
 bfa	UG	LA	Beri
+bfa	UG	LA	Kuku
 bfb	IN	L	Bareli, Pauri
 bfb	IN	LA	Bareli
 bfb	IN	LA	Barewali
@@ -5043,6 +5320,7 @@ bfc	CN	L	Bai, Panyi
 bfc	CN	LA	Bijiang Bai
 bfc	CN	LA	Lan-Bi Bai
 bfc	CN	LA	Leme
+bfc	CN	LA	Lemei
 bfc	CN	LA	Lemo
 bfc	CN	LA	Northern Bai
 bfc	CN	LA	Panyi
@@ -5056,6 +5334,7 @@ bfd	CM	LA	Fu
 bfd	CM	LA	Fut
 bfe	ID	L	Betaf
 bfe	ID	LA	Tena
+bfe	ID	LA	Ten’a
 bff	CF	L	Bofi
 bff	CF	LA	Boffi
 bfg	ID	D	Belayan
@@ -5079,6 +5358,7 @@ bfj	CM	LA	Chufie’
 bfj	CM	LA	Chuufi
 bfj	CM	LA	Nchufie
 bfk	TH	L	Ban Khor Sign Language
+bfk	TH	LA	pasa kidd
 bfl	CF	D	Banda-Ndélé
 bfl	CF	D	Junguru
 bfl	CF	D	Ngao
@@ -5171,6 +5451,7 @@ bfu	IN	LA	Bunan
 bfu	IN	LA	Erankad
 bfu	IN	LA	Ghara
 bfu	IN	LA	Keylong Boli
+bfu	IN	LA	Lahuli
 bfu	IN	LA	Lahuli of Bunan
 bfu	IN	LA	Poonan
 bfu	IN	LA	Punan
@@ -5243,6 +5524,8 @@ bga	NG	DA	Kokanawa
 bga	NG	DA	Wuranci
 bga	NG	DA	Wurawa
 bga	NG	L	Gwamhi-Wuri
+bga	NG	LA	Banganci
+bga	NG	LA	Bangawa
 bga	NG	LA	Lyase
 bga	NG	LA	Lyase-Ne
 bgb	ID	L	Bobongko
@@ -5262,6 +5545,8 @@ bgc	IN	LA	Haryani
 bgc	IN	LA	Jatu
 bgd	IN	L	Bareli, Rathwi
 bgd	IN	LA	Barel
+bgd	IN	LA	Barela
+bgd	IN	LA	Paura
 bgd	IN	LA	Pauri
 bgd	IN	LA	Pawari
 bgd	IN	LA	Pawri
@@ -5312,7 +5597,6 @@ bgk	LA	LA	Pasing
 bgk	LA	LA	Phsin
 bgk	LA	LA	Phsing
 bgl	LA	L	Bo
-bgm	GN	L	Baga Mboteni
 bgn	AF	D	Rakhshani
 bgn	AF	DA	Raxshani
 bgn	AF	L	Balochi, Western
@@ -5326,6 +5610,7 @@ bgn	IR	L	Balochi, Western
 bgn	IR	LA	Baloci
 bgn	IR	LA	Baluchi
 bgn	IR	LA	Baluci
+bgn	IR	LA	Yarahmadza
 bgn	PK	D	Lashari
 bgn	PK	D	Rakhshani
 bgn	PK	D	Sarawani
@@ -5526,6 +5811,7 @@ bhh	UZ	LA	Judeo-Tajik
 bhi	IN	D	Parya Bhilali
 bhi	IN	L	Bhilali
 bhi	IN	LA	Bhilala
+bhi	IN	LA	Bhili
 bhj	NP	D	Hangu
 bhj	NP	D	Moblocha
 bhj	NP	D	Nechali
@@ -5534,7 +5820,10 @@ bhj	NP	D	Tolacha
 bhj	NP	L	Bahing
 bhj	NP	LA	Baying
 bhj	NP	LA	Bayung
+bhj	NP	LA	Ikke lo
 bhj	NP	LA	Kiranti-Bayung
+bhj	NP	LA	Pai Lo
+bhj	NP	LA	Radu lo
 bhl	PG	D	Bim
 bhl	PG	D	Nimtep Weng
 bhl	PG	L	Bimin
@@ -5677,12 +5966,14 @@ bib	BF	D	Barka
 bib	BF	D	Lebir
 bib	BF	D	Lere
 bib	BF	L	Bisa
+bib	BF	LA	Boussanse
 bib	GH	D	Baraka
 bib	GH	D	Lebir
 bib	GH	DA	Eastern Bisa
 bib	GH	DA	Western Bisa
 bib	GH	L	Bisa
 bib	GH	LA	Bissa
+bib	GH	LA	Busansi
 bib	TG	L	Bissa
 bib	TG	LA	Bisa
 bic	PG	L	Bikaru
@@ -5721,8 +6012,6 @@ bij	NG	D	Legeri
 bij	NG	D	Vaghat
 bij	NG	D	Ya
 bij	NG	DA	Boi
-bij	NG	DA	Kadun
-bij	NG	DA	Kwanka
 bij	NG	DA	Tivaghat
 bij	NG	DA	Tiya
 bij	NG	L	Vaghat-Ya-Bijim-Legeri
@@ -5922,6 +6211,7 @@ bjn	ID	LA	Labuhan
 bjn	MY	L	Banjar
 bjn	MY	LA	Bandjarese
 bjn	MY	LA	Banjar Malay
+bjn	MY	LA	Banjar Melau
 bjn	MY	LA	Banjarese
 bjo	CD	D	Bendi
 bjo	CD	D	Yakpa
@@ -6075,6 +6365,7 @@ bkk	IN	LA	Brokpa
 bkk	IN	LA	Brokpa of Dah-Hanu
 bkk	IN	LA	Dokskat
 bkk	IN	LA	Kyango
+bkk	IN	LA	Minaro
 bkl	ID	L	Berik
 bkl	ID	LA	Berick
 bkl	ID	LA	Berrik
@@ -6086,6 +6377,7 @@ bkm	CM	DA	Mbesa
 bkm	CM	L	Kom
 bkm	CM	LA	Bamekon
 bkm	CM	LA	Bikom
+bkm	CM	LA	Itangikom
 bkm	CM	LA	Kong
 bkm	CM	LA	Nkom
 bkn	ID	D	Punan Busang
@@ -6170,8 +6462,10 @@ bkx	TL	D	Nu’af
 bkx	TL	L	Baikeno
 bkx	TL	LA	Ambeno
 bkx	TL	LA	Ambenu
+bkx	TL	LA	Atoni
 bkx	TL	LA	Baikenu
 bkx	TL	LA	Biqueno
+bkx	TL	LA	Laes Baikeno
 bkx	TL	LA	Lais Meto
 bkx	TL	LA	Molok Meto
 bkx	TL	LA	Oe Cusi
@@ -6246,13 +6540,17 @@ bla	CA	DA	Kainaa
 bla	CA	DA	Peigan
 bla	CA	L	Blackfoot
 bla	CA	LA	Blackfeet
+bla	CA	LA	Niitsipowahsin
 bla	CA	LA	Pied Noir
 bla	CA	LA	Pikanii
+bla	CA	LA	Siksika(ipowahsin)
 bla	US	D	Piegan
 bla	US	DA	Peigan
 bla	US	L	Blackfoot
 bla	US	LA	Blackfeet
+bla	US	LA	Niitsipowahsin
 bla	US	LA	Pikanii
+bla	US	LA	Siksika(ipowahsin)
 blb	SB	L	Bilua
 blb	SB	LA	Mbilua
 blb	SB	LA	Vella Lavella
@@ -6387,6 +6685,7 @@ blp	SB	LA	Goi
 blq	PG	D	Baluan
 blq	PG	D	Pam
 blq	PG	L	Baluan-Pam
+blq	PG	LA	Pam-Baluan
 blr	CN	D	Kem Degne
 blr	CN	D	Phang
 blr	CN	L	Blang
@@ -6535,6 +6834,7 @@ bmi	TD	LA	Mbarma
 bmi	TD	LA	Tar Bagrimma
 bmi	TD	LA	Tar Barma
 bmj	NP	L	Bote
+bmj	NP	LA	Bot
 bmj	NP	LA	Bote-Majhi
 bmj	NP	LA	Pakhe-Bote
 bmj	NP	LA	Pani-Bote
@@ -6573,6 +6873,7 @@ bmq	ML	LA	Western Bobo Oule
 bmq	ML	LA	Western Bwamu
 bmq	ML	LA	Western Red
 bmr	CO	L	Muinane
+bmr	CO	LA	Bora-Muinane
 bmr	CO	LA	Muename
 bmr	CO	LA	Muinana
 bmr	CO	LA	Muinani
@@ -6755,6 +7056,8 @@ bno	PH	D	Sibalenhon
 bno	PH	D	Simaranhon
 bno	PH	DA	Sibale
 bno	PH	L	Bantoanon
+bno	PH	LA	Asi
+bno	PH	LA	Asiq
 bnp	PG	D	Bola
 bnp	PG	D	Harua
 bnp	PG	DA	Garua
@@ -6791,6 +7094,7 @@ bnu	ID	LA	Dentong
 bnv	ID	L	Beneraf
 bnv	ID	LA	Boneraf
 bnv	ID	LA	Bonerif
+bnv	ID	LA	Edwas
 bnw	PG	L	Bisis
 bnw	PG	LA	Yambiyambi
 bnx	CD	D	Bangubangu
@@ -6815,6 +7119,8 @@ boa	CO	LA	Boro
 boa	CO	LA	Meamuyna
 boa	CO	LA	Miraña
 boa	PE	L	Bora
+boa	PE	LA	Booraa
+boa	PE	LA	Miamunaa
 boa	PE	LA	Miraña
 bob	KE	L	Aweer
 bob	KE	LA	Aweera
@@ -6962,6 +7268,7 @@ bon	PG	LA	Pine
 boo	ML	L	Bozo, Tiemacèwè
 boo	ML	LA	Boso
 boo	ML	LA	Tié
+boo	ML	LA	Tièma Cèwè
 boo	ML	LA	Tiema Ciewe
 boo	ML	LA	Tièma Cièwè
 boo	ML	LA	Tiemacewe
@@ -7008,6 +7315,10 @@ bow	PG	L	Rema
 bow	PG	LA	Bothar
 box	BF	D	Ouarkoye
 box	BF	L	Buamu
+box	BF	LA	Bobo
+box	BF	LA	Bomo
+box	BF	LA	Bouamou
+box	BF	LA	Bwaba
 box	BF	LA	Bwamu
 box	BF	LA	Eastern Bobo Oule
 box	BF	LA	Eastern Bobo Wule
@@ -7019,6 +7330,7 @@ boz	ML	LA	Tégué
 boz	ML	LA	Tie
 boz	ML	LA	Tiemaxo
 boz	ML	LA	Tiéyakho
+boz	ML	LA	Tieyaxo
 boz	ML	LA	Tigemaxo
 boz	ML	LA	Tiguémakho
 boz	ML	LA	Tyeyaxo
@@ -7087,6 +7399,7 @@ bpm	PG	L	Biyom
 bpm	PG	LA	Sasime
 bpn	CN	L	Dzao Min
 bpn	CN	LA	Ba Pai Yao
+bpn	CN	LA	dzau min
 bpn	CN	LA	Yao Min
 bpn	CN	LA	Yau Min
 bpn	CN	LA	Zaomin
@@ -7126,6 +7439,7 @@ bpy	BD	D	Madai Gang
 bpy	BD	D	Rajar Gang
 bpy	BD	L	Bishnupriya
 bpy	BD	LA	Bishnupria
+bpy	BD	LA	Bishnupriya Manipuri
 bpy	BD	LA	Bishnupuriya
 bpy	BD	LA	Bisna Puriya
 bpy	IN	D	Madai Gang
@@ -7134,6 +7448,7 @@ bpy	IN	DA	Leimanai
 bpy	IN	DA	Ningthaunai
 bpy	IN	L	Bishnupriya
 bpy	IN	LA	Bishnupria Manipuri
+bpy	IN	LA	Bishnupriya Manipuri
 bpy	IN	LA	Bishnupuriya
 bpy	IN	LA	Bisna Puriya
 bpz	ID	D	Bilba
@@ -7157,14 +7472,13 @@ bqa	BJ	LA	Tshummbuli
 bqb	ID	L	Bagusa
 bqb	ID	LA	Kapeso
 bqb	ID	LA	Suaseso
-bqc	BJ	D	Bo’o
 bqc	BJ	L	Boko
-bqc	BJ	LA	Boo
+bqc	BJ	LA	Bo’o
 bqc	NG	D	Illo Busa
 bqc	NG	DA	Busa
 bqc	NG	L	Boko
 bqc	NG	LA	Bokonya
-bqc	NG	LA	Boo
+bqc	NG	LA	Bo’o
 bqd	CM	L	Bung
 bqf	GN	L	Baga Kaloum
 bqg	TG	D	Bago
@@ -7197,6 +7511,7 @@ bqi	IR	DA	Kuhrang
 bqi	IR	L	Bakhtiâri
 bqi	IR	LA	Lori
 bqi	IR	LA	Lori-ye Khaveri
+bqi	IR	LA	Luri
 bqj	SN	D	Affiniam
 bqj	SN	D	Bandial
 bqj	SN	D	Elun
@@ -7207,6 +7522,7 @@ bqj	SN	L	Bandial
 bqj	SN	LA	Banjaal
 bqj	SN	LA	Eegima
 bqj	SN	LA	Eegimaa
+bqj	SN	LA	Gubanjalay
 bqk	CF	D	Buka
 bqk	CF	D	Mbre
 bqk	CF	D	Moruba
@@ -7252,11 +7568,13 @@ bqo	CM	L	Balo
 bqp	NG	D	New Busa
 bqp	NG	D	Wawa
 bqp	NG	L	Busa
+bqp	NG	LA	Bariba
 bqp	NG	LA	Bisã
 bqp	NG	LA	Bisayã
 bqp	NG	LA	Busa-Bisã
 bqp	NG	LA	Busano
 bqp	NG	LA	Bussanchi
+bqp	NG	LA	Bussawa
 bqq	ID	L	Biritai
 bqq	ID	LA	Aliki
 bqq	ID	LA	Ati
@@ -7283,6 +7601,7 @@ bqu	CD	DA	Bukuru
 bqu	CD	L	Boguru
 bqu	CD	LA	Buguru
 bqu	CD	LA	Guru
+bqu	CD	LA	Kinsong
 bqu	CD	LA	Kogoro
 bqu	CD	LA	Koguru
 bqu	SS	D	Boguru
@@ -7291,6 +7610,7 @@ bqu	SS	DA	Bukum
 bqu	SS	DA	Bukuru
 bqu	SS	L	Boguru
 bqu	SS	LA	Buguru
+bqu	SS	LA	Kinsong
 bqu	SS	LA	Kogoro
 bqu	SS	LA	Koguru
 bqv	NG	D	Koro Miamia
@@ -7384,6 +7704,7 @@ brc	GY	L	Berbice Creole Dutch
 brd	NP	D	Dandagaun
 brd	NP	D	Mailung
 brd	NP	L	Baram
+brd	NP	LA	Balkura
 brd	NP	LA	Baraamu
 brd	NP	LA	Baramu
 bre	FR	D	Gwenedeg
@@ -7395,6 +7716,7 @@ bre	FR	DA	Leonais
 bre	FR	DA	Tregorrois
 bre	FR	DA	Vannetais
 bre	FR	L	Breton
+bre	FR	LA	Berton
 bre	FR	LA	Brezhoneg
 brf	CD	L	Bera
 brf	CD	LA	Bira
@@ -7623,6 +7945,7 @@ bsh	AF	DA	Jadidi
 bsh	AF	DA	Ramgulviri
 bsh	AF	L	Kati
 bsh	AF	LA	Bashgali
+bsh	AF	LA	Kata viri
 bsh	AF	LA	Kativiri
 bsh	AF	LA	Nuristani
 bsh	PK	D	Eastern Kativiri
@@ -7631,6 +7954,7 @@ bsh	PK	D	Western Kativiri
 bsh	PK	DA	Shekhani
 bsh	PK	L	Kati
 bsh	PK	LA	Bashgali
+bsh	PK	LA	Kata viri
 bsh	PK	LA	Kativiri
 bsh	PK	LA	Nuristani
 bsi	CM	D	Mienge
@@ -7650,6 +7974,7 @@ bsj	NG	D	Naaban
 bsj	NG	L	Bangwinji
 bsj	NG	LA	Bangjinge
 bsj	NG	LA	Bangunji
+bsk	IN	L	Burushaski
 bsk	PK	D	Hunza
 bsk	PK	D	Nagar
 bsk	PK	D	Yasin
@@ -7751,6 +8076,11 @@ bsx	NG	LA	Bashar
 bsx	NG	LA	Basharawa
 bsx	NG	LA	Bashiri
 bsx	NG	LA	Yankam
+bsy	MY	D	Beaufort Bisaya
+bsy	MY	D	Klias Bisaya
+bsy	MY	D	Kuala Penyu Bisaya
+bsy	MY	D	Limbang Bisaya
+bsy	MY	D	Padas Bisaya
 bsy	MY	L	Bisaya, Sabah
 bsy	MY	LA	Basaya
 bsy	MY	LA	Besaya
@@ -7846,11 +8176,11 @@ bth	MY	LA	Bikuab
 bth	MY	LA	Kuap
 bth	MY	LA	Quop
 bth	MY	LA	Sentah
+bth	MY	LA	Siburan
 bti	ID	L	Burate
 btj	ID	L	Malay, Bacanese
 btj	ID	LA	Bacan
 btj	ID	LA	Batjan
-btl	IN	L	Bhatola
 btm	ID	L	Batak Mandailing
 btm	ID	LA	Batta
 btm	ID	LA	Mandailing Batak
@@ -8027,6 +8357,14 @@ bug	ID	LA	Buginese
 bug	ID	LA	De’
 bug	ID	LA	Rappang Buginese
 bug	ID	LA	Ugi
+bug	MY	D	Bone
+bug	MY	D	Duri
+bug	MY	D	Enrekang
+bug	MY	D	Makasar
+bug	MY	D	Mandar
+bug	MY	D	Pinrang
+bug	MY	D	Sinjai
+bug	MY	D	Soppeng
 bug	MY	L	Bugis
 bug	MY	LA	Buginese
 buh	CN	L	Bunu, Younuo
@@ -8041,6 +8379,7 @@ bui	CG	LA	Bongiri
 bui	CG	LA	Bungili
 bui	CG	LA	Bungiri
 buj	NG	L	Basa-Gurmana
+buj	NG	LA	Koromba
 buk	PG	D	Central Bugawac
 buk	PG	D	Central-Eastern Bugawac
 buk	PG	D	Central-Western Bugawac
@@ -8105,8 +8444,11 @@ buq	PG	LA	Bunubun
 bus	NG	D	Kaiama
 bus	NG	D	village Bokobaru
 bus	NG	L	Bokobaru
+bus	NG	LA	Bariba
 bus	NG	LA	Busa-Bokobaru
+bus	NG	LA	Bussanchi
 bus	NG	LA	Bussawa
+bus	NG	LA	Zogben
 but	PG	L	Bungain
 buu	CD	D	Bafwakoyi
 buu	CD	D	East Bafwangada
@@ -8229,6 +8571,7 @@ bvm	CM	LA	Mekoh
 bvm	CM	LA	Muka
 bvm	CM	LA	Ndop-Bamunka
 bvm	CM	LA	Ngiemekohke
+bvm	CM	LA	Niemeng
 bvn	PG	D	Kasmin
 bvn	PG	D	Masan
 bvn	PG	L	Buna
@@ -8394,6 +8737,7 @@ bwq	BF	LA	Black Bobo
 bwq	BF	LA	Bobo
 bwq	BF	LA	Bobo Fi
 bwq	BF	LA	Bobo Fing
+bwq	BF	LA	Boboda
 bwr	NG	D	Hyil Hawul
 bwr	NG	D	Pela
 bwr	NG	DA	Bura Hyilhawul
@@ -8434,7 +8778,9 @@ bwt	CM	DP	Bafaw
 bwt	CM	L	Bafaw-Balong
 bwt	CM	LA	Ngoe
 bwu	GH	L	Buli
+bwu	GH	LA	Builsa
 bwu	GH	LA	Bulisa
+bwu	GH	LA	Bulsa
 bwu	GH	LA	Guresha
 bwu	GH	LA	Kanjaga
 bww	CD	D	Bati
@@ -8605,6 +8951,7 @@ bxw	ML	LA	Banka
 bxw	ML	LA	Bankagoma
 bxw	ML	LA	Bankagoroma
 bxw	ML	LA	Bankaje
+bxw	ML	LA	Samogho
 bxz	PG	D	Ma
 bxz	PG	D	Neme
 bxz	PG	DA	Nemea
@@ -8748,6 +9095,7 @@ bzb	ID	LA	Masama
 bzb	ID	LP	Bobongko
 bzc	MG	L	Malagasy, Southern Betsimisaraka
 bzc	MG	LA	Betsimisaraka Antatsimo Malagasy
+bzc	MG	LA	Betsimisaraka Malagasy
 bzd	CR	D	Amubre-Katsi
 bzd	CR	D	Coroma
 bzd	CR	D	Salitre-Cabagra
@@ -8767,6 +9115,8 @@ bze	ML	LA	Sarkanci
 bze	ML	LA	Sarkawa
 bze	ML	LA	Sorko
 bze	ML	LA	Sorogaama
+bze	ML	LA	Sorogama
+bze	ML	LA	Sorogoye
 bze	NG	L	Sorko
 bze	NG	LA	Bozo
 bze	NG	LA	Corogama
@@ -8878,6 +9228,7 @@ bzx	ML	LA	Hain
 bzx	ML	LA	Hainyaxo Bozo
 bzx	ML	LA	Hanyaxo
 bzx	ML	LA	Kelenga
+bzx	ML	LA	Kelengaxo
 bzx	ML	LA	Kélinga
 bzx	ML	LA	Kéllingua
 bzx	ML	LA	Xan
@@ -8909,6 +9260,7 @@ bzz	NG	LA	Ovand
 bzz	NG	LA	Ovande
 bzz	NG	LA	Ovando
 caa	GT	L	Ch’orti’
+caa	GT	LA	Chorti’
 caa	HN	L	Ch’orti’
 cab	BZ	L	Garifuna
 cab	BZ	LA	Caribe
@@ -8937,9 +9289,11 @@ cac	GT	LA	Chuh
 cac	GT	LA	Chuhe
 cac	GT	LA	Chuj de San Mateo Ixtatán
 cac	GT	LA	Chuje
+cac	GT	LA	Koti’
 cac	MX	L	Chuj
 cac	MX	LA	Chapai
 cac	MX	LA	Chuj de San Mateo Ixtatán
+cac	MX	LA	Koti’
 cad	US	L	Caddo
 cad	US	LA	Caddoe
 cad	US	LA	Kado
@@ -8958,6 +9312,7 @@ cag	AR	D	Forest Nivaclé
 cag	AR	D	River Nivaclé
 cag	AR	L	Nivaclé
 cag	AR	LA	Ashlushlay
+cag	AR	LA	Guisnai
 cag	AR	LP	Chulupe
 cag	AR	LP	Chulupi
 cag	AR	LP	Chulupie
@@ -8968,13 +9323,16 @@ cag	PY	L	Nivaclé
 cag	PY	LA	Ashlushlay
 cag	PY	LA	Axluslay
 cag	PY	LA	Axluxlay
+cag	PY	LA	Guisnai
 cag	PY	LA	Nivaklé
+cag	PY	LP	Choropí
 cag	PY	LP	Chulupe
 cag	PY	LP	Chulupí
 cag	PY	LP	Chulupie
+cag	PY	LP	Chunupí
 cag	PY	LP	Churupí
 cah	PE	L	Cahuarano
-cak	GT	D	Akatenango Southwestern Cakchiquel
+cak	GT	D	Acatenango Southwestern Cakchiquel
 cak	GT	D	Eastern Cakchiquel
 cak	GT	D	Northern Cakchiquel
 cak	GT	D	Santa María de Jesús Cakchiquel
@@ -8986,15 +9344,17 @@ cak	GT	D	Yepocapa Southwestern Cakchiquel
 cak	GT	DA	Kach’ab’al
 cak	GT	L	Kaqchikel
 cak	GT	LA	Cakchiquel
-cak	GT	LA	Kaqchikel
 cak	GT	LA	Kaqchiquel
 cal	MP	L	Carolinian
+cal	MP	LA	Refalúwasch
 cal	MP	LA	Saipan Carolinian
 cal	MP	LA	Southern Carolinian
 cal	MP	LP	Gupallao
 cam	NC	L	Cemuhî
 cam	NC	LA	Camuhi
 cam	NC	LA	Camuki
+cam	NC	LA	Cemuhi
+cam	NC	LA	Cèmuhî
 cam	NC	LA	Tie
 cam	NC	LA	Touho
 cam	NC	LA	Tyamuhi
@@ -9017,6 +9377,8 @@ car	BR	LA	Caribe
 car	BR	LA	Cariña
 car	BR	LA	Kalihna
 car	BR	LA	Kalinya
+car	BR	LA	Kari’ña
+car	BR	LA	Kari’na auran
 car	BR	LA	Maraworno
 car	BR	LA	Marworno
 car	GF	D	Tyrewuju
@@ -9028,6 +9390,8 @@ car	GF	LA	Galibi
 car	GF	LA	Kalihna
 car	GF	LA	Kalin’a
 car	GF	LA	Kalinya
+car	GF	LA	Kari’ña
+car	GF	LA	Kari’na auran
 car	GY	D	Aretyry
 car	GY	D	Murato
 car	GY	DA	Myrato
@@ -9039,6 +9403,8 @@ car	GY	LA	Galibi
 car	GY	LA	Kalihna
 car	GY	LA	Kalinya
 car	GY	LA	Kariña
+car	GY	LA	Kari’ña
+car	GY	LA	Kari’na auran
 car	GY	LA	Kari’nja
 car	GY	LA	Kari’nya
 car	SR	D	Aretyry
@@ -9054,8 +9420,11 @@ car	SR	LA	Galibí
 car	SR	LA	Kalihna
 car	SR	LA	Kali’na
 car	SR	LA	Kalinya
+car	SR	LA	Kara’ibs
 car	SR	LA	Kari’na
+car	SR	LA	Kari’ña
 car	SR	LA	Karìna
+car	SR	LA	Kari’na auran
 car	SR	LA	Kari’nja
 car	SR	LA	Kari’nya
 car	SR	LA	Maraworno
@@ -9070,11 +9439,14 @@ car	VE	LA	Galibi
 car	VE	LA	Kalihna
 car	VE	LA	Kalinya
 car	VE	LA	Kariña
+car	VE	LA	Kari’ña
+car	VE	LA	Kari’na auran
 cas	BO	D	Mosetén
 cas	BO	D	Tsimané
 cas	BO	L	Tsimané
 cas	BO	LA	Chimané
 cas	BO	LA	Mosetén
+cas	BO	LA	Moseteno
 cat	AD	L	Catalan
 cat	AD	LA	Català
 cat	AD	LA	Catalan-Valencian-Balear
@@ -9105,8 +9477,10 @@ cat	ES	LA	Catalan-Valencian-Balear
 cat	ES	LA	Catalonian
 cat	ES	LA	Valencian
 cat	FR	L	Catalan
+cat	FR	LA	Català
 cat	IT	L	Catalan
 cat	IT	LA	Algherese Catalan
+cat	IT	LA	Català
 cav	BO	L	Cavineña
 cav	BO	LA	Kavinenya
 caw	BO	L	Callawalla
@@ -9163,7 +9537,6 @@ cbd	CO	LA	Karijona
 cbd	CO	LA	Koto
 cbd	CO	LA	Omagua
 cbd	CO	LA	Umawa
-cbe	CO	L	Chipiajes
 cbg	CO	L	Chimila
 cbg	CO	LA	Caca Weranos
 cbg	CO	LA	Chimile
@@ -9171,16 +9544,17 @@ cbg	CO	LA	Ette Ennaka
 cbg	CO	LA	San Jorge
 cbg	CO	LA	Shimizya
 cbg	CO	LA	Simiza
-cbh	CO	L	Cagua
 cbi	EC	L	Chachi
+cbi	EC	LA	Cayapa
 cbi	EC	LA	Cha’ Palaachi
-cbi	EC	LA	Cha’palaa
+cbi	EC	LA	Chachilla
+cbi	EC	LA	Cha’Palaa
 cbi	EC	LA	Cha’palaachi
 cbi	EC	LA	Kayapa
-cbi	EC	LP	Cayapa
 cbj	BJ	L	Ede Cabe
 cbj	BJ	LA	Caabe
 cbj	BJ	LA	Cabe
+cbj	BJ	LA	Tchabè
 cbk	PH	D	Caviteño
 cbk	PH	D	Cotabato Chavacano
 cbk	PH	D	Davaweño Zamboangueño
@@ -9188,19 +9562,26 @@ cbk	PH	D	Ermitaño
 cbk	PH	D	Ternateño
 cbk	PH	D	Zamboangueño
 cbk	PH	DA	Abakay Spanish
-cbk	PH	DA	Chavacano
+cbk	PH	DA	Bahra
+cbk	PH	DA	Cavite Chabacano
+cbk	PH	DA	Chabacano de Zamboanga
 cbk	PH	DA	Cotabateño
 cbk	PH	DA	Davao Chavacano
 cbk	PH	DA	Davaoeño
 cbk	PH	DA	Davaweño
 cbk	PH	DA	Ermiteño
+cbk	PH	DA	Español quebrao
+cbk	PH	DA	Southern Mindinao Creole
+cbk	PH	DA	Ternate Chabacano
 cbk	PH	DA	Ternateño Chavacano
+cbk	PH	DA	Zamboanga Chabacano
 cbk	PH	L	Chavacano
 cbk	PH	LA	Chabacano
 cbk	PH	LA	Chabakano
 cbk	PH	LA	Zamboangueño
 cbl	MM	L	Chin, Bualkhaw
 cbl	MM	LA	Bualkhaw-Chin
+cbl	MM	LA	Phadei
 cbn	TH	L	Nyahkur
 cbn	TH	LA	Chao Dong
 cbn	TH	LA	Chaodon
@@ -9213,18 +9594,26 @@ cbn	TH	LP	Chaobon
 cbn	TH	LP	Chaobun
 cbn	TH	LP	Chaubun
 cbo	NG	L	Izora
+cbo	NG	LA	Cokobanci
+cbo	NG	LA	Cokobawa
+cbo	NG	LA	Ndazora
 cbq	NG	L	Tsucuba
 cbq	NG	LA	Cuba
 cbq	NG	LA	Urcibar
-cbr	PE	D	Cacataibo de Mariscal
-cbr	PE	D	Cacataibo de Sinchi Roca
 cbr	PE	D	Cashibo
-cbr	PE	L	Cashibo-Cacataibo
+cbr	PE	D	Kakataibo de Mariscal
+cbr	PE	D	Kakataibo de Sinchi Roca
+cbr	PE	DA	Kashibo de Sungaroyacu
+cbr	PE	DA	Kashibo del Alto Aguaytía
+cbr	PE	L	Kakataibo-Kashibo
+cbr	PE	LA	Aincacatai
 cbr	PE	LA	Cachibo
 cbr	PE	LA	Cacibo
 cbr	PE	LA	Cahivo
+cbr	PE	LA	Cashibo-Cacataibo
 cbr	PE	LA	Caxibo
 cbr	PE	LA	Hagueti
+cbr	PE	LA	Incauncanibo
 cbr	PE	LA	Kashibo
 cbr	PE	LA	Managua
 cbs	BR	L	Cashinahua
@@ -9244,22 +9633,23 @@ cbs	PE	LA	Kaxinawá
 cbs	PE	LA	Kaxynawa
 cbt	PE	D	Cahuapana
 cbt	PE	D	Chayahuita
-cbt	PE	L	Chayahuita
+cbt	PE	L	Shawi
 cbt	PE	LA	Balsapuertino
 cbt	PE	LA	Cahuapa
 cbt	PE	LA	Chawi
 cbt	PE	LA	Chayabita
+cbt	PE	LA	Chayahuita
 cbt	PE	LA	Chayawita
 cbt	PE	LA	Chayhuita
 cbt	PE	LA	Paranapura
-cbt	PE	LA	Shawi
 cbt	PE	LA	Shayabit
 cbt	PE	LA	Tshaahui
 cbu	PE	D	Chapara
 cbu	PE	D	Kandoashi
 cbu	PE	DA	Shapra
-cbu	PE	L	Candoshi-Shapra
+cbu	PE	L	Kandozi-Chapra
 cbu	PE	LA	Candoshi
+cbu	PE	LA	Candoshi-Shapra
 cbu	PE	LA	Candoxi
 cbu	PE	LA	Kandoshi
 cbu	PE	LA	Murato
@@ -9278,6 +9668,8 @@ cbv	CO	LA	Wacara
 cbw	PH	L	Kinabalian
 cbw	PH	LA	Bisaya’
 cbw	PH	LA	Cabalian
+cbw	PH	LA	Cabalianon
+cbw	PH	LA	Kinabalianon
 cby	CO	L	Carabayo
 cby	CO	LA	Yuri
 cby	CO	LP	Amazonas Macusa
@@ -9333,6 +9725,7 @@ cch	NG	LA	Chawe
 cch	NG	LA	Chawi
 ccj	GW	L	Kasanga
 ccj	GW	LA	Cassanga
+ccj	GW	LA	Guhaaca
 ccj	GW	LA	Haal
 ccj	GW	LA	I-Hadja
 ccj	GW	LA	Kassanga
@@ -9342,6 +9735,7 @@ ccm	MY	L	Malaccan Creole Malay
 ccm	MY	LA	Chitties Creole Malay
 cco	MX	L	Chinantec, Comaltepec
 cco	MX	LA	Jmii’
+cco	MX	LA	juu jmiih
 ccp	BD	L	Chakma
 ccp	BD	LA	Sakma
 ccp	BD	LA	Sangma
@@ -9357,6 +9751,7 @@ ccr	SV	L	Cacaopera
 cda	CN	D	Hbrugchu
 cda	CN	D	Thewo
 cda	CN	DA	Diebu
+cda	CN	DA	Thebo
 cda	CN	DA	Zhouqu
 cda	CN	L	Choni
 cda	CN	LA	Chona
@@ -9387,6 +9782,7 @@ cdh	IN	LA	Chambiyali
 cdh	IN	LA	Chamiyali Pahari
 cdh	IN	LA	Chamya
 cdi	IN	L	Chodri
+cdi	IN	LA	Bhil
 cdi	IN	LA	Chaudhari
 cdi	IN	LA	Chaudri
 cdi	IN	LA	Chodhari
@@ -9400,10 +9796,12 @@ cdj	IN	LA	Churai Pahari
 cdm	NP	D	Eastern Chepang
 cdm	NP	D	Western Chepang
 cdm	NP	L	Chepang
+cdm	NP	LA	Cyo’bang
 cdm	NP	LA	Praja Bhasa
 cdm	NP	LA	Tsepang
 cdn	IN	L	Chaudangsi
 cdn	IN	LA	Bangba Lo
+cdn	IN	LA	Bangba-Lwo
 cdn	IN	LA	Bangbani
 cdn	IN	LA	Chanpa Lo
 cdn	IN	LA	Chaudans Lo
@@ -9489,6 +9887,7 @@ ceg	PY	D	Tomaraho
 ceg	PY	L	Chamacoco
 ceg	PY	LA	Ishiro
 ceg	PY	LA	Jeywo
+ceg	PY	LA	Yshyr Ybytoso
 ceg	PY	LA	Yshyro
 cek	MM	D	Asang
 cek	MM	D	Khenlak
@@ -9497,7 +9896,7 @@ cek	MM	D	Lemi
 cek	MM	D	Likhy
 cek	MM	D	Nideun
 cek	MM	D	Nisay
-cek	MM	D	Rengsa
+cek	MM	D	Rengcaa
 cek	MM	DA	Akelong
 cek	MM	DA	Aki Along
 cek	MM	DA	Amlai
@@ -9519,8 +9918,7 @@ cek	MM	DA	Taheunso
 cek	MM	DA	Tao Cha
 cek	MM	DA	Uiphaw
 cek	MM	L	Chin, Eastern Khumi
-cek	MM	LA	Ta-aw
-cek	MM	LA	Ta-oo
+cek	MM	LA	Khami
 cen	NG	D	Icen
 cen	NG	D	Icen Ibaas
 cen	NG	D	Ichen
@@ -9539,13 +9937,28 @@ ces	CZ	D	Southwest Bohemian
 ces	CZ	DA	Yalach
 ces	CZ	L	Czech
 ces	CZ	LA	Bohemian
+ces	CZ	LA	Ceský jazyk
 ces	CZ	LA	Cestina
 ces	HR	L	Czech
+ces	HR	LA	Ceský jazyk
+ces	HR	LA	Cestina
+ces	PL	L	Czech
+ces	PL	LA	Ceský jazyk
+ces	PL	LA	Cestina
 ces	RO	L	Czech
+ces	RO	LA	Ceský jazyk
+ces	RO	LA	Cestina
 ces	RS	L	Czech
 ces	RS	LA	Bohemian
+ces	RS	LA	Ceský jazyk
 ces	RS	LA	Cestina
 ces	UA	L	Czech
+ces	UA	LA	Ceský jazyk
+ces	UA	LA	Cestina
+ces	US	D	Texas Czech
+ces	US	L	Czech
+ces	US	LA	Ceský jazyk
+ces	US	LA	Cestina
 cet	NG	L	Centúúm
 cet	NG	LA	Cen Tuum
 cfa	NG	D	Bwilim
@@ -9571,6 +9984,7 @@ cfd	NG	LA	Teriya
 cfd	NG	LA	Terri
 cfg	NG	L	Como Karim
 cfg	NG	LA	Asom
+cfg	NG	LA	Bakula
 cfg	NG	LA	Chomo
 cfg	NG	LA	Kinzimba
 cfg	NG	LA	Kirim
@@ -9598,7 +10012,6 @@ cfm	MM	D	Hualngo
 cfm	MM	D	Khualsim
 cfm	MM	D	Laizo
 cfm	MM	D	Lente
-cfm	MM	D	Ngawn
 cfm	MM	D	Sim
 cfm	MM	D	Taisun
 cfm	MM	D	Tapong
@@ -9639,8 +10052,11 @@ cgg	UG	D	RuNyaifwe-Hororo
 cgg	UG	D	RuNyangyezi
 cgg	UG	D	RuSigi
 cgg	UG	L	Chiga
+cgg	UG	LA	Bachiga
+cgg	UG	LA	Bahororo
 cgg	UG	LA	Ciga
 cgg	UG	LA	Kiga
+cgg	UG	LA	Nkore
 cgg	UG	LA	Nkore-Kiga
 cgg	UG	LA	Oluchiga
 cgg	UG	LA	Orukiga
@@ -9666,7 +10082,10 @@ chd	MX	L	Chontal, Highland Oaxaca
 chd	MX	LA	Chontal de la Sierra de Oaxaca
 chd	MX	LA	Highland Chontal
 chd	MX	LA	Tequistlatec
+chd	MX	LA	Tsame
+chd	MX	LA	Tsome
 che	JO	L	Chechen
+che	JO	LA	Nokhchi
 che	RU	D	Akkin
 che	RU	D	Cheberloi
 che	RU	D	Itumkala
@@ -9678,6 +10097,7 @@ che	RU	DA	Shatoi
 che	RU	L	Chechen
 che	RU	LA	Galancho
 che	RU	LA	Nokchiin Muott
+che	RU	LA	Nokhchi
 che	RU	LA	Nokhchiin
 chf	MX	D	Buena Vista Chontal
 chf	MX	D	Chontal de Tabasco central
@@ -9692,16 +10112,19 @@ chf	MX	LA	Yocot’an
 chg	TM	L	Chagatai
 chg	TM	LA	Chaghatay
 chg	TM	LA	Jagatai
-chh	US	D	Clackama
-chh	US	D	Kiksht
 chh	US	D	Klatsop
+chh	US	D	Shoalwater
+chh	US	DA	Chinook Proper
+chh	US	DA	Clatsop
 chh	US	DA	Tlatsop
 chh	US	L	Chinook
-chh	US	LA	Kiksht
 chh	US	LA	Lower Chinook
+chh	US	LA	Shoalwater
 chj	MX	L	Chinantec, Ojitlán
 chj	MX	LA	Chinantec, Comaltepec
 chj	MX	LA	Chinanteco del Norte
+chj	MX	LA	Jmiih kia’ dzä ‘vï ï
+chj	MX	LA	Jujmi
 chk	FM	D	East Lagoon
 chk	FM	D	Fayichuck
 chk	FM	L	Chuukese
@@ -9715,18 +10138,24 @@ chm	RU	L	Mari
 chn	CA	L	Chinook Wawa
 chn	CA	LA	Chinook Jargon
 chn	CA	LA	Chinook Pidgin
+chn	CA	LA	Chinuk Wawa
+chn	CA	LA	Jargon
 chn	US	L	Chinook Wawa
 chn	US	LA	Chinook Jargon
 chn	US	LA	Chinook Pidgin
+chn	US	LA	Chinuk Wawa
+chn	US	LA	Jargon
 chn	US	LA	Tsinuk Wawa
 cho	US	L	Choctaw
 chp	CA	D	Yellowknife
 chp	CA	L	Dene
 chp	CA	LA	Dëne Súline
+chp	CA	LA	Dënesuhné
 chp	CA	LP	Chipewyan
 chq	MX	D	Yolox Chinanteco
 chq	MX	L	Chinantec, Quiotepec
 chq	MX	LA	Highland Chinantec
+chq	MX	LA	juu jmiih
 chr	US	D	Elati
 chr	US	D	Kituhwa
 chr	US	D	Otali
@@ -9776,6 +10205,7 @@ chz	MX	D	Ayotzintepec
 chz	MX	L	Chinantec, Ozumacín
 chz	MX	LA	Chinanteco de Ayotzintepec
 chz	MX	LA	Chinanteco del Sureste Alto
+chz	MX	LA	Jumi dsa mojai
 chz	MX	LA	Juujmii
 cia	ID	D	Kaesabu
 cia	ID	D	Masiri
@@ -9843,6 +10273,7 @@ ciw	US	D	Minnesota Border Chippewa
 ciw	US	D	Red Lake Chippewa
 ciw	US	D	Upper Michigan-Wisconsin Chippewa
 ciw	US	L	Chippewa
+ciw	US	LA	Minnesota Ojibwe
 ciw	US	LA	Ojibway
 ciw	US	LA	Ojibwe
 ciw	US	LA	Southwestern Ojibwa
@@ -9893,6 +10324,7 @@ cji	RU	DA	Gachitl-Kvankhi
 cji	RU	DA	Hihatl
 cji	RU	L	Chamalal
 cji	RU	LA	Camalal
+cji	RU	LA	Chamalal mitsts
 cji	RU	LA	Chamalin
 cjk	AO	D	Minungo
 cjk	AO	D	Ukhongo
@@ -9931,7 +10363,7 @@ cjn	PG	L	Chenapian
 cjn	PG	LA	Chenap
 cjn	PG	LA	Tsenap
 cjn	PG	LA	Zenap
-cjo	PE	L	Ashéninka Pajonal
+cjo	PE	L	Ashéninka, Pajonal
 cjo	PE	LA	Ashéninca
 cjo	PE	LA	Atsiri
 cjo	PE	LA	Pajonal
@@ -10110,6 +10542,7 @@ cla	NG	L	Ron
 cla	NG	LP	Chala
 cla	NG	LP	Challa
 clc	CA	L	Chilcotin
+clc	CA	LA	Nenqayni Ch’ih
 clc	CA	LA	Tsilhqot’in
 clc	CA	LA	Tzilkotin
 cld	IQ	D	Alqosh
@@ -10141,7 +10574,7 @@ clh	PK	LA	Galos
 cli	GH	L	Chakali
 clj	MM	D	Dalet Stream
 clj	MM	D	Kanni Stream
-clj	MM	D	Panmyaunggyi River
+clj	MM	D	Panmyaunggyi Stream
 clj	MM	D	Phuntha Stream
 clj	MM	D	Yaw Stream
 clj	MM	DA	Daaitu
@@ -10154,6 +10587,7 @@ clj	MM	LA	Daitu
 clj	MM	LA	Hio Bei
 clj	MM	LA	Hle-tu
 clj	MM	LA	Laikhy
+clj	MM	LA	Laitu Chin
 clj	MM	LA	Laitu Kheu
 clj	MM	LA	Ledu
 clj	MM	LA	Leitu
@@ -10185,8 +10619,11 @@ clo	MX	LA	Chontal de la Costa de Oaxaca
 clo	MX	LA	Chontal de Oaxaca de la costa
 clo	MX	LA	Huamelula Chontal
 clo	MX	LA	Huamelulteco
+clo	MX	LA	Lajltyaygi
+clo	MX	LA	Yocot’an
 clt	MM	L	Chin, Lautu
 clt	MM	LA	Lautu
+clt	MM	LA	Lautu Chin
 clt	MM	LA	Lawhtu
 clu	PH	D	Semirara
 clu	PH	L	Caluyanun
@@ -10200,6 +10637,7 @@ clw	RU	LA	Chulym Tatar
 clw	RU	LA	Chulym-Turkish
 clw	RU	LA	Melets Tatar
 cly	MX	L	Chatino, Eastern Highland
+cly	MX	LA	Cha’ jna’a
 cly	MX	LA	Chatino de la Zona Alta Oriental
 cly	MX	LA	Chatino Oriental Alto
 cly	MX	LA	Lachao-Yolotepec Chatino
@@ -10218,6 +10656,7 @@ cme	BF	D	Gouindougouba
 cme	BF	D	Niangoloko-Diarabakoko
 cme	BF	D	Soubakanedougou
 cme	BF	L	Cerma
+cme	BF	LA	Goin
 cme	BF	LA	Gouin
 cme	BF	LA	Gwe
 cme	BF	LA	Gwen
@@ -10230,12 +10669,16 @@ cme	CI	LA	Gwen
 cme	CI	LA	Kirma
 cmi	CO	L	Emberá-Chamí
 cmi	CO	LA	Chami
+cmi	CO	LA	Embena
+cmi	CO	LA	Embera
+cmi	CO	LA	Epena
 cml	ID	D	Buku
 cml	ID	D	Campalagian
 cml	ID	L	Campalagian
 cml	ID	LA	Tallumpanuae
 cml	ID	LA	Tasing
 cml	ID	LA	Tjampalagian
+cmn	AU	L	Chinese, Mandarin
 cmn	BN	L	Chinese, Mandarin
 cmn	CN	D	Huabei Guanhua
 cmn	CN	D	Jinghuai Guanhua
@@ -10261,6 +10704,7 @@ cmn	CN	LA	Zhongguohua
 cmn	CN	LA	Zhongwen
 cmn	HK	L	Chinese, Mandarin
 cmn	ID	L	Chinese, Mandarin
+cmn	KH	L	Chinese, Mandarin
 cmn	MM	D	Kokang
 cmn	MM	DA	Kokant
 cmn	MM	L	Chinese, Mandarin
@@ -10335,16 +10779,14 @@ cmr	MM	DA	Ahraing Khami
 cmr	MM	DA	Areung
 cmr	MM	DA	Aroeng
 cmr	MM	DA	Hrengna
+cmr	MM	DA	Wakun
 cmr	MM	DA	Wakung
-cmr	MM	L	Chin, Mro-Khimi
+cmr	MM	L	Mro-Khimi
 cmr	MM	LA	Awa Khami
+cmr	MM	LA	Chin, Mro-Khimi
 cmr	MM	LA	Khimi
 cmr	MM	LA	Khumi Awa
 cmr	MM	LA	Mro
-cmr	MM	LA	Mro Chin
-cmr	MM	LA	Vakung
-cmr	MM	LA	Wakun
-cmr	MM	LA	Wakung
 cmr	MM	LP	Kwe Myi
 cmt	ZA	L	Camtho
 cmt	ZA	LA	Iscamtho
@@ -10353,6 +10795,7 @@ cmt	ZA	LA	Tsotsitaal
 cna	IN	L	Changthang
 cna	IN	LA	Byangskat
 cna	IN	LA	Byanskat
+cna	IN	LA	Champas
 cna	IN	LA	Changs-Skat
 cna	IN	LA	Changtang
 cna	IN	LA	Changtang Ladakhi
@@ -10384,23 +10827,26 @@ cng	CN	LA	Ch’iang
 cnh	IN	D	Klangklang
 cnh	IN	D	Zokhua
 cnh	IN	DA	Thlantlang
-cnh	IN	L	Chin, Haka
+cnh	IN	L	Chin, Hakha
 cnh	IN	LA	Baungshe
+cnh	IN	LA	Haka Chin
 cnh	IN	LA	Lai
 cnh	IN	LA	Lai Hawlh
 cnh	IN	LA	Lai Pawi
 cnh	IN	LP	Haka
 cnh	MM	D	Klangklang
 cnh	MM	D	Zokhua
-cnh	MM	DA	Thlantlang
-cnh	MM	L	Chin, Haka
+cnh	MM	DA	Thantlang
+cnh	MM	L	Chin, Hakha
 cnh	MM	LA	Baungshe
 cnh	MM	LA	Haka
+cnh	MM	LA	Haka Chin
 cnh	MM	LA	Hakha
 cnh	MM	LA	Lai
 cnh	MM	LA	Lai Chin
 cni	PE	L	Asháninka
 cni	PE	LA	Asháninca
+cni	PE	LA	Ashinanca
 cni	PE	LP	Campa
 cni	PE	LP	Kampa
 cnk	BD	D	Khami
@@ -10410,7 +10856,7 @@ cnk	BD	DA	Yindu
 cnk	BD	L	Chin, Khumi
 cnk	BD	LA	Khami
 cnk	BD	LA	Khuni
-cnk	BD	LA	Khweymi
+cnk	BD	LP	Khweymi
 cnk	IN	D	Khami
 cnk	IN	D	Khimi
 cnk	IN	L	Chin, Khumi
@@ -10418,23 +10864,21 @@ cnk	IN	LA	Kami
 cnk	IN	LA	Khami
 cnk	IN	LA	Khumi
 cnk	IN	LA	Khuni
-cnk	IN	LA	Khweymi
 cnk	IN	LA	Kumi
+cnk	IN	LP	Khweymi
 cnk	MM	D	Eastern Kaladan
 cnk	MM	D	Kaladan
 cnk	MM	D	Pi Chaung
 cnk	MM	D	Southern Paletwa
 cnk	MM	L	Chin, Khumi
-cnk	MM	LA	Common Khumi
 cnk	MM	LA	Kaladan Khumi
-cnk	MM	LA	Khami
-cnk	MM	LA	Khimi
 cnk	MM	LA	Khumi
-cnk	MM	LA	Khweymi
 cnk	MM	LA	Yangpan
+cnk	MM	LP	Khweymi
 cnl	MX	L	Chinantec, Lalana
 cnl	MX	LA	Chinanteco de San Juan Lalana
 cnl	MX	LA	Chinanteco del Sureste Bajo
+cnl	MX	LA	Jujmi
 cno	LA	L	Con
 cns	ID	D	Ajam
 cns	ID	D	Misman
@@ -10447,6 +10891,9 @@ cns	ID	LA	Manowee
 cns	ID	LA	Yas
 cnt	MX	L	Chinantec, Tepetotutla
 cnt	MX	LA	Chinanteco del Oeste Central Bajo
+cnt	MX	LA	Jajmi dzä kï ï’
+cnt	MX	LA	Jejmei
+cnt	MX	LA	Jejmi
 cnu	DZ	D	Beni Menacer
 cnu	DZ	D	Chenoui
 cnu	DZ	D	Djebel Bissa
@@ -10466,6 +10913,10 @@ coa	AU	LA	Cocos
 coa	AU	LA	Kokos
 coa	AU	LA	Kukus
 coa	MY	L	Malay, Cocos Islands
+coa	MY	LA	Cocos
+coa	MY	LA	Cocos Islands
+coa	MY	LA	Melayu Cocos
+coa	MY	LA	Ong Pulu
 cob	GT	L	Chicomuceltec
 cob	GT	LA	Cakchiquel Mam
 cob	MX	L	Chicomuceltec
@@ -10479,12 +10930,14 @@ coc	MX	LA	Cocopah
 coc	MX	LA	Cucapá
 coc	MX	LA	Cucupá
 coc	MX	LA	Kikimá
+coc	MX	LA	Kuapá
 coc	MX	LA	Kwikapá
 coc	US	L	Cocopa
 coc	US	LA	Cocopah
 coc	US	LA	Cucapá
 coc	US	LA	Delta River Yuman
 coc	US	LA	Kikima
+coc	US	LA	Kuapá
 coc	US	LA	Kwikapa
 cod	BR	D	Cocama
 cod	BR	D	Cocamilla
@@ -10496,14 +10949,17 @@ cod	BR	LA	Cocama
 cod	BR	LA	Kokama
 cod	CO	L	Cocama-Cocamilla
 cod	CO	LA	Cocama
+cod	CO	LA	Inikana
 cod	CO	LA	Kokama
 cod	PE	D	Cocama
 cod	PE	D	Cocamilla
-cod	PE	L	Cocama-Cocamilla
+cod	PE	L	Kukama-Kukamiria
 cod	PE	LA	Cocama
+cod	PE	LA	Cocama-Cocamilla
 cod	PE	LA	Huallaga
 cod	PE	LA	Kokama
 cod	PE	LA	Kokama-Kokamilya
+cod	PE	LA	Kukama
 cod	PE	LA	Pampadeque
 cod	PE	LA	Pandequebo
 cod	PE	LA	Ucayali
@@ -10521,6 +10977,7 @@ cof	EC	LA	Tsachila
 cof	EC	LA	Tsafiki
 cof	EC	LA	Tsafiqui
 cog	KH	L	Chong
+cog	KH	LA	Khmer Chong
 cog	TH	L	Chong
 cog	TH	LA	Chawng
 cog	TH	LA	Shong
@@ -10539,6 +10996,7 @@ coj	MX	LA	Cadegomeño
 coj	MX	LA	Cadegomo
 coj	MX	LA	Cochetimi
 coj	MX	LA	Cochima
+coj	MX	LA	Cochimí
 coj	MX	LA	Cochimtee
 coj	MX	LA	Didiu
 coj	MX	LA	Joaquín
@@ -10559,6 +11017,7 @@ cok	MX	D	San Juan Corapan Cora
 cok	MX	D	Santa Teresa Cora
 cok	MX	DA	Cora francisqueño
 cok	MX	L	Cora, Santa Teresa
+cok	MX	LA	Kwéimarusa’na
 col	US	D	Columbia
 col	US	D	Wenatchi
 col	US	DA	Chelan
@@ -10571,6 +11030,7 @@ col	US	LA	Chelan
 col	US	LA	Columbian
 col	US	LA	Moses-Colombia
 col	US	LA	Moses-Colombia Salish
+col	US	LA	Nxa’amxcin
 col	US	LA	Wenatchee
 col	US	LA	Wenatchi
 col	US	LA	Wenatchi-Columbia
@@ -10584,6 +11044,7 @@ con	CO	LA	Kofan
 con	CO	LA	Kofane
 con	EC	L	Cofán
 con	EC	LA	A’i
+con	EC	LA	A’ingae
 con	EC	LA	Kofán
 con	EC	LA	Kofane
 coo	CA	D	Island Comox
@@ -10593,6 +11054,7 @@ coo	CA	DA	Klahoose
 coo	CA	DA	Sliammon
 coo	CA	L	Comox
 coo	CA	LA	Comox-Sliammon
+coo	CA	LA	Éy7á7juuthem
 cop	EG	D	Bohairic
 cop	EG	D	Sahidic
 cop	EG	L	Coptic
@@ -10621,7 +11083,9 @@ cos	IT	LA	Corsi
 cos	IT	LA	Corso
 cos	IT	LA	Corsu
 cot	PE	L	Caquinte
+cot	PE	LA	Aguenquetsatsare
 cot	PE	LA	Caquinte Campa
+cot	PE	LA	Kakinte
 cot	PE	LA	Poyenisati
 cot	PE	LP	Cachomashiri
 cou	GN	L	Wamey
@@ -10639,6 +11103,7 @@ cou	SN	LA	Conhague
 cou	SN	LA	Coniagui
 cou	SN	LA	Koniagui
 cou	SN	LA	Konyagi
+cou	SN	LA	Wamay
 cou	SN	LA	Wamei
 cov	CN	L	Cao Miao
 cov	CN	LA	Grass Miao
@@ -10649,7 +11114,6 @@ cow	US	LA	Lower Cowlitz
 cox	PE	L	Nanti
 cox	PE	LP	Cogapacori
 cox	PE	LP	Kogapakori
-coy	CO	L	Coyaima
 coz	MX	D	Chocholteco del Este
 coz	MX	D	Chocholteco del Oeste
 coz	MX	D	Chocholteco del Sur
@@ -10659,8 +11123,13 @@ coz	MX	LA	Chocholteco
 coz	MX	LA	Chochon
 coz	MX	LA	Chochonteco
 coz	MX	LA	Chochotec
+coz	MX	LA	Ngiba
+coz	MX	LA	Ngigua
+coz	MX	LA	Ngiwa
 cpa	MX	L	Chinantec, Palantla
 cpa	MX	LA	Chinanteco de San Pedro Tlatepuzco
+cpa	MX	LA	Jajme dzä mii
+cpa	MX	LA	Jmiih kia’ dzä mii
 cpb	BR	L	Ashéninka, Ucayali-Yurúa
 cpb	BR	LA	Campa
 cpb	BR	LA	Kampa
@@ -10668,9 +11137,9 @@ cpb	PE	L	Ashéninka, Ucayali-Yurúa
 cpb	PE	LA	Ucayali Ashéninca
 cpc	PE	L	Ajyíninka Apurucayali
 cpc	PE	LA	Ajyéninka
-cpc	PE	LA	Apurucayali Campa
 cpc	PE	LA	Ashaninca
 cpc	PE	LA	Ashéninca Apurucayali
+cpc	PE	LP	Apurucayali Campa
 cpc	PE	LP	Axininka Campa
 cpc	PE	LP	Campa
 cpc	PE	LP	Kampa
@@ -10682,6 +11151,7 @@ cpg	GR	DA	Misti
 cpg	GR	DA	Mistiot
 cpg	GR	L	Cappadocian Greek
 cpi	NR	L	Chinese Pidgin English
+cpi	NR	LA	China Coast Pidgin
 cpi	NR	LA	Melanesian-Chinese Mixed Pidgin English
 cpn	GH	L	Cherepon
 cpn	GH	LA	Chiripon
@@ -10695,6 +11165,7 @@ cpo	BF	LA	Numu
 cps	PH	L	Capiznon
 cps	PH	LA	Capisano
 cps	PH	LA	Capiseño
+cpu	PE	D	Bajo Pichís
 cpu	PE	L	Ashéninka, Pichis
 cpu	PE	LA	Pichis Ashéninca
 cpu	PE	LP	Pichis Campa
@@ -10785,10 +11256,10 @@ cqd	CN	LA	Core Farwestern Hmongic
 cqd	CN	LA	Hua Miao
 cqd	CN	LA	Sichuan-Guizhou-Yunnan Miao
 cqd	CN	LA	Western Miao
-cqu	CL	L	Quechua, Chilean
 cra	ET	D	Buch’a
 cra	ET	L	Chara
 cra	ET	LA	Ciara
+cra	ET	LA	Gimiri Nona
 crc	VU	L	Lonwolwol
 crc	VU	LA	Ambrym
 crc	VU	LA	Craig Cove
@@ -10812,6 +11283,8 @@ crh	BG	DA	Steppe Crimean
 crh	BG	L	Crimean Tatar
 crh	BG	LA	Crimean
 crh	BG	LA	Crimean Turkish
+crh	BG	LA	Qirim
+crh	BG	LA	Qirimtatar
 crh	RO	D	Central Crimean
 crh	RO	D	Northern Crimean
 crh	RO	D	Southern Crimean
@@ -10819,6 +11292,8 @@ crh	RO	DA	Crimean Nogai
 crh	RO	DA	Steppe Crimean
 crh	RO	L	Crimean Tatar
 crh	RO	LA	Crimean Turkish
+crh	RO	LA	Qirim
+crh	RO	LA	Qirimtatar
 crh	TR	D	Central Crimean
 crh	TR	D	Northern Crimean
 crh	TR	D	Southern Crimean
@@ -10826,9 +11301,13 @@ crh	TR	DA	Crimean Nogai
 crh	TR	DA	Steppe Crimean
 crh	TR	L	Crimean Tatar
 crh	TR	LA	Crimean Turkish
+crh	TR	LA	Qirim
+crh	TR	LA	Qirimtatar
 crh	UA	L	Crimean Tatar
 crh	UA	LA	Crimean
 crh	UA	LA	Crimean Turkish
+crh	UA	LA	Qirim
+crh	UA	LA	Qirimtatar
 crh	UZ	D	Central Crimean
 crh	UZ	D	Northern Crimean
 crh	UZ	D	Southern Crimean
@@ -10836,6 +11315,8 @@ crh	UZ	DA	Crimean Nogai
 crh	UZ	DA	Steppe Crimean
 crh	UZ	L	Crimean Tatar
 crh	UZ	LA	Crimean Turkish
+crh	UZ	LA	Qirim
+crh	UZ	LA	Qirimtatar
 cri	ST	L	Sãotomense
 cri	ST	LA	Forro
 cri	ST	LA	Santomense
@@ -10847,8 +11328,12 @@ crk	CA	D	Northern Alberta Cree
 crk	CA	D	Plains Cree
 crk	CA	D	Western York Cree
 crk	CA	L	Cree, Plains
+crk	CA	LA	Nehiyaw
+crk	CA	LA	Nēhiyawēwin
 crk	CA	LA	Western Cree
 crk	US	L	Cree, Plains
+crk	US	LA	Nehiyaw
+crk	US	LA	Nēhiyawēwin
 crk	US	LA	Western Cree
 crl	CA	L	Cree, Northern East
 crl	CA	LA	Eastern James Bay Cree Northern Dialect
@@ -10873,6 +11358,10 @@ crn	MX	L	Cora, El Nayar
 crn	MX	LA	Cora
 crn	MX	LA	Cora de El Nayar
 crn	MX	LA	Kora
+crn	MX	LA	Kuráàpa
+crn	MX	LA	Múxata’ana
+crn	MX	LA	Wachí hapwa
+crn	MX	LA	Yaúhke’ena
 cro	US	L	Crow
 cro	US	LA	Apsaalooke
 crq	AR	D	Chorote
@@ -10882,6 +11371,7 @@ crq	AR	DA	I’no’
 crq	AR	DA	Iyowujwa
 crq	AR	DA	Manjuy
 crq	AR	L	Chorote, Iyo’wujwa
+crq	AR	LA	Yojwaja
 crq	PY	D	Choroti
 crq	PY	D	Yofuáha
 crq	PY	D	Yowúwa
@@ -10892,6 +11382,7 @@ crq	PY	LA	Choroti
 crq	PY	LA	Inkijwas
 crq	PY	LA	I’no’
 crq	PY	LA	Manjuy
+crq	PY	LA	Yojwaja
 crs	SC	L	Seselwa Creole French
 crs	SC	LA	Creole
 crs	SC	LA	Ilois
@@ -10901,6 +11392,7 @@ crs	SC	LA	Seselwa
 crs	SC	LA	Seychelles Creole French
 crs	SC	LA	Seychellois Creole
 crt	AR	L	Chorote, Iyojwa’ja
+crt	AR	LA	Chorote
 crt	AR	LA	Choroti
 crt	AR	LA	Eklenjuy
 crt	AR	LA	Yofuaha
@@ -10931,12 +11423,17 @@ crx	CA	D	Tachie
 crx	CA	L	Carrier
 crx	CA	LA	Central Carrier
 crx	CA	LA	Dakelh
+crx	CA	LA	Dakelhne
+crx	CA	LA	Takelne
+crx	CA	LA	Takulie
 cry	NG	L	Cori
 cry	NG	LA	Chori
 crz	US	L	Cruzeño
 crz	US	LA	Island Chumash
 crz	US	LA	Isleño
 csa	MX	L	Chinantec, Chiltepec
+csa	MX	LA	Jajme dzä mii
+csa	MX	LA	Jmiih kia’ dzä mii
 csb	PL	D	Kashubian Proper
 csb	PL	D	Slovincian
 csb	PL	L	Kashubian
@@ -10951,6 +11448,11 @@ csc	ES	LA	Llengua de Signes Catalana
 csc	ES	LA	LSC
 csd	TH	L	Chiangmai Sign Language
 csd	TH	LA	Chiengmai Sign Language
+csd	TH	LA	OCMSL
+csd	TH	LA	Old Chiang Mai Sign Language
+csd	TH	LA	Old Chiangmai Sign Language
+csd	TH	LA	Original Chiang Mai Sign Language
+csd	TH	LA	Original Chiangmai Sign Language
 cse	CZ	L	Czech Sign Language
 cse	CZ	LA	Český Znakový Jazyk
 cse	CZ	LA	CZJ
@@ -11012,14 +11514,23 @@ csk	SN	LA	Jóola-Kasa
 csl	CN	D	Southern Chinese Sign Language
 csl	CN	DA	Shanghai Sign Language
 csl	CN	L	Chinese Sign Language
-csl	CN	LA	China Coast Pidgin
 csl	CN	LA	Zhongguo Shouyu
 csm	US	D	Eastern Central Sierra Miwok
 csm	US	D	Western Central Sierra Miwok
 csm	US	L	Miwok, Central Sierra
+csn	CO	D	Central
+csn	CO	D	North
+csn	CO	D	Southwest
+csn	CO	DA	Bogotá-Eje cafetero
+csn	CO	DA	Cali
+csn	CO	DA	Caribe
 csn	CO	L	Colombian Sign Language
+csn	CO	LA	Lengua de señas colombiana
+csn	CO	LA	LSC
 cso	MX	L	Chinantec, Sochiapam
 cso	MX	LA	Chinanteco del Oeste
+cso	MX	LA	Jaú jm_
+cso	MX	LA	Jmiih kia’ dzä jii’
 cso	MX	LA	Sochiapan Chinantec
 csq	HR	L	Croatia Sign Language
 csq	HR	LA	CSL
@@ -11047,6 +11558,7 @@ csv	MM	LA	Chang
 csv	MM	LA	Hmyo
 csv	MM	LA	Settu
 csv	MM	LA	Settu Hmyo
+csv	MM	LA	Sumtu Chin
 csv	MM	LA	Sungtu
 csw	CA	D	Eastern Swampy Cree
 csw	CA	D	Western Swampy Cree
@@ -11061,6 +11573,7 @@ csy	MM	LA	Sizang
 csz	US	L	Coos
 csz	US	LA	Hanis
 cta	MX	L	Chatino, Tataltepec
+cta	MX	LA	Cha’ jna’a
 cta	MX	LA	Chatino Occidental Bajo
 cta	MX	LA	Lowland Chatino
 ctc	US	L	Chetco
@@ -11079,16 +11592,20 @@ ctd	MM	L	Chin, Tedim
 ctd	MM	LA	Hai-Dim
 ctd	MM	LA	Tedim
 ctd	MM	LA	Tiddim
+ctd	MM	LA	Zomi
 cte	MX	L	Chinantec, Tepinapa
 cte	MX	LA	Chinanteco del Sureste Medio
+cte	MX	LA	Jujmi
 ctg	BD	L	Chittagonian
 ctg	BD	LA	Chatgaiyan Buli
 ctg	BD	LA	Chatgaya
 ctg	BD	LA	Chittagonian Bengali
 cth	MM	L	Chin, Thaiphum
+cth	MM	LA	Thaiphum
 cth	MM	LA	Thui Phum
 ctl	MX	L	Chinantec, Tlacoatzintepec
 ctl	MX	LA	Chinanteco del Noroeste
+ctl	MX	LA	Jau jmai
 ctm	US	L	Chitimacha
 ctn	NP	D	Mulgaun
 ctn	NP	D	Sambhugaon
@@ -11100,6 +11617,8 @@ ctn	NP	LA	Teli
 cto	CO	L	Emberá-Catío
 cto	CO	LA	Catio
 cto	CO	LA	Embena
+cto	CO	LA	Embera
+cto	CO	LA	Epena
 cto	CO	LA	Eyabida
 cto	CO	LA	Katio
 cto	PA	L	Emberá-Catío
@@ -11111,6 +11630,7 @@ ctp	MX	D	Panixtlahuaca Chatino
 ctp	MX	D	San Juan Quiahije Chatino
 ctp	MX	D	Yaitepec Chatino
 ctp	MX	L	Chatino, Western Highland
+ctp	MX	LA	Cha’ jna’a
 ctp	MX	LA	Cha’t-An
 ctp	MX	LA	Chatino Central
 ctp	MX	LA	Chatino de la Zona Alta Occidental
@@ -11127,7 +11647,9 @@ ctu	MX	D	Chol de Tumbalá
 ctu	MX	DA	Ch’ol del Noroeste
 ctu	MX	DA	Ch’ol del Sureste
 ctu	MX	L	Chol
+ctu	MX	LA	Lakty’añ
 ctz	MX	L	Chatino, Zacatepec
+ctz	MX	LA	Cha’ jna’a
 ctz	MX	LA	Chatino de San Marcos Zacatepec
 ctz	MX	LA	Chatino de Zacatepec
 cua	VN	D	Kol
@@ -11162,13 +11684,17 @@ cub	CO	LA	Hipnwa
 cub	CO	LA	Kobeua
 cub	CO	LA	Kobewa
 cub	CO	LA	Kubwa
+cub	CO	LA	Pamié
 cub	CO	LA	Pamiwa
 cuc	MX	L	Chinantec, Usila
 cuc	MX	LA	Chinanteco del Oeste Central Alto
+cuc	MX	LA	Jaú jm_
+cuc	MX	LA	Jmiih kia’ dzä jii’
 cug	CM	D	Chung
 cug	CM	D	Mbuk
-cug	CM	L	Cung
+cug	CM	L	Chungmboko
 cug	CM	LA	Chung
+cug	CM	LA	Cung
 cuh	KE	L	Gichuka
 cuh	KE	LA	Chuka
 cuh	KE	LA	Chuku
@@ -11215,12 +11741,14 @@ cuk	PA	DA	Alto Bayano
 cuk	PA	DA	Maje
 cuk	PA	L	Kuna, San Blas
 cuk	PA	LA	Cuna
+cuk	PA	LA	Guna
 cuk	PA	LA	San Blas Cuna
 cul	BR	L	Kulina
 cul	BR	LA	Corina
 cul	BR	LA	Culina
 cul	BR	LA	Kulína
 cul	BR	LA	Kulyna
+cul	BR	LA	Madiha
 cul	BR	LA	Madihá
 cul	BR	LA	Madija
 cul	PE	L	Culina
@@ -11229,9 +11757,9 @@ cul	PE	LA	Kulina
 cul	PE	LA	Kulino
 cul	PE	LA	Kulyna
 cul	PE	LA	Kurina
+cul	PE	LA	Madiha
 cul	PE	LA	Madihá
 cul	PE	LA	Madija
-cum	CO	L	Cumeral
 cuo	VE	L	Cumanagoto
 cup	US	L	Cupeño
 cuq	CN	L	Cun
@@ -11249,6 +11777,9 @@ cur	NP	LA	Chülüng
 cut	MX	D	Cuicateco del Norte
 cut	MX	D	Cuicateco del oriente
 cut	MX	L	Cuicatec, Teutila
+cut	MX	LA	Dbaku
+cut	MX	LA	Duaku
+cut	MX	LA	Dubaku
 cuu	CN	D	Tai Chung
 cuu	CN	D	Tai Kha
 cuu	CN	D	Tai Sai
@@ -11273,18 +11804,24 @@ cuu	TH	LA	Ya
 cuv	CM	L	Cuvok
 cuv	CM	LA	Tchouvok
 cuw	NP	L	Chukwa
+cuw	NP	LA	Chukuwa
 cuw	NP	LA	Cukwa Ring
 cuw	NP	LA	Pohing
 cuw	NP	LA	Pohing Kha
 cux	MX	D	Santa María Pápalo
 cux	MX	L	Cuicatec, Tepeuxila
 cux	MX	LA	Cuicateco del centro
+cux	MX	LA	Dbaku
+cux	MX	LA	Dibaku
 cvg	IN	L	Chug
 cvg	IN	LA	Chug Monpa
 cvg	IN	LA	Chugpa
 cvg	IN	LA	Monpa
 cvn	MX	L	Chinantec, Valle Nacional
 cvn	MX	LA	Chinanteco Central Bajo
+cvn	MX	LA	Jajmi dzä kï ï’
+cvn	MX	LA	Jejmei
+cvn	MX	LA	Jejmi
 cwa	TZ	L	Kabwa
 cwa	TZ	LA	Ekikabhwa
 cwa	TZ	LA	Ekikabwa
@@ -11299,6 +11836,7 @@ cwe	TZ	LA	Kakwere
 cwe	TZ	LA	Kikwere
 cwe	TZ	LA	Kinghwele
 cwe	TZ	LA	Kwele
+cwe	TZ	LA	Nghwele
 cwe	TZ	LA	Ngh’wele
 cwe	TZ	LA	Ngwele
 cwe	TZ	LA	Ng’were
@@ -11315,6 +11853,7 @@ cwg	MY	LA	Siwang
 cwt	SN	L	Kuwaataay
 cwt	SN	LA	Kwatay
 cya	MX	L	Chatino, Nopala
+cya	MX	LA	Cha’ jna’a
 cya	MX	LA	Chatino Oriental Bajo
 cyb	BO	L	Cayubaba
 cyb	BO	LA	Cayuvava
@@ -11322,6 +11861,7 @@ cyb	BO	LA	Cayuwaba
 cyb	BO	LA	Kayuvava
 cym	AR	D	Patagonian Welsh
 cym	AR	L	Welsh
+cym	AR	LA	Cymraeg
 cym	GB	D	Northern Welsh
 cym	GB	D	Patagonian Welsh
 cym	GB	D	Southern Welsh
@@ -11343,6 +11883,7 @@ czh	CN	L	Chinese, Huizhou
 czh	CN	LA	Hui
 czh	CN	LA	Huizhou
 czn	MX	L	Chatino, Zenzontepec
+czn	MX	LA	Cha’ jna’a
 czn	MX	LA	Chatino Occidental Alto
 czn	MX	LA	Northern Chatino
 czo	CN	L	Chinese, Min Zhong
@@ -11378,6 +11919,7 @@ dag	GH	DA	Nanumba
 dag	GH	L	Dagbani
 dag	GH	LA	Dagbamba
 dag	GH	LA	Dagbane
+dag	GH	LA	Dagbanli
 dag	GH	LA	Dagomba
 dah	PG	D	Gora
 dah	PG	D	Gwahamere
@@ -11397,6 +11939,7 @@ daj	SD	D	Nyala
 daj	SD	DA	Lagawa
 daj	SD	L	Daju, Dar Fur
 daj	SD	LA	Beke
+daj	SD	LA	Bekke
 daj	SD	LA	Dagu
 daj	SD	LA	Daju Ferne
 daj	SD	LA	Fininga
@@ -11421,30 +11964,39 @@ dal	KE	L	Dahalo
 dal	KE	LA	Guo Garimani
 dal	KE	LA	Sanye
 dam	NG	L	Damakawa
+dan	DE	D	Southern Jutish
+dan	DE	DA	Sønderjysk
 dan	DE	L	Danish
 dan	DE	LA	Dänisch
 dan	DE	LA	Dansk
 dan	DK	D	Bornholmsk
-dan	DK	D	Sønderjysk
-dan	DK	DA	Southern Jutlandic
+dan	DK	D	Island Danish
+dan	DK	D	Jutlandic
+dan	DK	DA	Bornholmian
+dan	DK	DA	Eastern Danish
+dan	DK	DA	Insular Danish
+dan	DK	DA	Jutish
+dan	DK	DA	Jutlandish
+dan	DK	DA	Jysk
+dan	DK	DA	Western Danish
 dan	DK	L	Danish
 dan	DK	LA	Dansk
 dan	DK	LA	Rigsdansk
+dan	FO	L	Danish
 dan	GL	L	Danish
-dao	MM	D	Kanpetlet Daai
-dao	MM	D	Matupi Daai
-dao	MM	D	Mindat Daai
-dao	MM	D	Paletwa Daai
-dao	MM	DA	Duk-Msang
-dao	MM	DA	Kheng
-dao	MM	DA	Ma-Tu
-dao	MM	DA	Mkui
-dao	MM	DA	Nghngilo/Yang
-dao	MM	DA	Ngxang
-dao	MM	DA	Shiip
-dao	MM	DA	Vet
+dan	NO	L	Danish
+dan	SE	L	Danish
+dao	MM	D	Daa Yindu
+dao	MM	D	Duk-Msang
+dao	MM	D	Kheng
+dao	MM	D	Ma-Tu
+dao	MM	D	Mkui
+dao	MM	D	Nghngilo
+dao	MM	D	Ngxang
+dao	MM	D	Shiip
+dao	MM	D	Vet
+dao	MM	DA	Yang
 dao	MM	DA	Yet
-dao	MM	DA	Yindu
 dao	MM	L	Chin, Daai
 dao	MM	LA	Dai
 dao	MM	LA	Khyo
@@ -11478,6 +12030,7 @@ dar	RU	DA	Urakha-Akhush
 dar	RU	DA	Urkarax
 dar	RU	DA	Xajdak
 dar	RU	L	Dargwa
+dar	RU	LA	Dargan Medz
 dar	RU	LA	Dargi
 dar	RU	LA	Dargin
 dar	RU	LA	Darginski
@@ -11497,6 +12050,7 @@ dau	SD	LA	Sila
 dau	SD	LA	Sula
 dau	TD	L	Daju, Dar Sila
 dau	TD	LA	Bokorike
+dau	TD	LA	Bokoruge
 dau	TD	LA	Dadjo
 dau	TD	LA	Dajou
 dau	TD	LA	Daju
@@ -11529,6 +12083,7 @@ daz	ID	L	Dao
 daz	ID	LA	Maniwo
 daz	ID	LP	X-Ray
 dba	ML	L	Bangime
+dba	ML	LA	Bangana
 dba	ML	LA	Bangeri Me
 dba	ML	LA	Bangeri Me Dogon
 dba	ML	LA	Bangerime
@@ -11615,6 +12170,7 @@ dbr	SO	DA	Af-Iroole
 dbr	SO	L	Dabarre
 dbr	SO	LA	Af-Dabarre
 dbt	ML	L	Dogon, Ben Tey
+dbt	ML	LA	Ben Tey
 dbu	ML	D	Kindjim
 dbu	ML	D	Nadjamba
 dbu	ML	L	Dogon, Bondum Dom
@@ -11626,6 +12182,7 @@ dbv	NG	LA	Dungi
 dbv	NG	LA	Dunjawa
 dbv	NG	LA	Dwingi
 dbw	ML	L	Dogon, Bankan Tey
+dbw	ML	LA	Bankan Tey
 dbw	ML	LA	Oualo
 dbw	ML	LA	Walo
 dby	PG	L	Dibiyaso
@@ -11701,7 +12258,9 @@ dec	SD	LA	Dagig
 dec	SD	LA	Masakin
 dec	SD	LA	Masakin Dagig
 dec	SD	LA	Masakin Gusar
+dec	SD	LA	Ruwa
 dec	SD	LA	Thakik
+dec	SD	LA	Tharuwa
 ded	PG	D	Dzeigoc
 ded	PG	D	Fanic
 ded	PG	L	Dedua
@@ -11713,6 +12272,7 @@ dee	LR	LA	Dey
 def	IR	D	Dezfuli
 def	IR	D	Shushtari
 def	IR	L	Dezfuli
+def	IR	LA	Dezhfili
 def	IR	LA	Dizfuli
 deg	NG	D	Atala
 deg	NG	D	Usokun
@@ -11756,18 +12316,25 @@ des	CO	LA	Kusibi
 des	CO	LA	Oregu
 des	CO	LA	Wina
 des	CO	LA	Wira
+deu	AR	L	German, Standard
 deu	AT	D	Kärntnerisch
 deu	AT	L	German, Standard
+deu	AU	L	German, Standard
 deu	BE	L	German, Standard
+deu	BR	L	German, Standard
+deu	CA	L	German, Standard
 deu	CH	L	German, Standard
+deu	CL	L	German, Standard
 deu	CZ	L	German, Standard
 deu	DE	L	German, Standard
 deu	DE	LA	Deutsch
 deu	DE	LA	Tedesco
 deu	DK	L	German, Standard
+deu	EC	L	German, Standard
 deu	HU	L	German, Standard
 deu	IT	L	German, Standard
 deu	IT	LA	Tedesco
+deu	KG	L	German, Standard
 deu	KZ	L	German, Standard
 deu	LI	L	German, Standard
 deu	LU	L	German, Standard
@@ -11779,6 +12346,7 @@ deu	RO	L	German, Standard
 deu	SI	L	German, Standard
 deu	SK	L	German, Standard
 deu	UA	L	German, Standard
+deu	UY	L	German, Standard
 dev	PG	L	Domung
 dez	CD	L	Dengese
 dez	CD	LA	Ileo
@@ -11796,6 +12364,7 @@ dga	GH	LA	Dogaari
 dga	GH	LA	Southern Dagari
 dgb	ML	L	Dogon, Bunoge
 dgb	ML	LA	Budu-Tagu
+dgb	ML	LA	Bunoge
 dgb	ML	LA	Korandabo
 dgc	PH	L	Agta, Casiguran Dumagat
 dgc	PH	LA	Casiguran Dumagat
@@ -11835,7 +12404,9 @@ dgi	BF	LA	Northern Dagaare
 dgk	CF	L	Dagba
 dgk	TD	L	Dagba
 dgl	SD	L	Andaandi
+dgl	SD	LA	Danaagla
 dgl	SD	LA	Dongola
+dgl	SD	LA	Dongola Nubian
 dgl	SD	LA	Dongolawi
 dgl	SD	LA	Dongolawi Nubian
 dgl	SD	LA	Dongolese
@@ -11852,6 +12423,7 @@ dgo	IN	LA	Tokkaru
 dgr	CA	D	Central Dogrib
 dgr	CA	D	Weledeh
 dgr	CA	L	Dogrib
+dgr	CA	LA	Tlicho
 dgs	BF	L	Dogoso
 dgs	BF	LA	Bambadion-Dogoso
 dgs	BF	LA	Bambadion-Dokhosié
@@ -11878,14 +12450,13 @@ dgz	PG	LA	Nawp
 dhd	IN	L	Dhundari
 dhd	IN	LA	Dhundari-Marwari
 dhd	IN	LA	Jaipuri
-dhg	AU	D	Dhangu-Djangu
 dhg	AU	D	Gaalpu
 dhg	AU	D	Golumala
 dhg	AU	D	Ngaymil
 dhg	AU	D	Rirratjingu
 dhg	AU	D	Wangurri
 dhg	AU	DA	Kalbu
-dhg	AU	L	Djangu
+dhg	AU	L	Dhangu-Djangu
 dhg	AU	LA	Budalpudal
 dhg	AU	LA	Burada
 dhg	AU	LA	Buralbural
@@ -11894,11 +12465,13 @@ dhg	AU	LA	Dangu
 dhg	AU	LA	Dhaangu
 dhg	AU	LA	Dhangu
 dhg	AU	LA	Dhangu’mi
+dhg	AU	LA	Djangu
 dhg	AU	LA	Warameri
 dhg	AU	LA	Waramiri
 dhg	AU	LA	Warramiri
 dhg	AU	LA	War-ramirri
 dhg	AU	LA	Warumeri
+dhg	AU	LA	Yolngu-Matha
 dhg	AU	LA	Yuulngu
 dhi	IN	D	Eastern Dhimal
 dhi	IN	L	Dhimal
@@ -11961,6 +12534,7 @@ dhs	TZ	L	Dhaiso
 dhs	TZ	LA	Daiso
 dhs	TZ	LA	Daisu
 dhs	TZ	LA	Kidhaiso
+dhs	TZ	LA	Kisegeju
 dhs	TZ	LA	Segeju
 dhs	TZ	LA	Sengeju
 dhu	AU	L	Dhurga
@@ -12069,6 +12643,8 @@ dih	US	LA	Diegueño
 dih	US	LA	Digueño
 dih	US	LA	Kamia
 dih	US	LA	Kumeyaay
+dih	US	LA	Tipai’
+dii	CM	D	Ripey
 dii	CM	L	Dimbong
 dii	CM	LA	Bape
 dii	CM	LA	Bumbong
@@ -12134,9 +12710,12 @@ dil	SD	D	Debri
 dil	SD	D	Dilling
 dil	SD	L	Dilling
 dil	SD	LA	Delen
+dil	SD	LA	Warki
 dil	SD	LA	Warkimbe
 dim	ET	L	Dime
 dim	ET	LA	Dima
+dim	ET	LA	Dim-af
+dim	ET	LA	Dim-ap
 din	SS	L	Dinka
 dio	NG	L	Dibo
 dio	NG	LA	Ganagana
@@ -12286,6 +12865,7 @@ djc	TD	LA	Dajou
 djc	TD	LA	Daju
 djc	TD	LA	Daju Mongo
 djc	TD	LA	Daju Oum Hadjer
+djc	TD	LA	Saaronge
 djd	AU	D	Ngaliwuru
 djd	AU	DA	Ngaliwerra
 djd	AU	L	Djamindjung
@@ -12349,6 +12929,7 @@ dji	AU	L	Djinang
 dji	AU	LA	Jandijinung
 djj	AU	L	Djeebbana
 djj	AU	LA	Gunavidji
+djj	AU	LA	Ndjébbana
 djk	GF	D	Aluku
 djk	GF	D	Pamaka
 djk	GF	L	Aukan
@@ -12485,18 +13066,19 @@ dme	CM	LA	Dougour
 dme	CM	LA	Memekere
 dme	CM	LA	Mofu-Dugwor
 dme	CM	LA	Tchakidjebe
-dmg	MY	D	Dusun Segama
 dmg	MY	D	Kalabuan
+dmg	MY	D	Kuamut
 dmg	MY	D	Makiang
 dmg	MY	D	Sinabu’
+dmg	MY	D	Sinarupa
 dmg	MY	DA	Kolobuan
-dmg	MY	DA	Saga-i
-dmg	MY	DA	Segai
-dmg	MY	DA	Sinabu
-dmg	MY	DA	Soghai
+dmg	MY	DA	Sinobu’
 dmg	MY	L	Kinabatangan, Upper
+dmg	MY	LA	Orang Sungai
 dmg	MY	LA	Sungai Milian
 dmk	PK	L	Domaaki
+dmk	PK	LA	Bericho
+dmk	PK	LA	Dom
 dmk	PK	LA	Doma
 dmk	PK	LA	Dumaki
 dml	PK	L	Dameli
@@ -12531,6 +13113,7 @@ dmw	AU	LA	Madbara
 dmw	AU	LA	Moodburra
 dmw	AU	LA	Mootburra
 dmw	AU	LA	Mudbara
+dmw	AU	LA	Mudbarra
 dmw	AU	LA	Mudbera
 dmw	AU	LA	Mudbra
 dmw	AU	LA	Mudbura
@@ -12554,11 +13137,13 @@ dng	KG	DA	Gansu
 dng	KG	DA	Shensi
 dng	KG	L	Dungan
 dng	KG	LA	Dzhunyan
+dng	KG	LA	Huizu
 dng	KG	LA	Kwuizwu
 dng	KG	LA	Tungan
 dng	KG	LA	Zwn’jan
 dng	KZ	D	Shaanxi
 dng	KZ	L	Dungan
+dng	KZ	LA	Huizu
 dni	ID	D	Lower Bele
 dni	ID	D	Lower Grand Valley Hitigima
 dni	ID	D	Lower Kimbin
@@ -12613,6 +13198,7 @@ dnn	BF	D	Kpeengo
 dnn	BF	DA	Samogohiri
 dnn	BF	DA	Samorogouan
 dnn	BF	L	Dzùùngoo
+dnn	BF	LA	Dzùùn
 dnn	BF	LA	Eastern Duun
 dnn	BF	LA	Kpango
 dnn	BF	LA	Samogho
@@ -12639,6 +13225,7 @@ dnw	ID	LA	Timorini
 dny	BR	D	Inauini
 dny	BR	L	Dení
 dny	BR	LA	Dani
+dny	BR	LA	Madiha
 doa	PG	D	Era
 doa	PG	L	Dom
 dob	PG	D	Central Dobu
@@ -12763,15 +13350,21 @@ doy	GH	LA	Ndmpo
 doz	ET	L	Dorze
 dpp	MY	L	Papar
 dpp	MY	LA	Bajau Bukit
+dpp	MY	LA	Bajau Pa’par
+dpp	MY	LA	Pa’par
+dpp	MY	LA	Pappar
+dpp	MY	LP	Papar Hanyut
 drb	SD	L	Dair
 drb	SD	LA	Dabab
 drb	SD	LA	Daier
 drb	SD	LA	Thaminyi
 drc	PT	L	Minderico
+drc	PT	LA	Piação dos Charales do Ninhou
 drd	IN	L	Darmiya
 drd	IN	LA	Darimiya
 drd	IN	LA	Darma
 drd	IN	LA	Darma Lwo
+drd	IN	LA	Darma-Lwo
 drd	IN	LA	Darmani
 drd	IN	LA	Saukas
 drd	IN	LA	Shaukas
@@ -12785,11 +13378,12 @@ drg	MY	D	Gandahon
 drg	MY	D	Gonsomon
 drg	MY	D	Nuluw
 drg	MY	D	Pilapazan
-drg	MY	DA	Central Rungus
-drg	MY	DA	Rungus Tanga
 drg	MY	L	Rungus
+drg	MY	LA	Dayak Laut
 drg	MY	LA	Dusun Dayak
+drg	MY	LA	Kadazan
 drg	MY	LA	Melobong Rungus
+drg	MY	LA	Melubong Rungus
 drg	MY	LA	Memagun
 drg	MY	LA	Memogun
 drg	MY	LA	Momogun
@@ -12817,6 +13411,7 @@ dri	NG	LA	Dakarkari
 dri	NG	LA	Dakkarkari
 dri	NG	LA	Kolela
 dri	NG	LA	Lalawa
+dri	NG	LA	Lela
 drl	AU	D	Kurnu
 drl	AU	D	Marrawarra
 drl	AU	D	Milpulo
@@ -12835,6 +13430,7 @@ drl	AU	DA	Barindji
 drl	AU	DA	Maruara
 drl	AU	L	Paakantyi
 drl	AU	LA	Baagandji
+drl	AU	LA	Bagandji
 drl	AU	LA	Darling
 drl	AU	LA	Kula
 drl	AU	LA	Paakanti
@@ -12890,6 +13486,7 @@ dry	NP	L	Darai
 dsb	DE	L	Sorbian, Lower
 dsb	DE	LA	Bas Sorabe
 dsb	DE	LA	Delnoserbski
+dsb	DE	LA	Dolnoserbski
 dsb	DE	LA	Lluzykie
 dsb	DE	LA	Lower Lusatian
 dsb	DE	LA	Lusatian
@@ -12955,6 +13552,7 @@ dsq	ML	LA	Daoussahaq
 dsq	ML	LA	Daoussak
 dsq	ML	LA	Dausahaq
 dsq	ML	LA	Dawsahaq
+dsq	ML	LA	Idaksahak
 dta	CN	D	Buteha
 dta	CN	D	Haila’er
 dta	CN	D	Ili
@@ -13007,9 +13605,12 @@ dtb	MY	L	Kadazan, Labuk-Kinabatangan
 dtb	MY	LA	Eastern Kadazan
 dtb	MY	LA	Labuk Kadazan
 dtb	MY	LA	Sogilitan
+dtb	MY	LA	Sungai
+dtb	MY	LA	Sungai Kinabatangan
 dtb	MY	LA	Tindakon
 dtb	MY	LA	Tompulung
 dtd	CA	L	Ditidaht
+dtd	CA	LA	Diidiitidq
 dtd	CA	LA	Diitiid’aatx
 dtd	CA	LA	Nitinaht
 dtd	CA	LA	Nitinat
@@ -13039,37 +13640,72 @@ dtm	ML	D	Tie Bara
 dtm	ML	D	Tienwan Ganda
 dtm	ML	L	Dogon, Tomo Kan
 dtm	ML	LA	Tomo-Kan
+dtn	ET	L	Daatsʼíin
+dtn	ET	LA	Sa-Daatsʼíin
 dto	ML	L	Dogon, Tommo So
 dto	ML	LA	Tombo-So
+dto	ML	LA	Tommo So
 dtp	MY	D	Beaufort
 dtp	MY	D	Bundu
+dtp	MY	D	Coastal Kadazan
 dtp	MY	D	Dusun Sinulihan
 dtp	MY	D	Kadazan-Tagaro
 dtp	MY	D	Kiundu
-dtp	MY	D	Kuala Monsok Dusun
+dtp	MY	D	Kuriyou
+dtp	MY	D	Liwan
 dtp	MY	D	Luba
 dtp	MY	D	Menggatal
 dtp	MY	D	Pahu’
 dtp	MY	D	Ranau
 dtp	MY	D	Sokid
+dtp	MY	D	Tambunan Dusun
+dtp	MY	D	Tinagas Dusun
 dtp	MY	D	Tindal
+dtp	MY	D	Tindal Dusun
+dtp	MY	DA	Dusun
+dtp	MY	DA	Kadamaian Dusun
+dtp	MY	DA	Kadazan
+dtp	MY	DA	Kadazan Tangaa’
 dtp	MY	DA	Kiulu
+dtp	MY	DA	Kota Marudu Tinagas
+dtp	MY	DA	Kuala Monsok Dusun
+dtp	MY	DA	Membakut Kadazan
+dtp	MY	DA	Papar Kadazan
+dtp	MY	DA	Penampang Kadazan
 dtp	MY	DA	Sinulihan
 dtp	MY	DA	Tagaro
 dtp	MY	DA	Taginambur
+dtp	MY	DA	Talantang
+dtp	MY	DA	Tambunan
+dtp	MY	DA	Tampasok
+dtp	MY	DA	Tampassuk
 dtp	MY	DA	Telipok
-dtp	MY	L	Dusun, Central
+dtp	MY	DA	Tempasok
+dtp	MY	DA	Tempasuk
+dtp	MY	DA	Tempasuk Dusun
+dtp	MY	DA	Tinagas
+dtp	MY	DA	Tindal
+dtp	MY	DA	Tinombunan
+dtp	MY	DA	Ulu Sugut Dusun
+dtp	MY	DP	Panansawa
+dtp	MY	L	Dusun, Kadazan
+dtp	MY	LA	Central Dusun
 dtp	MY	LA	Central Kadazan
 dtp	MY	LA	Dusan
 dtp	MY	LA	Dusum
 dtp	MY	LA	Dusun
 dtp	MY	LA	Dusur
+dtp	MY	LA	Idaan
 dtp	MY	LA	Kadasan
 dtp	MY	LA	Kadayan
+dtp	MY	LA	Kadazandusun
 dtp	MY	LA	Kedayan
+dtr	MY	D	Dusun Kadayan
+dtr	MY	D	Suang Lotud
+dtr	MY	D	Suang Olung
+dtr	MY	D	Suang Sarayoh
 dtr	MY	L	Lotud
 dtr	MY	LA	Dusun Lotud
-dtr	MY	LA	Suang Lotud
 dts	ML	D	Ibi
 dts	ML	D	Ireli
 dts	ML	D	Sangha
@@ -13082,6 +13718,7 @@ dtt	ML	L	Dogon, Toro Tegu
 dtt	ML	LA	Tandam
 dtu	ML	L	Dogon, Tebul Ure
 dtu	ML	LA	Oru yille
+dtu	ML	LA	Tebul Ure
 dty	IN	L	Dotyali
 dty	NP	D	Baitadeli
 dty	NP	D	Bajhangi
@@ -13144,26 +13781,13 @@ duf	NC	LA	Naa Drubea
 duf	NC	LA	Naa Dubea
 duf	NC	LA	Ndumbea
 duf	NC	LA	Nraa Drubea
+duf	NC	LA	Paita
 dug	KE	L	Chiduruma
 dug	KE	LA	Duruma
 dug	KE	LP	Wanyika
 duh	IN	L	Dungra Bhil
 dui	PG	L	Dumun
 dui	PG	LA	Bai
-duj	AU	D	Datiwuy
-duj	AU	D	Dhuwal
-duj	AU	D	Dhuwaya
-duj	AU	D	Djapu
-duj	AU	D	Liyagalawumirr
-duj	AU	D	Liyagawumirr
-duj	AU	D	Marrakulu
-duj	AU	D	Marrangu
-duj	AU	DA	Daatiwuy
-duj	AU	L	Dhuwal
-duj	AU	LA	Dual
-duj	AU	LA	Duala
-duj	AU	LA	Wulamba
-duj	AU	LA	Yolngu
 duk	PG	D	Amowe
 duk	PG	D	Uyajitaya
 duk	PG	L	Uyajitaya
@@ -13244,9 +13868,11 @@ duu	CN	DA	Northern Dulongjiang
 duu	CN	DA	Nujiang Dulong
 duu	CN	DA	Southern Dulongjiang
 duu	CN	L	Drung
+duu	CN	LA	Qiuzu
 duu	MM	L	Drung
 duu	MM	LA	Derung
 duu	MM	LA	Dulong
+duu	MM	LA	Durung
 duu	MM	LA	Qiu
 duu	MM	LA	Rawang
 duu	MM	LA	Tarong
@@ -13254,6 +13880,7 @@ duu	MM	LA	Thrung
 duu	MM	LA	Trung
 duu	MM	LA	T’rung
 duu	MM	LA	Tulung
+duu	MM	LA	Tvrung
 duv	ID	D	Eastern Duvle
 duv	ID	D	Western Duvle
 duv	ID	L	Duvle
@@ -13275,8 +13902,12 @@ dux	ML	LA	Samoro
 dux	ML	LA	Western Duun
 duy	PH	L	Agta, Dicamay
 duy	PH	LA	Dicamay Dumagat
-duz	CM	L	Duli
+duz	CM	L	Duli-Gey
 duz	CM	LA	Dui
+duz	CM	LA	Duli
+duz	CM	LA	Gewe
+duz	CM	LA	Gey
+duz	CM	LA	Gueve
 dva	PG	D	Dawada
 dva	PG	D	Guleguleu
 dva	PG	D	Mwalukwasia
@@ -13298,8 +13929,23 @@ dwr	ET	LA	Cullo
 dwr	ET	LA	Dauro
 dwr	ET	LA	Kullo
 dwr	ET	LA	Ometay
+dwu	AU	D	Datiwuy
+dwu	AU	D	Dhuwal
+dwu	AU	D	Djapu
+dwu	AU	D	Liyagalawumirr
+dwu	AU	D	Liyagawumirr
+dwu	AU	D	Marrakulu
+dwu	AU	D	Marrangu
+dwu	AU	DA	Daatiwuy
+dwu	AU	L	Dhuwal
+dwu	AU	LA	Dual
+dwu	AU	LA	Duala
+dwu	AU	LA	Wulamba
+dwu	AU	LA	Yolngu
 dww	PG	L	Dawawa
 dww	PG	LA	Dawana
+dwy	AU	L	Dhuwaya
+dwy	AU	LA	Baby Gumatj
 dya	BF	D	Zanga
 dya	BF	L	Dyan
 dya	BF	LA	Dan
@@ -13324,6 +13970,7 @@ dyi	CI	LA	Djimini
 dyi	CI	LA	Dyimini
 dyi	CI	LA	Jinmini
 dym	ML	L	Dogon, Yanda Dom
+dym	ML	LA	Yanda Dom
 dyn	AU	L	Dyangadi
 dyn	AU	LA	Boorkutti
 dyn	AU	LA	Burgadi
@@ -13435,6 +14082,7 @@ dzg	TD	L	Dazaga
 dzg	TD	LA	Dasa
 dzg	TD	LA	Daza
 dzg	TD	LA	Dazza
+dzg	TD	LA	Gorane
 dzl	BT	D	Khomakha
 dzl	BT	L	Dzalakha
 dzl	BT	LA	Dzala
@@ -13475,8 +14123,10 @@ ebk	PH	LA	Eastern Bontoc
 ebk	PH	LA	Finallig
 ebk	PH	LA	Southern Bontoc
 ebo	CD	L	Teke, Eboo
+ebo	CD	LA	Aboo
 ebo	CG	D	Teke-Nzikou
 ebo	CG	L	Teke-Eboo
+ebo	CG	LA	Aboo
 ebo	CG	LA	Bamboma
 ebo	CG	LA	Boma
 ebo	CG	LA	Boo
@@ -13518,6 +14168,7 @@ ega	CI	LA	Diés
 ega	CI	LA	Egwa
 egl	IT	L	Emilian
 egl	IT	LA	Bolognese
+egl	IT	LA	Emigliân
 egl	IT	LA	Ferrarese
 egl	IT	LA	Modenese
 egl	IT	LA	Parmigiano
@@ -13587,6 +14238,7 @@ ekg	ID	DA	Jabi
 ekg	ID	L	Ekari
 ekg	ID	LA	Ekagi
 ekg	ID	LA	Kapauku
+ekg	ID	LA	Me
 ekg	ID	LA	Me Mana
 ekg	ID	LA	Mee Mana
 ekg	ID	LA	Tapiro
@@ -13598,6 +14250,7 @@ ekk	EE	DA	Dorpat
 ekk	EE	DA	Reval
 ekk	EE	L	Estonian, Standard
 ekk	EE	LA	Eesti
+ekk	EE	LA	Eesti Kirjakeel
 ekk	FI	D	Muly
 ekk	FI	D	Tallinn
 ekk	FI	D	Tartu
@@ -13609,6 +14262,7 @@ ekk	FI	DA	Southern Estonian
 ekk	FI	DA	Tatu
 ekk	FI	L	Estonian, Standard
 ekk	FI	LA	Eesti
+ekk	FI	LA	Eesti Kirjakeel
 ekl	BD	L	Kol
 ekl	BD	LA	Hor
 ekm	CM	D	Nukanya
@@ -13657,11 +14311,13 @@ eky	MM	LA	Karenni
 eky	MM	LA	Karennyi
 eky	MM	LA	Kayah Li
 eky	MM	LA	Kayay
+eky	MM	LA	Kayeh
 eky	MM	LA	Red Karen
 eky	TH	L	Kayah, Eastern
 eky	TH	LA	Karennyi
 eky	TH	LA	Kayah
 eky	TH	LA	Kayay
+eky	TH	LA	Kayeh
 eky	TH	LA	Red Karen
 eky	TH	LP	Yang Daeng
 ele	PG	L	Elepi
@@ -13674,10 +14330,9 @@ elk	PG	L	Elkei
 elk	PG	LA	Olkoi
 ell	AL	D	Northern Estonian
 ell	AL	L	Greek
+ell	AU	L	Greek
 ell	CY	D	Cypriot Greek
 ell	CY	L	Greek
-ell	FR	D	Cargese
-ell	FR	L	Greek
 ell	GR	D	Dimotiki
 ell	GR	D	Katharevousa
 ell	GR	D	Saracatsan
@@ -13700,6 +14355,7 @@ ell	UA	D	Mariupol Greek
 ell	UA	DA	Crimeo-Rumeic
 ell	UA	DA	Tavro-Rumeic
 ell	UA	L	Greek
+ell	UA	LA	Urum
 elm	NG	D	Nchia
 elm	NG	D	Odido
 elm	NG	L	Eleme
@@ -13752,6 +14408,7 @@ emi	PG	D	Eastern Mussau
 emi	PG	D	Emira
 emi	PG	D	Southern Mussau
 emi	PG	D	Western Mussau
+emi	PG	DA	Emirau
 emi	PG	L	Mussau-Emira
 emi	PG	LA	Emira-Mussau
 emi	PG	LA	Musao
@@ -13802,7 +14459,10 @@ emp	CO	LA	Cholo
 emp	CO	LA	Darién
 emp	CO	LA	Eberã
 emp	CO	LA	Eberã Bed’ea
+emp	CO	LA	Embena
+emp	CO	LA	Embera
 emp	CO	LA	Emperã
+emp	CO	LA	Epena
 emp	CO	LA	Eperã Pedea
 emp	CO	LA	Panama Embera
 emp	CO	LA	Sambú
@@ -13813,11 +14473,13 @@ emp	PA	LA	Cholo
 emp	PA	LA	Darien
 emp	PA	LA	Darien Emberá
 emp	PA	LA	Ebera Bedea
+emp	PA	LA	Embera
 emp	PA	LA	Empera
 emp	PA	LA	Panama Embera
 ems	US	D	Chugach
 ems	US	D	Koniag
 ems	US	L	Yupik, Pacific Gulf
+ems	US	LA	Aleut
 ems	US	LA	Alutiiq
 ems	US	LA	Chugach Eskimo
 ems	US	LA	Koniag-Chugach
@@ -13899,6 +14561,7 @@ eng	DM	D	Dominican English
 eng	DM	L	English
 eng	DO	D	Samaná English
 eng	DO	L	English
+eng	EE	L	English
 eng	ER	L	English
 eng	ET	L	English
 eng	FJ	L	English
@@ -13962,6 +14625,7 @@ eng	IO	L	English
 eng	JE	L	English
 eng	JM	L	English
 eng	KE	L	English
+eng	KH	L	English
 eng	KI	L	English
 eng	KN	L	English
 eng	KY	D	Cayman Islands English
@@ -13986,9 +14650,12 @@ eng	MY	L	English
 eng	NA	L	English
 eng	NF	L	English
 eng	NG	L	English
+eng	NL	L	English
+eng	NP	L	English
 eng	NR	L	English
 eng	NU	L	English
 eng	NZ	L	English
+eng	OM	L	English
 eng	PG	L	English
 eng	PH	L	English
 eng	PK	L	English
@@ -14117,6 +14784,7 @@ ero	CN	D	sTau
 ero	CN	DA	Daofu
 ero	CN	DA	Dawu
 ero	CN	DA	Geshiza
+ero	CN	DA	Nyarong Minyak
 ero	CN	DA	rTau
 ero	CN	DA	Xinlong-Muya
 ero	CN	L	Horpa
@@ -14185,17 +14853,24 @@ ese	BO	LA	Essejja
 ese	BO	LA	Huarayo
 ese	BO	LA	Tiatinagua
 ese	BO	LP	Chama
-ese	PE	L	Ese Ejja
-ese	PE	LA	Ese Eja
+ese	PE	L	Ese Eja
+ese	PE	LA	Ese Ejja
 ese	PE	LA	Ese Exa
 ese	PE	LA	Ese’ejja
 ese	PE	LA	Huarayo
 ese	PE	LA	Tambopata-Guarayo
 ese	PE	LA	Tiatinagua
 ese	PE	LP	Chama
+esg	IN	D	Bhamragarh
+esg	IN	D	Etapally Gondi
+esg	IN	D	Sironcha
+esg	IN	L	Gondi, Aheri
+esg	IN	LA	Koyam
+esg	IN	LA	Raj Gond
 esh	IR	L	Eshtehardi
 esi	CA	D	North Slope Inupiaq
 esi	CA	D	West Arctic Inupiatun
+esi	CA	DA	Bulkley Valley
 esi	CA	DA	Mackenzie Delta Inupiatun
 esi	CA	DA	Mackenzie Inupiatun
 esi	CA	DA	Western Iñupiaq
@@ -14235,7 +14910,7 @@ esl	EG	LA	Egypt Sign Language
 esl	EG	LA	ESL
 esn	SV	L	Salvadoran Sign Language
 esn	SV	LA	El Salvadoran Sign Language
-esn	SV	LA	Lengua de Señas Salvadoreñas
+esn	SV	LA	Lengua de señas salvadoreñas
 esn	SV	LA	LESSA
 eso	EE	L	Estonian Sign Language
 eso	EE	LA	Eesti viipekeel
@@ -14269,6 +14944,14 @@ esu	US	D	Western Mampruli
 esu	US	DA	Unaliq
 esu	US	L	Yupik, Central
 esu	US	LA	Central Alaskan Yupik
+esy	PH	L	Eskayan
+esy	PH	LA	Bisayan Declarado
+esy	PH	LA	Bisayan Diklaradu
+esy	PH	LA	Bisayan-Eskaya
+esy	PH	LA	Eskaya’
+esy	PH	LA	Ineskaya
+esy	PH	LA	Iniskaya
+esy	PH	LA	Iskaya’
 etb	NG	L	Etebi
 eth	ET	L	Ethiopian Sign Language
 eth	ET	LA	EthSL
@@ -14349,22 +15032,31 @@ etz	ID	LA	Etna Bay
 etz	ID	LA	Muri
 etz	ID	LA	Wesrau
 eus	ES	D	Alavan
-eus	ES	D	Alto Navarro Meridional
-eus	ES	D	Alto Navarro Septentrional
-eus	ES	D	Biscayan
-eus	ES	D	Gipuzkera
-eus	ES	D	Roncalese
+eus	ES	D	Eastern Navarrese
+eus	ES	D	Middle Basque
+eus	ES	D	South High Navarrese
+eus	ES	D	Western Basque
+eus	ES	DA	Alto Navarro Meridional
+eus	ES	DA	Arabar euskalkia
+eus	ES	DA	Biscayan
+eus	ES	DA	Ekialdeko nafarrera
+eus	ES	DA	Gipuzkera
 eus	ES	DA	Gipuzkoan
 eus	ES	DA	Guipuzcoan
 eus	ES	DA	Guipuzcoano
+eus	ES	DA	Hegoaldeko goi nafarrera
 eus	ES	DA	High Navarrese
+eus	ES	DA	Mendebaldeko euskalkia
+eus	ES	DA	Roncalese
 eus	ES	DA	Upper Navarran
 eus	ES	DA	Vizcaino
 eus	ES	L	Basque
+eus	ES	LA	Euska
 eus	ES	LA	Euskara
 eus	ES	LA	Euskera
-eus	ES	LA	Vascuense
-eus	FR	D	Navarro-Labourdin
+eus	ES	LA	Euskerie
+eus	ES	LP	Vascuense
+eus	FR	D	Navarrese-Labourtan
 eus	FR	D	Souletin
 eus	FR	DA	Bajo Navarro Occidental
 eus	FR	DA	Bajo Navarro Oriental
@@ -14372,13 +15064,21 @@ eus	FR	DA	Benaffarera
 eus	FR	DA	Eastern Low Navarrese
 eus	FR	DA	Labourdin
 eus	FR	DA	Lapurdiera
+eus	FR	DA	Nafar-lapurtera
+eus	FR	DA	Navarro-Labourdin
 eus	FR	DA	Souletino
 eus	FR	DA	Suberoan
 eus	FR	DA	Suletino
 eus	FR	DA	Western Low Navarrese
 eus	FR	DA	Xiberoera
+eus	FR	DA	Zuberera
 eus	FR	DA	Zuberoera
 eus	FR	L	Basque
+eus	FR	LA	Euskara
+eus	PH	L	Basque
+eus	PH	LA	Euskara
+eus	US	L	Basque
+eus	US	LA	Euskara
 eve	RU	D	Arman
 eve	RU	D	Indigirka
 eve	RU	D	Kamchatka
@@ -14530,6 +15230,7 @@ ext	ES	DA	Artu Ehtremeñu
 ext	ES	DA	Bahu Ehtremeñu
 ext	ES	DA	Meyu Ehtremeñu
 ext	ES	L	Extremaduran
+ext	ES	LA	Barranquênhu
 ext	ES	LA	Barranquian
 ext	ES	LA	Cahtúo
 ext	ES	LA	Cahtúö
@@ -14537,6 +15238,7 @@ ext	ES	LA	Ehtremeñu
 ext	ES	LA	Extremeño
 ext	PT	L	Barranquian
 ext	PT	LA	Barranquenho
+ext	PT	LA	Barranquênhu
 ext	PT	LA	Cahtúo
 ext	PT	LA	Cahtúö
 ext	PT	LA	Ehtremeñu
@@ -14646,9 +15348,10 @@ fan	GQ	L	Fang
 fan	GQ	LA	Pahouin
 fan	GQ	LA	Pamue
 fan	GQ	LA	Pangwe
-fao	DK	L	Faroese
-fao	DK	LA	Faeroese
-fao	DK	LA	Føroyskt
+fao	FO	D	Suthuroy
+fao	FO	L	Faroese
+fao	FO	LA	Faeroese
+fao	FO	LA	Føroyskt
 fap	SN	D	Ba’ol
 fap	SN	D	Kajor
 fap	SN	L	Palor
@@ -14661,8 +15364,15 @@ fap	SN	LA	Siili-Siili
 fap	SN	LA	Waro
 far	SB	L	Fataleka
 fas	IR	L	Persian
+fat	GH	L	Fante
+fat	GH	LA	Fanti
+fat	GH	LA	Mfantse
 fau	ID	L	Fayu
+fau	ID	LA	Iyarike
+fau	ID	LA	Sefoiri
 fau	ID	LA	Sehudate
+fau	ID	LA	Tearu
+fau	ID	LA	Tikere
 fax	ES	D	Lagarteiru
 fax	ES	D	Mañegu
 fax	ES	D	Valvideiru
@@ -14698,6 +15408,7 @@ fer	SS	LA	Kaliki
 ffi	PG	L	Foia Foia
 ffi	PG	LA	Foiafoia
 ffi	PG	LA	Foyafoya
+ffm	CI	L	Fulfulde, Maasina
 ffm	GH	L	Fulfulde, Maasina
 ffm	GH	LA	Fulbe
 ffm	GH	LA	Maacina
@@ -14705,8 +15416,11 @@ ffm	GH	LA	Peul
 ffm	ML	D	Eastern Macina
 ffm	ML	D	Western Macina
 ffm	ML	L	Fulfulde, Maasina
+ffm	ML	LA	Fulani
+ffm	ML	LA	Fulbe
 ffm	ML	LA	Macina
 ffm	ML	LA	Peul
+ffm	ML	LA	Toucouleur
 fgr	TD	L	Fongoro
 fgr	TD	LA	Gele
 fgr	TD	LA	Kole
@@ -14772,6 +15486,7 @@ fij	FJ	L	Fijian
 fij	FJ	LA	Boumaa Fijian
 fij	FJ	LA	Eastern Fijian
 fij	FJ	LA	Fiji
+fij	FJ	LA	Nadroga
 fij	FJ	LA	Standard Fijian
 fil	PH	L	Filipino
 fin	FI	D	Central and North Pohjanmaa
@@ -14818,6 +15533,7 @@ fip	TZ	DA	Yantili
 fip	TZ	L	Fipa
 fip	TZ	LA	Cifipa
 fip	TZ	LA	Fiba
+fip	TZ	LA	Ichifipa
 fip	TZ	LA	Icifipa
 fip	TZ	LA	Kifipa
 fir	NG	L	Firan
@@ -14843,7 +15559,9 @@ fkk	NG	LA	Fali of Kiria
 fkk	NG	LA	Fali of Kiriya
 fkk	NG	LA	Fali of Kirya
 fkk	NG	LA	Fali of Mijilu
+fkk	NG	LA	Karya
 fkk	NG	LA	Kirya
+fkk	NG	LA	Konzal
 fkv	NO	L	Finnish, Kven
 fkv	NO	LA	Kven
 fkv	NO	LA	North Finnish
@@ -14852,12 +15570,14 @@ fla	US	D	Flathead
 fla	US	D	Kalispel
 fla	US	D	Pend d’Oreille
 fla	US	L	Kalispel-Pend d’Oreille
+fla	US	LA	Nqlispélišcn
 fla	US	LA	Salish
 fla	US	LP	Flathead-Kalispel
 fla	US	LP	Kalispel-Flathead
 flh	ID	L	Foau
 flh	ID	LA	Abawiri
 flh	ID	LA	Doa
+flh	ID	LA	Fuau
 fli	NG	D	Bwin
 fli	NG	D	Huli
 fli	NG	D	Madzarin
@@ -14931,6 +15651,8 @@ fmu	IN	L	Muria, Far Western
 fmu	IN	LA	Gondi
 fmu	IN	LA	Koitor Boli
 fmu	IN	LA	Koitori
+fnb	VU	L	Fanbak
+fnb	VU	LA	Orkon
 fng	ZA	L	Pidgin Bantu
 fng	ZA	LA	Basic Zulu
 fng	ZA	LA	Fanagoloi
@@ -14986,6 +15708,7 @@ foi	PG	LA	Mubi River
 fom	CD	L	Foma
 fom	CD	LA	Fuma
 fom	CD	LA	Lifoma
+fom	CD	LA	Pseudo-Bambole
 fon	BJ	D	Agbome
 fon	BJ	D	Arohun
 fon	BJ	D	Gbekon
@@ -15038,6 +15761,7 @@ fqs	PG	D	Eastern Fas
 fqs	PG	D	Western Fas
 fqs	PG	L	Fas
 fqs	PG	LA	Bembi
+fqs	PG	LA	Momu
 fra	AD	L	French
 fra	BE	D	Lorraine
 fra	BE	L	French
@@ -15083,8 +15807,8 @@ fra	FR	DA	Normand
 fra	FR	L	French
 fra	FR	LA	Français
 fra	GA	L	French
-fra	GB	L	French
 fra	GF	L	French
+fra	GG	L	French
 fra	GN	L	French
 fra	GP	L	French
 fra	GQ	L	French
@@ -15094,6 +15818,8 @@ fra	HT	L	French
 fra	IN	L	French
 fra	IT	L	French
 fra	IT	LA	Français
+fra	JE	L	French
+fra	KH	L	French
 fra	KM	L	French
 fra	LB	L	French
 fra	LU	L	French
@@ -15179,6 +15905,7 @@ frr	DE	L	Frisian, Northern
 frr	DE	LA	Nordfriesisch
 frs	DE	L	Saxon, East Frisian Low
 frs	DE	LA	Ostfriesisch
+frs	DE	LA	Ostfriesisch-Niederdeutsch
 frt	VU	L	Fortsenal
 frt	VU	LA	Kiai
 fry	NL	D	Klaaifrysk
@@ -15235,6 +15962,7 @@ fub	NG	LA	Fillanci
 fub	NG	LA	Fula
 fub	NG	LA	Fulani
 fub	NG	LA	Fulatanchi
+fub	NG	LA	Fulbe
 fub	SD	D	Gombe
 fub	SD	L	Fulfulde, Adamawa
 fub	SD	LA	Fellata
@@ -15377,6 +16105,7 @@ fuf	GN	LA	Futa Fula
 fuf	GN	LA	Futa Jallon
 fuf	GN	LA	Fuuta Jalon
 fuf	GN	LA	Jalon
+fuf	GW	L	Pular
 fuf	ML	L	Pular
 fuf	ML	LA	Foula Fouta
 fuf	ML	LA	Fouta Dyalon
@@ -15414,6 +16143,7 @@ fuh	BF	DA	Barain
 fuh	BF	DA	Baraniire
 fuh	BF	DA	Yaaga
 fuh	BF	L	Fulfulde, Northeastern Burkina Faso
+fuh	BF	LA	Fulfulde
 fuh	BJ	L	Fulfulde, Gorgal
 fuh	BJ	LA	Fulfulde
 fuh	BJ	LA	Peul
@@ -15426,6 +16156,7 @@ fuh	NE	L	Fulfulde, Western Niger
 fuh	NE	LA	Fula
 fuh	NE	LA	Fulani
 fuh	NE	LA	Fulbe
+fuh	NE	LA	Fulfulde
 fuh	NE	LA	Gorgal Fulfulde
 fuh	NE	LA	Northeastern Burkina Faso Fulfulde
 fuh	NE	LA	Peul
@@ -15554,6 +16285,7 @@ gaa	GH	LA	Accra
 gaa	GH	LA	Acra
 gaa	GH	LA	Amina
 gaa	GH	LA	Gain
+gaa	GH	LA	Gamei
 gab	TD	D	Darbé
 gab	TD	D	Dormon
 gab	TD	L	Gabri
@@ -15563,6 +16295,7 @@ gab	TD	LA	Ngabre
 gab	TD	LA	Southern Gabri
 gac	IN	L	Great Andamanese, Mixed
 gac	IN	LA	Andamese
+gac	IN	LA	Jeru
 gad	PH	L	Gaddang
 gad	PH	LA	Cagayan
 gae	BR	L	Guarequena
@@ -15608,6 +16341,7 @@ gai	PG	LA	Borei
 gai	PG	LA	Gamai
 gai	PG	LA	Gamei
 gai	PG	LA	Mborei
+gai	PG	LA	Mborena Kam
 gaj	PG	D	Gadsup
 gaj	PG	D	Oyana
 gaj	PG	DA	Oiyana
@@ -15655,6 +16389,7 @@ gan	CN	LA	Jiangxinese
 gan	CN	LA	Kan
 gao	PG	L	Gants
 gao	PG	LA	Gaj
+gao	PG	LA	Ganj
 gap	PG	L	Gal
 gap	PG	LA	Baimak
 gap	PG	LA	Weim
@@ -15711,6 +16446,7 @@ gax	KE	D	Guji
 gax	KE	L	Borana
 gax	KE	LA	Booran
 gax	KE	LA	Boraan
+gax	KE	LA	Boraana
 gax	KE	LA	Boran
 gax	KE	LA	Oromo
 gax	KE	LA	Southern Oromo
@@ -15949,6 +16685,7 @@ gby	NG	LA	Gwari Yamma
 gby	NG	LA	Nkwa
 gby	NG	LA	West Gwari
 gbz	IR	L	Dari, Zoroastrian
+gbz	IR	LA	Dari
 gbz	IR	LP	Gabar
 gbz	IR	LP	Gabri
 gbz	IR	LP	Yazdi
@@ -15970,10 +16707,12 @@ gcf	BL	L	Saint Barthélemy Creole French
 gcf	GP	D	Marie Galante Creole French
 gcf	GP	D	Saint Barth Creole French
 gcf	GP	L	Guadeloupean Creole French
+gcf	GP	LA	Guadeloupean Creole
 gcf	GP	LA	Kreyol
 gcf	GP	LA	Patois
 gcf	GP	LA	Patwa
 gcf	MQ	L	Martiniquan Creole French
+gcf	MQ	LA	Martinican Creole
 gcf	MQ	LA	Patois
 gcf	MQ	LA	Patwa
 gcl	GD	D	Carriacou Creole English
@@ -16076,6 +16815,10 @@ gdi	CF	L	Gundi
 gdi	CF	LA	Ngondi
 gdi	CF	LA	Ngundi
 gdj	AU	L	Gurdjar
+gdj	AU	LA	Goom-Gharra
+gdj	AU	LA	Gunggara
+gdj	AU	LA	Kunggara
+gdj	AU	LA	Kunggera
 gdj	AU	LA	Kurtjjar
 gdk	TD	L	Gadang
 gdl	ET	D	Kusumitta
@@ -16084,6 +16827,7 @@ gdl	ET	L	Dirasha
 gdl	ET	LA	Dhirasha
 gdl	ET	LA	Diraasha
 gdl	ET	LA	Dirayta
+gdl	ET	LA	Diraytta
 gdl	ET	LA	Gardulla
 gdl	ET	LA	Ghidole
 gdl	ET	LA	Gidole
@@ -16104,6 +16848,7 @@ gdo	RU	D	Zibirkhali
 gdo	RU	L	Ghodoberi
 gdo	RU	LA	Godoberi
 gdo	RU	LA	Godoberin
+gdo	RU	LA	Qibdili mitstsi
 gdq	KW	L	Mehri
 gdq	KW	LA	Mahri
 gdq	OM	D	Nagdi
@@ -16177,6 +16922,7 @@ geh	CA	LA	Hutterite German
 geh	US	L	German, Hutterite
 geh	US	LA	Carinthian German
 geh	US	LA	Hutterian German
+geh	US	LA	Hutterisch
 geh	US	LA	Tirolean
 geh	US	LA	Tyrolese
 gei	ID	D	Umera
@@ -16324,24 +17070,6 @@ ggk	AU	LA	Gungarakanj
 ggk	AU	LA	Kangarraga
 ggk	AU	LA	Kungarakan
 ggl	PG	L	Ganglau
-ggn	NP	D	Gorkha Gurung
-ggn	NP	D	Lamjung Gurung
-ggn	NP	D	Tamu Kyi
-ggn	NP	L	Gurung, Eastern
-ggn	NP	LA	Daduwa
-ggn	NP	LA	Gurung
-ggn	NP	LA	Tamu Kyi
-ggo	IN	D	Aheri
-ggo	IN	D	Bhamragarh
-ggo	IN	D	Etapally Gondi
-ggo	IN	D	Nirmal
-ggo	IN	D	Rajura
-ggo	IN	D	Sironcha
-ggo	IN	D	Utnoor
-ggo	IN	DA	Adilabad
-ggo	IN	L	Gondi, Southern
-ggo	IN	LA	Koi Gondi
-ggo	IN	LA	Telugu Gondi
 ggt	PG	L	Gitua
 ggt	PG	LA	Gitoa
 ggt	PG	LA	Kelana
@@ -16366,6 +17094,7 @@ ghe	NP	D	Laprak
 ghe	NP	L	Ghale, Southern
 ghe	NP	LA	Galle Gurung
 ghe	NP	LA	Lila
+ghe	NP	LA	Lila Ke
 ghe	NP	LA	Ril-Lila
 ghh	NP	D	Jagat
 ghh	NP	D	Khorla
@@ -16395,6 +17124,7 @@ ghk	MM	LA	Keku
 ghk	MM	LA	Yathu Gekho
 ghl	SD	L	Ghulfan
 ghl	SD	LA	Gulfan
+ghl	SD	LA	Uncu
 ghl	SD	LA	Uncunwee
 ghl	SD	LA	Wunci
 ghl	SD	LA	Wuncimbe
@@ -16518,7 +17248,9 @@ git	CA	L	Gitxsan
 git	CA	LA	Giklsan
 git	CA	LA	Gitksan
 git	CA	LA	Gitsenimx
+git	CA	LA	Gitxsen
 git	CA	LA	Gityskyan
+git	CA	LA	Hazelton
 git	CA	LA	Nass-Gitksan
 giu	CN	L	Mulao
 giu	CN	LA	Ayo
@@ -16613,6 +17345,13 @@ gjn	GH	D	Choruba
 gjn	GH	D	Gonja
 gjn	GH	DA	Choroba
 gjn	GH	L	Gonja
+gjn	GH	LA	Ngbanyito
+gjr	AU	L	Gurindji Kriol
+gjr	AU	LA	Gurindji
+gjr	AU	LA	Gurindji Children’s Language
+gjr	AU	LA	Gurinji
+gjr	AU	LA	Gurinji Kriol
+gjr	AU	LA	Miksimap
 gju	AF	L	Gujari
 gju	AF	LA	Gojari
 gju	AF	LA	Gojri
@@ -16679,9 +17418,15 @@ gkp	GN	LA	Pessa
 gkp	GN	LA	Pessy
 gku	ZA	L	‡Ungkue
 gku	ZA	LA	||Kxau
-gla	GB	L	Gaelic, Scottish
+gla	CA	L	Scottish Gaelic
+gla	CA	LA	Albannach Gàidhlig
+gla	CA	LA	Gàidhlig
+gla	CA	LA	Gàidhlig na h-Alba
+gla	GB	L	Scottish Gaelic
+gla	GB	LA	Albannach Gàidhlig
 gla	GB	LA	Gaelic
 gla	GB	LA	Gàidhlig
+gla	GB	LA	Gàidhlig na h-Alba
 gla	GB	LA	Scots Gaelic
 glc	TD	L	Bon Gula
 glc	TD	LA	Bon
@@ -16721,10 +17466,12 @@ gld	RU	LA	Hezhe
 gld	RU	LA	Hezhen
 gld	RU	LA	Nanaj
 gle	CA	L	Irish
+gle	CA	LA	Gaeilge
 gle	GB	L	Irish
 gle	GB	LA	Erse
 gle	GB	LA	Gaeilge
 gle	GB	LA	Gaelic Irish
+gle	GB	LA	Irish Gaelic
 gle	IE	D	Connacht
 gle	IE	D	Donegal
 gle	IE	D	Munster-Leinster
@@ -16736,6 +17483,7 @@ gle	IE	L	Irish
 gle	IE	LA	Erse
 gle	IE	LA	Gaeilge
 gle	IE	LA	Gaelic Irish
+gle	IE	LA	Irish Gaelic
 glg	ES	L	Galician
 glg	ES	LA	Galego
 glg	ES	LA	Gallego
@@ -16777,6 +17525,7 @@ glj	TD	L	Gula Iro
 glj	TD	LA	Goula d’Iro
 glj	TD	LA	Goula Iro
 glj	TD	LA	Kulaal
+glj	TD	LA	Moriil
 glk	IR	D	Bandar Anzali
 glk	IR	D	Fumani
 glk	IR	D	Galeshi
@@ -16861,6 +17610,7 @@ gmn	CM	LA	Yotubo
 gmu	PG	L	Gumalu
 gmv	ET	D	Dache
 gmv	ET	L	Gamo
+gmv	ET	LA	Gamotso
 gmv	ET	LA	Gemu
 gmx	TZ	L	Magoma
 gmx	TZ	LA	Kimagoma
@@ -16978,6 +17728,7 @@ gno	IN	LA	Goudwal
 gnq	MY	L	Gana
 gnq	MY	LA	Gana’
 gnq	MY	LA	Ganaq
+gnq	MY	LA	Ganna
 gnq	MY	LA	Keningau Dusun
 gnq	MY	LA	Minansut
 gnr	AU	L	Gureng Gureng
@@ -16996,6 +17747,7 @@ goa	CI	L	Guro
 goa	CI	LA	Baba
 goa	CI	LA	Dalo
 goa	CI	LA	Dipa
+goa	CI	LA	Golo
 goa	CI	LA	Gouro
 goa	CI	LA	Ku
 goa	CI	LA	Kwéndré
@@ -17038,12 +17790,14 @@ gog	TZ	L	Gogo
 gog	TZ	LA	Chigogo
 gog	TZ	LA	Cigogo
 gog	TZ	LA	Kigogo
+gog	TZ	LA	Wagogo
 goi	PG	D	Gobasi
 goi	PG	D	Honibo
 goi	PG	D	Oibae
 goi	PG	DA	Bibo
 goi	PG	DA	Oiba
 goi	PG	L	Gobasi
+goi	PG	LA	Gebusi
 goi	PG	LA	Nomad
 goj	IN	L	Gowlan
 gok	IN	D	Khamla
@@ -17154,6 +17908,7 @@ gpa	NG	D	Abawa
 gpa	NG	D	Gupa
 gpa	NG	L	Gupa-Abawa
 gpe	GH	L	Ghanaian Pidgin English
+gpe	GH	LA	Broken
 gpe	GH	LA	Kroo Brofo
 gpe	GH	LA	Kru English
 gpe	GH	LA	Pidgin
@@ -17186,6 +17941,7 @@ gqr	TD	LA	Bodo
 gqu	CN	L	Qau
 gqu	CN	LA	Aqao
 gqu	CN	LA	Gao
+gqu	CN	LA	Klau55
 gra	IN	L	Garasia, Rajput
 gra	IN	LA	Dhungri Garasia
 gra	IN	LA	Dungari Garasia
@@ -17342,7 +18098,8 @@ gsl	SN	LA	Kusiilaay
 gsl	SN	LA	Kusilay
 gsm	GT	L	Guatemalan Sign Language
 gsm	GT	LA	Lensegua
-gsn	PG	L	Gusan
+gsn	PG	L	Nema
+gsn	PG	LA	Gusan
 gso	CF	D	Biyanda
 gso	CF	D	Bokare
 gso	CF	D	Bosoko
@@ -17465,6 +18222,7 @@ gug	PY	D	Jopará
 gug	PY	DA	Yopará
 gug	PY	L	Guaraní, Paraguayan
 gug	PY	LA	Avañe’e
+gug	PY	LA	Guaraní
 guh	CO	D	Amorua
 guh	CO	D	Guahibo
 guh	CO	D	Tigrero
@@ -17477,11 +18235,13 @@ guh	CO	LA	Goahiva
 guh	CO	LA	Guaigua
 guh	CO	LA	Guajibo
 guh	CO	LA	Guayba
+guh	CO	LA	Hivi
 guh	CO	LA	Wahibo
 guh	CO	LP	Sicuani
 guh	CO	LP	Sikuani
 guh	VE	L	Guahibo
 guh	VE	LA	Guajibo
+guh	VE	LA	Hivi
 guh	VE	LA	Hiwi
 guh	VE	LA	Jiwi
 guh	VE	LA	Sikuani
@@ -17509,6 +18269,7 @@ gui	PY	LA	Guaraní Occidental
 gui	PY	LA	Guasurango
 gui	PY	LP	Chawuncu
 gui	PY	LP	Chiriguano
+guj	BH	L	Gujarati
 guj	IN	D	Gamadia
 guj	IN	D	Kakari
 guj	IN	D	Kathiyawadi
@@ -17564,6 +18325,7 @@ guk	ET	LA	Dehenda
 guk	ET	LA	Gombo
 guk	ET	LA	Gumis
 guk	ET	LA	Gumuzinya
+guk	ET	LA	Kadallu
 guk	ET	LA	Mendeya
 guk	ET	LA	Sigumza
 guk	ET	LP	Shankilligna
@@ -17593,6 +18355,7 @@ guk	SD	LA	Deguba
 guk	SD	LA	Dehenda
 guk	SD	LA	Gombo
 guk	SD	LA	Gumis
+guk	SD	LA	Kadallu
 guk	SD	LA	Mendeya
 guk	SD	LA	Shankillinya
 guk	SD	LA	Shanqilla
@@ -17602,9 +18365,11 @@ gul	US	LA	Gullah
 gum	CO	L	Guambiano
 gum	CO	LA	Guambia
 gum	CO	LA	Moguex
+gum	CO	LA	Namdrik
 gun	AR	L	Guaraní, Mbyá
 gun	AR	LA	Eastern Argentina Guaraní
 gun	AR	LA	Mbua
+gun	AR	LA	Mbya
 gun	AR	LA	Mbyá
 gun	BR	D	Baticola
 gun	BR	D	Tambéopé
@@ -17612,10 +18377,12 @@ gun	BR	L	Guaraní, Mbyá
 gun	BR	LA	Bugre
 gun	BR	LA	Mbiá
 gun	BR	LA	Mbua
+gun	BR	LA	Mbya
 gun	BR	LA	Mbyá
 gun	PY	L	Guaraní, Mbyá
 gun	PY	LA	Ka’yngua
 gun	PY	LA	Mbua
+gun	PY	LA	Mbya
 gun	PY	LA	Mbyá
 gun	PY	LA	Mbya-apytere
 guo	CO	L	Guayabero
@@ -17654,10 +18421,12 @@ gur	BF	D	Gudeni
 gur	BF	D	Nankana
 gur	BF	D	Nankani
 gur	BF	L	Ninkare
+gur	BF	LA	Farefare
 gur	BF	LA	Frafra
 gur	BF	LA	Gurenne
 gur	BF	LA	Gurne
 gur	BF	LA	Nankani
+gur	BF	LA	Ninkarsé
 gur	GH	D	Booni
 gur	GH	D	Gurune
 gur	GH	D	Nabt
@@ -17686,6 +18455,8 @@ gur	GH	LA	Gurenne
 gur	GH	LA	Gurune
 gur	GH	LA	Nankani
 gur	GH	LA	Ninkare
+gur	GH	LA	Ninkarsé
+gur	GH	LA	Talensi
 gus	GN	L	Guinean Sign Language
 gut	CR	L	Maléku Jaíka
 gut	CR	LA	Guatuso
@@ -17713,9 +18484,6 @@ guu	VE	LA	Guajaribo
 guu	VE	LA	Shamatari
 guu	VE	LA	Yanomame
 guu	VE	LA	Yanomami
-guv	CM	L	Gey
-guv	CM	LA	Gewe
-guv	CM	LA	Gueve
 guw	BJ	D	Ajra
 guw	BJ	D	Alada
 guw	BJ	D	Seto
@@ -17763,6 +18531,7 @@ gux	BF	LA	Gurma
 gux	BF	LA	Migulimancema
 gux	BJ	L	Gourmanchéma
 gux	BJ	LA	Goulmancema
+gux	BJ	LA	Gourma
 gux	BJ	LA	Gourmantche
 gux	BJ	LA	Gulimancema
 gux	BJ	LA	Gurma
@@ -17773,6 +18542,7 @@ gux	NE	LA	Gourma
 gux	NE	LA	Gourmantche
 gux	NE	LA	Gurma
 gux	TG	L	Gourmanchéma
+gux	TG	LA	Gourma
 gux	TG	LA	Gourmantche
 gux	TG	LA	Gulimancema
 gux	TG	LA	Gurma
@@ -17784,7 +18554,6 @@ guz	KE	LA	Kisii
 guz	KE	LA	Kosova
 guz	TZ	L	Gusii
 guz	TZ	LA	Ekegusii
-guz	TZ	LA	Gusii
 guz	TZ	LA	Guzii
 guz	TZ	LA	Kisii
 guz	TZ	LA	Kosova
@@ -17796,6 +18565,7 @@ gva	PY	DA	Niguecactemigi
 gva	PY	L	Guana
 gva	PY	LA	Cashquiha
 gva	PY	LA	Kaskihá
+gva	PY	LA	Vana
 gvc	BR	L	Guanano
 gvc	BR	LA	Anana
 gvc	BR	LA	Kótedia
@@ -17861,14 +18631,14 @@ gvp	BR	LA	Gavião do Mãe Maria
 gvp	BR	LA	Parakatêjê
 gvp	BR	LA	Perkatêjê
 gvp	BR	LA	Pukobjê
-gvr	IN	L	Gurung, Western
+gvr	IN	L	Gurung
 gvr	IN	LA	Gurung Kura
-gvr	NP	D	Northwestern Gurung
-gvr	NP	D	Southern Gurung
-gvr	NP	DA	Kaski Gurung
-gvr	NP	DA	Syangja Gurung
-gvr	NP	L	Gurung, Western
-gvr	NP	LA	Gurung
+gvr	IN	LA	Gurung, Western
+gvr	IN	LA	Tamu Kyi
+gvr	NP	D	Central dialect of Gurung
+gvr	NP	L	Gurung
+gvr	NP	LA	Daduwa
+gvr	NP	LA	Gurung, Western
 gvr	NP	LA	Tamu Kyi
 gvs	PG	D	Gumawana
 gvs	PG	D	Kotoita
@@ -17930,6 +18700,7 @@ gwd	ET	DA	Tihinte
 gwd	ET	DA	Worase
 gwd	ET	L	Gawwada
 gwd	ET	LA	Ale
+gwd	ET	LA	Dabosse
 gwd	ET	LA	Dullay
 gwd	ET	LA	Gauwada
 gwd	ET	LA	Gawata
@@ -17957,6 +18728,7 @@ gwi	CA	DA	Loucheux
 gwi	CA	DA	Takudh
 gwi	CA	DA	Tukudh
 gwi	CA	L	Gwich’in
+gwi	CA	LA	Dinju Zhuh K’yuu
 gwi	CA	LA	Kutchin
 gwi	CA	LA	Loucheux
 gwi	CA	LA	Tukudh
@@ -17968,6 +18740,7 @@ gwi	US	DA	Loucheux
 gwi	US	DA	Takudh
 gwi	US	DA	Tukudh
 gwi	US	L	Gwich’in
+gwi	US	LA	Dinju Zhuh K’yuu
 gwi	US	LA	Kutchin
 gwj	BW	D	Khute
 gwj	BW	L	|Gwi
@@ -18008,6 +18781,7 @@ gwt	PK	LA	Satre
 gwu	AU	L	Guwamu
 gww	AU	L	Kwini
 gww	AU	LA	Cuini
+gww	AU	LA	Goonan
 gww	AU	LA	Gunin
 gww	AU	LA	Gwiini
 gww	AU	LA	Gwini
@@ -18039,6 +18813,7 @@ gxx	CI	L	Wè Southern
 gxx	CI	LA	Central Guéré
 gxx	CI	LA	Gere
 gxx	CI	LA	Guéré
+gxx	CI	LA	Wèè
 gya	CF	D	Bodoe
 gya	CF	D	Gbaya Kara
 gya	CF	D	Lai
@@ -18143,6 +18918,7 @@ gym	PA	DA	Tolé
 gym	PA	L	Ngäbere
 gym	PA	LA	Chiriqui
 gym	PA	LA	Guaymí
+gym	PA	LA	Ngäbe
 gym	PA	LA	Ngobere
 gym	PA	LA	Valiente
 gyn	GY	D	Afro-Guyanese Creole
@@ -18182,7 +18958,6 @@ hab	VN	L	Hanoi Sign Language
 hac	IQ	D	Kakai
 hac	IQ	D	Zengana
 hac	IQ	DA	Kakkai
-hac	IQ	DA	Macho
 hac	IQ	L	Macho
 hac	IQ	LA	Gorani
 hac	IQ	LA	Gurani
@@ -18227,6 +19002,7 @@ had	ID	LA	Tinam
 had	ID	LA	Uran
 hae	ET	L	Oromo, Eastern
 hae	ET	LA	Harar
+hae	ET	LA	Harar Oromo
 hae	ET	LA	Harer
 hae	ET	LA	Ittu
 hae	ET	LP	Kwottu
@@ -18284,6 +19060,8 @@ hak	GF	L	Chinese, Hakka
 hak	HK	L	Chinese, Hakka
 hak	ID	L	Chinese, Hakka
 hak	KH	L	Chinese, Hakka
+hak	MY	D	Her Po
+hak	MY	D	Loong Chun
 hak	MY	L	Chinese, Hakka
 hak	PA	L	Chinese, Hakka
 hak	PF	L	Chinese, Hakka
@@ -18344,15 +19122,23 @@ har	ET	LA	Hararri
 has	CA	D	Kitimat
 has	CA	DA	Kitamat
 has	CA	L	Haisla
+has	CA	LA	Kitlope
+has	CA	LA	Northern Kwakiutl
 has	CA	LA	Xenaksialakala
-hat	DO	L	Haitian
+hat	DO	L	Haitian Creole
+hat	DO	LA	Aiysyen
 hat	DO	LA	Creole
-hat	DO	LA	Haitian Creole
+hat	DO	LA	Haitian
+hat	DO	LA	Kreyol
 hat	HT	D	Fablas
 hat	HT	D	Plateau Haitian Creole
-hat	HT	L	Haitian
+hat	HT	L	Haitian Creole
+hat	HT	LA	Aiysyen
 hat	HT	LA	Creole
-hat	HT	LA	Haitian Creole
+hat	HT	LA	Haitian
+hat	HT	LA	Kreyol
+hat	HT	LA	Kreyòl
+hat	HT	LA	Kreyòl ayisyen
 hat	HT	LA	Western Caribbean Creole
 hau	BF	L	Hausa
 hau	BF	LA	Haoussa
@@ -18484,11 +19270,13 @@ hch	MX	DA	Western Huichol
 hch	MX	L	Huichol
 hch	MX	LA	Vixaritari Vaniuqui
 hch	MX	LA	Vizaritari Vaniuki
+hch	MX	LA	Wixárika
 hdn	CA	L	Haida, Northern
 hdn	CA	LA	Masset
 hdn	CA	LA	Xaad Kil
 hdn	US	L	Haida, Northern
 hdn	US	LA	Masset
+hdn	US	LA	Xaad Kil
 hds	HN	L	Honduras Sign Language
 hds	HN	LA	Honduran Sign Language
 hds	HN	LA	Lengua de Señas Hondureñas
@@ -18552,7 +19340,11 @@ heh	TZ	LA	Ekiehe
 heh	TZ	LA	Kihehe
 hei	CA	D	Bella Bella
 hei	CA	D	Oowekyala
+hei	CA	DA	Heiltsuk-Oweek’ala
 hei	CA	DA	Northern Heiltsuk
+hei	CA	DA	Oowekeno
+hei	CA	DA	Oweek’ala
+hei	CA	DA	’Uikala
 hei	CA	L	Heiltsuk
 hei	CA	LA	Hailhzaqvla
 hem	CD	L	Hemba
@@ -18565,12 +19357,16 @@ her	BW	L	Herero
 her	BW	LA	Ochiherero
 her	BW	LA	Otjiherero
 her	NA	D	Central Herero
+her	NA	D	Himba
 her	NA	D	Mbandieru
 her	NA	DA	East Herero
 her	NA	DA	Mbanderu
+her	NA	DA	Ovahimba
 her	NA	L	Herero
 her	NA	LA	Ochiherero
 her	NA	LA	Otjiherero
+her	NA	LA	Ovaherero
+hgm	BW	L	Hai||om
 hgm	NA	D	‡Akhoe
 hgm	NA	D	Gomkhoe
 hgm	NA	D	Kede
@@ -18622,7 +19418,9 @@ hid	US	L	Hidatsa
 hid	US	LA	Hinatsa
 hid	US	LA	Hiraca
 hid	US	LA	Minitari
+hif	FJ	D	Labasa
 hif	FJ	L	Hindi, Fiji
+hif	FJ	LA	Fiji Baat
 hif	FJ	LA	Fiji Hindustani
 hif	FJ	LP	Fijian Hindi
 hif	FJ	LP	Fijian Hindustani
@@ -18678,6 +19476,8 @@ hio	BW	LA	Hiotshuwau
 hio	BW	LA	Kwe
 hio	BW	LA	Kwe-Etshori Kwee
 hio	BW	LA	Kwe-Tshori
+hio	BW	LA	Sarwa
+hio	BW	LA	Sesarwa
 hio	BW	LA	Tati
 hio	BW	LA	Tati Bushman
 hio	BW	LA	Tshuwau
@@ -18724,6 +19524,9 @@ hkk	PG	L	Hunjara-Kaina Ke
 hks	HK	L	Hong Kong Sign Language
 hks	HK	LA	Heung Kong Sau Yue
 hks	HK	LA	HKSL
+hks	MO	L	Macao Sign Language
+hks	MO	LA	Macau Sign Language
+hks	MO	LA	MacauSL
 hla	PG	D	Hanahan
 hla	PG	D	Hangan
 hla	PG	D	Selau
@@ -18965,6 +19768,7 @@ hne	IN	L	Chhattisgarhi
 hne	IN	LA	Khaltahi
 hne	IN	LA	Laria
 hnh	BW	L	||Ani
+hnh	BW	LA	||Anikhwe
 hnh	BW	LA	|Anda
 hnh	BW	LA	Handá
 hnh	BW	LA	Handádam
@@ -18973,10 +19777,12 @@ hnh	BW	LA	Handakwe-Dam
 hnh	BW	LA	Ts’exa
 hnh	BW	LA	Ts’éxa
 hni	CN	L	Hani
+hni	CN	LA	Ha Nhi
 hni	CN	LA	Hanhi
 hni	CN	LA	Hani Proper
 hni	CN	LA	Haw
 hni	LA	L	Hani
+hni	LA	LA	Ha Nhi
 hni	LA	LA	Hanhi
 hni	LA	LA	Haw
 hni	VN	L	Hani
@@ -19005,21 +19811,21 @@ hnj	CN	LA	Qing Miao
 hnj	CN	LA	Tak Miao
 hnj	LA	L	Hmong Njua
 hnj	LA	LA	Blue Hmong
-hnj	LA	LA	Blue Meo
 hnj	LA	LA	Ching Miao
 hnj	LA	LA	Green Hmong
-hnj	LA	LA	Green Meo
 hnj	LA	LA	Hmong Leng
 hnj	LA	LA	Hmong Nzhua
 hnj	LA	LA	Hmoob Leeg
 hnj	LA	LA	Lu Miao
-hnj	LA	LA	Meo Dam
-hnj	LA	LA	Meo Lai
 hnj	LA	LA	Mong Leng
 hnj	LA	LA	Mong Njua
 hnj	LA	LA	Mong Ntsua
 hnj	LA	LA	Qing Miao
 hnj	LA	LA	Tak Miao
+hnj	LA	LP	Blue Meo
+hnj	LA	LP	Green Meo
+hnj	LA	LP	Meo Dam
+hnj	LA	LP	Meo Lai
 hnj	MM	L	Hmong Njua
 hnj	MM	LA	Blue Hmong
 hnj	MM	LA	Blue Meo
@@ -19038,20 +19844,20 @@ hnj	MM	LA	Mong Ntsua
 hnj	MM	LA	Qing Miao
 hnj	MM	LA	Tak Miao
 hnj	TH	L	Hmong Njua
-hnj	TH	LA	Blue Meo
 hnj	TH	LA	Ching Miao
 hnj	TH	LA	Green Hmong
-hnj	TH	LA	Green Meo
 hnj	TH	LA	Hmong Leng
 hnj	TH	LA	Hmong Nzhua
 hnj	TH	LA	Hmoob Leeg
 hnj	TH	LA	Lu Miao
-hnj	TH	LA	Meo Dam
-hnj	TH	LA	Meo Lai
 hnj	TH	LA	Mong Leng
 hnj	TH	LA	Mong Ntsua
 hnj	TH	LA	Qing Miao
 hnj	TH	LA	Tak Miao
+hnj	TH	LP	Blue Meo
+hnj	TH	LP	Green Meo
+hnj	TH	LP	Meo Dam
+hnj	TH	LP	Meo Lai
 hnj	VN	L	Hmong Njua
 hnj	VN	LA	Mong Leng
 hnn	PH	D	Binli
@@ -19202,6 +20008,7 @@ hps	US	L	Hawaii Sign Language
 hps	US	LA	Hawai’i Pidgin Sign Language
 hps	US	LA	Hawaiian Sign Language
 hps	US	LA	HPS
+hps	US	LA	HSL
 hra	IN	D	Hadem
 hra	IN	L	Hrangkhol
 hra	IN	LA	Hrangkol
@@ -19236,6 +20043,7 @@ hrm	CN	LA	A-Hmo
 hrm	CN	LA	Bai Miao
 hrm	CN	LA	Changjiao Miao
 hrm	CN	LA	Forest Miao
+hrm	CN	LA	Hmo
 hrm	CN	LA	Hmong Khua Shua Ndrang
 hrm	CN	LA	Hmong Ndong
 hrm	CN	LA	Hmong Ndou
@@ -19356,10 +20164,10 @@ htu	ID	D	Mamala
 htu	ID	D	Morela
 htu	ID	D	Wakal
 htu	ID	L	Hitu
-hub	PE	L	Huambisa
+hub	PE	L	Wampís
+hub	PE	LA	Huambisa
 hub	PE	LA	Huambiza
 hub	PE	LA	Wambisa
-hub	PE	LA	Wampis
 huc	BW	D	‡Hua
 huc	BW	D	Sasi
 huc	BW	L	‡Hua
@@ -19374,6 +20182,7 @@ hud	ID	LA	Alakamat
 hud	ID	LA	Bahasa Asli
 hue	MX	L	Huave, San Francisco del Mar
 hue	MX	LA	Huave del Este
+hue	MX	LA	Ombeyajts
 huf	PG	D	Humene
 huf	PG	D	Lagume
 huf	PG	DA	Lakume
@@ -19383,10 +20192,17 @@ hug	PE	D	Arasairi
 hug	PE	D	Huachipaire
 hug	PE	D	Sapiteri
 hug	PE	D	Toyeri
+hug	PE	DA	Arasa
+hug	PE	DA	Arasaeri
+hug	PE	DA	Arasaire
+hug	PE	DA	Araza
+hug	PE	DA	Arazaire
+hug	PE	DA	Careneri
 hug	PE	DA	Toyoeri
 hug	PE	DA	Tuyuneri
 hug	PE	L	Huachipaeri
 hug	PE	LA	Huachipaire
+hug	PE	LA	Wachipaeri
 hug	PE	LA	Wacipaire
 hug	PE	LP	Mashco
 huh	CL	D	Tsesungún
@@ -19441,6 +20257,7 @@ huq	CN	L	Tsat
 huq	CN	LA	Hainan Cham
 huq	CN	LA	Hui
 huq	CN	LA	Huihui
+huq	CN	LA	Poi Tsat
 huq	CN	LA	Sanya Hui
 huq	CN	LA	Utsat
 huq	CN	LA	Utset
@@ -19456,7 +20273,9 @@ hur	US	D	Cowichan
 hur	US	D	Musqueam
 hur	US	D	Nanaimo
 hur	US	L	Halkomelem
+hur	US	LA	Halq’eméylem
 hur	US	LA	Holkomelem
+hur	US	LA	Hul’q’umi’num’
 hus	MX	D	Huasteco de Tantoyuca
 hus	MX	D	Huasteco de Veracruz
 hus	MX	D	San Luis Potosi Huastec
@@ -19481,16 +20300,23 @@ hut	NP	LA	Phoke
 hut	NP	LP	Humla Bhotia
 huu	CO	L	Huitoto, Murui
 huu	CO	LA	Bue
+huu	CO	LA	Murui
 huu	CO	LA	Witoto
 huu	PE	D	Mica
 huu	PE	L	Huitoto, Murui
 huu	PE	LA	Bue
+huu	PE	LA	Murui
 huu	PE	LA	Witoto
 huv	MX	L	Huave, San Mateo del Mar
 huv	MX	LA	Huave del Oeste
+huv	MX	LA	Ombeayiüts
 huw	ID	L	Hukumina
+huw	ID	LA	Balamata
 huw	ID	LA	Bambaa
-hux	PE	L	Huitoto, Nüpode
+huw	ID	LA	Palamata
+huw	ID	LA	Palumata
+hux	PE	L	Witoto, Muinani
+hux	PE	LA	Huitoto, Nüpode
 hux	PE	LA	Muinane Huitoto
 hux	PE	LA	Nipode Witoto
 huy	IL	D	Kerend
@@ -19507,9 +20333,11 @@ huy	IL	LA	Kurdit
 huy	IL	LA	Lishana Axni
 huy	IL	LA	Lishana Noshan
 huz	GE	L	Hunzib
+huz	GE	LA	Hontl’os myts
 huz	RU	L	Hunzib
 huz	RU	LA	Enzeb
 huz	RU	LA	Gunzib
+huz	RU	LA	Hontl’os myts
 huz	RU	LA	Khunzal
 huz	RU	LA	Khunzaly
 huz	RU	LA	Xunzal
@@ -19518,6 +20346,7 @@ hvc	HT	LA	Langaj
 hvc	HT	LA	Langay
 hve	MX	L	Huave, San Dionisio del Mar
 hve	MX	LA	Huave del Este
+hve	MX	LA	Ombeyajts
 hvk	NC	L	Haveke
 hvk	NC	LA	Aveke
 hvk	NC	LA	’Aveke
@@ -19539,6 +20368,7 @@ hvn	ID	LA	Sawu
 hvn	ID	LA	Sawunese
 hvv	MX	L	Huave, Santa María del Mar
 hvv	MX	LA	Huave del Oeste
+hvv	MX	LA	Ombeayiüts
 hwa	CI	L	Wané
 hwa	CI	LA	Hwane
 hwa	CI	LA	Ngwané
@@ -19553,6 +20383,7 @@ hwo	NG	L	Hwana
 hwo	NG	LA	Fiterya
 hwo	NG	LA	Hona
 hwo	NG	LA	Hwona
+hwo	NG	LA	Tuftera
 hya	CM	L	Hya
 hya	CM	LA	Ghye
 hya	CM	LA	Za
@@ -19630,6 +20461,7 @@ hye	AM	LA	Armjanski Yazyk
 hye	AM	LA	Ena
 hye	AM	LA	Ermeni Dili
 hye	AM	LA	Ermenice
+hye	AM	LA	Haieren
 hye	AM	LA	Somkhuri
 hye	AZ	D	Western Armenian
 hye	AZ	L	Armenian
@@ -19644,8 +20476,10 @@ hye	CY	LA	Ermenice
 hye	CY	LA	Haieren
 hye	CY	LA	Somkhuri
 hye	GE	L	Armenian
+hye	GE	LA	Haieren
 hye	GE	LA	Somkhuri
 hye	HU	L	Armenian
+hye	HU	LA	Haieren
 hye	IL	D	Western Armenian
 hye	IL	L	Armenian
 hye	IL	LA	Armjanski
@@ -19654,6 +20488,7 @@ hye	IL	LA	Haieren
 hye	IL	LA	Somkhuri
 hye	IQ	D	Western Armenian
 hye	IQ	L	Armenian
+hye	IQ	LA	Haieren
 hye	IR	D	Agulis
 hye	IR	D	Astrakhân
 hye	IR	D	Eastern Armenian
@@ -19672,13 +20507,17 @@ hye	IR	LA	Haieren
 hye	IR	LA	Somekhuri
 hye	JO	D	Western Armenian
 hye	JO	L	Armenian
+hye	JO	LA	Haieren
 hye	LB	D	Western Armenian
 hye	LB	L	Armenian
 hye	LB	LA	Armanski
 hye	LB	LA	Ermenice
 hye	LB	LA	Haieren
 hye	LB	LA	Somkhuri
+hye	PL	L	Armenian
+hye	PL	LA	Haieren
 hye	RO	L	Armenian
+hye	RO	LA	Haieren
 hye	SY	D	Western Armenian
 hye	SY	L	Armenian
 hye	SY	LA	Armjanski
@@ -19692,6 +20531,7 @@ hye	TR	LA	Ermenice
 hye	TR	LA	Haieren
 hye	TR	LA	Somkhuri
 hye	UA	L	Armenian
+hye	UA	LA	Haieren
 iai	NC	L	Iaai
 iai	NC	LA	Hwen Iaai
 iai	NC	LA	Iai
@@ -19741,6 +20581,7 @@ iba	MY	D	Skrang
 iba	MY	D	Ulu Ai
 iba	MY	D	Undup
 iba	MY	L	Iban
+iba	MY	LA	Iban Sabah
 iba	MY	LA	Sea Dayak
 ibb	NG	D	Central Ibibio
 ibb	NG	D	Enyong
@@ -19826,7 +20667,7 @@ ich	NG	LA	Kyato
 ich	NG	LA	Nyidu
 icl	IS	L	Icelandic Sign Language
 icl	IS	LA	Íslenskt Táknmál
-icl	IS	LA	ÍTM
+icl	IS	LA	ITM
 icr	CO	L	Islander Creole English
 icr	CO	LA	Bende
 icr	CO	LA	San Andrés Creole
@@ -19856,6 +20697,8 @@ idd	BJ	D	Idàátchà
 idd	BJ	L	Ede Idaca
 idd	BJ	LA	Idaaca
 idd	BJ	LA	Idaasa
+idd	BJ	LA	Idaasha
+idd	BJ	LA	Ìdàáshà
 idd	BJ	LA	Idaatcha
 idd	BJ	LA	Idaca
 idd	BJ	LA	Idáìtsà
@@ -19915,6 +20758,7 @@ ifk	PH	LA	Gilipanes
 ifk	PH	LA	Ifugaw
 ifk	PH	LA	Kiangan Ifugao
 ifk	PH	LA	Quiangan
+ifk	PH	LA	Tuwali
 ifm	CG	D	Fuumu
 ifm	CG	D	Wuumu
 ifm	CG	DA	Fumu
@@ -20199,28 +21043,30 @@ ilk	PH	L	Ilongot
 ilk	PH	LA	Bugkalut
 ilk	PH	LA	Bukalot
 ilk	PH	LA	Lingotes
-ill	MY	L	Iranun
-ill	MY	LA	Illanoan
-ill	MY	LA	Illanoon
-ill	MY	LA	Illanos
-ill	MY	LA	Illanun
-ill	MY	LA	Iranon Maranao
-ill	MY	LA	Iranum
-ill	MY	LA	Lanoon
-ill	MY	LA	Lanun
-ill	MY	LA	Ylanos
-ill	MY	LP	Ilanun
-ill	PH	D	Ilanon
-ill	PH	D	Ilanum
-ill	PH	D	Illanon
-ill	PH	D	Iranon
-ill	PH	L	Iranun
+ilm	MY	L	Iranun
+ilm	MY	LA	Ilanun
+ilm	MY	LA	Illanoan
+ilm	MY	LA	Illanoon
+ilm	MY	LA	Illanos
+ilm	MY	LA	Illanun
+ilm	MY	LA	Iranon Maranao
+ilm	MY	LA	Iranum
+ilm	MY	LA	Lanoon
+ilm	MY	LA	Lanun
+ilm	MY	LA	Ylanos
 ilo	PH	L	Ilocano
 ilo	PH	LA	Ilokano
 ilo	PH	LA	Iloko
+ilp	PH	D	Ilanon
+ilp	PH	D	Ilanum
+ilp	PH	D	Illanon
+ilp	PH	D	Iranon
+ilp	PH	L	Iranun
+ilp	PH	LA	Illanun
 ils	IT	L	International Sign
 ils	IT	LA	Gestuno
 ils	IT	LA	International Sign Language
+ils	IT	LA	IS
 ilu	ID	D	Eray
 ilu	ID	D	Esulit
 ilu	ID	D	Ilmaumau
@@ -20349,11 +21195,13 @@ ipo	PG	LA	Epai
 ipo	PG	LA	Higa
 ipo	PG	LA	Ipikoi
 iqu	PE	D	Pintuyacu
-iqu	PE	L	Iquito
+iqu	PE	L	Iquitu
+iqu	PE	LA	Akenóiri
 iqu	PE	LA	Amacacore
 iqu	PE	LA	Hamacore
 iqu	PE	LA	Ikito
 iqu	PE	LA	Iquita
+iqu	PE	LA	Iquito
 iqu	PE	LA	Puca-Uma
 iqu	PE	LA	Quiturran
 iqw	NG	L	Ikwo
@@ -20374,6 +21222,8 @@ iri	NG	LA	Kwal
 iri	NG	LA	Kwan
 iri	NG	LA	Kwoll
 iri	NG	LA	Miango
+iri	NG	LA	Miyango
+iri	NG	LA	Nkarigwe
 iri	NG	LA	Nnerigwe
 iri	NG	LA	Nyango
 iri	NG	LA	Rigwe
@@ -20395,6 +21245,7 @@ irn	BR	L	Irántxe
 irn	BR	LA	Iranche
 irn	BR	LA	Iranshe
 irn	BR	LA	Iranxe
+irn	BR	LA	Münkü
 irr	LA	L	Ir
 irr	LA	LA	In
 irr	LA	LA	Yiir
@@ -20439,6 +21290,7 @@ isa	PG	L	Isabi
 isa	PG	LA	Maruhia
 isc	PE	L	Isconahua
 isc	PE	LA	Iscobaquebu
+isc	PE	LA	Iskobákebo
 isd	PH	D	Bayag
 isd	PH	D	Calanasan
 isd	PH	D	Dibagat-Kabugao
@@ -20447,12 +21299,15 @@ isd	PH	D	Talifugu-Ripang
 isd	PH	DA	Daragawan
 isd	PH	DA	Tawini
 isd	PH	L	Isnag
+isd	PH	LA	Apayao
 isd	PH	LA	Dibagat-Kabugao-Isneg
 isd	PH	LA	Isneg
 isd	PH	LA	Maragat
 ise	IT	L	Italian Sign Language
 ise	IT	LA	Lingua Italiana Dei Segni
 ise	IT	LA	LIS
+isg	AU	L	Australian Irish Sign Language
+isg	AU	LA	AISL
 isg	IE	L	Irish Sign Language
 isg	IE	LA	Teanga Chomharthaíochta na hÉireann
 ish	NG	D	Egoro
@@ -20547,6 +21402,8 @@ isr	IL	LA	ISL
 ist	HR	L	Istriot
 ist	HR	LA	Istro-Romance
 isu	CM	L	Isu
+ita	AU	L	Italian
+ita	BR	L	Italian
 ita	CH	L	Italian
 ita	ER	L	Italian
 ita	FR	L	Italian
@@ -20559,6 +21416,7 @@ ita	IT	D	Molisano
 ita	IT	D	Pugliese
 ita	IT	D	Tuscan
 ita	IT	D	Umbrian
+ita	IT	DA	Salentino
 ita	IT	L	Italian
 ita	IT	LA	Italiano
 ita	MC	L	Italian
@@ -20570,6 +21428,33 @@ ita	VA	L	Italian
 itb	PH	L	Itneg, Binongan
 itb	PH	LA	Tingguian
 itb	PH	LA	Tinguian
+itd	ID	D	Nonukan
+itd	ID	D	Penchangan
+itd	ID	D	Sedalir
+itd	ID	D	Sesayap
+itd	ID	D	Sibuku
+itd	ID	D	Tarakan
+itd	ID	D	Tidung
+itd	ID	DA	Nunukan
+itd	ID	DA	Sadalir
+itd	ID	DA	Salalir
+itd	ID	DA	Saralir
+itd	ID	DA	Selalir
+itd	ID	DA	Sesajap
+itd	ID	DA	Terakan
+itd	ID	L	Tidung, Southern
+itd	ID	LA	Camucones
+itd	ID	LA	Tedong
+itd	ID	LA	Tidoeng
+itd	ID	LA	Tidong
+itd	ID	LA	Tidung
+itd	ID	LA	Tiran
+itd	ID	LA	Tirones
+itd	ID	LA	Tiroon
+itd	ID	LA	Zedong
+itd	MY	L	Tidung, Southern
+itd	MY	LA	Tidong
+itd	MY	LA	Tidung
 ite	BO	D	Itoreauhip
 ite	BO	L	Itene
 ite	BO	LA	Iteneo
@@ -20578,6 +21463,7 @@ ite	BO	LA	More
 ite	BR	L	Itene
 ite	BR	LA	More
 iti	PH	L	Itneg, Inlaod
+iti	PH	LA	Inlaod
 iti	PH	LA	Tinggian
 iti	PH	LA	Tinguian
 itk	GR	D	Corfiote Italkian
@@ -20718,6 +21604,7 @@ iws	PG	L	Iwam, Sepik
 iws	PG	LA	Yawenian
 ixc	MX	L	Ixcatec
 ixc	MX	LA	Ixcateco
+ixc	MX	LA	Xwja
 ixl	GT	L	Ixil
 iya	NG	L	Iyayu
 iya	NG	LA	Idoani
@@ -20729,6 +21616,7 @@ iyo	CM	LA	Iyon
 iyo	CM	LA	Messaga
 iyo	CM	LA	Messaga-Ekol
 iyo	CM	LA	Messaka
+iyo	CM	LA	Ugare
 iyx	CG	L	Yaka
 iyx	CG	LA	Iyaka
 iyx	CG	LA	West Teke
@@ -20749,12 +21637,15 @@ izr	NG	D	South Izere
 izr	NG	L	Izere
 izr	NG	LA	Afizare
 izr	NG	LA	Afizarek
+izr	NG	LA	Afizere
+izr	NG	LA	Afudelek
 izr	NG	LA	Afusare
 izr	NG	LA	Feserek
 izr	NG	LA	Fezere
 izr	NG	LA	Fizere
 izr	NG	LA	Hill Jarawa
 izr	NG	LA	Izarek
+izr	NG	LA	Izer
 izr	NG	LA	Jarawa
 izr	NG	LA	Jarawan Dutse
 izr	NG	LA	Jari
@@ -20795,9 +21686,11 @@ jac	GT	DA	Eastern Jacalteco
 jac	GT	DA	Western Jacaltec
 jac	GT	DA	Western Jacalteco
 jac	GT	L	Jakalteko
+jac	GT	LA	Jakalteko-Popti’
 jac	GT	LA	Popti’
 jac	MX	L	Jakalteko
 jac	MX	LA	Jakalteko del Oeste
+jac	MX	LA	Jakalteko-Popti’
 jad	GN	L	Jahanka
 jad	GN	LA	Diakhanke
 jad	GN	LA	Diakkanke
@@ -20812,6 +21705,7 @@ jad	ML	LA	Diakkanke
 jad	ML	LA	Dyakanke
 jad	ML	LA	Jahanque
 jad	ML	LA	Jahonque
+jad	ML	LA	Jakankalou
 jae	PG	L	Yabem
 jae	PG	LA	Jabem
 jae	PG	LA	Jabim
@@ -20845,6 +21739,7 @@ jal	ID	LA	Awaiya
 jal	ID	LA	Jahalatan
 jal	ID	LA	Jahalatane
 jam	CR	L	Limón Creole English
+jam	CR	LA	Limonese Creole
 jam	CR	LA	Southwestern Caribbean Creole English
 jam	JM	L	Jamaican Creole English
 jam	JM	LA	Bongo Talk
@@ -20855,6 +21750,8 @@ jam	JM	LA	Patwa
 jam	JM	LA	Quashie Talk
 jam	JM	LA	Western Caribbean Creole
 jam	PA	L	Panamanian Creole English
+jam	PA	LA	Guari Guari
+jam	PA	LA	Patois
 jam	PA	LA	Southwestern Caribbean Creole English
 jan	AU	L	Jandai
 jan	AU	LA	Coobenpil
@@ -20887,13 +21784,14 @@ jaq	ID	LA	Mapi
 jaq	ID	LA	Sohur
 jaq	ID	LA	Yaqai
 jas	NC	L	Javanese, New Caledonian
-jat	UA	L	Jakati
-jat	UA	LA	Jat
-jat	UA	LA	Jataki
-jat	UA	LA	Jati
-jat	UA	LA	Jatu
-jat	UA	LA	Kayani
-jat	UA	LA	Musali
+jat	AF	L	Inku
+jat	AF	LA	Jakati
+jat	AF	LA	Jat
+jat	AF	LA	Jataki
+jat	AF	LA	Jati
+jat	AF	LA	Jatu
+jat	AF	LA	Kayani
+jat	AF	LA	Musali
 jau	ID	L	Yaur
 jau	ID	LA	Jaur
 jav	ID	D	Banten
@@ -20927,6 +21825,7 @@ jax	ID	LA	Djambi
 jay	AU	D	Garmalangga
 jay	AU	D	Gurjindi
 jay	AU	L	Yan-nhangu
+jay	AU	LA	Gokulu mana dhanguny’ bulthun
 jay	AU	LA	Jarnango
 jay	AU	LA	Nangu
 jay	AU	LA	Yanangu
@@ -21049,6 +21948,7 @@ jdt	IL	LA	Dzhuhuric
 jdt	IL	LA	Jewish Tat
 jdt	IL	LA	Judeo-Tatic
 jdt	IL	LA	Juhuri
+jdt	IL	LA	Juwri
 jdt	IL	LP	Tati
 jdt	RU	D	North Tat
 jdt	RU	D	South Tat
@@ -21059,9 +21959,9 @@ jdt	RU	LA	Hebrew Tat
 jdt	RU	LA	Jewish Tat
 jdt	RU	LA	Judeo-Tatic
 jdt	RU	LA	Juhuri
+jdt	RU	LA	Juwri
 jdt	RU	LA	Lahji
 jdt	RU	LA	Mountain Jewish
-jdt	RU	LA	Musulman Tats
 jdt	RU	LA	Tati
 jeb	PE	L	Jebero
 jeb	PE	LA	Chebero
@@ -21113,9 +22013,11 @@ jel	ID	LA	Jabsch
 jel	ID	LA	Jelmek
 jel	ID	LA	Jelmik
 jen	NG	L	Dza
+jen	NG	LA	E Idza
 jen	NG	LA	Janjo
 jen	NG	LA	Jen
 jen	NG	LA	Jenjo
+jen	NG	LA	Ngwa Idza
 jer	NG	D	Boze
 jer	NG	D	Bunu
 jer	NG	D	Ezelle
@@ -21172,6 +22074,8 @@ jgb	CD	LA	Mangbele
 jge	GE	L	Judeo-Georgian
 jge	IL	L	Judeo-Georgian
 jgk	NG	L	Gwak
+jgk	NG	LA	Bankalawa
+jgk	NG	LA	Gingwak
 jgk	NG	LA	Jar
 jgk	NG	LA	Jaracin Kasa
 jgk	NG	LA	Jaranchi
@@ -21180,6 +22084,7 @@ jgk	NG	LA	Jarancin Kasa
 jgk	NG	LA	Jarawa
 jgk	NG	LA	Jarawan Bununu
 jgk	NG	LA	Jarawan Kasa
+jgk	NG	LA	Lasjar
 jgo	CM	D	Babete
 jgo	CM	D	Bamendjinda
 jgo	CM	D	Bamendjo
@@ -21278,6 +22183,7 @@ jiq	CN	D	Xiaoyili
 jiq	CN	D	Yelong
 jiq	CN	L	Lavrung
 jiq	CN	LA	Guanyingqiao
+jiq	CN	LA	Khroskyabs
 jiq	CN	LA	Western Jiarong
 jiq	CN	LA	Zhongzhai
 jit	TZ	L	Jita
@@ -21291,6 +22197,7 @@ jiu	CN	LA	Youle
 jiv	EC	L	Shuar
 jiv	EC	LA	Chiwaro
 jiv	EC	LA	Jivaro
+jiv	EC	LA	Shuar Chicham
 jiv	EC	LA	Shuara
 jiv	EC	LA	Siurra
 jiv	EC	LA	Siwora
@@ -21316,6 +22223,7 @@ jjr	NG	LA	Jarancin Kasa
 jjr	NG	LA	Jarawa
 jjr	NG	LA	Jarawan Kasa
 jjr	NG	LA	Zhar
+jka	ID	L	Kaera
 jkm	MM	D	Dermuha
 jkm	MM	D	Palaychi
 jkm	MM	DA	Southern Mobwa
@@ -21324,6 +22232,7 @@ jkm	MM	LA	Bilichi
 jkm	MM	LA	Blimaw
 jkm	MM	LA	Dermuha
 jkm	MM	LA	Maleh
+jkm	MM	LA	Mobwa Karen
 jkm	MM	LA	Monpwa
 jkm	MM	LA	Mopwa
 jkm	MM	LA	Palachi
@@ -21344,6 +22253,7 @@ jkp	MM	LA	Mopaga
 jkp	MM	LA	Mopha
 jkp	MM	LA	Pagu
 jkp	MM	LA	Paku
+jkp	MM	LA	Paku Karen
 jkp	MM	LA	Thalwepwe
 jkr	IN	L	Koro
 jkr	IN	LA	Aka Koro
@@ -21355,6 +22265,8 @@ jle	SD	D	Daloka
 jle	SD	D	Masakin Tuwal
 jle	SD	DA	Taloka
 jle	SD	L	Ngile
+jle	SD	LA	Angire
+jle	SD	LA	Arra
 jle	SD	LA	Daloka
 jle	SD	LA	Darra
 jle	SD	LA	Masakin
@@ -21406,6 +22318,7 @@ jml	NP	LA	Sijali
 jml	NP	LA	Singja
 jml	NP	LA	Sinjali
 jmn	IN	L	Naga, Makuri
+jmn	IN	LA	Makuri
 jmn	IN	LA	Makury Naga
 jmn	MM	D	Arale
 jmn	MM	D	Kyaungphuri
@@ -21417,6 +22330,7 @@ jmn	MM	DA	Saingpuri
 jmn	MM	DA	Shaera
 jmn	MM	DA	Shu
 jmn	MM	L	Naga, Makuri
+jmn	MM	LA	Makuri
 jmn	MM	LA	Makury
 jmr	GH	L	Kamara
 jms	NG	L	Mashi
@@ -21427,6 +22341,7 @@ jmx	MX	D	San Martín Peras
 jmx	MX	L	Mixtec, Western Juxtlahuaca
 jmx	MX	LA	Coicoyán Mixtec
 jmx	MX	LA	Mixteco del Oeste de Juxtlahuaca
+jmx	MX	LA	To’on Savi
 jna	IN	L	Jangshung
 jna	IN	LA	Central Kinnauri
 jna	IN	LA	Jangiam
@@ -21450,7 +22365,6 @@ jnj	ET	D	Fuga of Jimma
 jnj	ET	D	Toba
 jnj	ET	L	Yemsa
 jnj	ET	LA	Yem
-jnj	ET	LA	Yemma
 jnj	ET	LP	Janjerinya
 jnj	ET	LP	Janjero
 jnj	ET	LP	Janjor
@@ -21459,6 +22373,7 @@ jnj	ET	LP	Zinjero
 jnl	IN	L	Rawat
 jnl	IN	LA	Ban Manus
 jnl	IN	LA	Ban Rauts
+jnl	IN	LA	Bãt-kha
 jnl	IN	LA	Bhulla
 jnl	IN	LA	Dzanggali
 jnl	IN	LA	Jangali
@@ -21493,6 +22408,7 @@ jod	CI	L	Wojenaka
 jod	CI	LA	Malinké
 jod	CI	LA	Odienné Jula
 jod	CI	LA	Odiennekakan
+jog	PK	L	Jogi
 jor	BO	L	Jorá
 jor	BO	LA	Hora
 jos	JO	L	Jordanian Sign Language
@@ -21504,11 +22420,11 @@ jow	BF	LA	Samogho
 jow	ML	L	Jowulu
 jow	ML	LA	Jo
 jow	ML	LA	Samogho
+jpn	AU	L	Japanese
 jpn	JP	D	Eastern Japanese
 jpn	JP	D	Western Japanese
 jpn	JP	D	Zu-zu-ben
 jpn	JP	L	Japanese
-jpn	PW	L	Japanese
 jpr	IL	L	Dzhidi
 jpr	IL	LA	Judeo-Persian
 jpr	IR	L	Dzhidi
@@ -21556,6 +22472,7 @@ jra	VN	LA	Mthur
 jrb	IL	L	Judeo-Arabic
 jrr	NG	L	Jiru
 jrr	NG	LA	Atak
+jrr	NG	LA	Bakula
 jrr	NG	LA	Kir
 jrr	NG	LA	Wiyap
 jrr	NG	LA	Zhiru
@@ -21573,6 +22490,7 @@ jua	BR	LA	Arara
 jua	BR	LA	Kagwahibm
 jua	BR	LA	Kagwahiph
 jua	BR	LA	Kagwahiv
+jua	BR	LA	Kagwahiva
 jua	BR	LA	Kavahiva
 jua	BR	LA	Kawahip
 jua	BR	LA	Kawaib
@@ -21647,10 +22565,12 @@ jum	SD	L	Jumjum
 jum	SD	LA	Berin
 jum	SD	LA	Olga
 jum	SD	LA	Wadega
+jum	SD	LA	Wadkai
 jum	SS	L	Jumjum
 jum	SS	LA	Berin
 jum	SS	LA	Olga
 jum	SS	LA	Wadega
+jum	SS	LA	Wadkai
 jun	IN	L	Juang
 jun	IN	LA	Juango
 jun	IN	LA	Patra-Saara
@@ -21667,6 +22587,7 @@ jup	BR	D	Tuhup
 jup	BR	L	Hupdë
 jup	BR	LA	Hup
 jup	BR	LA	Hupda
+jup	BR	LA	Hupdah
 jup	BR	LA	Jupde
 jup	BR	LA	Ubdé
 jup	BR	LP	Hupdá Makú
@@ -21675,6 +22596,7 @@ jup	BR	LP	Macú de Tucano
 jup	BR	LP	Makú-Hupdá
 jup	CO	L	Hupdë
 jup	CO	LA	Hup
+jup	CO	LA	Hupdah
 jup	CO	LA	Ubdé
 jup	CO	LP	Hupdá Makú
 jup	CO	LP	Jupdá Macú
@@ -21683,13 +22605,10 @@ jup	CO	LP	Makú-Hupdá
 jur	BR	L	Jurúna
 jur	BR	LA	Iuruna
 jur	BR	LA	Jaruna
+jur	BR	LA	Yudjá
 jur	BR	LA	Yudya
 jur	BR	LA	Yurúna
 jus	NP	L	Jumla Sign Language
-jut	DK	L	Jutish
-jut	DK	LA	Jutlandish
-jut	DK	LA	Jysk
-jut	DK	LA	Western Danish
 juu	NG	L	Ju
 juw	NG	L	Wãpha
 juw	NG	LA	Wase
@@ -21707,8 +22626,10 @@ jwi	GH	L	Jwira-Pepesa
 jwi	GH	LA	Gwira
 jwi	GH	LA	Pepesa-Jwira
 jya	CN	D	Chabao
-jya	CN	D	Sidaba
+jya	CN	D	Japhug
+jya	CN	D	Showu
 jya	CN	D	Situ
+jya	CN	D	Tshobdun
 jya	CN	DA	Caodeng
 jya	CN	DA	Central Jiarong
 jya	CN	DA	Dazang
@@ -21716,6 +22637,7 @@ jya	CN	DA	Eastern Jiarong
 jya	CN	DA	Northeastern Jiarong
 jya	CN	DA	Northern Jiarong
 jya	CN	DA	Northwestern Jiarong
+jya	CN	DA	Sidaba
 jya	CN	DA	Western Jiarong
 jya	CN	L	Jiarong
 jya	CN	LA	Chiarong
@@ -21767,7 +22689,6 @@ kac	CN	DA	Gauri
 kac	CN	DA	Hka-Hku
 kac	CN	DA	Hkauri
 kac	CN	DA	Jili
-kac	CN	DA	Kauri
 kac	CN	DA	Kauzhika
 kac	CN	DA	Khauri
 kac	CN	DA	Nkhum
@@ -21794,12 +22715,14 @@ kac	MM	DA	Hka-Hku
 kac	MM	DA	Hkauri
 kac	MM	DA	Jili
 kac	MM	L	Jingpho
+kac	MM	LA	Aphu
 kac	MM	LA	Chingpaw
 kac	MM	LA	Chingp’o
 kac	MM	LA	Jinghpaw
 kac	MM	LA	Jinghpo
 kac	MM	LA	Jingphaw
 kac	MM	LA	Kachin
+kac	MM	LA	Phu
 kad	NG	D	Ada
 kad	NG	D	Adara
 kad	NG	D	Eneje
@@ -21841,31 +22764,36 @@ kaj	NG	LA	Kajji
 kak	PH	D	Central Kalanguya
 kak	PH	D	Northern Kalanguya
 kak	PH	D	Southern Kalanguya
+kak	PH	D	Western Kalanguya
 kak	PH	DA	Ambaguio
+kak	PH	DA	Benguet
 kak	PH	DA	Kayapa
 kak	PH	DA	Santa Fe
-kak	PH	L	Kallahan, Kayapa
+kak	PH	DA	Tinoc
+kak	PH	L	Kalanguya
 kak	PH	LA	Ikalahan
 kak	PH	LA	Kalangoya
 kak	PH	LA	Kalangoya-Ikalahan
-kak	PH	LA	Kalanguya
-kal	DK	L	Kalaallisut, Greenlandic
-kal	DK	LA	Greenlandic
+kak	PH	LA	Kallahan, Kayapa
+kal	DK	L	Greenlandic
+kal	DK	LA	Greenlandic Kalaallisut
 kal	DK	LA	Inuktitut
+kal	DK	LA	Kalaallisut
 kal	GL	D	East Greenlandic
 kal	GL	D	Thule Inuit
 kal	GL	D	West Greenlandic
 kal	GL	DA	North Greenlandic
 kal	GL	DA	Polar Inuit
 kal	GL	DP	Polar Eskimo
-kal	GL	L	Inuktitut, Greenlandic
-kal	GL	LA	Greenlandic
+kal	GL	L	Greenlandic
+kal	GL	LA	Greenlandic Inuktitut
 kal	GL	LA	Kalaallisut
 kam	KE	D	Masaku
 kam	KE	D	Mumoni
 kam	KE	D	North Kitui
 kam	KE	D	South Kitui
 kam	KE	L	Kamba
+kam	KE	LA	Akamba
 kam	KE	LA	Kekamba
 kam	KE	LA	Kikamba
 kan	IN	D	Aine Kuruba
@@ -21895,6 +22823,7 @@ kao	ML	LA	Malinke
 kao	ML	LA	Maninka
 kao	ML	LA	Xaasonga
 kao	ML	LA	Xasonga
+kao	ML	LA	Xasongo
 kao	ML	LA	Xasonke
 kao	SN	L	Xasonga
 kao	SN	LA	Kasonke
@@ -21904,8 +22833,10 @@ kao	SN	LA	Kassonke
 kao	SN	LA	Khasonke
 kao	SN	LA	Xaasonga
 kao	SN	LA	Xaasongaxango
+kao	SN	LA	Xasongo
 kao	SN	LA	Xasonke
 kap	GE	L	Bezhta
+kap	GE	LA	Bezht’alas mits
 kap	RU	D	Bezhta proper
 kap	RU	D	Khocharkhotin
 kap	RU	D	Tlyadaly
@@ -21917,6 +22848,7 @@ kap	RU	LA	Bexita
 kap	RU	LA	Bezheta
 kap	RU	LA	Bezhita
 kap	RU	LA	Bezhituri
+kap	RU	LA	Bezht’alas mits
 kap	RU	LA	Bezhti
 kap	RU	LA	Kapuch
 kap	RU	LA	Kapucha
@@ -21928,7 +22860,10 @@ kap	RU	LA	Kiburabi
 kap	RU	LA	Kupuca
 kaq	PE	D	Pahenbaquebo
 kaq	PE	L	Capanahua
+kaq	PE	LA	Capa Baquebo
+kaq	PE	LA	Capanawa
 kaq	PE	LA	Kapanawa
+kaq	PE	LA	Nuquencaibo
 kas	IN	D	Bakawali
 kas	IN	D	Bunjwali
 kas	IN	D	Kishtwari
@@ -21959,6 +22894,7 @@ kas	PK	LA	Cashmiri
 kas	PK	LA	Kacmiri
 kas	PK	LA	Kaschemiri
 kas	PK	LA	Keshuri
+kat	AZ	L	Georgian
 kat	GE	D	Adzhar
 kat	GE	D	Ferejdan
 kat	GE	D	Imeretian
@@ -21984,6 +22920,7 @@ kat	GE	LA	Kartuli
 kat	IR	D	Fereydan
 kat	IR	DA	Ferejdan
 kat	IR	L	Georgian
+kat	IR	LA	Gorji
 kat	IR	LA	Gruzin
 kat	IR	LA	Kartuli
 kat	TR	D	Imerxev
@@ -22057,7 +22994,6 @@ kbc	BR	L	Kadiwéu
 kbc	BR	LA	Caduvéo
 kbc	BR	LA	Ediu-Adig
 kbc	BR	LA	Mbaya-Guaikuru
-kbd	DE	L	Kabardian
 kbd	JO	L	Kabardian
 kbd	RU	D	Baksan
 kbd	RU	D	Beslenei
@@ -22103,6 +23039,7 @@ kbh	CO	LA	Sibundoy-Gaché
 kbi	ID	L	Kaptiau
 kbi	ID	LA	Kapitiauw
 kbi	ID	LA	Kaptiauw
+kbi	ID	LA	Sobei
 kbj	CD	L	Kari
 kbj	CD	LA	Kare
 kbj	CD	LA	Li-Kari-Li
@@ -22207,6 +23144,7 @@ kbv	PG	LA	Komberatoro
 kbv	PG	LA	Mangguar
 kbw	PG	L	Kaiep
 kbw	PG	LA	Samap
+kbw	PG	LA	Sumup
 kbx	PG	D	Kambaramba
 kbx	PG	L	Ap Ma
 kbx	PG	LA	Ap Ma Botin
@@ -22312,10 +23250,12 @@ kci	NG	LA	Kamanton
 kcj	GW	L	Kobiana
 kcj	GW	LA	Buy
 kcj	GW	LA	Cobiana
+kcj	GW	LA	Guboy
 kcj	GW	LA	Uboi
 kcj	SN	L	Kobiana
 kcj	SN	LA	Buy
 kcj	SN	LA	Cobiana
+kcj	SN	LA	Guboy
 kcj	SN	LA	Uboi
 kck	BW	D	Ikalanga
 kck	BW	D	Lilima
@@ -22362,6 +23302,10 @@ kck	ZW	LA	Sekalaña
 kck	ZW	LA	Tjikalanga
 kck	ZW	LA	Wakalanga
 kck	ZW	LA	Western Shona
+kcl	PG	D	Apoze
+kcl	PG	D	Kamiali-Alẽso-Kui
+kcl	PG	D	Lambu
+kcl	PG	D	Manidala
 kcl	PG	L	Kala
 kcl	PG	LA	Apoze
 kcl	PG	LA	Gela
@@ -22421,6 +23365,7 @@ kcs	NG	L	Koenoem
 kcs	NG	LA	Kanam
 kct	PG	L	Kayan
 kct	PG	LA	Kaian
+kct	PG	LA	Kayan Na Yon
 kcu	TZ	L	Kami
 kcu	TZ	LA	Kikami
 kcv	CD	D	Kete
@@ -22446,6 +23391,7 @@ kcx	ET	DA	Get’eme
 kcx	ET	DA	Makka
 kcx	ET	L	Kachama-Ganjule
 kcy	DZ	L	Korandje
+kcy	DZ	LA	Belbalis
 kcy	DZ	LA	Kwarandzyey
 kcz	TZ	L	Konongo
 kcz	TZ	LA	Kikonongo
@@ -22463,6 +23409,7 @@ kdc	TZ	LA	Kixutu
 kdd	AU	L	Yankunytjatjara
 kdd	AU	LA	Jangkundjara
 kdd	AU	LA	Kulpantja
+kdd	AU	LA	Southern Luritja
 kdd	AU	LA	Yankunjtjatjarra
 kdd	AU	LA	Yankuntatjara
 kde	MZ	D	Maviha
@@ -22547,7 +23494,6 @@ kdj	UG	D	Jie
 kdj	UG	D	Matheniko
 kdj	UG	D	Napore
 kdj	UG	D	Pian
-kdj	UG	DA	Dodoth
 kdj	UG	DA	Jiye
 kdj	UG	L	Ng’akarimojong
 kdj	UG	LA	Karamojong
@@ -22655,6 +23601,7 @@ kdt	KH	D	Kuy Mlor
 kdt	KH	DA	Kuy Ma’ay
 kdt	KH	L	Kuy
 kdt	KH	LA	Kuay
+kdt	KH	LA	Kui
 kdt	LA	D	Antra
 kdt	LA	D	Na Nhyang
 kdt	LA	L	Kuy
@@ -22707,6 +23654,7 @@ kdu	SD	LA	Kaderu
 kdu	SD	LA	Kodhin
 kdu	SD	LA	Kodhinniai
 kdu	SD	LA	Kodoro
+kdu	SD	LA	Tamya
 kdw	ID	L	Koneraw
 kdw	ID	LA	Konorau
 kdx	NG	L	Kam
@@ -22743,8 +23691,7 @@ kec	SD	D	Keiga
 kec	SD	DA	Aigang
 kec	SD	DA	Rofik
 kec	SD	L	Keiga
-kec	SD	LA	Aigang
-kec	SD	LA	Demik
+kec	SD	LA	Kayigang
 kec	SD	LA	Keiga-Al-Kheil
 kec	SD	LA	Keiga-Timero
 kec	SD	LA	Yega
@@ -22794,7 +23741,7 @@ kej	IN	L	Kadar
 kej	IN	LA	Kada
 kek	BZ	L	Kekchí
 kek	BZ	LA	Cacché
-kek	BZ	LA	Ketchí
+kek	BZ	LA	Ketchi
 kek	BZ	LA	Quecchí
 kek	GT	D	Alta Verapaz Cobán
 kek	GT	L	Q’eqchi’
@@ -22803,9 +23750,6 @@ kek	GT	LA	Kekchi’
 kek	GT	LA	Kekchí
 kek	GT	LA	Ketchi’
 kek	GT	LA	Quecchi’
-kek	SV	L	Kekchí
-kek	SV	LA	Cacché
-kek	SV	LA	Quecchí
 kel	CD	L	Kela
 kel	CD	LA	Ikela
 kel	CD	LA	Lemba
@@ -22815,8 +23759,16 @@ kem	ID	D	Nogo
 kem	ID	DA	Nogo-Nogo
 kem	ID	L	Kemak
 kem	ID	LA	Ema
+kem	TL	D	Atabae
+kem	TL	D	Atsabe
+kem	TL	D	Hatolia
+kem	TL	D	Haubaa
+kem	TL	D	Kailaku
 kem	TL	D	Kemak
+kem	TL	D	Maliana
+kem	TL	D	Marobo
 kem	TL	D	Nogo
+kem	TL	DA	Ermera
 kem	TL	DA	Nogo-Nogo
 kem	TL	L	Kemak
 kem	TL	LA	Ema
@@ -22867,6 +23819,7 @@ keu	TG	L	Akebu
 keu	TG	LA	Akebou
 keu	TG	LA	Akébou
 keu	TG	LA	Ekpeebhe
+keu	TG	LA	Ekpeebhibhe
 keu	TG	LA	Gakagba
 keu	TG	LA	Kabu
 keu	TG	LA	Kébou
@@ -22897,6 +23850,7 @@ kez	NG	LA	Bakele
 kez	NG	LA	Ukele
 kfa	IN	L	Kodava
 kfa	IN	LA	Coorge
+kfa	IN	LA	Coorgi Kodava
 kfa	IN	LA	Kadagi
 kfa	IN	LA	Khurgi
 kfa	IN	LA	Kodagu
@@ -23033,36 +23987,38 @@ kfq	IN	LA	Kurku
 kfq	IN	LA	Kurku-Ruma
 kfq	IN	LA	Ramekhera
 kfr	IN	D	Jadeji
-kfr	IN	L	Kachchi
+kfr	IN	L	Kacchi
 kfr	IN	LA	Cuchi
 kfr	IN	LA	Cutch
 kfr	IN	LA	Kachchhi
+kfr	IN	LA	Kachchi
 kfr	IN	LA	Kachi
 kfr	IN	LA	Katch
 kfr	IN	LA	Katchi
 kfr	IN	LA	Kautchy
 kfr	IN	LA	Kutchchi
 kfr	IN	LA	Kutchie
-kfr	MW	L	Kachchi
+kfr	MW	L	Kacchi
 kfr	MW	LA	Cuchi
 kfr	MW	LA	Cutch
-kfr	MW	LA	Kacchi
+kfr	MW	LA	Kachchi
 kfr	MW	LA	Kachi
 kfr	MW	LA	Katchi
 kfr	PK	D	Jadeji
-kfr	PK	L	Kachchi
+kfr	PK	L	Kacchi
 kfr	PK	LA	Cuchi
 kfr	PK	LA	Cutch
 kfr	PK	LA	Kachchhi
+kfr	PK	LA	Kachchi
 kfr	PK	LA	Kachi
 kfr	PK	LA	Katch
 kfr	PK	LA	Katchi
 kfr	PK	LA	Kautchy
 kfr	PK	LA	Kutchchi
 kfr	PK	LA	Kutchie
-kfr	TZ	L	Kachchi
+kfr	TZ	L	Kacchi
 kfr	TZ	LA	Cutchi
-kfr	TZ	LA	Kacchi
+kfr	TZ	LA	Kachchi
 kfr	TZ	LA	Kachi
 kfr	TZ	LA	Katchi
 kfs	IN	L	Bilaspuri
@@ -23130,6 +24086,7 @@ kfz	BF	D	Koromba
 kfz	BF	L	Koromfé
 kfz	BF	LA	Fula
 kfz	BF	LA	Fulse
+kfz	BF	LA	Koromba
 kfz	BF	LA	Kouroumba
 kfz	BF	LA	Kuruma
 kfz	BF	LA	Kurumba
@@ -23139,6 +24096,7 @@ kfz	ML	D	Western Koromfe
 kfz	ML	L	Koromfé
 kfz	ML	LA	Foula
 kfz	ML	LA	Foulse
+kfz	ML	LA	Koromba
 kfz	ML	LA	Kurum-Korey
 kfz	ML	LA	Tellem
 kga	CI	D	Koyaga
@@ -23153,10 +24111,6 @@ kga	CI	LA	Koyagakan
 kga	CI	LA	Koyaka
 kga	CI	LA	Koyara
 kgb	ID	L	Kawe
-kgc	LA	L	Kasseng
-kgc	LA	LA	Kaseng
-kgc	LA	LA	Koseng
-kgc	LA	LA	Kraseng
 kgd	LA	L	Kataang
 kgd	LA	LA	Katang
 kgd	TH	L	Kataang
@@ -23213,6 +24167,7 @@ kgo	SD	LA	Dimodongo
 kgo	SD	LA	Kadumodi
 kgo	SD	LA	Korongo
 kgo	SD	LA	Kurungu
+kgo	SD	LA	Niino mo-di
 kgo	SD	LA	Tabanya
 kgp	BR	D	Central Kaingang
 kgp	BR	D	Paraná Kaingang
@@ -23270,9 +24225,12 @@ kgx	ID	L	Kamaru
 kgy	CN	L	Kyerung
 kgy	CN	LA	Kyerong
 kgy	CN	LA	Kyirong
+kgy	CN	LA	Kyirong kai
 kgy	NP	L	Kyirong
 kgy	NP	LA	Gyirong
 kgy	NP	LA	Kyerung
+kgy	NP	LA	Kyirong kai
+kgy	NP	LA	Kyirong-nga
 kgy	NP	LA	Kyirung
 kha	BD	L	Khasi
 kha	BD	LA	Cossyah
@@ -23369,6 +24327,7 @@ khg	CN	D	Southern Khams
 khg	CN	D	Western Khams
 khg	CN	L	Tibetan, Khams
 khg	CN	LA	Kam
+khg	CN	LA	Kami
 khg	CN	LA	Kang
 khg	CN	LA	Khamba
 khg	CN	LA	Khampa
@@ -23422,6 +24381,7 @@ khm	KH	DA	Stung Treng
 khm	KH	L	Khmer, Central
 khm	KH	LA	Cambodian
 khm	KH	LA	Khmer
+khm	LA	L	Khmer, Central
 khm	VN	D	Central Khmer
 khm	VN	D	Southern Khmer
 khm	VN	L	Khmer, Central
@@ -23597,6 +24557,7 @@ kie	TD	DA	Daggal
 kie	TD	DA	Mourro
 kie	TD	DA	Muro
 kie	TD	L	Kibet
+kie	TD	LA	Kaben
 kie	TD	LA	Kabentang
 kie	TD	LA	Kibeet
 kie	TD	LA	Kibeit
@@ -23660,9 +24621,9 @@ kin	CD	D	Mulenge
 kin	CD	D	Twa
 kin	CD	DA	Kinyabwisha
 kin	CD	DA	Kinyamulenge
-kin	CD	L	Rwanda
-kin	CD	LA	Kinyarwanda
+kin	CD	L	Kinyarwanda
 kin	CD	LA	Ruanda
+kin	CD	LA	Rwanda
 kin	RW	D	Bufumbwa
 kin	RW	D	Gitwa
 kin	RW	D	Hutu
@@ -23681,14 +24642,16 @@ kin	RW	DA	Tshiga
 kin	RW	DA	Tshogo
 kin	RW	DA	Twa
 kin	RW	DA	Ululera
-kin	RW	L	Rwanda
+kin	RW	L	Kinyarwanda
+kin	RW	LA	Hima
 kin	RW	LA	Ikinyarwanda
-kin	RW	LA	Kinyarwanda
 kin	RW	LA	Orunyarwanda
 kin	RW	LA	Ruanda
+kin	RW	LA	Rwanda
 kin	RW	LA	Rwandan
 kin	RW	LA	Urunyaruanda
 kin	UG	L	Fumbira
+kin	UG	LA	Kinyarwanda
 kin	UG	LA	Ruanda
 kin	UG	LA	Rufumbira
 kin	UG	LA	Runyarwanda
@@ -23732,6 +24695,7 @@ kiu	TR	LA	Dersimki
 kiu	TR	LA	Dimilki
 kiu	TR	LA	Kirmanjki
 kiu	TR	LA	Northern Zaza
+kiu	TR	LA	Shar Ma
 kiu	TR	LA	So-Bê
 kiu	TR	LA	Zaza
 kiu	TR	LA	Zonê Ma
@@ -23812,6 +24776,8 @@ kje	ID	LA	Meher
 kje	ID	LA	Yotowawa
 kjf	AZ	L	Khalaj
 kjf	IR	L	Khalaj
+kjg	CN	D	Damailao
+kjg	CN	D	Damaile
 kjg	CN	L	Khmu
 kjg	CN	LA	Chaman
 kjg	CN	LA	Damai
@@ -23829,15 +24795,20 @@ kjg	CN	LA	Lao Terng
 kjg	CN	LA	Mou
 kjg	CN	LA	Pouteng
 kjg	CN	LA	Theng
+kjg	LA	D	Cwaa
 kjg	LA	D	Hat
 kjg	LA	D	Khroong
 kjg	LA	D	Luang Prabang
-kjg	LA	D	Lyy
 kjg	LA	D	Rok
 kjg	LA	D	Sayabury
 kjg	LA	D	U
 kjg	LA	D	Yuan
+kjg	LA	DA	Eastern Khmu
 kjg	LA	DA	Krong
+kjg	LA	DA	Kroong
+kjg	LA	DA	Lii
+kjg	LA	DA	Lyy
+kjg	LA	DA	Uu
 kjg	LA	L	Khmu
 kjg	LA	LA	Kamhmu
 kjg	LA	LA	Kammu
@@ -24052,6 +25023,7 @@ kke	GN	LA	Fulajonkan
 kke	GN	LA	Jon Kule
 kke	GN	LA	Ourekabakan
 kkf	IN	L	Monpa, Kalaktang
+kkf	IN	LA	Sharpa-lo
 kkf	IN	LA	Southern Monpa
 kkf	IN	LA	Tsangla Monpa
 kkg	PH	L	Kalinga, Mabaka Valley
@@ -24128,6 +25100,8 @@ kko	SD	D	Kasha
 kko	SD	D	Shifir
 kko	SD	L	Karko
 kko	SD	LA	Garko
+kko	SD	LA	Kaak
+kko	SD	LA	Kakenbi
 kko	SD	LA	Karme
 kko	SD	LA	Kithonirishe
 kkp	AU	L	Gugubera
@@ -24155,6 +25129,7 @@ kkt	NP	D	Behere
 kkt	NP	D	Sungdel
 kkt	NP	L	Koi
 kkt	NP	LA	Kohi
+kkt	NP	LA	Koi Ba’a
 kkt	NP	LA	Koyee
 kkt	NP	LA	Koyi
 kkt	NP	LA	Koyu
@@ -24186,12 +25161,14 @@ kkz	CA	L	Kaska
 kkz	CA	LA	Caska
 kkz	CA	LA	Danezāgé’
 kkz	CA	LA	Eastern Nahane
+kkz	CA	LA	Kaska Dena
 kkz	CA	LA	Nahane
 kkz	CA	LA	Nahani
 kla	US	L	Klamath-Modoc
 kla	US	LA	Klamath
 klb	MX	L	Kiliwa
 klb	MX	LA	Kiliwi
+klb	MX	LA	Ko’lew
 klb	MX	LA	Quiligua
 klc	CM	L	Kolbila
 klc	CM	LA	Kolbilari
@@ -24199,6 +25176,7 @@ klc	CM	LA	Kolbili
 klc	CM	LA	Kolbilla
 klc	CM	LA	Kolena
 klc	CM	LA	Zoono
+kld	AU	D	Yuwaalaraay
 kld	AU	L	Gamilaraay
 kld	AU	LA	Camileroi
 kld	AU	LA	Gamilaroi
@@ -24257,10 +25235,12 @@ klq	PG	LA	Tumu
 klr	IN	L	Khaling
 klr	IN	LA	Khael Baat
 klr	IN	LA	Khael Bra
+klr	IN	LA	Khael Braa
 klr	IN	LA	Khalinge Rai
 klr	NP	D	Northern Khaling
 klr	NP	D	Southern Khaling
 klr	NP	L	Khaling
+klr	NP	LA	Khael Braa
 klr	NP	LA	Khaling Kura
 kls	PK	D	Northern Kalasha
 kls	PK	D	Southern Kalasha
@@ -24398,6 +25378,7 @@ kmo	PG	DA	Washkuk
 kmo	PG	L	Kwoma
 kmo	PG	LA	Washkuk
 kmp	CM	L	Gimme
+kmp	CM	LA	Gimma
 kmp	CM	LA	Koma Kompana
 kmp	CM	LA	Kompana
 kmp	CM	LA	Kompara
@@ -24744,6 +25725,7 @@ knj	GT	LA	Acatec
 knj	GT	LA	Acateco
 knj	GT	LA	Conob
 knj	GT	LA	Kanjobal
+knj	GT	LA	K’anjob’al
 knj	GT	LA	Q’anjob’al
 knj	GT	LA	San Miguel Acatán Kanjobal
 knj	GT	LA	Western Kanjobal
@@ -24752,6 +25734,7 @@ knj	MX	L	Kanjobal, Western
 knj	MX	LA	Acatec
 knj	MX	LA	Acateco
 knj	MX	LA	Conob
+knj	MX	LA	K’anjob’al
 knj	MX	LA	Kanjobal de San Miguel Acatán
 knk	GN	D	Faranah
 knk	GN	D	Fineriya
@@ -24932,6 +25915,7 @@ knw	AO	LA	!Hu
 knw	AO	LA	!Ku
 knw	AO	LA	!Kung
 knw	AO	LA	!Xu
+knw	AO	LA	!Xun
 knw	AO	LA	!Xung
 knw	AO	LA	Ekoko-!Xû
 knw	AO	LA	Qxû
@@ -24947,6 +25931,16 @@ knw	NA	LA	Ekoka !Xung
 knw	NA	LA	Ekoka-!Xû
 knw	NA	LA	Kung
 knw	NA	LA	Qxü
+knw	ZA	L	Kung-Ekoka
+knw	ZA	LA	!Hu
+knw	ZA	LA	!Khung
+knw	ZA	LA	!Ku
+knw	ZA	LA	!Kung
+knw	ZA	LA	!Xu
+knw	ZA	LA	!Xun
+knw	ZA	LA	Ekoka-!Xû
+knw	ZA	LA	Kung
+knw	ZA	LA	Qxü
 knx	ID	D	Ahe
 knx	ID	D	Ambawang
 knx	ID	D	Kendayan
@@ -24975,7 +25969,7 @@ knz	BF	DA	Logma
 knz	BF	DA	West Kalamsé
 knz	BF	L	Kalamsé
 knz	BF	LA	Kalemsé
-knz	BF	LA	Kalenga
+knz	BF	LA	Sàmó
 knz	BF	LA	Sàmòmá
 knz	ML	D	Logremma
 knz	ML	DA	Logma
@@ -24984,6 +25978,7 @@ knz	ML	L	Sàmòmá
 knz	ML	LA	Kalamsé
 knz	ML	LA	Kalemsé
 knz	ML	LA	Kalenga
+knz	ML	LA	Sàmó
 koa	PG	D	Konomala
 koa	PG	D	Laket
 koa	PG	L	Konomala
@@ -24995,7 +25990,9 @@ kod	ID	DA	Nggaura
 kod	ID	L	Kodi
 kod	ID	LA	Kudi
 koe	ET	L	Kacipo-Balesi
+koe	ET	LA	Kacipo
 koe	ET	LA	Silmamo
+koe	ET	LA	Suri
 koe	ET	LA	Suri-Baale
 koe	ET	LA	Tsilmano
 koe	ET	LA	Zelmamu
@@ -25003,6 +26000,7 @@ koe	ET	LA	Zilmamu
 koe	ET	LA	Zulmamu
 koe	SS	L	Kacipo-Balesi
 koe	SS	LA	Baale
+koe	SS	LA	Kacipo
 kof	NG	L	Kubi
 kof	NG	LA	Kuba
 kof	NG	LA	Kubawa
@@ -25047,6 +26045,7 @@ koo	UG	D	Sanza
 koo	UG	DA	Ekisanza
 koo	UG	DA	Rukonjo
 koo	UG	L	Konzo
+koo	UG	LA	Bayira
 koo	UG	LA	Konjo
 koo	UG	LA	Lhukonzo
 koo	UG	LA	Olukonjo
@@ -25074,23 +26073,25 @@ kor	KP	DA	North P’yong’ando
 kor	KP	DA	South Hamgyongdo
 kor	KP	DA	South P’yong’ando
 kor	KP	L	Korean
-kor	KR	D	Cheju Island
-kor	KR	D	Chollado
-kor	KR	D	Ch’ungch’ongdo
+kor	KR	D	Chungcheongdo
+kor	KR	D	Jeju Island
+kor	KR	D	Jeollado
 kor	KR	D	Kyongsangdo
 kor	KR	D	Seoul
 kor	KR	DA	Kangwondo
 kor	KR	DA	Kyonggido
-kor	KR	DA	North Chollado
-kor	KR	DA	North Ch’ungch’ong
+kor	KR	DA	North Chungcheongdo
+kor	KR	DA	North Jeollado
 kor	KR	DA	North Kyongsangdo
-kor	KR	DA	South Chollado
-kor	KR	DA	South Ch’ungch’ong
+kor	KR	DA	South Chungcheongdo
+kor	KR	DA	South Jeollado
 kor	KR	DA	South Kyongsangdo
 kor	KR	L	Korean
 kor	KR	LA	Hanguk Mal
 kor	KR	LA	Hanguk Uh
 kor	RU	L	Korean
+kor	TM	L	Korean
+kor	UZ	L	Korean
 kos	FM	D	Lelu-Tafunsak
 kos	FM	D	Malen-Utwe
 kos	FM	L	Kosraean
@@ -25127,8 +26128,6 @@ kow	NG	LA	Kugamma
 kow	NG	LA	Wegam
 kow	NG	LA	Yamale
 kow	NG	LA	Yamalo
-kox	CO	L	Coxima
-kox	CO	LA	Koxima
 koy	US	D	Central Koyukon
 koy	US	D	Central Koyukuk River
 koy	US	D	Lower Koyukon
@@ -25328,6 +26327,7 @@ kpt	RU	LA	Karatai
 kpt	RU	LA	Karatay
 kpt	RU	LA	Karatin
 kpt	RU	LA	Kirdi
+kpt	RU	LA	Kk’irtli micc’i
 kpu	ID	L	Kafoa
 kpu	ID	LA	Aikoli
 kpu	ID	LA	Fanating
@@ -25384,6 +26384,7 @@ kqd	IQ	LA	Koi Sanjaq Soorit
 kqd	IQ	LA	Koi-Sanjaq Sooret
 kqd	IQ	LA	Koy Sanjaq Sooret
 kqd	IQ	LA	Koy Sanjaq Soorit
+kqd	IQ	LA	Surat
 kqe	PH	D	Eastern Kalagan
 kqe	PH	D	Isamal
 kqe	PH	D	Western Kalagan
@@ -25487,6 +26488,8 @@ kqs	SL	LA	Kisi
 kqs	SL	LA	Kisie
 kqs	SL	LA	Kissien
 kqt	MY	L	Kadazan, Klias River
+kqt	MY	LA	Kuijou
+kqt	MY	LA	Kuizou
 kqu	ZA	D	!Gã!nge
 kqu	ZA	D	||Ku||e
 kqu	ZA	DA	!Gã!ne
@@ -25496,12 +26499,14 @@ kqv	ID	LA	Kolod
 kqv	ID	LA	Kolour
 kqv	ID	LA	Kolur
 kqv	ID	LA	Okolod Murut
-kqv	MY	L	Okolod
+kqv	MY	L	Kolor
 kqv	MY	LA	Kolod
 kqv	MY	LA	Kolour
 kqv	MY	LA	Kolur
+kqv	MY	LA	Okolod
 kqv	MY	LA	Okolod Murut
 kqw	PG	L	Kandas
+kqw	PG	LA	Kadas
 kqw	PG	LA	King
 kqx	CM	D	Gawi
 kqx	CM	D	Houlouf
@@ -25569,6 +26574,9 @@ krc	RU	LA	Karachai
 krc	RU	LA	Karachaitsy
 krc	RU	LA	Karachay
 krc	RU	LA	Karachayla
+krc	RU	LA	Malqartil
+krc	RU	LA	Qarachaytil
+krc	RU	LA	Taulu til
 krd	TL	D	Kairui
 krd	TL	D	Midiki
 krd	TL	DA	Midik
@@ -25576,6 +26584,7 @@ krd	TL	L	Kairui-Midiki
 krd	TL	LA	Cairui
 krd	TL	LA	Midiki
 kre	BR	L	Panará
+kre	BR	LA	Indios Gigantes
 kre	BR	LA	Kreen Akarore
 kre	BR	LA	Kren Akarore
 krf	VU	L	Koro
@@ -25584,7 +26593,6 @@ krh	NG	LA	Akurmi
 krh	NG	LA	Akurumi
 krh	NG	LA	Azumu
 krh	NG	LA	Bagwama
-krh	NG	LA	Bukurumi
 krh	NG	LA	Tikurami
 kri	SL	D	Aku
 kri	SL	L	Krio
@@ -25733,14 +26741,17 @@ krw	LR	LA	Kran
 krw	LR	LA	Northern Krahn
 krw	LR	LA	Western Kran
 krx	GM	L	Karon
+krx	GM	LA	Kaloon
 krx	GM	LA	Karone
 krx	GM	LA	Karoninka
+krx	GM	LA	Kulonay
 krx	SN	L	Karon
 krx	SN	LA	Jola-Karone
 krx	SN	LA	Kaloon
 krx	SN	LA	Karone
 krx	SN	LA	Karoninka
 krx	SN	LA	Kouloonaay
+krx	SN	LA	Kulonay
 kry	AZ	D	Alyk
 kry	AZ	D	Dzhek
 kry	AZ	D	Kryts
@@ -25806,8 +26817,8 @@ ksf	CM	D	Kpa
 ksf	CM	L	Bafia
 ksf	CM	LA	Bekpak
 ksf	CM	LA	Kpa
+ksf	CM	LA	Rikpa
 ksf	CM	LA	Rikpa’
-ksf	CM	LA	Ripey
 ksg	SB	L	Kusaghe
 ksg	SB	LA	Kusage
 ksg	SB	LA	Kushage
@@ -25921,8 +26932,13 @@ ksx	ID	LA	Kdang
 ksx	ID	LA	Kédang
 ksx	ID	LA	Kedangese
 ksy	IN	L	Kharia Thar
+ksy	IN	LA	Erenga
+ksy	IN	LA	Kheria
+ksy	IN	LA	Pahari
+ksy	IN	LA	Sabar
 ksz	IN	L	Kodaku
 ksz	IN	LA	Koraku
+ksz	IN	LA	Korwa
 kta	VN	L	Katua
 kta	VN	LA	Ca Tua
 ktb	ET	D	Tambaro
@@ -25961,6 +26977,8 @@ kte	NP	D	Namrung
 kte	NP	D	Prok
 kte	NP	D	Sama
 kte	NP	L	Nubri
+kte	NP	LA	Bhote
+kte	NP	LA	Bhotia
 kte	NP	LA	Kutang
 kte	NP	LA	Kutang Bhotia
 kte	NP	LA	Larkye
@@ -26021,7 +27039,6 @@ ktp	CN	LA	Khatu
 ktp	LA	L	Kaduo
 ktp	LA	LA	Khatu
 ktq	PH	L	Katabaga
-ktr	MY	L	Kota Marudu Tinagas
 kts	ID	D	Metomka
 kts	ID	L	Muyu, South
 kts	ID	LA	Digoel
@@ -26045,6 +27062,7 @@ ktu	CD	LA	Kibulamatadi
 ktu	CD	LA	Kikongo Commercial
 ktu	CD	LA	Kikongo Simplifié
 ktu	CD	LA	Kikongo Ya Leta
+ktu	CD	LA	Kikongo-Kituba
 ktu	CD	LA	Kikongo-Kutuba
 ktu	CD	LA	Kileta
 ktv	VN	L	Katu, Eastern
@@ -26075,6 +27093,7 @@ ktz	BW	DA	Ssu Ghassi
 ktz	BW	DA	Zhu’oase
 ktz	BW	L	Ju|’hoan
 ktz	BW	LA	!Xo
+ktz	BW	LA	!Xun
 ktz	BW	LA	Dobe Kung
 ktz	BW	LA	Dzu’oasi
 ktz	BW	LA	Ju’oasi
@@ -26083,7 +27102,6 @@ ktz	BW	LA	Kung-Tsumkwe
 ktz	BW	LA	Tsumkwe
 ktz	BW	LA	Xaixai
 ktz	BW	LA	Xû
-ktz	BW	LA	Xun
 ktz	BW	LA	Zhu’oasi
 ktz	NA	D	‡Kx’au||’ein
 ktz	NA	D	Dzu’oasi
@@ -26100,6 +27118,7 @@ ktz	NA	DA	Ssu Ghassi
 ktz	NA	DA	Zhu’oase
 ktz	NA	L	Ju|’hoan
 ktz	NA	LA	!Xo
+ktz	NA	LA	!Xun
 ktz	NA	LA	Dobe Kung
 ktz	NA	LA	Dzu’oasi
 ktz	NA	LA	Ju’oasi
@@ -26108,7 +27127,6 @@ ktz	NA	LA	Kung-Tsumkwe
 ktz	NA	LA	Tshumkwe
 ktz	NA	LA	Xaixai
 ktz	NA	LA	Xû
-ktz	NA	LA	Xun
 ktz	NA	LA	Zhu’oasi
 kua	AO	D	Kwanyama
 kua	AO	D	Mbadja
@@ -26279,6 +27297,7 @@ kun	ER	LA	Baza
 kun	ER	LA	Bazen
 kun	ER	LA	Cunama
 kun	ER	LA	Diila
+kun	ET	L	Kunama
 kuo	PG	L	Kumukio
 kuo	PG	LA	Kumokio
 kup	PG	D	Gajili
@@ -26306,6 +27325,7 @@ kus	BF	DA	Toende
 kus	BF	DA	Western Kusaal
 kus	BF	L	Kusaal
 kus	BF	LA	Koussassé
+kus	BF	LA	Kusaas
 kus	BF	LA	Kusale
 kus	BF	LA	Kusasi
 kus	GH	D	Agole
@@ -26314,10 +27334,12 @@ kus	GH	DA	Angole
 kus	GH	DA	Eastern Kusaal
 kus	GH	DA	Western Kusaal
 kus	GH	L	Kusaal
+kus	GH	LA	Kusaas
 kus	GH	LA	Kusaasi
 kus	GH	LA	Kusale
 kus	GH	LA	Kusasi
 kus	TG	L	Kusaal
+kus	TG	LA	Kusaas
 kut	CA	L	Kutenai
 kut	CA	LA	Kootenai
 kut	CA	LA	Kootenay
@@ -26379,10 +27401,9 @@ kvd	ID	DA	Kramang
 kvd	ID	DA	Lerabaing
 kvd	ID	L	Kui
 kvd	ID	LA	Lerabain
+kvd	ID	LA	Masin-Lak
 kve	MY	L	Kalabakan
 kve	MY	LA	Kalabakan Murut
-kve	MY	LA	Tawau Murut
-kve	MY	LA	Tidung
 kvf	TD	L	Kabalai
 kvf	TD	LA	Gablai
 kvf	TD	LA	Kaba-Lai
@@ -26467,6 +27488,7 @@ kvn	PA	L	Kuna, Border
 kvn	PA	LA	Caiman Nuevo
 kvn	PA	LA	Colombia Cuna
 kvn	PA	LA	Cuna
+kvn	PA	LA	Guna
 kvn	PA	LA	Kuna de la Frontera
 kvn	PA	LA	Long Hair Cuna
 kvn	PA	LA	Paya-Pucuro Kuna
@@ -26497,10 +27519,6 @@ kvq	MM	LA	Northern Bwe
 kvr	ID	L	Kerinci
 kvr	ID	LA	Kerinchi
 kvr	ID	LA	Kinchai
-kvs	AU	L	Kunggara
-kvs	AU	LA	Goom-Gharra
-kvs	AU	LA	Gunggara
-kvs	AU	LA	Kunggera
 kvt	MM	L	Lahta
 kvt	MM	LA	Kayan Lahta
 kvt	MM	LA	Khahta
@@ -26607,11 +27625,14 @@ kwi	CO	LA	Awa
 kwi	CO	LA	Awa Pit
 kwi	CO	LA	Coaiquer
 kwi	CO	LA	Cuaiquer
+kwi	CO	LA	Înkal Awa
 kwi	CO	LA	Kwaiker
 kwi	CO	LA	Quaiquer
 kwi	EC	L	Awa-Cuaiquer
 kwi	EC	LA	Awa
+kwi	EC	LA	Awa Pit
 kwi	EC	LA	Cuaiquer
+kwi	EC	LA	Înkal Awa
 kwj	PG	D	Apos
 kwj	PG	D	Bongos
 kwj	PG	D	Tau
@@ -26627,6 +27648,7 @@ kwj	PG	LA	Gawanga
 kwj	PG	LA	Kawanga
 kwk	CA	L	Kwakiutl
 kwk	CA	LA	Kwagiutl
+kwk	CA	LA	Kwakwaka’wakw
 kwk	CA	LA	Kwak’wala
 kwl	NG	D	Bwol
 kwl	NG	D	Dimmuk
@@ -26650,6 +27672,8 @@ kwl	NG	DA	Mbol
 kwl	NG	DA	Mernyang
 kwl	NG	L	Kofyar
 kwm	NA	L	Kwambi
+kwm	NA	LA	Otjiwambo
+kwm	NA	LA	Owambo
 kwn	AO	D	Sambyu
 kwn	AO	DA	Sambio
 kwn	AO	DA	Sambiu
@@ -26773,6 +27797,7 @@ kxc	ET	LA	Conso
 kxc	ET	LA	Gato
 kxc	ET	LA	Karate
 kxc	ET	LA	Kareti
+kxc	ET	LA	Khonso
 kxc	ET	LA	Komso
 kxd	BN	D	Brunei Malay
 kxd	BN	D	Kampong Ayer
@@ -26801,16 +27826,18 @@ kxd	MY	DA	Kedien
 kxd	MY	DA	Kedyan
 kxd	MY	DA	Kerayan
 kxd	MY	L	Brunei
+kxd	MY	LA	Brunai
 kxd	MY	LA	Brunei-Kadaian
-kxd	MY	LA	Orang Bukit
+kxd	MY	LP	Orang Bukit
 kxf	MM	D	Doloso
 kxf	MM	D	Tawkhu
-kxf	MM	L	Manumanaw
+kxf	MM	L	Kawyaw
 kxf	MM	LA	Kayah-Munu
 kxf	MM	LA	Kayàw
 kxf	MM	LA	Manö
 kxf	MM	LA	Manu
 kxf	MM	LA	Manu Manaw
+kxf	MM	LA	Manumanaw
 kxf	MM	LA	Manumanaw Karen
 kxf	MM	LA	Monu
 kxh	ET	L	Karo
@@ -26818,7 +27845,6 @@ kxh	ET	LA	Cherre
 kxh	ET	LA	Kere
 kxh	ET	LA	Kerre
 kxi	MY	D	Ambual
-kxi	MY	D	Dusun Murut
 kxi	MY	D	Nabay
 kxi	MY	DA	Dabai
 kxi	MY	DA	Dabay
@@ -26826,7 +27852,7 @@ kxi	MY	DA	Nabai
 kxi	MY	DA	Nebee
 kxi	MY	DA	Rabai
 kxi	MY	DA	Rabay
-kxi	MY	L	Keningau Murut
+kxi	MY	L	Murut, Keningau
 kxi	MY	LA	Central Murut
 kxj	TD	D	Bara
 kxj	TD	D	Kulfa
@@ -26848,8 +27874,10 @@ kxl	NP	LA	Jangad
 kxl	NP	LA	Janghard
 kxl	NP	LA	Jhangad
 kxl	NP	LA	Jhanger
+kxl	NP	LA	Kurux
 kxl	NP	LA	Oraon
 kxl	NP	LA	Orau
+kxl	NP	LA	Uranw
 kxl	NP	LA	Uraon
 kxl	NP	LA	Uraw
 kxm	TH	D	Buriram
@@ -26981,6 +28009,7 @@ kyk	PH	LA	Davawenyo
 kyk	PH	LA	Kadi
 kyk	PH	LA	Kinadi
 kyk	PH	LA	Kinamayo
+kyk	PH	LA	Mandaya
 kyl	US	D	Santiam
 kyl	US	L	Kalapuya
 kyl	US	LA	Kalapuyan
@@ -27113,11 +28142,6 @@ kzi	MY	DA	spoken in Bario
 kzi	MY	L	Kelabit
 kzi	MY	LA	Kalabit
 kzi	MY	LA	Kerabit
-kzj	MY	L	Kadazan, Coastal
-kzj	MY	LA	Kadazan Tangaa’
-kzj	MY	LA	Membakut Kadazan
-kzj	MY	LA	Papar Kadazan
-kzj	MY	LA	Penampang Kadazan
 kzk	SB	L	Kazukuru
 kzl	ID	D	Kayeli
 kzl	ID	D	Leliali
@@ -27180,8 +28204,6 @@ kzs	MY	LA	Sugut
 kzs	MY	LA	Sugut Kadazan
 kzs	MY	LA	Tanggal
 kzs	MY	LA	Tilau-Ilau
-kzt	MY	L	Dusun, Tambunan
-kzt	MY	LA	Tambunan
 kzu	ID	L	Kayupulau
 kzu	ID	LA	Kajupulau
 kzv	ID	L	Komyandaret
@@ -27221,6 +28243,7 @@ laa	PH	LA	Subanun, Lapuyan
 lac	MX	D	Lacanjá
 lac	MX	D	Najá
 lac	MX	L	Lacandon
+lac	MX	LA	Jach-t’aan
 lac	MX	LA	Lacandón
 lac	MX	LA	Lakantún
 lad	IL	D	Haquetiya
@@ -27269,6 +28292,7 @@ laf	SD	DA	Jebel
 laf	SD	DA	Tegem
 laf	SD	DA	Tekeim
 laf	SD	L	Lafofa
+laf	SD	LA	Kidie Lafofa
 lag	TZ	D	Busi
 lag	TZ	D	Haubi
 lag	TZ	D	Kolo
@@ -27280,7 +28304,9 @@ lag	TZ	LA	Kelangi
 lag	TZ	LA	Kilaangi
 lag	TZ	LA	Kilangi
 lag	TZ	LA	Kirangi
+lag	TZ	LA	Klaangi
 lag	TZ	LA	Rangi
+lag	TZ	LA	Valaangi
 lah	PK	L	Lahnda
 lai	MW	D	Central Lambya
 lai	MW	L	Lambya
@@ -27361,6 +28387,7 @@ lap	TD	LA	Kabba Laka
 laq	CN	L	Qabiao
 laq	CN	LA	Bendi Lolo
 laq	CN	LA	Ka Bao
+laq	CN	LA	Ka Beo
 laq	CN	LA	Ka Biao
 laq	CN	LA	Kabeo
 laq	CN	LA	Laqua
@@ -27370,11 +28397,14 @@ laq	CN	LA	Pu Beo
 laq	CN	LA	Pu Péo
 laq	CN	LA	Pubiao
 laq	CN	LA	Pupeo
+laq	CN	LA	Qa Biao
+laq	CN	LA	Qa Qiau
 laq	CN	LA	Qabiau
 laq	CN	LA	Qaqiau
 laq	VN	L	Qabiao
 laq	VN	LA	Bendi Lolo
 laq	VN	LA	Ka Bao
+laq	VN	LA	Ka Beo
 laq	VN	LA	Ka Biao
 laq	VN	LA	Laqua
 laq	VN	LA	Lolo
@@ -27523,13 +28553,6 @@ lbn	LA	LA	Khamed
 lbn	LA	LA	Khamet
 lbn	LA	LA	Lemet
 lbn	LA	LA	Rmeet
-lbn	TH	D	Lower Lamet
-lbn	TH	D	Upper Lamet
-lbn	TH	L	Lamet
-lbn	TH	LA	Kamet
-lbn	TH	LA	Kha Lamet
-lbn	TH	LA	Khamet
-lbn	TH	LA	Lemet
 lbo	LA	L	Laven
 lbo	LA	LA	Boloven
 lbo	LA	LA	Boriwen
@@ -27550,6 +28573,7 @@ lbr	NP	LA	Lohrung
 lbr	NP	LA	Lohrung Khanawa
 lbr	NP	LA	Lorung
 lbr	NP	LA	Northern Lorung
+lbr	NP	LA	Yakkhaba Khap
 lbs	LY	L	Libyan Sign Language
 lbt	CN	D	Lipuke
 lbt	CN	D	Lipuliongtco
@@ -27669,6 +28693,7 @@ lce	ID	LA	Lonchong
 lce	ID	LA	Loncong
 lce	ID	LA	Lontjong
 lce	ID	LA	Orang Laut
+lce	ID	LA	Orang Sawang
 lce	ID	LA	Sawang
 lce	ID	LA	Seka
 lce	ID	LA	Sekah
@@ -27712,6 +28737,7 @@ lcp	TH	D	Northern Western Lawa
 lcp	TH	D	Omphai
 lcp	TH	L	Lawa, Western
 lcp	TH	LA	Lava
+lcp	TH	LA	Lavua
 lcp	TH	LA	Lavüa
 lcp	TH	LA	Luwa
 lcp	TH	LA	L’wa
@@ -27735,7 +28761,9 @@ lcs	ID	LA	Nuniali
 lda	CI	D	Santa
 lda	CI	D	Zouzoupleu
 lda	CI	L	Kla-Dan
+lda	CI	LA	Kla
 lda	GN	L	Kla-Dan
+lda	GN	LA	Kla
 ldb	NG	L	Duya
 ldb	NG	LA	Adong
 ldb	NG	LA	Idun
@@ -27744,6 +28772,7 @@ ldb	NG	LA	Jaba Lunga
 ldb	NG	LA	Lungu
 ldb	NG	LA	Ungu
 ldd	NG	L	Luri
+ldd	NG	LA	Lúr
 ldg	NG	L	Lenyima
 ldg	NG	LA	Anyima
 ldg	NG	LA	Inyima
@@ -27770,9 +28799,9 @@ ldj	NG	L	Lemoro
 ldj	NG	LA	Anemoro
 ldj	NG	LA	Anowuru
 ldj	NG	LA	Emoro
-ldj	NG	LA	Limoro
 ldj	NG	LA	Limorro
 ldk	NG	L	Leelau
+ldk	NG	LA	Bakula
 ldk	NG	LA	Lelau
 ldk	NG	LA	Lelo
 ldk	NG	LA	Munga
@@ -27869,6 +28898,7 @@ led	CD	LA	Bbaledha
 led	CD	LA	Hema-Nord
 led	CD	LA	Kihema-Nord
 led	CD	LA	Kilendu
+led	CD	LA	Ndrulo
 led	UG	L	Ndrulo
 led	UG	LP	Lendu
 lee	BF	D	Central Lyélé
@@ -27877,7 +28907,10 @@ lee	BF	D	Northern Lyélé
 lee	BF	D	Southern Lyélé
 lee	BF	DA	Reo
 lee	BF	L	Lyélé
+lee	BF	LA	Gurunsi
+lee	BF	LA	Lela
 lee	BF	LA	Lele
+lee	BF	LA	Lyela
 lef	GH	L	Lelemi
 lef	GH	LA	Buem
 lef	GH	LA	Lafana
@@ -28091,6 +29124,7 @@ lgg	CD	D	Otsho
 lgg	CD	D	Zaki
 lgg	CD	L	Lugbara
 lgg	CD	LA	High Lugbara
+lgg	CD	LA	Lugbarati
 lgg	UG	D	Arua
 lgg	UG	D	Maracha
 lgg	UG	D	Terego
@@ -28100,6 +29134,7 @@ lgg	UG	L	Lugbara
 lgg	UG	LA	High Lugbara
 lgg	UG	LA	Logbara
 lgg	UG	LA	Lubarati
+lgg	UG	LA	Lugbarati
 lgg	UG	LA	Western Lugbara
 lgh	VN	L	Laghuu
 lgh	VN	LA	Laopa
@@ -28156,6 +29191,7 @@ lgn	SS	LA	Kwina
 lgn	SS	LA	Opo
 lgn	SS	LA	Opo-Shita
 lgn	SS	LA	Opuo
+lgn	SS	LA	Pur
 lgn	SS	LA	Shita
 lgn	SS	LA	Shitta
 lgn	SS	LP	Langa
@@ -28223,13 +29259,19 @@ lhl	IN	LA	Garas
 lhl	IN	LA	Lohar
 lhm	CN	L	Lhomi
 lhm	CN	LA	Lhoket
+lhm	CN	LA	Lhomi dzyükki keccyok
+lhm	CN	LA	Lhomiki keccyok
 lhm	CN	LA	Shing Saapa
 lhm	IN	L	Lhomi
 lhm	IN	LA	Lhoket
+lhm	IN	LA	Lhomi dzyükki keccyok
+lhm	IN	LA	Lhomiki keccyok
 lhm	IN	LA	Shing Saapa
 lhm	IN	LA	Syingsaaba
 lhm	NP	L	Lhomi
 lhm	NP	LA	Lhoket
+lhm	NP	LA	Lhomi dzyükki keccyok
+lhm	NP	LA	Lhomiki keccyok
 lhm	NP	LP	Bho Te bhasha
 lhm	NP	LP	Kar Bhote
 lhm	NP	LP	Kath Bhote
@@ -28240,6 +29282,7 @@ lhp	BT	L	Lhokpu
 lhp	BT	LA	Lhobikha
 lhp	BT	LA	Taba-Damey-Bikha
 lhs	SY	L	Mlahsö
+lhs	SY	LA	Suryoyo
 lht	VU	D	Lo
 lht	VU	D	Toga
 lht	VU	L	Lo-Toga
@@ -28391,6 +29434,7 @@ lif	IN	L	Limbu
 lif	IN	LA	Limbo
 lif	IN	LA	Limboo
 lif	IN	LA	Lumbu
+lif	IN	LA	Yakthung Pan
 lif	NP	D	Chaubise
 lif	NP	D	Chhatthare
 lif	NP	D	Panthare
@@ -28403,6 +29447,7 @@ lif	NP	DA	Chhathar
 lif	NP	DA	Taplejunge
 lif	NP	DA	Yanggruppe
 lif	NP	L	Limbu
+lif	NP	LA	Yakthung Pan
 lig	GH	D	Atumfuor
 lig	GH	D	Bungase
 lig	GH	D	Dwera
@@ -28460,13 +29505,20 @@ lik	CD	LA	Kilika
 lik	CD	LA	Kpongo
 lik	CD	LA	Liko
 lik	CD	LA	Mabiti
+lik	CD	LA	Maliko
 lik	CD	LA	Toriko
 lil	CA	D	Lower Lillooet
 lil	CA	D	Upper Lillooet
 lil	CA	L	Lillooet
+lil	CA	LA	Slatlemuk
+lil	CA	LA	Statimc
 lil	CA	LA	St’at’imcets
+lil	CA	LA	Stl’atl’imc
+lil	CA	LA	Stl’atl’imx
+lil	CA	LA	Stlatliumh
 lim	BE	L	Limburgish
 lim	BE	LA	Limberger
+lim	BE	LA	Limbourgeois
 lim	BE	LA	Limburgan
 lim	BE	LA	Limburgian
 lim	BE	LA	Limburgic
@@ -28474,15 +29526,19 @@ lim	BE	LA	Limburgs
 lim	BE	LA	Limburgs Plat
 lim	DE	L	Limburgish
 lim	DE	LA	Limberger
+lim	DE	LA	Limbourgeois
 lim	DE	LA	Limburgan
 lim	DE	LA	Limburgian
 lim	DE	LA	Limburgic
+lim	DE	LA	Limburgs
 lim	DE	LA	Limburgs Plat
 lim	NL	L	Limburgish
 lim	NL	LA	Limberger
+lim	NL	LA	Limbourgeois
 lim	NL	LA	Limburgan
 lim	NL	LA	Limburgian
 lim	NL	LA	Limburgic
+lim	NL	LA	Limburgs
 lim	NL	LA	Limburgs Plat
 lin	CD	L	Lingala
 lin	CD	LA	Ngala
@@ -28569,17 +29625,11 @@ lis	TH	LA	Yeh-Jen
 lit	LT	D	Aukshtaičių
 lit	LT	D	Dzukų
 lit	LT	D	Suvalkiečių
-lit	LT	D	Žemaičių
 lit	LT	DA	Aukshtaičiai
 lit	LT	DA	Aukstaitiškai
 lit	LT	DA	Dzukiškai
 lit	LT	DA	Highland Lithuanian
-lit	LT	DA	Lowland Lithuanian
-lit	LT	DA	Samogitian
 lit	LT	DA	Suvalkietiškai
-lit	LT	DA	Žemaičiai
-lit	LT	DA	Žemaitis
-lit	LT	DA	Žemaitiškai
 lit	LT	L	Lithuanian
 lit	LT	LA	Lietuviškai
 lit	LT	LA	Lietuviu
@@ -28621,6 +29671,7 @@ liy	CF	DA	Ngapu
 liy	CF	L	Banda-Bambari
 liy	CF	LA	Banda of Bambari
 liy	CF	LA	Banda-Linda
+liy	CF	LA	Linda
 liz	CD	D	Boniange
 liz	CD	D	Kutu
 liz	CD	D	Monia
@@ -28709,6 +29760,7 @@ lki	IR	LA	Leki
 lkj	MY	L	Remun
 lkj	MY	LA	Milikin
 lkj	MY	LA	Millikin
+lkj	MY	LA	Remun Iban
 lkl	PG	L	Laeko-Libuat
 lkl	PG	LA	Laeko
 lkl	PG	LA	Laeko-Limbuat
@@ -29034,9 +30086,11 @@ lmr	ID	LA	Lebatukan
 lmr	ID	LA	Mulan
 lmu	VU	D	Galokumali
 lmu	VU	D	Galoparua
+lmu	VU	D	Galovasoro
 lmu	VU	L	Lamenu
 lmu	VU	LA	Lamen
 lmu	VU	LA	Lewo
+lmu	VU	LA	Lewo-Lamen
 lmu	VU	LA	Varmali
 lmv	FJ	L	Lomaiviti
 lmw	US	L	Miwok, Lake
@@ -29086,7 +30140,7 @@ lnd	ID	LA	Lun Dayoh
 lnd	ID	LA	Lundaya Putuk
 lnd	ID	LA	Lundayeh
 lnd	ID	LA	Southern Murut
-lnd	MY	D	Kolur
+lnd	MY	D	Kolod
 lnd	MY	D	Lepu Potong
 lnd	MY	D	Lun Bawang
 lnd	MY	D	Lun Dayah
@@ -29105,6 +30159,7 @@ lnd	MY	LA	Lun Lod
 lnd	MY	LA	Lun-Bawang
 lnd	MY	LA	Lundaya
 lnd	MY	LA	Lundayeh
+lnd	MY	LA	Lundayu
 lnd	MY	LA	Southern Murut
 lnh	MY	L	Lanoh
 lnh	MY	LA	Jengjeng
@@ -29207,6 +30262,7 @@ loe	ID	DA	Baloa’
 loe	ID	DA	Kohumama’
 loe	ID	DA	Lingketeng
 loe	ID	L	Saluan
+loe	ID	LA	Coastal Saluan
 loe	ID	LA	Loinang
 loe	ID	LA	Loindang
 loe	ID	LA	Madi
@@ -29229,6 +30285,7 @@ log	CD	DA	Ogamaru
 log	CD	L	Logo
 log	CD	LA	Logoti
 loh	SS	L	Narim
+loh	SS	LA	Boya
 loh	SS	LA	Lariim
 loh	SS	LA	Larim
 loh	SS	LA	Lariminit
@@ -29401,6 +30458,7 @@ lou	US	D	Pointe Coupée Creole
 lou	US	DA	Gombó
 lou	US	DA	Kourí-viní
 lou	US	L	Louisiana Creole
+lou	US	LA	Kréyol
 lou	US	LA	Louisiana Creole French
 lov	CN	L	Lopi
 low	MY	L	Lobu, Tampias
@@ -29416,6 +30474,7 @@ loy	NP	LA	Glo Skad
 loy	NP	LA	Lhopa
 loy	NP	LA	Lo Montang
 loy	NP	LA	Loba
+loy	NP	LA	Loket
 loy	NP	LA	Lopa
 loy	NP	LA	Lowa
 loy	NP	LA	Loyu
@@ -29459,6 +30518,7 @@ lpo	CN	LA	Central Lisu
 lpo	CN	LA	Dayao
 lpo	CN	LA	Eastern Lisu
 lpo	CN	LA	Lolongo
+lpo	CN	LA	Lolopo
 lpx	SS	D	Iboni
 lpx	SS	D	Logonowati
 lpx	SS	D	Lolongo
@@ -29477,8 +30537,10 @@ lra	ID	LA	Bekati’ Nyam-Pelayo
 lra	ID	LA	Bekatiq
 lra	ID	LA	Lara’
 lra	ID	LA	Luru
+lra	ID	LA	Rara Bakati
 lra	MY	L	Bakati’, Rara
 lra	MY	LA	Luru
+lra	MY	LA	Rara Bakati
 lrc	IR	D	Andimeshki
 lrc	IR	D	Bala-Gariva’i
 lrc	IR	D	Borujerdi
@@ -29487,6 +30549,7 @@ lrc	IR	D	Feyli
 lrc	IR	D	Khorramabadi
 lrc	IR	D	Mahali
 lrc	IR	D	Nahavandi
+lrc	IR	D	Solasi
 lrc	IR	DA	Rural Mahali
 lrc	IR	L	Luri, Northern
 lrc	IR	LA	Lori
@@ -29502,6 +30565,7 @@ lri	KE	LA	Marachi
 lrk	PK	L	Loarki
 lrl	IR	D	Lari
 lrl	IR	L	Lari
+lrl	IR	LA	Achomi
 lrl	IR	LA	Larestani
 lrm	KE	L	Olumarama
 lrm	KE	LA	Marama
@@ -29594,6 +30658,7 @@ lsh	IN	LA	Monpa
 lsi	CN	L	Lashi
 lsi	CN	LA	Acye
 lsi	CN	LA	Chashanhua
+lsi	CN	LA	Lachik
 lsi	CN	LA	Lachikwaw
 lsi	CN	LA	Laji
 lsi	CN	LA	Laqi
@@ -29601,13 +30666,15 @@ lsi	CN	LA	Lasi
 lsi	CN	LA	Leqi
 lsi	CN	LA	Leshi
 lsi	CN	LA	Letsi
-lsi	MM	L	Lashi
+lsi	MM	L	Lacid
 lsi	MM	LA	Ac’ye
 lsi	MM	LA	Chashan
 lsi	MM	LA	La Chit
+lsi	MM	LA	Lachi
+lsi	MM	LA	Lachik
 lsi	MM	LA	Lachikwaw
-lsi	MM	LA	Lacid
 lsi	MM	LA	Lacik
+lsi	MM	LA	Lashi
 lsi	MM	LA	Lashi-Maru
 lsi	MM	LA	Lasi
 lsi	MM	LA	Lechi
@@ -29644,6 +30711,7 @@ lsy	MU	L	Mauritian Sign Language
 lsy	MU	LA	MSL
 ltg	LV	L	Latgalian
 ltg	LV	LA	Latgaliešu
+ltg	LV	LA	Latgališu
 lti	ID	L	Leti
 ltn	BR	L	Latundê
 ltn	BR	LA	Leitodu
@@ -29826,8 +30894,10 @@ lut	US	L	Lushootseed
 luu	NP	L	Lumba-Yakkha
 luu	NP	LA	Yakkhaba Cea
 luv	OM	L	Luwati
+luv	OM	LA	Hyderabadi
+luv	OM	LA	Khoja
 luv	OM	LA	Khojki
-luv	OM	LA	Lawatiyya
+luv	OM	LA	Lawatiya
 luw	CM	L	Luo
 luy	KE	L	Oluluyia
 luz	IR	D	Boyerahmadi
@@ -29841,6 +30911,7 @@ luz	IR	LA	Lor
 luz	IR	LA	Lori
 luz	IR	LA	Lori-ye Jonubi
 luz	IR	LA	Lur
+luz	IR	LA	Ruliy Luri
 lva	TL	L	Makuva
 lva	TL	LA	Lovaea
 lva	TL	LA	Lovaia
@@ -29878,6 +30949,7 @@ lwl	TH	D	Bo Luang
 lwl	TH	D	Bo Sangae
 lwl	TH	L	Lawa, Eastern
 lwl	TH	LA	Bo Luang Lawa
+lwl	TH	LA	Lavua
 lwl	TH	LP	Lua
 lwm	CN	D	Dakao
 lwm	CN	D	Huaipa
@@ -29956,12 +31028,14 @@ lzz	GE	LA	Chan
 lzz	GE	LA	Chanuri
 lzz	GE	LA	Chanzan
 lzz	GE	LA	Laze
+lzz	GE	LA	Lazuri
 lzz	GE	LA	Zan
 lzz	TR	L	Laz
 lzz	TR	LA	Chan
 lzz	TR	LA	Chanuri
 lzz	TR	LA	Chanzan
 lzz	TR	LA	Laze
+lzz	TR	LA	Lazuri
 lzz	TR	LA	Zan
 maa	MX	D	San Antonio Eloxochitlán Mazatec
 maa	MX	D	San Francisco Huehuetlán Mazatec
@@ -29980,6 +31054,7 @@ mab	MX	L	Mixtec, Yutanduchi
 mab	MX	LA	Mixteco de Yutanduchi
 mab	MX	LA	Mixteco de Yutanduchi de Guerrero
 mab	MX	LA	Southern Nochixtlan Mixtec
+mab	MX	LA	Tu’un savi
 mad	ID	D	Bangkalan
 mad	ID	D	Bawean
 mad	ID	D	Pamekesan
@@ -30100,6 +31175,7 @@ maj	MX	L	Mazatec, Jalapa de Díaz
 maj	MX	LA	Lowland Mazatec
 maj	MX	LA	Mazateco de San Felipe Jalapa de Díaz
 maj	MX	LA	Mazateco del Este Bajo
+maj	MX	LA	Ntaxjo
 mak	ID	D	Gowa
 mak	ID	D	Maros-Pangkep
 mak	ID	D	Turatea
@@ -30167,7 +31243,9 @@ mam	GT	DA	Tiló
 mam	GT	DA	Todos Santos Mam
 mam	GT	DA	Western Mam
 mam	GT	L	Mam
+mam	GT	LA	B’anax Mam
 mam	GT	LA	Huehuetenango Mam
+mam	GT	LA	Qyool
 mam	MX	D	Mam de la Frontera
 mam	MX	D	Mam de la Sierra
 mam	MX	D	Mam del Norte
@@ -30179,10 +31257,13 @@ mam	MX	DA	Mame
 mam	MX	DA	Tacana Mam
 mam	MX	DA	Tacaneco
 mam	MX	L	Mam
+mam	MX	LA	B’anax Mam
+mam	MX	LA	Qyool
 man	GN	L	Mandingo
 maq	MX	L	Mazatec, Chiquihuitlán
 maq	MX	LA	Mazateco de San Juan Chiquihuitlán
 maq	MX	LA	Mazateco del Sur
+maq	MX	LA	Nne nangui ngaxni
 mar	IN	D	Gawdi of Goa
 mar	IN	D	Kasargod
 mar	IN	D	Kosti
@@ -30241,6 +31322,7 @@ mas	TZ	LA	Maa
 mas	TZ	LA	Masai
 mas	TZ	LA	Massai
 mat	MX	L	Matlatzinca, San Francisco
+mat	MX	LA	Bot’una
 mat	MX	LA	Matlatzinca
 mat	MX	LA	Matlatzinca de San Francisco de los Ranchos
 mau	MX	D	Mazateco de presa alto
@@ -30248,6 +31330,7 @@ mau	MX	D	Mazateco del Norte
 mau	MX	D	San Mateo
 mau	MX	D	San Miguel
 mau	MX	L	Mazatec, Huautla
+mau	MX	LA	Enna
 mau	MX	LA	Highland Mazatec
 mau	MX	LA	Mazateco de Huautla de Jimenez
 mau	MX	LA	Mazateco de la Sierra
@@ -30264,14 +31347,17 @@ maw	GH	D	Eastern Mampruli
 maw	GH	L	Mampruli
 maw	GH	LA	Mampelle
 maw	GH	LA	Mamprule
+maw	GH	LA	Mamprusi
 maw	GH	LA	Manpelle
 maw	GH	LA	Ngmamperli
+maw	TG	L	Mampruli
 max	ID	L	Malay, North Moluccan
 max	ID	LA	Ternate Malay
 maz	MX	D	Atlacomulco-Temascalcingo
 maz	MX	D	San Miguel Tenoxtitlán
 maz	MX	D	Santa María Citendejé-Banos
 maz	MX	L	Mazahua, Central
+maz	MX	LA	Jnatrjo
 maz	MX	LA	Masawa
 maz	MX	LA	Mazahua de oriente
 mba	PH	L	Higaonon
@@ -30337,6 +31423,7 @@ mbj	BR	LA	Kabori
 mbj	BR	LA	Makú Nadëb
 mbj	BR	LA	Makunadöbö
 mbj	BR	LA	Nadeb Macu
+mbj	BR	LA	Nadöb
 mbj	BR	LA	Nadöbö
 mbj	BR	LA	Xiriwai
 mbj	BR	LA	Xuriwai
@@ -30391,7 +31478,7 @@ mbq	PG	L	Maisin
 mbq	PG	LA	Maisan
 mbr	CO	L	Nukak Makú
 mbr	CO	LA	Guaviare
-mbr	CO	LA	Maczsa
+mbr	CO	LA	Macusa
 mbr	CO	LA	Nukak
 mbs	PH	D	Governor Generoso Manobo
 mbs	PH	L	Manobo, Sarangani
@@ -30435,6 +31522,7 @@ mbx	PG	L	Mari
 mby	PK	L	Memoni
 mbz	MX	L	Mixtec, Amoltepec
 mbz	MX	LA	Mixteco de Amoltepec
+mbz	MX	LA	Tnu’u Ñuu Savi
 mbz	MX	LA	Western Sola de Vega Mixtec
 mca	PY	L	Maka
 mca	PY	LA	Enimaca
@@ -30444,11 +31532,11 @@ mca	PY	LA	Macá
 mca	PY	LA	Maká
 mca	PY	LA	Mak’á
 mca	PY	LA	Towolhi
-mcb	PE	L	Machiguenga
+mcb	PE	L	Matsigenka
+mcb	PE	LA	Machiguenga
 mcb	PE	LA	Mañaries
 mcb	PE	LA	Matsiganga
 mcb	PE	LA	Matsigenga
-mcb	PE	LA	Matsigenka
 mcc	PG	L	Bitur
 mcc	PG	LA	Bituri
 mcc	PG	LA	Dudi
@@ -30469,6 +31557,7 @@ mcd	PE	L	Sharanahua
 mce	MX	L	Mixtec, Itundujia
 mce	MX	LA	Eastern Putla Mixtec
 mce	MX	LA	Mixteco de Santa Cruz Itundujia
+mce	MX	LA	Tu’un savi
 mcf	BR	L	Matsés
 mcf	BR	LA	Matse
 mcf	BR	LA	Mayoruna
@@ -30503,6 +31592,7 @@ mch	BR	LA	Maquiritare
 mch	BR	LA	Mayongong
 mch	BR	LA	Pawana
 mch	BR	LA	Soto
+mch	BR	LA	Ye’kuana
 mch	BR	LA	Yekuána
 mch	VE	L	Maquiritari
 mch	VE	LA	Cunuana
@@ -30515,6 +31605,7 @@ mch	VE	LA	Pawana
 mch	VE	LA	Soto
 mch	VE	LA	Ye’cuana
 mch	VE	LA	Yekuana
+mch	VE	LA	Ye’kuana
 mci	PG	D	East Mese
 mci	PG	D	Momolili
 mci	PG	D	West-Central Mese
@@ -30594,6 +31685,7 @@ mcn	TD	LP	Banana
 mco	MX	D	Camotlán Mixe
 mco	MX	D	Coatlán Mixe
 mco	MX	L	Mixe, Coatlán
+mco	MX	LA	Ayuk
 mco	MX	LA	Southeastern Mixe
 mcp	CM	D	Bebent
 mcp	CM	D	Besep
@@ -30750,6 +31842,8 @@ mde	TD	D	Kodroy
 mde	TD	D	Kondongo
 mde	TD	D	Maba
 mde	TD	L	Maba
+mde	TD	LA	Aulad Djema
+mde	TD	LA	Awlad Djema
 mde	TD	LA	Borgu
 mde	TD	LA	Bura Mabang
 mde	TD	LA	Kana Mabang
@@ -30758,9 +31852,11 @@ mde	TD	LA	Mabak
 mde	TD	LA	Mabang
 mde	TD	LA	Ouaddai
 mde	TD	LA	Ouaddaien
+mde	TD	LA	Uled Djemma
 mde	TD	LA	Wadai
 mde	TD	LA	Waddayen
 mdf	RU	L	Moksha
+mdf	RU	LA	Moksha Mordvin
 mdf	RU	LA	Mokshan
 mdf	RU	LA	Mordoff
 mdf	RU	LA	Mordov
@@ -30925,6 +32021,7 @@ mea	CM	LA	Mamwoh
 mea	CM	LA	Wando Bando
 meb	PG	D	Dukemi
 meb	PG	D	Gorau
+meb	PG	D	Mena
 meb	PG	D	Pimuru
 meb	PG	D	Upper Kikori Kaser
 meb	PG	D	Upper Turama-Kaser
@@ -31141,6 +32238,7 @@ mey	MR	LA	Hassaniya
 mey	MR	LA	Hassaniyya Arabic
 mey	MR	LA	Klem El Bithan
 mey	MR	LA	Maure
+mey	MR	LA	Moor
 mey	NE	L	Arabic, Hassaniyya
 mey	NE	LA	Hasanya
 mey	NE	LA	Hassani
@@ -31158,6 +32256,9 @@ mez	US	L	Menominee
 mez	US	LA	Menomini
 mfa	TH	L	Malay, Pattani
 mfa	TH	LA	Baso Jawi
+mfa	TH	LA	Jawi
+mfa	TH	LA	Jawi-Malay
+mfa	TH	LA	oré Jawi
 mfb	ID	D	Capital City Urban Bangka
 mfb	ID	D	Central Bangka
 mfb	ID	D	Lom
@@ -31425,6 +32526,7 @@ mfw	PG	L	Mulaha
 mfx	ET	L	Melo
 mfx	ET	LA	Malo
 mfy	MX	L	Mayo
+mfy	MX	LA	Yoreme Nokki
 mfz	SS	L	Mabaan
 mfz	SS	LA	Barga
 mfz	SS	LA	Gura
@@ -31578,6 +32680,7 @@ mgp	NP	LA	Magar
 mgp	NP	LA	Magari
 mgp	NP	LA	Manggar
 mgq	TZ	L	Malila
+mgq	TZ	LA	Bamalila
 mgq	TZ	LA	Ishimalilia
 mgq	TZ	LA	Kimalila
 mgq	TZ	LA	Malilia
@@ -31664,6 +32767,7 @@ mhd	TZ	LA	Kimbugu
 mhd	TZ	LA	Ma’a
 mhd	TZ	LA	Mbougou
 mhd	TZ	LA	Wa Maathi
+mhd	TZ	LA	Wa-Ma’a
 mhd	TZ	LA	Wama’a
 mhe	MY	D	Betise’
 mhe	MY	D	Kuala Langot Besisi
@@ -31782,6 +32886,7 @@ mhs	ID	LA	Boeroe
 mhs	ID	LA	Buruese
 mht	VE	L	Mandahuaca
 mht	VE	LA	Arihini
+mht	VE	LA	Bale
 mht	VE	LA	Cunipusana
 mht	VE	LA	Ihini
 mht	VE	LA	Maldavaca
@@ -31838,11 +32943,13 @@ mhw	ZM	LA	Thimukushu
 mhx	CN	L	Lhaovo
 mhx	CN	LA	Diso
 mhx	CN	LA	Lang’e
+mhx	CN	LA	Langsu
 mhx	CN	LA	Langwa
 mhx	CN	LA	Laungaw
 mhx	CN	LA	Laungwaw
 mhx	CN	LA	Lawng
 mhx	CN	LA	Liangsu
+mhx	CN	LA	Lovo
 mhx	CN	LA	Malu
 mhx	CN	LA	Maru
 mhx	CN	LA	Matu
@@ -31858,12 +32965,13 @@ mhx	MM	D	Zagaran Mran
 mhx	MM	L	Lhao Vo
 mhx	MM	LA	Diso
 mhx	MM	LA	Lang
-mhx	MM	LA	Langsu
 mhx	MM	LA	Laungaw
 mhx	MM	LA	Laungwaw
 mhx	MM	LA	Lawgore
 mhx	MM	LA	Lawng
 mhx	MM	LA	Lhaovo
+mhx	MM	LA	Liangsu
+mhx	MM	LA	Lovo
 mhx	MM	LA	Malu
 mhx	MM	LA	Mulu
 mhx	MM	LA	Zi
@@ -31893,16 +33001,19 @@ mic	CA	D	Northern Micmac
 mic	CA	D	Southern Micmac
 mic	CA	L	Micmac
 mic	CA	LA	Mi’gmaq
+mic	CA	LA	Mi’gmaw
 mic	CA	LA	Miigmao
 mic	CA	LA	Mi’kmaq
 mic	CA	LA	Restigouche
 mic	US	L	Micmac
 mic	US	LA	Mi’gmaw
 mic	US	LA	Miigmao
+mic	US	LA	Mi’kmaq
 mic	US	LA	Mi’kmaw
 mic	US	LA	Restigouche
 mid	IQ	D	Iraqi Neo-Mandaic
 mid	IQ	L	Mandaic
+mid	IQ	LA	Mandaayi
 mid	IQ	LA	Mandaean
 mid	IQ	LA	Mandi
 mid	IQ	LA	Mandini
@@ -31917,6 +33028,7 @@ mid	IR	D	Shushtar
 mid	IR	DA	Ahvaz
 mid	IR	DA	Shustar
 mid	IR	L	Mandaic
+mid	IR	LA	Mandaayi
 mid	IR	LA	Mandaean
 mid	IR	LA	Mandi
 mid	IR	LA	Mandini
@@ -31930,6 +33042,7 @@ mie	MX	LA	Mixteco de Santo Tomás Ocotepec
 mie	MX	LA	Mixteco de Sierra Sur Noroeste
 mie	MX	LA	Ocotepec Mixtec
 mie	MX	LA	Santo Tomás Ocotepec Mixtec
+mie	MX	LA	Tu’un savi
 mif	CM	D	Dimeo
 mif	CM	D	Gudur
 mif	CM	D	Massagal
@@ -31950,8 +33063,10 @@ mih	MX	D	Mechoán
 mih	MX	L	Mixtec, Chayuco
 mih	MX	LA	Eastern Jamiltepec-Chayuco Mixtec
 mih	MX	LA	Mixteco de Chayucu
+mih	MX	LA	Tu’un savi
 mii	MX	L	Mixtec, Chigmecatitlán
 mii	MX	LA	Central Puebla Mixtec
+mii	MX	LA	Da’an davi
 mii	MX	LA	Mixteco de Santa María Chigmecatitlán
 mij	CM	D	Abar
 mij	CM	D	Biya
@@ -31969,6 +33084,7 @@ mik	US	LA	Mikasuki Seminole
 mil	MX	L	Mixtec, Peñoles
 mil	MX	LA	Eastern Mixtec
 mil	MX	LA	Mixteco de Santa María Peñoles
+mil	MX	LA	Tu’un savi
 mim	MX	D	Atlamajalcingo del Monte
 mim	MX	D	Cahuatache Tototepec
 mim	MX	D	Cuatzoquitengo
@@ -32036,6 +33152,7 @@ mir	MX	LA	Guichicovi Mixe
 mir	MX	LA	Mixe del Istmo
 mit	MX	L	Mixtec, Southern Puebla
 mit	MX	LA	Acatlán Mixtec
+mit	MX	LA	Da’an davi
 mit	MX	LA	Mixteco de la Frontera Puebla-Oaxaca
 mit	MX	LA	Mixteco del Sur de Puebla
 mit	MX	LA	Xayacatlán de Bravo
@@ -32057,13 +33174,18 @@ mix	MX	LA	Mixteco de San Juan Mixtepec
 miy	MX	L	Mixtec, Ayutla
 miy	MX	LA	Coastal Guerrero Mixtec
 miy	MX	LA	Mixteco de Ayutla
+miy	MX	LA	Tu’un savi
 miz	MX	L	Mixtec, Coatzospan
 miz	MX	LA	Mixteco de Coatzóspan
 miz	MX	LA	Mixteco de San Juan Coatzospan
 miz	MX	LA	Teotitlán Mixtec
+miz	MX	LA	Tu’un davi
+mjb	TL	L	Makalero
+mjb	TL	LA	Maklere
 mjc	MX	L	Mixtec, San Juan Colorado
 mjc	MX	LA	Mixteco de Oaxaca de la Costa Noroeste
 mjc	MX	LA	Mixteco de San Juan Colorado
+mjc	MX	LA	Tu’un sav
 mjd	US	L	Maidu, Northwest
 mjd	US	LA	Concow
 mjd	US	LA	Holólupai
@@ -32087,9 +33209,12 @@ mjg	CN	DA	Mangghuer
 mjg	CN	DA	Mongghul
 mjg	CN	DA	Naringhol
 mjg	CN	L	Tu
+mjg	CN	LA	Mangghuer
+mjg	CN	LA	Mongghul
 mjg	CN	LA	Mongor
 mjg	CN	LA	Mongour
 mjg	CN	LA	Monguor
+mjg	CN	LA	Qighaan Mongghul
 mjh	TZ	L	Mwera
 mjh	TZ	LA	Kimwera
 mjh	TZ	LA	Kinyasa
@@ -32103,6 +33228,7 @@ mji	CN	LA	Gem Mun
 mji	CN	LA	Hainan Miao
 mji	CN	LA	Jim Mun
 mji	CN	LA	Jinmen
+mji	CN	LA	Kem di mun
 mji	CN	LA	Kem Mun
 mji	CN	LA	Kimmun
 mji	CN	LA	Lan Tin
@@ -32114,6 +33240,7 @@ mji	CN	LA	Mun
 mji	CN	LA	Shanzi Yao
 mji	LA	L	Kim Mun
 mji	LA	LA	Jim Mun
+mji	LA	LA	Kem di mun
 mji	LA	LA	Lan Tin
 mji	LA	LA	Lanten
 mji	LA	LA	Lowland Yao
@@ -32127,6 +33254,7 @@ mji	VN	LA	Dao Quan Trang
 mji	VN	LA	Dao Thanh Y
 mji	VN	LA	Great Tunic Yao
 mji	VN	LA	Jinmen
+mji	VN	LA	Kem di mun
 mji	VN	LA	Lan Ten
 mji	VN	LA	Lanten
 mji	VN	LA	Lantin
@@ -32196,6 +33324,7 @@ mjt	IN	LA	Maltu
 mjt	IN	LA	Sawriya Malto
 mju	IN	L	Manna-Dora
 mjv	IN	L	Mannan
+mjv	IN	LA	Inavan petch
 mjv	IN	LA	Mannan Pasha
 mjv	IN	LA	Manne
 mjv	IN	LA	Mannyod
@@ -32311,7 +33440,7 @@ mki	PK	LA	Dhati
 mkj	FM	L	Mokilese
 mkj	FM	LA	Mokil
 mkj	FM	LA	Mwoakilese
-mkj	FM	LA	Mwoakiloa
+mkj	FM	LA	Mwoakilloa
 mkj	US	L	Mokilese
 mkk	CM	D	Besep
 mkk	CM	D	Byep
@@ -32370,6 +33499,7 @@ mku	LR	LA	Konyanka
 mkv	VU	L	Mafea
 mkv	VU	LA	Mavea
 mkw	CG	L	Kituba
+mkw	CG	LA	Kikongo-Kituba
 mkw	CG	LA	Kikoongo
 mkw	CG	LA	Monokutuba
 mkw	CG	LA	Munukutuba
@@ -32386,7 +33516,6 @@ mky	ID	L	Makian, East
 mky	ID	LA	Makian Dalam
 mky	ID	LA	Makian Timur
 mkz	TL	D	Makasae
-mkz	TL	D	Maklere
 mkz	TL	L	Makasae
 mkz	TL	LA	Ma’asae
 mkz	TL	LA	Macassai
@@ -32417,12 +33546,15 @@ mle	PG	L	Manambu
 mlf	LA	L	Mal
 mlf	LA	LA	Htin
 mlf	LA	LA	Khatin
+mlf	LA	LA	Ma’di
+mlf	LA	LA	Madl
 mlf	LA	LA	Thin
 mlf	LA	LA	Tin
 mlf	LA	LA	T’in
 mlf	TH	L	Mal
 mlf	TH	LA	Ht’in
 mlf	TH	LA	Khatin
+mlf	TH	LA	Ma’di
 mlf	TH	LA	Thin
 mlf	TH	LA	Tin
 mlf	TH	LA	T’in
@@ -32552,6 +33684,7 @@ mma	NG	LA	Kantana
 mma	NG	LA	Kwarra
 mmb	ID	L	Momina
 mmc	MX	L	Mazahua, Michoacán
+mmc	MX	LA	Jnatjo
 mmc	MX	LA	Mazahua de occidente
 mmd	CN	L	Maonan
 mmd	CN	LA	Ai Nan
@@ -32758,6 +33891,7 @@ mni	BD	DA	Pangal
 mni	BD	L	Meitei
 mni	BD	LA	Manipuri
 mni	BD	LA	Meetei
+mni	BD	LA	Meitei Manipuri
 mni	BD	LA	Meithei
 mni	IN	D	Loi
 mni	IN	D	Meitei
@@ -32770,6 +33904,7 @@ mni	IN	L	Meitei
 mni	IN	LA	Kathe
 mni	IN	LA	Kathi
 mni	IN	LA	Manipuri
+mni	IN	LA	Meitei Manipuri
 mni	IN	LA	Meiteilon
 mni	IN	LA	Meiteiron
 mni	IN	LA	Meithe
@@ -32822,6 +33957,7 @@ mnq	MY	LA	Menriq
 mnr	US	D	Eastern Mono
 mnr	US	D	Western Mono
 mnr	US	L	Mono
+mnr	US	LA	Monache
 mnr	US	LA	Monachi
 mns	RU	D	Eastern Vogul
 mns	RU	D	Northern Vogul
@@ -32958,6 +34094,7 @@ moo	VN	LA	Menam
 moo	VN	LA	Monam
 mop	BZ	L	Maya, Mopán
 mop	BZ	LA	Maya Mopán
+mop	BZ	LA	Mopan
 mop	BZ	LA	Mopane
 mop	GT	L	Maya, Mopán
 mop	GT	LA	Maya Mopán
@@ -32967,6 +34104,7 @@ moq	ID	LA	Mor2
 mor	SD	D	Laiyen
 mor	SD	D	Nderre
 mor	SD	D	Nubwa
+mor	SD	D	Thetogovela
 mor	SD	D	Ulba
 mor	SD	D	Umm Dorein
 mor	SD	D	Umm Gabralla
@@ -32989,8 +34127,10 @@ mos	BF	L	Mòoré
 mos	BF	LA	Mole
 mos	BF	LA	Moose
 mos	BF	LA	More
+mos	BF	LA	Moré
 mos	BF	LA	Moshi
 mos	BF	LA	Mossi
+mos	ML	L	Mòoré
 mos	TG	D	Yanga
 mos	TG	DA	Jaan
 mos	TG	DA	Timbou
@@ -33005,12 +34145,14 @@ mos	TG	LA	More
 mos	TG	LA	Moshi
 mos	TG	LA	Mossi
 mot	CO	L	Barí
+mot	CO	LA	Bari
 mot	CO	LA	Barira
 mot	CO	LA	Cunausaya
 mot	CO	LA	Dobocubi
 mot	CO	LA	Motilón
 mot	CO	LA	Motilone
 mot	VE	L	Barí
+mot	VE	LA	Bari
 mot	VE	LA	Motilón
 mot	VE	LA	Motilone
 mou	TD	D	Jegu
@@ -33109,7 +34251,9 @@ mpg	TD	DA	Bananna
 mpg	TD	DA	Kolong
 mpg	TD	DA	Kulung
 mpg	TD	DA	Leou
+mpg	TD	DA	Lew
 mpg	TD	DA	Maraba
+mpg	TD	DA	Monogoy
 mpg	TD	L	Marba
 mpg	TD	LA	Azumeina
 mph	AU	L	Maung
@@ -33197,6 +34341,7 @@ mpt	PG	D	Usage
 mpt	PG	L	Mian
 mpt	PG	LA	Mianmin
 mpu	BR	L	Makuráp
+mpu	BR	LA	Kurateg
 mpu	BR	LA	Macuráp
 mpu	BR	LA	Macurapi
 mpu	BR	LA	Makurápi
@@ -33248,6 +34393,7 @@ mqg	ID	L	Malay, Kota Bangun Kutai
 mqh	MX	L	Mixtec, Tlazoyaltepec
 mqh	MX	LA	Mixteco Bajo de Valles
 mqh	MX	LA	Mixteco de Santiago Tlazoyaltepec
+mqh	MX	LA	Tu’un dau
 mqi	ID	L	Mariri
 mqi	ID	LA	Mairiri
 mqj	ID	D	Central Mamasa
@@ -33263,14 +34409,22 @@ mqj	ID	LA	Mamasa Toraja
 mqk	PH	L	Manobo, Rajah Kabunsuwan
 mqk	PH	LA	Rajah Kabungsuan Manobo
 mql	BJ	L	Mbelime
+mql	BJ	LA	Bèbèdibè
+mql	BJ	LA	Bebelibe
 mql	BJ	LA	Mbèlimè
 mql	BJ	LA	Mbilme
+mql	BJ	LA	Oubièlo
+mql	BJ	LA	Ubielo
 mql	BJ	LP	M’Bermè
 mql	BJ	LP	Niende
 mql	BJ	LP	Niendé
 mql	BJ	LP	Niendi
 mql	BJ	LP	Nyende
 mql	TG	L	Mbelime
+mql	TG	LA	Bèbèdibè
+mql	TG	LA	Bebelibe
+mql	TG	LA	Oubièlo
+mql	TG	LA	Ubielo
 mqm	PF	D	Fatu Hiva
 mqm	PF	D	Hiva Oa
 mqm	PF	D	Tahuata
@@ -33337,6 +34491,7 @@ mra	TH	L	Mlabri
 mra	TH	LA	Luang
 mra	TH	LA	Ma Ku
 mra	TH	LA	Mabri
+mra	TH	LA	Malabri
 mra	TH	LA	Mla
 mra	TH	LA	Mla Bri
 mra	TH	LA	Mrabri
@@ -33396,6 +34551,7 @@ mri	NZ	D	Taranaki
 mri	NZ	D	Wanganui
 mri	NZ	L	Maori
 mri	NZ	LA	New Zealand Maori
+mri	NZ	LA	te reo Maori
 mrj	RU	D	Kozymodemyan
 mrj	RU	D	Yaran
 mrj	RU	L	Mari, Hill
@@ -33538,8 +34694,11 @@ msc	GN	LA	Sankarankan
 msd	MX	L	Yucatec Maya Sign Language
 msd	MX	LA	Chican Sign Language
 msd	MX	LA	Lengua de Señas Chicana
+msd	MX	LA	Lenguaje Manual Maya
 msd	MX	LA	LSChicana
+msd	MX	LA	Mayan Sign Language
 msd	MX	LA	Nohya Sign Language
+msd	MX	LP	Lengua Mímica Maya
 mse	CM	D	Pe
 mse	CM	L	Musey
 mse	CM	LA	Bananna
@@ -33557,7 +34716,6 @@ mse	CM	LA	Mussoi
 mse	CM	LA	Mussoy
 mse	TD	D	Bongor-Jodo-Tagal-Berem-Gunu
 mse	TD	D	Jaraw-Domo
-mse	TD	D	Lew
 mse	TD	D	Pe-Holom-Gamé
 mse	TD	L	Musey
 mse	TD	LA	Bananna
@@ -33582,8 +34740,10 @@ msf	ID	LA	Munkei
 msg	ID	L	Moraid
 msh	MG	L	Malagasy, Masikoro
 msi	MY	L	Malay, Sabah
+msi	MY	LA	Bahasa Sabah
 msi	MY	LA	Bazaar Malay
 msi	MY	LA	Pasar Malay
+msi	MY	LA	Sabah Malay Dialect
 msj	CD	L	Ma
 msj	CD	LA	Amadi
 msj	CD	LA	Madi
@@ -33598,6 +34758,8 @@ msm	PH	D	Surigao
 msm	PH	D	Umayam
 msm	PH	L	Manobo, Agusan
 msm	PH	LA	Agusan
+msm	PH	LA	Manobo
+msm	PH	LA	Minanubu
 msn	VU	D	Mwesen
 msn	VU	DA	Mosin
 msn	VU	DA	Mosina
@@ -33610,6 +34772,7 @@ mso	ID	LA	Kemelom
 mso	ID	LA	Kemelomsch
 mso	ID	LA	Komolom
 msp	BR	D	Arupai
+msp	BR	DA	Arupati
 msp	BR	DA	Urupaya
 msp	BR	L	Maritsauá
 msp	BR	LA	Manitsawá
@@ -33752,6 +34915,7 @@ mtu	MX	D	Santa María Acatepec
 mtu	MX	L	Mixtec, Tututepec
 mtu	MX	LA	Mixteco de San Pedro Tututepec
 mtu	MX	LA	Mixteco de Villa de Tututepec
+mtu	MX	LA	Tu’un savi
 mtv	PG	D	Molet
 mtv	PG	L	Asaro’o
 mtv	PG	LA	Morafa
@@ -33762,6 +34926,7 @@ mtx	MX	L	Mixtec, Tidaá
 mtx	MX	LA	Mixteco de San Pedro Tidaá
 mtx	MX	LA	Mixteco de Tidaá
 mtx	MX	LA	North Central Nochixtlán Mixtec
+mtx	MX	LA	Tnu’un dawi
 mty	PG	L	Nabi
 mty	PG	LA	Metan
 mty	PG	LA	Mitang
@@ -33809,7 +34974,15 @@ mud	RU	LA	Copper Island Aleut
 mud	RU	LA	Copper Island Attuan
 mud	RU	LA	Creolized Attuan
 mud	RU	LA	Medny
+mue	EC	D	Cotopaxi Media Lengua
+mue	EC	D	Imbabura Media Lengua
 mue	EC	L	Media Lengua
+mue	EC	LA	Chapu-shimi
+mue	EC	LA	Chaupi-lengua
+mue	EC	LA	Chaupi-shimi
+mue	EC	LA	Quichuañol
+mue	EC	LA	Uchilla-shimi
+mue	EC	LP	Llanga-shimi
 mug	CM	D	Beege
 mug	CM	D	Luggoy
 mug	CM	D	Maniling
@@ -33829,6 +35002,7 @@ mug	CM	L	Musgu
 mug	CM	LA	Mousgou
 mug	CM	LA	Mousgoum
 mug	CM	LA	Mousgoun
+mug	CM	LA	Mulwi
 mug	CM	LA	Munjuk
 mug	CM	LA	Musgum
 mug	CM	LA	Musuk
@@ -33967,6 +35141,7 @@ muu	KE	LA	Mukoquodo
 muu	KE	LA	Siegu
 muu	KE	LA	Yaakua
 muu	KE	LA	Yiaku
+muu	KE	LA	Yiakunte
 muu	KE	LP	Ndorobo
 muu	KE	LP	Ntorobo
 muv	IN	D	Eastern Muthuvan
@@ -33981,6 +35156,7 @@ muv	IN	LA	Muduva
 muv	IN	LA	Muduvan
 muv	IN	LA	Muduvar
 muv	IN	LA	Mutuvar
+muv	IN	LA	Paanti naattu peeccu
 mux	PG	D	Ku Waru
 mux	PG	D	Mara-Gomu
 mux	PG	D	Miyemu
@@ -34029,13 +35205,14 @@ mvf	CN	D	Jo-Uda
 mvf	CN	D	Ordos
 mvf	CN	D	Shilingol
 mvf	CN	D	Tumut
+mvf	CN	D	Ujumchin
 mvf	CN	D	Ulanchab
 mvf	CN	DA	Bairin
 mvf	CN	DA	Balin
 mvf	CN	DA	Chaha’er
 mvf	CN	DA	Chakhar
 mvf	CN	DA	Eastern Tumut
-mvf	CN	DA	E’erduosite
+mvf	CN	DA	E’erduos
 mvf	CN	DA	Gorlos
 mvf	CN	DA	Jalait
 mvf	CN	DA	Kalaqin
@@ -34049,7 +35226,6 @@ mvf	CN	DA	Mingan
 mvf	CN	DA	Naiman
 mvf	CN	DA	Qahar
 mvf	CN	DA	Tumet
-mvf	CN	DA	Ujumchin
 mvf	CN	DA	Urat
 mvf	CN	L	Mongolian, Peripheral
 mvf	CN	LA	Inner Mongolian
@@ -34074,6 +35250,7 @@ mvf	MN	LA	Southern-Eastern Mongolian
 mvg	MX	L	Mixtec, Yucuañe
 mvg	MX	LA	Mixteco de San Bartolomé Yucuañe
 mvg	MX	LA	Mixteco del Sureste Central
+mvg	MX	LA	Tnu’u savi
 mvh	TD	L	Mulgi
 mvh	TD	LA	Mire
 mvi	JP	D	Irabu-Jima
@@ -34145,52 +35322,48 @@ mvv	ID	DA	Tagol
 mvv	ID	DA	Tagul
 mvv	ID	DA	Telekoson
 mvv	ID	DA	Tumaniq
-mvv	ID	L	Tagal Murut
+mvv	ID	L	Murut, Tagal
 mvv	ID	LA	Semambu
 mvv	ID	LA	Semembu
 mvv	ID	LA	Sumambu
 mvv	ID	LA	Sumambuq
 mvv	ID	LA	Sumambu-Tagal
-mvv	MY	D	Alumbis
 mvv	MY	D	Maligan
 mvv	MY	D	Pensiangan Murut
 mvv	MY	D	Rundum
 mvv	MY	D	Salalir
-mvv	MY	D	Sapulot Murut
 mvv	MY	D	Sumambu
-mvv	MY	D	Tagal
-mvv	MY	D	Tawan
 mvv	MY	D	Tolokoson
 mvv	MY	D	Tomani
 mvv	MY	DA	Arundum
 mvv	MY	DA	Bol Murut
 mvv	MY	DA	Bole Murut
 mvv	MY	DA	Lagunan Murut
-mvv	MY	DA	Loembis
-mvv	MY	DA	Lumbis
 mvv	MY	DA	Mauligan
 mvv	MY	DA	Meligan
-mvv	MY	DA	North Borneo Murut
 mvv	MY	DA	Pentjangan
-mvv	MY	DA	Sabah Murut
 mvv	MY	DA	Sadalir
-mvv	MY	DA	Sapulut Murut
 mvv	MY	DA	Saralir
 mvv	MY	DA	Sedálir
 mvv	MY	DA	Semambu
 mvv	MY	DA	Semembu
 mvv	MY	DA	Sumambuq
-mvv	MY	DA	Taggal
-mvv	MY	DA	Tagol
-mvv	MY	DA	Tagul
 mvv	MY	DA	Telekoson
 mvv	MY	DA	Tumaniq
-mvv	MY	L	Tagal Murut
+mvv	MY	L	Tahol
+mvv	MY	LA	Pensiangan
+mvv	MY	LA	Sumambu
+mvv	MY	LA	Tagal
+mvv	MY	LA	Tagal Murut
+mvv	MY	LA	Tagol
 mvw	TZ	L	Machinga
 mvx	ID	L	Meoswar
 mvx	ID	LA	War
+mvy	PK	D	Bankad
 mvy	PK	D	Duber-Kandia
 mvy	PK	D	Indus
+mvy	PK	D	Ranolia
+mvy	PK	DA	Duber
 mvy	PK	DA	Jijal
 mvy	PK	DA	Khili
 mvy	PK	DA	Mani
@@ -34229,6 +35402,9 @@ mwf	AU	L	Murrinh-Patha
 mwf	AU	LA	Garama
 mwf	AU	LA	Murinbada
 mwf	AU	LA	Murinbata
+mwf	AU	LA	Murinhpatha
+mwf	AU	LA	Murinpatha
+mwf	AU	LA	Murinypata
 mwg	PG	L	Aiklep
 mwg	PG	LA	Agerlep
 mwg	PG	LA	Eklep
@@ -34261,6 +35437,7 @@ mwl	PT	DA	Mirandés Raiano
 mwl	PT	DA	Mirandés Sendinês
 mwl	PT	DA	Sendinês
 mwl	PT	L	Mirandese
+mwl	PT	LA	Mirandés
 mwl	PT	LA	Mirandês
 mwm	TD	D	Majingai
 mwm	TD	D	Nar
@@ -34313,6 +35490,7 @@ mwq	MM	DA	Hmong-K’cha
 mwq	MM	DA	Nitu
 mwq	MM	L	Chin, Müün
 mwq	MM	LA	Cho
+mwq	MM	LA	K’cho
 mwq	MM	LA	K’cho Chin
 mwq	MM	LA	Mindat
 mwq	MM	LA	Mün
@@ -34384,11 +35562,11 @@ mww	LA	L	Hmong Daw
 mww	LA	LA	Bai Miao
 mww	LA	LA	Hmong Der
 mww	LA	LA	Hmoob Dawb
-mww	LA	LA	Meo Kao
 mww	LA	LA	White Hmong
 mww	LA	LA	White Lum
-mww	LA	LA	White Meo
 mww	LA	LA	White Miao
+mww	LA	LP	Meo Kao
+mww	LA	LP	White Meo
 mww	TH	D	Hmong Gu Mba
 mww	TH	D	Petchabun Miao
 mww	TH	DA	Hmong Qua Mba
@@ -34399,13 +35577,13 @@ mww	TH	LA	Bai Miao
 mww	TH	LA	Chuan Miao
 mww	TH	LA	Hmong Der
 mww	TH	LA	Hmoob Dawb
-mww	TH	LA	Meo Kao
 mww	TH	LA	Pe Miao
 mww	TH	LA	Peh Miao
 mww	TH	LA	White Hmong
 mww	TH	LA	White Lum
-mww	TH	LA	White Meo
 mww	TH	LA	White Miao
+mww	TH	LP	Meo Kao
+mww	TH	LP	White Meo
 mww	VN	D	Hmong Xi
 mww	VN	DA	Meo Do
 mww	VN	L	Hmong Daw
@@ -34425,8 +35603,10 @@ mxa	MX	L	Mixtec, Northwest Oaxaca
 mxa	MX	LA	Mixteco de Yucuná
 mxa	MX	LA	Mixteco del Noroeste
 mxa	MX	LA	Mixteco del Noroeste de Oaxaca
+mxa	MX	LA	Tu’un sav
 mxb	MX	L	Mixtec, Tezoatlán
 mxb	MX	LA	Mixteco de Tezoatlán de Segura y Luna
+mxb	MX	LA	Tu’un nda’i
 mxc	MZ	D	Bocha
 mxc	MZ	D	Bunji
 mxc	MZ	D	Bvumba
@@ -34568,6 +35748,7 @@ mxs	MX	L	Mixtec, Huitepec
 mxs	MX	LA	Mixteco de Huitepec
 mxs	MX	LA	Mixteco de San Antonio Huitepec
 mxs	MX	LA	Mixteco de Zaachila
+mxs	MX	LA	Tu’un sav
 mxt	MX	L	Mixtec, Jamiltepec
 mxt	MX	LA	Eastern Jamiltepec-San Cristobal Mixtec
 mxt	MX	LA	Mixteco de Jamiltepec
@@ -34591,6 +35772,8 @@ mxx	CI	LA	Maou
 mxx	CI	LA	Mau
 mxx	CI	LA	Mauka
 mxx	CI	LA	Mauke
+mxx	CI	LA	Mawu
+mxx	CI	LA	Mawukakan
 mxy	MX	D	San Andrés Nuxiño Mixtec
 mxy	MX	D	Santa Inés de Zaragoza Mixtec
 mxy	MX	D	Santo Domingo Nuxaá Mixtec
@@ -34673,6 +35856,7 @@ myh	US	LA	Kweedishchaaht
 myh	US	LA	Kwe-Nee-Chee-Aht
 myi	IN	L	Mina
 myj	SS	L	Mangayat
+myj	SS	LA	Bug
 myj	SS	LA	Buga
 myj	SS	LA	Mangaya
 myj	SS	LA	Mongaiyat
@@ -34686,6 +35870,7 @@ myk	ML	D	Nejuu
 myk	ML	D	Sõghoo
 myk	ML	D	Suõõ
 myk	ML	L	Sénoufo, Mamara
+myk	ML	LA	Bamaraga
 myk	ML	LA	Mamara
 myk	ML	LA	Mianka
 myk	ML	LA	Minianka
@@ -34702,10 +35887,16 @@ mym	ET	DA	Mela
 mym	ET	DA	Podi
 mym	ET	L	Me’en
 mym	ET	LA	Mekan
+mym	ET	LA	Mela
 mym	ET	LA	Men
 mym	ET	LA	Meqan
 mym	ET	LA	Mie’en
 mym	ET	LA	Mieken
+mym	ET	LA	Suro
+mym	ET	LP	Teshenna
+mym	ET	LP	Teshina
+mym	ET	LP	Tishana
+mym	ET	LP	Tishena
 myo	ET	L	Anfillo
 myo	ET	LA	Southern Mao
 myp	BR	D	Múra
@@ -34726,7 +35917,10 @@ myu	BR	LA	Pari
 myu	BR	LA	Weidyenye
 myv	AM	L	Erzya
 myv	RU	L	Erzya
+myv	RU	LA	Erza-Mordvin
 myv	RU	LA	Erzia
+myv	RU	LA	Erzya Mordva
+myv	RU	LA	Erzya Mordvin
 myv	RU	LA	Mordvin
 myv	RU	LA	Mordvin-Erzya
 myw	PG	D	Iwa
@@ -34809,10 +36003,13 @@ mzd	CM	LA	Mulimba
 mze	PG	L	Morawa
 mzh	AR	L	Wichí Lhamtés Güisnay
 mzh	AR	LA	Güisnay
+mzh	AR	LA	Wichí
+mzh	AR	LA	Wichí Lhamtés
 mzh	AR	LP	Mataco
 mzh	AR	LP	Mataco Güisnay
 mzh	AR	LP	Mataco Pilcomayo
 mzi	MX	L	Mazatec, Ixcatlán
+mzi	MX	LA	En ningotsie
 mzi	MX	LA	Mazateco de presa bajo
 mzi	MX	LA	Mazateco de San Pedro Ixcatlán
 mzj	GN	D	Koinyaka
@@ -34885,7 +36082,6 @@ mzq	ID	D	Tambee
 mzq	ID	D	Ulu Uwoi
 mzq	ID	DA	Ajo
 mzq	ID	DA	South Mori
-mzq	ID	DA	Tambee
 mzq	ID	DA	Zuid-Mori
 mzq	ID	L	Mori Atas
 mzq	ID	LA	Aikoa
@@ -34957,14 +36153,6 @@ nab	BR	LA	Nambikwara
 nab	BR	LA	Nambiquara
 nac	PG	L	Narak
 nac	PG	LA	Ganja
-nad	AU	L	Nijadali
-nad	AU	LA	Bailko
-nad	AU	LA	Balgu
-nad	AU	LA	Balygu
-nad	AU	LA	Balyku
-nad	AU	LA	Jauna
-nad	AU	LA	Paljgu
-nad	AU	LA	Palyku
 nae	ID	L	Naka’ela
 naf	PG	L	Nabak
 naf	PG	LA	Naba
@@ -35053,6 +36241,12 @@ nan	ID	DA	Tiu Chiu
 nan	ID	L	Chinese, Min Nan
 nan	ID	LA	Min Nan
 nan	ID	LA	Minnan
+nan	KH	D	Hainan
+nan	KH	D	Hokkien
+nan	KH	D	Teochiu
+nan	KH	L	Chinese, Min Nan
+nan	KH	LA	Minnan
+nan	KH	LA	Southern Min
 nan	MO	L	Chinese, Min Nan
 nan	MY	D	Hainanese
 nan	MY	D	Hokkien
@@ -35145,6 +36339,8 @@ naq	NA	DA	Sesfontein Damara
 naq	NA	DA	Topnaar
 naq	NA	L	Khoekhoe
 naq	NA	LA	Bergdamara
+naq	NA	LA	Damara
+naq	NA	LA	Hai||’om
 naq	NA	LA	Khoekhoegowab
 naq	NA	LA	Khoekhoegowap
 naq	NA	LA	Maqua
@@ -35193,11 +36389,14 @@ nat	NG	LA	Ngwoi
 nat	NG	LA	Nkwoi
 nat	NG	LA	Ungwe
 nau	NR	L	Nauruan
+nau	NR	LA	Nauru
 nav	US	L	Navajo
+nav	US	LA	Diné
 nav	US	LA	Navaho
 naw	GH	L	Nawuri
 nax	PG	L	Nakwi
 nay	AU	L	Narrinyeri
+nay	AU	LA	Narinjari
 nay	AU	LA	Ngarinyeri
 nay	AU	LA	Ngarrindjeri
 nay	AU	LA	Yaralde
@@ -35368,6 +36567,7 @@ nbu	IN	LA	Maruongmai
 nbu	IN	LA	Nruanghmei
 nbu	IN	LA	Rongmai
 nbu	IN	LA	Rongmei
+nbu	IN	LA	Zeliang
 nbv	CM	L	Ngamambo
 nbv	CM	LA	Bafuchu
 nbv	CM	LA	Banja
@@ -35422,6 +36622,7 @@ ncd	NP	LA	Nacering Ra
 ncd	NP	LA	Nachering Tûm
 ncd	NP	LA	Nachiring
 ncd	NP	LA	Nasring
+ncd	NP	LA	Nasru Bhra
 nce	PG	L	Yale
 nce	PG	LA	Nagatiman
 nce	PG	LA	Nagatman
@@ -35440,11 +36641,14 @@ nch	MX	L	Nahuatl, Central Huasteca
 ncj	MX	L	Nahuatl, Northern Puebla
 ncj	MX	LA	Náhuatl del Norte de Puebla
 ncj	MX	LA	North Puebla Aztec
+ncj	MX	LA	North Puebla Sierra Nahuatl
 nck	AU	L	Nakara
 nck	AU	LA	Kokori
 nck	AU	LA	Nagara
+nck	AU	LA	Nakarra
 nck	AU	LA	Nakkara
 ncl	MX	L	Nahuatl, Michoacán
+ncl	MX	LA	Gente natural
 ncl	MX	LA	Mexicano
 ncl	MX	LA	Michoacan Aztec
 ncl	MX	LA	Nahual de Michoacán
@@ -35523,6 +36727,7 @@ ndb	CM	LA	Kenswey Nsey
 ndb	CM	LA	Melamba
 ndb	CM	LA	Mesing
 ndb	CM	LA	Ndop-Bamessing
+ndb	CM	LA	Nsei
 ndb	CM	LA	Veteng
 ndb	CM	LA	Vetweng
 ndc	MZ	D	Danda
@@ -35724,7 +36929,7 @@ nds	DE	LA	Nedderdütsch
 nds	DE	LA	Neddersassisch
 nds	DE	LA	Nedersaksisch
 nds	DE	LA	Niederdeutsch
-nds	DE	LA	Niedersaechsisch
+nds	DE	LA	Niedersächsisch
 nds	DE	LA	Plattdeutsch
 nds	DE	LA	Plattdüütsch
 ndt	CD	L	Ndunga
@@ -35777,6 +36982,7 @@ ndy	TD	DA	Rito
 ndy	TD	DA	Routo
 ndy	TD	L	Lutos
 ndz	SS	L	Ndogo
+ndz	SS	LA	Co Ndogo
 nea	ID	L	Ngad’a, Eastern
 nea	ID	LA	Southeast Ngada
 neb	CI	D	Boo
@@ -35876,6 +37082,9 @@ nev	LA	LA	Nyah Heuny
 nev	LA	LA	Nyahön
 nev	LA	LA	Yaheun
 new	IN	L	Newar
+new	IN	LA	Newa Bhaye
+new	IN	LA	Newaah Bhaae
+new	IN	LA	Newah Bhaaye
 new	IN	LP	Newari
 new	NP	D	Badikhel Pahari
 new	NP	D	Baglung
@@ -35893,7 +37102,10 @@ new	NP	DA	Pahari
 new	NP	DA	Pahri
 new	NP	L	Newar
 new	NP	LA	Nepal Bhasa
+new	NP	LA	Newa Bhaye
+new	NP	LA	Newaah Bhaae
 new	NP	LA	Newaah Bhaaye
+new	NP	LA	Newah Bhaaye
 new	NP	LA	Newal Bhaye
 new	NP	LP	Newari
 nex	PG	L	Neme
@@ -35935,6 +37147,7 @@ nfr	CI	L	Nafaanra
 nfr	GH	D	Fantera
 nfr	GH	D	Pantera
 nfr	GH	L	Nafaanra
+nfr	GH	LA	Banafo
 nfr	GH	LA	Banda
 nfr	GH	LA	Dzama
 nfr	GH	LA	Gambo
@@ -36012,17 +37225,23 @@ nge	CM	DA	Nsongwa
 nge	CM	L	Ngemba
 nge	CM	LA	Megimba
 nge	CM	LA	Mogimba
+nge	CM	LA	Mundum
 nge	CM	LA	Ngomba
 nge	CM	LA	Nguemba
 ngg	CF	L	Ngbaka Manza
+ngh	ZA	D	||Au
 ngh	ZA	D	||Ng!ke
-ngh	ZA	D	|’Auni
 ngh	ZA	D	N|u
 ngh	ZA	DA	||Ng
+ngh	ZA	DA	|’Auni
 ngh	ZA	DA	|Ing|ke
 ngh	ZA	DA	Ng||-|e
 ngh	ZA	L	N|u
 ngh	ZA	LA	‡Khomani
+ngh	ZA	LA	N||ng
+ngh	ZA	LA	N|huuki
+ngh	ZA	LA	N|uu
+ngh	ZA	LA	N|uuki
 ngh	ZA	LA	Nghuki
 ngh	ZA	LA	Ng’uki
 ngi	NG	L	Ngizim
@@ -36145,6 +37364,7 @@ ngt	LA	LA	Nkriang
 ngu	MX	L	Nahuatl, Guerrero
 ngu	MX	LA	Guerrero Aztec
 ngu	MX	LA	Náhuatl de Guerrero
+ngu	MX	LA	Xalitla Nahuatl
 ngv	CM	L	Nagumi
 ngv	CM	LA	Bama
 ngv	CM	LA	Gong
@@ -36191,9 +37411,9 @@ nhb	CI	LA	Nguin
 nhc	MX	L	Nahuatl, Tabasco
 nhc	MX	LA	Tabasco Aztec
 nhd	AR	D	Apapocuva
-nhd	AR	L	Chiripá
+nhd	AR	L	Ava Guaraní
 nhd	AR	LA	Apytare
-nhd	AR	LA	Ava Guaraní
+nhd	AR	LA	Chiripá
 nhd	AR	LA	Ñandeva
 nhd	AR	LA	Nhandeva
 nhd	AR	LA	Tsiripá
@@ -36201,6 +37421,7 @@ nhd	AR	LA	Txiripá
 nhd	BR	D	Apapocuva
 nhd	BR	L	Chiripá
 nhd	BR	LA	Apytare
+nhd	BR	LA	Ava Guaraní
 nhd	BR	LA	Guaraní
 nhd	BR	LA	Nandeva
 nhd	BR	LA	Ñandeva
@@ -36211,6 +37432,7 @@ nhd	PY	D	Apapocuva
 nhd	PY	L	Guaraní, Ava
 nhd	PY	LA	Apytare
 nhd	PY	LA	Ava
+nhd	PY	LA	Ava Guaraní
 nhd	PY	LA	Chiripá
 nhd	PY	LA	Tsiripá
 nhd	PY	LA	Txiripá
@@ -36240,6 +37462,7 @@ nhm	MX	LA	Náhuatl de Cuentepec
 nhn	MX	L	Nahuatl, Central
 nhn	MX	LA	Central Aztec
 nhn	MX	LA	Náhuatl del Centro
+nhn	MX	LA	Nawa
 nhn	MX	LA	Tlaxcala-Puebla Nahuatl
 nho	PG	L	Takuu
 nho	PG	LA	Mortlock
@@ -36248,16 +37471,18 @@ nho	PG	LA	Tau
 nho	PG	LA	Tauu
 nhp	MX	L	Nahuatl, Isthmus-Pajapan
 nhp	MX	LA	Náhuat de Pajapan
+nhp	MX	LA	Pajapan Nahuatl
 nhq	MX	L	Nahuatl, Huaxcaleca
 nhq	MX	LA	Huaxcaleca Aztec
 nhq	MX	LA	Náhuatl de Chichiquila
 nhr	BW	D	N|hai-Ntse’e
 nhr	BW	D	Qabekhoe
-nhr	BW	D	Ts’aokhoe
+nhr	BW	D	Ts’ao
 nhr	BW	DA	!Kabbakwe
 nhr	BW	DA	N||hai
 nhr	BW	DA	Qabekho
 nhr	BW	DA	Ts’ao
+nhr	BW	DA	Ts’aokhoe
 nhr	BW	DA	Tsaokhwe
 nhr	BW	DA	Tsaukwe
 nhr	BW	L	Naro
@@ -36289,6 +37514,8 @@ nhw	MX	LA	Náhuatl de Tamazunchale
 nhw	MX	LA	Western Huasteca Aztec
 nhx	MX	L	Nahuatl, Isthmus-Mecayapan
 nhx	MX	LA	Isthmus Aztec-Mecayapan
+nhx	MX	LA	Isthmus Nahuatl
+nhx	MX	LA	Mecayapan Isthmus Nahuatl
 nhx	MX	LA	Náhuat de Mecayapan
 nhy	MX	L	Nahuatl, Northern Oaxaca
 nhy	MX	LA	Náhuatl del Norte de Oaxaca
@@ -36433,10 +37660,12 @@ nix	CD	LA	Runyoro
 nix	CD	LA	Southern Hema
 niy	CD	L	Ngiti
 niy	CD	LA	Bindi
+niy	CD	LA	Dru
 niy	CD	LA	Druna
 niy	CD	LA	Kingeti
 niy	CD	LA	Kingiti
 niy	CD	LA	Lendu-Sud
+niy	CD	LA	Ndruna
 niy	CD	LA	Ngeti
 niz	PG	L	Ningil
 nja	CM	D	Holma
@@ -36559,6 +37788,7 @@ njn	IN	LA	Liangmei
 njn	IN	LA	Liyang
 njn	IN	LA	Lyangmay
 njn	IN	LA	Lyengmai
+njn	IN	LA	Zeliang
 njo	IN	D	Changki
 njo	IN	D	Chongli
 njo	IN	D	Dordar
@@ -36664,6 +37894,7 @@ nke	SB	LA	Kolombangara
 nke	SB	LA	Ndughore
 nke	SB	LA	Nduke
 nkf	IN	L	Naga, Inpui
+nkf	IN	LA	Inpui
 nkf	IN	LA	Kabui
 nkf	IN	LA	Kabui Naga
 nkf	IN	LA	Kapwi
@@ -36758,7 +37989,6 @@ nld	BE	D	Antwerps
 nld	BE	D	Brabants
 nld	BE	D	Oost-Vlaams
 nld	BE	L	Dutch
-nld	BE	LA	Dutch
 nld	BE	LA	Flemish
 nld	BE	LA	Nederlands
 nld	BE	LA	Vlaams
@@ -36810,17 +38040,6 @@ nlo	CD	LA	Ngulu
 nlq	MM	L	Naga, Lao
 nlq	MM	LA	Law
 nlq	MM	LA	Loh
-nlr	AU	L	Ngarla
-nlr	AU	LA	Inawangga
-nlr	AU	LA	Inawonga
-nlr	AU	LA	Inawongga
-nlr	AU	LA	Nalawonga
-nlr	AU	LA	Ngalawonga
-nlr	AU	LA	Ngalawongga
-nlr	AU	LA	Ngarla-warngga
-nlr	AU	LA	Ngaunmardi
-nlr	AU	LA	Ninanu
-nlr	AU	LA	Yinhawangka
 nlu	GH	L	Nchumbulu
 nlv	MX	D	Ixhuatlancillo Nahuatl
 nlv	MX	L	Nahuatl, Orizaba
@@ -36955,8 +38174,10 @@ nmm	NP	LA	Manang
 nmm	NP	LA	Manang Ke
 nmm	NP	LA	Manange
 nmm	NP	LA	Manangi
+nmm	NP	LA	Nyangmi ke
 nmm	NP	LA	Nyeshang
 nmm	NP	LA	Nyeshangte
+nmm	NP	LA	Nyeshangte Ke
 nmm	NP	LA	Nyishang
 nmm	NP	LP	Manangbhot
 nmn	BW	D	!Kwi
@@ -37022,6 +38243,7 @@ nmq	BW	LA	Chinambya
 nmq	BW	LA	Nambzya
 nmq	BW	LA	Nanzva
 nmq	ZW	L	Nambya
+nmq	ZW	LA	Banyai
 nmq	ZW	LA	Chinambya
 nmq	ZW	LA	Nambzya
 nmq	ZW	LA	Nanzva
@@ -37054,6 +38276,7 @@ nmy	CN	D	Western Namuyi
 nmy	CN	L	Namuyi
 nmy	CN	LA	Naimuci
 nmy	CN	LA	Naimuzi
+nmy	CN	LA	Namuzi
 nmz	GH	L	Nawdm
 nmz	GH	LA	Naoudem
 nmz	GH	LA	Naudm
@@ -37143,6 +38366,7 @@ nnh	CM	LA	Bamileke-Ngiemboon
 nnh	CM	LA	Bamileke-Ngyemboon
 nnh	CM	LA	Nguemba
 nnh	CM	LA	Ngyemboon
+nnh	CM	LA	Shwoge
 nni	ID	L	Nuaulu, North
 nni	ID	LA	Fatakai
 nni	ID	LA	Nuaulu
@@ -37170,6 +38394,8 @@ nnn	TD	LA	Nge’dé
 nnn	TD	LA	Ngueté
 nnn	TD	LA	Nguetté
 nnn	TD	LA	Zime
+nno	NO	L	Norwegian Nynorsk
+nno	NO	LA	Nynorsk
 nnp	IN	D	Bor Muthun
 nnp	IN	D	Changnoi
 nnp	IN	D	Horu Muthun
@@ -37205,6 +38431,7 @@ nnu	GH	D	Bekye
 nnu	GH	D	Kenyen
 nnu	GH	D	Wiase
 nnu	GH	L	Dwang
+nnu	GH	LA	Bassa
 nnu	GH	LA	Dwan
 nnu	GH	LA	Nchumunu
 nnv	AU	L	Nugunu
@@ -37262,6 +38489,8 @@ noa	CO	L	Woun Meu
 noa	CO	LA	Waumeo
 noa	CO	LA	Waun Meo
 noa	CO	LA	Waunana
+noa	CO	LA	Woun Meo
+noa	CO	LA	Wounaan
 noa	PA	L	Woun Meu
 noa	PA	LA	Chanco
 noa	PA	LA	Chocama
@@ -37271,17 +38500,23 @@ noa	PA	LA	Nonama
 noa	PA	LA	Waumeo
 noa	PA	LA	Waun Meo
 noa	PA	LA	Waunana
+noa	PA	LA	Woun Meo
+noa	PA	LA	Wounaan
 noa	PA	LA	Wounmeu
+nob	NO	L	Norwegian Bokmål
+nob	NO	LA	Norsk Bokmål
 noc	PG	D	North Nuk
 noc	PG	D	South Nuk
 noc	PG	L	Nuk
 nod	LA	D	Nan
 nod	LA	L	Thai, Northern
+nod	LA	LA	Kam Mueang
 nod	LA	LA	Lan Na
 nod	LA	LA	Lanatai
 nod	LA	LA	Lanna
 nod	LA	LA	Lannatai
 nod	LA	LA	Muang
+nod	LA	LA	Mueang
 nod	LA	LA	Myang
 nod	LA	LP	Youanne
 nod	LA	LP	Youon
@@ -37291,16 +38526,19 @@ nod	TH	D	Nan
 nod	TH	D	Tai Wang
 nod	TH	L	Thai, Northern
 nod	TH	LA	Kam Mu’ang
+nod	TH	LA	Kam Mueang
 nod	TH	LA	Kammüang
 nod	TH	LA	Kammyang
 nod	TH	LA	Khon
 nod	TH	LA	Khon Meang
 nod	TH	LA	Khon Myang
+nod	TH	LA	Khonmuang
 nod	TH	LA	La Nya
 nod	TH	LA	Lan Na
 nod	TH	LA	Lanatai
 nod	TH	LA	Lanna
 nod	TH	LA	Mu’ang
+nod	TH	LA	Mueang
 nod	TH	LA	Mung
 nod	TH	LA	Myang
 nod	TH	LA	Northern Thai
@@ -37344,9 +38582,13 @@ nog	RU	LA	Noghaylar
 noh	PG	L	Nomu
 noi	IN	D	Barutiya
 noi	IN	L	Noiri
+noi	IN	LA	Mathwadi Bhilori
 noj	CO	L	Nonuya
+noj	CO	LA	Nononota
 noj	PE	L	Nonuya
+noj	PE	LA	Nononota
 nok	US	L	Nooksack
+nok	US	LA	Lhéchelesem
 nok	US	LA	Nootsack
 nol	US	L	Nomlaki
 nol	US	LA	Central Wintun
@@ -37367,9 +38609,12 @@ nor	NO	L	Norwegian
 nor	NO	LA	Norsk
 nos	CN	L	Nisu, Eastern
 nos	CN	LA	Nisu
+nos	CN	LA	Nisupho
 nos	CN	LA	Shiping-Jianshui Nisu
 nos	CN	LA	Shiping-Jianshui Yi
-not	PE	L	Nomatsiguenga
+not	PE	L	Nomatsigenga
+not	PE	LA	Atiri
+not	PE	LA	Nomatsiguenga
 not	PE	LP	Nomatsiguenga Campa
 nou	PG	D	Ewage-Notu
 nou	PG	D	Yega
@@ -37408,9 +38653,11 @@ npg	MM	D	Ponyo
 npg	MM	L	Naga, Ponyo-Gongwang
 npg	MM	LA	Gongvan
 npg	MM	LA	Gongwang
+npg	MM	LA	Gongwang Naga
 npg	MM	LA	Manauk
 npg	MM	LA	Mannok
 npg	MM	LA	Ponyo
+npg	MM	LA	Ponyo Naga
 npg	MM	LA	Pounyu
 npg	MM	LA	Saplow
 npg	MM	LA	Solo
@@ -37484,6 +38731,7 @@ nqg	BJ	LA	Nago
 nqg	BJ	LA	Nagot
 nqg	BJ	LA	Nagots
 nqk	BJ	L	Ede Nago, Kura
+nqk	BJ	LA	Kura
 nqk	BJ	LA	Nago
 nqm	ID	L	Ndom
 nqn	PG	L	Nen
@@ -37504,6 +38752,7 @@ nqq	MM	LA	Kayaw
 nqq	MM	LA	Kayu
 nqq	MM	LA	Kyan
 nqy	MM	L	Naga, Akyaung Ari
+nqy	MM	LA	Akyaung Ari Naga
 nqy	MM	LA	Ngachan
 nra	CG	L	Ngom
 nra	CG	LA	Angom
@@ -37526,6 +38775,7 @@ nrb	ER	D	Higir
 nrb	ER	D	Koyta
 nrb	ER	D	Santora
 nrb	ER	L	Nara
+nrb	ER	LA	Nera
 nrb	ER	LP	Barea
 nrb	ER	LP	Baria
 nrb	ER	LP	Barya
@@ -37545,6 +38795,10 @@ nre	IN	LA	Rengma Naga
 nre	IN	LA	Southern Rengma
 nre	IN	LA	Unza
 nre	IN	LA	Western Rengma
+nrf	FR	D	Augeron
+nrf	FR	D	Cauchois
+nrf	FR	D	Cotentinais
+nrf	FR	L	Norman French
 nrf	GG	D	Serquiais
 nrf	GG	L	Guernésiais
 nrf	GG	LA	Dgernesiais
@@ -37559,6 +38813,14 @@ nri	IN	LA	Chakrima Naga
 nri	IN	LA	Chakru
 nri	IN	LA	Chokri
 nri	IN	LA	Eastern Angami
+nrk	AU	L	Ngarla
+nrk	AU	LA	Gnalla
+nrk	AU	LA	Kudjunguru
+nrk	AU	LA	Ngala
+nrk	AU	LA	Ngalana
+nrk	AU	LA	Ngerla
+nrk	AU	LA	Ngirla
+nrk	AU	LA	Ngurla
 nrl	AU	L	Ngarluma
 nrl	AU	LA	Gnalluma
 nrl	AU	LA	Gnalouma
@@ -37579,9 +38841,11 @@ nrr	IN	LA	Noza
 nrr	IN	LA	Nurra
 nru	CN	L	Narua
 nru	CN	LA	Eastern Naxi
+nru	CN	LA	Meng yu
 nru	CN	LA	Moso
 nru	CN	LA	Mosso
 nru	CN	LA	Mosuo
+nru	CN	LA	Musuo yu
 nru	CN	LA	Na
 nru	CN	LA	Naru
 nru	CN	LA	Nazu
@@ -37614,6 +38878,7 @@ nsc	NG	L	Nshi
 nsd	CN	D	Mojiang Nisu
 nsd	CN	D	Yuanyang Nisu
 nsd	CN	L	Nisu, Southern
+nsd	CN	LA	Nisupho
 nsd	CN	LA	Yuan-Mo Yi
 nse	MZ	L	Nsenga
 nse	MZ	LA	Chinsenga
@@ -37632,6 +38897,7 @@ nse	ZW	LA	Chinsenga
 nse	ZW	LA	Cinsenga
 nse	ZW	LA	Senga
 nsf	CN	L	Nisu, Northwestern
+nsf	CN	LA	Nisu
 nsg	TZ	L	Ngasa
 nsg	TZ	LA	Kingasa
 nsg	TZ	LA	Kingassa
@@ -37640,6 +38906,10 @@ nsg	TZ	LA	Shaka
 nsh	CM	L	Ngoshie
 nsh	CM	LA	Ngishe
 nsh	CM	LA	Oshie
+nsi	NG	D	Southern/southeastern
+nsi	NG	D	Western
+nsi	NG	DA	Imo state
+nsi	NG	DA	Lagos
 nsi	NG	L	Nigerian Sign Language
 nsi	NG	LA	NSL
 nsk	CA	D	Eastern Naskapi
@@ -37664,8 +38934,9 @@ nsm	IN	L	Naga, Sumi
 nsm	IN	LA	Sema
 nsm	IN	LA	Simi
 nsm	IN	LA	Sumi
-nsn	PG	D	Nehan
 nsn	PG	D	Pinipel
+nsn	PG	D	Sirouatan
+nsn	PG	D	Uanuleik
 nsn	PG	DA	Pinipin
 nsn	PG	L	Nehan
 nsn	PG	LA	Nihan
@@ -37761,6 +39032,7 @@ nst	IN	LA	Cham Chang
 nst	IN	LA	Rangpan
 nst	IN	LA	Tangsa
 nst	IN	LA	Tangshang
+nst	IN	LA	Tase
 nst	IN	LA	Tasey
 nst	MM	D	Asen
 nst	MM	D	Bote
@@ -37916,6 +39188,7 @@ nst	MM	LA	Rangpan
 nst	MM	LA	Rangpang
 nst	MM	LA	Tangshang
 nst	MM	LA	Tangwa
+nst	MM	LA	Tase
 nsu	MX	D	Coyomeapan
 nsu	MX	D	Zoquitlan
 nsu	MX	L	Nahuatl, Sierra Negra
@@ -37934,6 +39207,21 @@ nsz	US	LA	Nishinam
 nsz	US	LA	Pujuni
 nsz	US	LA	Southern Maidu
 nsz	US	LA	Wapumni
+ntd	MY	D	Sesayap
+ntd	MY	D	Tarakan
+ntd	MY	DA	Sesajap
+ntd	MY	DA	Terakan
+ntd	MY	L	Tidung, Northern
+ntd	MY	LA	Camucones
+ntd	MY	LA	Nonukan
+ntd	MY	LA	Tedong
+ntd	MY	LA	Tidoeng
+ntd	MY	LA	Tidong
+ntd	MY	LA	Tidung
+ntd	MY	LA	Tiran
+ntd	MY	LA	Tirones
+ntd	MY	LA	Tiroon
+ntd	MY	LA	Zedong
 nte	MZ	L	Nathembo
 nte	MZ	LA	Esakaji
 nte	MZ	LA	Sakaji
@@ -37953,6 +39241,7 @@ nti	BF	LA	Natyoro
 ntj	AU	L	Ngaanyatjarra
 ntj	AU	LA	Ngaanjatjarra
 ntj	AU	LA	Ngaanyatjara
+ntj	AU	LA	Western Desert Language
 ntk	TZ	D	Ikoma
 ntk	TZ	D	Isenye
 ntk	TZ	D	Nata
@@ -38002,7 +39291,6 @@ ntr	TG	L	Delo
 ntr	TG	LA	Ntribou
 ntr	TG	LA	Ntribu
 ntr	TG	LA	Ntrubo
-nts	CO	L	Natagaimas
 ntu	SB	D	Bënwë
 ntu	SB	D	Londai
 ntu	SB	D	Malo
@@ -38014,11 +39302,13 @@ ntu	SB	L	Natügu
 ntu	SB	LA	Nambakaengö
 ntu	SB	LA	Natqgu
 ntu	SB	LA	Northern Santa Cruz
+ntu	SB	LA	Santa Cruz
 ntw	US	L	Nottoway
 ntx	MM	D	Somra
 ntx	MM	L	Naga, Tangkhul
 ntx	MM	LA	Somara
 ntx	MM	LA	Somra
+ntx	MM	LA	Tangkhul Naga
 nty	VN	L	Mantsi
 nty	VN	LA	Black Lolo
 nty	VN	LA	Flowery Lolo
@@ -38111,11 +39401,12 @@ nuk	CA	D	Ucluelet
 nuk	CA	L	Nuu-chah-nulth
 nuk	CA	LA	Aht
 nuk	CA	LA	Nootka
+nuk	CA	LA	Nootkans
 nuk	CA	LA	Nutka
 nuk	CA	LA	Nuučaan’ul
 nuk	CA	LA	Quuquu’aca
 nuk	CA	LA	T’aat’aaqsapa
-nuk	CA	LA	Westcoast
+nuk	CA	LA	West Coast
 nul	ID	L	Nusa Laut
 nul	ID	LA	Nusalaut
 num	TO	L	Niuafo’ou
@@ -38174,10 +39465,11 @@ nuq	PG	D	Nukumanu
 nuq	PG	L	Nukumanu
 nuq	PG	LA	Tasman
 nur	PG	D	Nukeria
-nur	PG	L	Nukuria
+nur	PG	L	Nukeria
 nur	PG	LA	Fead
 nur	PG	LA	Nahoa
 nur	PG	LA	Nuguria
+nur	PG	LA	Nukuria
 nus	ET	D	Eastern Nuer
 nus	ET	DA	Abigar
 nus	ET	DA	Door
@@ -38224,6 +39516,7 @@ nut	VN	DA	Nùng Fan Slihng
 nut	VN	L	Nung
 nut	VN	LA	Bu-Nong
 nut	VN	LA	Highland Nung
+nut	VN	LA	Lungchow
 nut	VN	LA	Nong
 nut	VN	LA	Tai Nung
 nut	VN	LA	Tay
@@ -38258,14 +39551,16 @@ nvo	CM	LA	Fung
 nvo	CM	LA	Hung
 nvo	CM	LA	Ni Nyo’o
 nvo	CM	LA	Nyo’on
-nwb	CI	D	Kouzié
+nwb	CI	D	Kouzii
 nwb	CI	D	Nyabwa
 nwb	CI	D	Nyedebwa
+nwb	CI	DA	Kouzié
 nwb	CI	DA	Niédéboua
 nwb	CI	L	Nyabwa
 nwb	CI	LA	Niaboua
 nwb	CI	LA	Nyaboa
 nwb	CI	LA	Nyabwa-Nyédébwa
+nwb	CI	LP	Bété
 nwe	CM	L	Ngwe
 nwe	CM	LA	Bamileke-Ngwe
 nwe	CM	LA	Fomopea
@@ -38289,7 +39584,6 @@ nwm	SS	D	Molo
 nwm	SS	D	Nyamusa
 nwm	SS	L	Nyamusa-Molo
 nwo	AU	L	Nauo
-nwo	AU	LA	Battara
 nwo	AU	LA	Growoo
 nwo	AU	LA	Naua
 nwo	AU	LA	Nawo
@@ -38328,14 +39622,16 @@ nxg	ID	LA	Rokka
 nxi	TZ	L	Nindi
 nxi	TZ	LA	Kinindi
 nxi	TZ	LA	Manundi
-nxk	MM	L	Naga, Koki
+nxk	MM	L	Kokak
+nxk	MM	LA	Koki
 nxk	MM	LA	Konke
+nxk	MM	LA	Naga, Koki
 nxl	ID	L	Nuaulu, South
 nxl	ID	LA	Fatakai
 nxl	ID	LA	Nuaulu
 nxl	ID	LA	Patakai
 nxn	AU	L	Ngawun
-nxo	GA	L	Ndambono
+nxo	GA	L	Ndambomo
 nxq	CN	D	Lapao
 nxq	CN	D	Lijiang
 nxq	CN	D	Ludian
@@ -38371,6 +39667,10 @@ nxr	PG	LA	Tedi
 nxr	PG	LA	Tidi
 nxu	ID	L	Narau
 nxx	ID	L	Nafri
+nya	BW	L	Chichewa
+nya	BW	LA	Chinjanja
+nya	BW	LA	Chinyanja
+nya	BW	LA	Nyanja
 nya	MW	D	Chewa
 nya	MW	D	Manganja
 nya	MW	D	Ngoni
@@ -38531,6 +39831,7 @@ nyo	UG	D	Rutagwenda
 nyo	UG	DA	Nyoro
 nyo	UG	L	Nyoro
 nyo	UG	LA	Kyopi
+nyo	UG	LA	Lunyoro
 nyo	UG	LA	Orunyoro
 nyo	UG	LA	Runyoro
 nyp	UG	L	Nyang’i
@@ -38705,14 +40006,19 @@ nzm	IN	D	Njauna
 nzm	IN	D	Paren
 nzm	IN	L	Naga, Zeme
 nzm	IN	LA	Arung
+nzm	IN	LA	Empeo
 nzm	IN	LA	Empui
 nzm	IN	LA	Jeme
 nzm	IN	LA	Kacha
 nzm	IN	LA	Kachcha
+nzm	IN	LA	Kachcha Naga
 nzm	IN	LA	Kutcha
 nzm	IN	LA	Mezama
 nzm	IN	LA	Sangrima
 nzm	IN	LA	Sengima
+nzm	IN	LA	Zeliang
+nzm	IN	LA	Zeliangrong
+nzm	IN	LA	Zeme
 nzm	IN	LA	Zemi
 nzs	NZ	L	New Zealand Sign Language
 nzs	NZ	LA	NZSL
@@ -38768,6 +40074,7 @@ obo	PH	D	Marilog
 obo	PH	L	Manobo, Obo
 obo	PH	LA	Bagobo
 obo	PH	LA	Kidapawan Manobo
+obo	PH	LA	Manobo
 obo	PH	LA	Obo Bagobo
 obu	NG	L	Obulom
 obu	NG	LA	Abuloma
@@ -38802,7 +40109,6 @@ oci	FR	DA	Lemosin
 oci	FR	DA	Lengadoucian
 oci	FR	DA	Mistralien
 oci	FR	DA	Prouvençau
-oci	FR	DA	Provençal
 oci	FR	L	Occitan
 oci	FR	LA	Occitani
 oci	IT	D	Provençal
@@ -38813,6 +40119,7 @@ oci	MC	D	Provencal
 oci	MC	L	Occitan
 ocu	MX	L	Matlatzinca, Atzingo
 ocu	MX	LA	Atzinteco
+ocu	MX	LA	Matlatzinka
 ocu	MX	LA	Ocuiltec
 ocu	MX	LA	Ocuilteco
 ocu	MX	LA	Tlahuica
@@ -38820,6 +40127,7 @@ ocu	MX	LA	Tlahura
 oda	NG	L	Odut
 odk	PK	L	Od
 odk	PK	LA	Oad
+odk	PK	LA	Oadki
 odk	PK	LA	Odki
 odu	NG	D	Adibom
 odu	NG	D	Arughunya
@@ -38851,6 +40159,7 @@ ogo	NG	LA	Kana
 ogo	NG	LA	Ogoni
 ogu	NG	L	Ogbronuagum
 ogu	NG	LA	Bukuma
+ogu	NG	LA	Obronuagum
 oia	ID	L	Oirata
 oia	ID	LA	Maaro
 oin	PG	L	One, Inebu
@@ -38893,13 +40202,16 @@ ojv	SB	LA	Lord Howe
 ojv	SB	LA	Luangiua
 ojv	SB	LA	Luaniua
 ojw	CA	L	Ojibwa, Western
+ojw	CA	LA	Anishnaubemowin
 ojw	CA	LA	Ojibway
 ojw	CA	LA	Ojibwe
 ojw	CA	LA	Plains Ojibway
+ojw	CA	LA	Saulteau
 ojw	CA	LA	Saulteaux
 oka	CA	D	Sanpoil
 oka	CA	D	Southern Okanogan
 oka	CA	L	Okanagan
+oka	CA	LA	Colville-Okanagan
 oka	CA	LA	Nsyilxcen
 oka	CA	LA	Okanagan-Colville
 oka	CA	LA	Okanagon
@@ -38909,11 +40221,13 @@ oka	US	D	Lake
 oka	US	D	Sanpoil
 oka	US	D	Southern Okanogan
 oka	US	L	Okanagan
+oka	US	LA	Nsyilxcen
 oka	US	LA	Okanagan-Colville
 oka	US	LA	Okanagon
 oka	US	LA	Okanogan
 okb	NG	L	Okobo
 okd	NG	L	Okodia
+okd	NG	LA	Akita
 okd	NG	LA	Okordia
 oke	NG	L	Okpe
 okg	AU	L	Koko Babangk
@@ -38934,6 +40248,7 @@ oki	KE	LA	Kinare
 oki	KE	LA	Ogiek
 oki	KE	LP	Ndorobo
 oki	TZ	L	Okiek
+oki	TZ	LA	Akie
 oki	TZ	LA	Akiek
 okj	IN	L	Oko-Juwoi
 okj	IN	LA	Junoi
@@ -38978,6 +40293,8 @@ okv	PG	L	Orokaiva
 okv	PG	LA	Ehija
 okv	PG	LA	Etija
 okx	NG	L	Okpe
+ola	CN	L	Walungge
+ola	IN	L	Walungge
 ola	NP	D	Ghunsa River
 ola	NP	D	Olangchung Gola
 ola	NP	D	Topke Gola
@@ -39020,6 +40337,7 @@ olm	NG	L	Oloma
 olo	FI	L	Livvi
 olo	FI	LA	Aunus
 olo	FI	LA	Livvikovian
+olo	FI	LA	Livvin kieli
 olo	FI	LA	Olonets
 olo	FI	LA	Olonetsian
 olo	RU	L	Livvi-Karelian
@@ -39027,12 +40345,18 @@ olo	RU	LA	Karelian
 olo	RU	LA	Livvi
 olo	RU	LA	Livvikovian
 olo	RU	LA	Livvikovskij Jazyk
+olo	RU	LA	Livvin kieli
 olo	RU	LA	Olonets
 olo	RU	LA	Southern Olonetsian
 olr	VU	L	Olrat
+olu	AO	L	Kuvale
+olu	AO	LA	Mucubal
+olu	AO	LA	Olukuvale
 oma	US	D	Omaha
 oma	US	D	Ponca
 oma	US	L	Omaha-Ponca
+oma	US	LA	Cegiha
+oma	US	LA	Dhegiha
 oma	US	LA	Mahairi
 oma	US	LA	Ponka
 oma	US	LA	Ppankka
@@ -39051,7 +40375,6 @@ omb	VU	LA	Northeast Aoba
 omb	VU	LA	Oba
 omb	VU	LA	Omba
 omb	VU	LA	Walurigi
-ome	CO	L	Omejes
 omg	BR	D	Aizuare
 omg	BR	D	Curacirari
 omg	BR	D	Curucicuri
@@ -39190,6 +40513,7 @@ onu	VU	D	Pangkumu
 onu	VU	L	Unua
 onu	VU	LA	Onua
 onx	ID	L	Onin Based Pidgin
+ood	MX	L	Tohono O’odham
 ood	US	D	Akimel O’odham
 ood	US	D	Tohono O’odam
 ood	US	DA	Pima
@@ -39200,6 +40524,7 @@ ood	US	LA	Nevome
 ood	US	LA	O’odham
 ood	US	LA	O’othham
 ood	US	LA	Papago-Pima
+ood	US	LA	Tohono O’otham
 ood	US	LA	Upper Piman
 oog	LA	L	Ong
 oog	LA	LA	Hantong
@@ -39239,14 +40564,15 @@ orc	KE	DA	Korokoro
 orc	KE	DA	Munyo Yaya
 orc	KE	L	Orma
 ore	PE	D	Nebaji
-ore	PE	L	Orejón
+ore	PE	L	Maijuna
 ore	PE	LA	Coto
 ore	PE	LA	Koto
 ore	PE	LA	Mai Ja
-ore	PE	LA	Orechon
-ore	PE	LA	Oregon
 ore	PE	LA	Payagua
 ore	PE	LA	Tutapi
+ore	PE	LP	Orechon
+ore	PE	LP	Oregon
+ore	PE	LP	Orejón
 org	NG	D	Okpoto
 org	NG	D	Ufia
 org	NG	D	Ufiom
@@ -39286,7 +40612,10 @@ ors	MY	L	Orang Seletar
 ors	MY	LA	Orang Laut
 ors	SG	L	Orang Seletar
 ort	IN	L	Oriya, Adivasi
+ort	IN	LA	Adivasi
 ort	IN	LA	Adiwasi Oriya
+ort	IN	LA	Desiya
+ort	IN	LA	Kotia
 ort	IN	LA	Kotia Oriya
 ort	IN	LA	Kotiya
 ort	IN	LA	Tribal Oriya
@@ -39310,20 +40639,21 @@ orw	BR	L	Oro Win
 orx	NG	L	Oro
 orx	NG	LA	Oron
 ory	IN	D	Halbi
-ory	IN	D	Midnapore Oriya
+ory	IN	D	Midnapore Odia
 ory	IN	D	Mughalbandi
-ory	IN	D	North Balasore Oriya
-ory	IN	D	Northwestern Oriya
-ory	IN	D	Southern Oriya
-ory	IN	D	Western Oriya
-ory	IN	DA	Oriya Proper
+ory	IN	D	North Balasore Odia
+ory	IN	D	Northwestern Odia
+ory	IN	D	Southern Odia
+ory	IN	D	Western Odia
+ory	IN	DA	Odia Proper
 ory	IN	DA	Sambalpuri
-ory	IN	DA	Standard Oriya
-ory	IN	L	Oriya
+ory	IN	DA	Standard Odia
+ory	IN	L	Odia
 ory	IN	LA	Odisha
 ory	IN	LA	Odri
 ory	IN	LA	Odrum
 ory	IN	LA	Oliya
+ory	IN	LA	Oriya
 ory	IN	LA	Uriya
 ory	IN	LA	Utkali
 ory	IN	LA	Vadiya
@@ -39388,10 +40718,11 @@ otm	MX	L	Otomi, Eastern Highland
 otm	MX	LA	Eastern Otomi
 otm	MX	LA	Otomí de Huehuetla
 otm	MX	LA	Otomí de la Sierra
-otm	MX	LA	Otomi de la Sierra Madre Oriental
-otm	MX	LA	Otomi de la Sierra Oriental
+otm	MX	LA	Otomí de la Sierra Madre Oriental
+otm	MX	LA	Otomí de la Sierra Oriental
 otm	MX	LA	Otomí del Oriente
 otm	MX	LA	Sierra Oriental Otomi
+otm	MX	LA	Sierra Otomi
 otm	MX	LA	Yuhu
 otn	MX	L	Otomi, Tenango
 otn	MX	LA	Otomí de Tenango
@@ -39399,6 +40730,7 @@ otq	MX	L	Otomi, Querétaro
 otq	MX	LA	Hñohño
 otq	MX	LA	Northwestern Otomi
 otq	MX	LA	Otomí de Querétaro
+otq	MX	LA	Santiago Mexquititlan Otomi
 otq	MX	LA	Western Otomi
 otr	SD	D	Dogoridi
 otr	SD	D	Dorobe
@@ -39411,7 +40743,7 @@ otr	SD	LA	Kawarma
 otr	SD	LA	Litoro
 otr	SD	LA	Utoro
 ots	MX	D	San Felipe Santiago Otomí
-ots	MX	L	Otomi, Estado de México
+ots	MX	L	Otomí, Estado de México
 ots	MX	LA	Hñatho
 ots	MX	LA	Otomí de San Felipe Santiago
 ots	MX	LA	Otomí del Estado de México
@@ -39431,11 +40763,12 @@ otw	US	LA	Eastern Ojibwa
 otw	US	LA	Odawa
 otw	US	LA	Ojibwe
 otx	MX	L	Otomi, Texcatepec
-otx	MX	LA	Northeastern Otomí
+otx	MX	LA	Northeastern Otomi
 otx	MX	LA	Otomí de Texcatepec
 otz	MX	L	Otomi, Ixtenco
 otz	MX	LA	Otomí de Ixtenco
 otz	MX	LA	Southeastern Otomí
+otz	MX	LA	Yühmu
 oua	DZ	D	Ouedghir
 oua	DZ	D	Tariyit
 oua	DZ	D	Temacin
@@ -39459,12 +40792,17 @@ oue	PG	LA	Ounge
 oum	PG	L	Ouma
 owi	PG	L	Owiniga
 owi	PG	LA	Bero
+owi	PG	LA	Owininga
 owi	PG	LA	Samo
 owi	PG	LA	Taina
 oyb	LA	D	Inn Tea
+oyb	LA	D	Khen Sang
+oyb	LA	D	Kongsang
 oyb	LA	D	Kranyeu
+oyb	LA	D	La-Nyao
 oyb	LA	D	Riyao
 oyb	LA	D	Tamal Euy
+oyb	LA	D	The
 oyb	LA	L	Oy
 oyb	LA	LA	Huei
 oyb	LA	LA	Oi
@@ -39524,8 +40862,10 @@ pab	BR	LA	Haliti
 pab	BR	LA	Pareás
 pab	BR	LA	Paresí
 pab	BR	LA	Paressí
-pac	LA	D	Ka’do
+pac	LA	D	Kado
 pac	LA	D	Pahi
+pac	LA	DA	Cado
+pac	LA	DA	Cadô
 pac	LA	L	Pacoh
 pac	LA	LA	Bo River Van Kieu
 pac	LA	LA	Pokoh
@@ -39577,6 +40917,7 @@ pah	BR	DA	Tenharem
 pah	BR	DA	Tenharin
 pah	BR	L	Tenharim
 pah	BR	LA	Kagwahiv
+pah	BR	LA	Kagwahiva
 pah	BR	LA	Kawaib
 pah	BR	LA	Tenharem
 pah	BR	LA	Tenharin
@@ -39647,6 +40988,7 @@ paq	AF	LA	Laghmani
 paq	TJ	L	Parya
 paq	TJ	LA	Afghana-Yi Nasfurush
 paq	TJ	LA	Afghana-Yi Siyarui
+paq	TJ	LA	Changgars
 paq	TJ	LA	Laghmani
 paq	TJ	LA	Pbharya
 par	US	L	Timbisha
@@ -39690,18 +41032,27 @@ pbb	CO	D	Paniquita
 pbb	CO	D	Pitayo
 pbb	CO	DA	Panikita
 pbb	CO	L	Páez
+pbb	CO	LA	Nasa Yuwe
+pbb	CO	LA	Paes
 pbc	BR	L	Patamona
 pbc	GY	L	Patamona
 pbc	GY	LA	Eremagok
 pbc	GY	LA	Ingariko
 pbc	GY	LA	Kapon
 pbc	VE	L	Patamona
+pbc	VE	LA	Kapon
 pbe	MX	L	Popoloca, Mezontla
 pbe	MX	LA	Los Reyes Metzontla Popoloca
+pbe	MX	LA	Ngiba
+pbe	MX	LA	Ngigua
+pbe	MX	LA	Ngiwa
 pbe	MX	LA	Southern Popoloca
 pbf	MX	D	San Mateo Zoyamazalco Popoloca
 pbf	MX	D	San Vicente Coyotepec Popoloca
 pbf	MX	L	Popoloca, Coyotepec
+pbf	MX	LA	Ngiba
+pbf	MX	LA	Ngigua
+pbf	MX	LA	Ngiwa
 pbg	VE	D	Alile
 pbg	VE	D	Toa
 pbg	VE	L	Paraujano
@@ -39712,6 +41063,7 @@ pbh	VE	L	E’ñapa Woromaipu
 pbh	VE	LA	Abira
 pbh	VE	LA	Eñapa
 pbh	VE	LA	Eñepa
+pbh	VE	LA	E’ñepa
 pbh	VE	LA	Eye
 pbh	VE	LA	Panare
 pbh	VE	LA	Panari
@@ -39814,10 +41166,12 @@ pbu	AF	L	Pashto, Northern
 pbu	AF	LA	Afghan
 pbu	AF	LA	Eastern Afghan Pashto
 pbu	AF	LA	Northwestern Pakhto
-pbu	AF	LA	Pakhtoo
-pbu	AF	LA	Pakhtu
+pbu	AF	LA	Pakhtoon
+pbu	AF	LA	Pakhtun
 pbu	AF	LA	Paktu
+pbu	AF	LA	Pashtoon
 pbu	AF	LA	Sharqi
+pbu	IN	L	Pashto, Northern
 pbu	PK	D	Eastern Afghan Pashto
 pbu	PK	D	Ningraharian Pashto
 pbu	PK	D	Northeastern Pashto
@@ -39836,6 +41190,8 @@ pby	PG	L	Pyu
 pca	MX	D	Ahuatempan Popoloca
 pca	MX	D	Todos Santos Almolonga Popoloca
 pca	MX	L	Popoloca, Santa Inés Ahuatempan
+pca	MX	LA	Ngiba
+pca	MX	LA	Ngigua
 pca	MX	LA	Popoloca de Santa Inés Ahuatempan
 pca	MX	LA	Popoloca del Poniente
 pcb	KH	L	Pear
@@ -39986,6 +41342,7 @@ pci	IN	LA	Tagara
 pci	IN	LA	Thakara
 pci	IN	LA	Tugara
 pcj	IN	L	Parenga
+pcj	IN	LA	Gadaba
 pcj	IN	LA	Gorum
 pcj	IN	LA	Gorum Sama
 pcj	IN	LA	Pareng
@@ -40011,6 +41368,8 @@ pck	IN	LA	Haithe
 pck	IN	LA	Paite
 pck	IN	LA	Paithe
 pck	IN	LA	Parte
+pck	IN	LA	Vuite
+pck	IN	LA	Zomi
 pck	IN	LA	Zoukam
 pcl	IN	D	Haran Shikari
 pcl	IN	D	Neelishikari
@@ -40031,6 +41390,7 @@ pcm	NG	D	Cross River Pidgin
 pcm	NG	D	Delta Pidgin
 pcm	NG	D	Lagos Pidgin
 pcm	NG	L	Pidgin, Nigerian
+pcm	NG	LA	Anglo-Nigerian Pidgin
 pcm	NG	LA	Broken English
 pcm	NG	LA	Brokin
 pcm	NG	LA	Brokun
@@ -40073,6 +41433,7 @@ pdo	ID	D	Central Padoe
 pdo	ID	D	Western Padoe
 pdo	ID	L	Padoe
 pdo	ID	LA	Alalao
+pdo	ID	LA	Mori
 pdo	ID	LA	Pado-e
 pdo	ID	LA	Padoé
 pdo	ID	LA	South Mori
@@ -40151,6 +41512,7 @@ peh	CN	L	Bonan
 peh	CN	LA	Bao’an
 peh	CN	LA	Baonan
 peh	CN	LA	Boan
+peh	CN	LA	Manikacha
 peh	CN	LA	Paoan
 peh	CN	LA	Paongan
 pei	MX	L	Chichimeco-Jonaz
@@ -40159,6 +41521,7 @@ pei	MX	LA	Chichimeca
 pei	MX	LA	Chichimeco
 pei	MX	LA	Meco
 pei	MX	LA	Pame de Chichimeca-Jonaz
+pei	MX	LA	Uzá’
 pej	US	D	Guidiville
 pej	US	D	Sherwood Valley
 pej	US	L	Pomo, Northern
@@ -40184,8 +41547,10 @@ peq	US	L	Pomo, Southern
 peq	US	LA	Gallinoméro
 pes	AE	L	Persian, Iranian
 pes	AE	LA	Persian
+pes	AE	LA	Western Farsi
 pes	IQ	L	Persian, Iranian
 pes	IQ	LA	Persian
+pes	IQ	LA	Western Farsi
 pes	IR	D	Abadani
 pes	IR	D	Araki
 pes	IR	D	Bandari
@@ -40206,16 +41571,21 @@ pes	IR	D	Tehrani
 pes	IR	D	Yazdi
 pes	IR	DA	Meshed
 pes	IR	L	Persian, Iranian
+pes	IR	LA	Farsi
 pes	IR	LA	New Persian
 pes	IR	LA	Parsi
 pes	IR	LA	Persian
 pes	IR	LA	West Persian
+pes	IR	LA	Western Farsi
 pes	OM	L	Persian, Iranian
 pes	OM	LA	Persian
+pes	OM	LA	Western Farsi
 pes	QA	L	Persian, Iranian
 pes	QA	LA	Persian
+pes	QA	LA	Western Farsi
 pes	TJ	L	Persian, Iranian
 pes	TJ	LA	Persian
+pes	TJ	LA	Western Farsi
 pev	VE	L	Pémono
 pex	PG	D	Hitau-Pororan
 pex	PG	D	Matsungan
@@ -40315,6 +41685,9 @@ pgu	ID	DA	Toliliko
 pgu	ID	L	Pagu
 pgu	ID	LA	Pago
 pgu	ID	LA	Pagoe
+pgz	PG	L	Papua New Guinean Sign Language
+pgz	PG	LA	Melanesian Sign Language
+pgz	PG	LA	PNGSL
 pha	CN	D	Northern Pa-Hng
 pha	CN	D	Southern Pa-Hng
 pha	CN	L	Pa-Hng
@@ -40431,6 +41804,7 @@ pia	MX	L	Pima Bajo
 pia	MX	LA	Lower Piman
 pia	MX	LA	Mountain Pima
 pia	MX	LA	Névome
+pia	MX	LA	Oob No’ok
 pib	PE	L	Yine
 pib	PE	LA	Chontaquiro
 pib	PE	LA	Contaquiro
@@ -40454,12 +41828,16 @@ pid	CO	LA	Guagua
 pid	CO	LA	Kuakua
 pid	CO	LA	Maco
 pid	CO	LA	Quaqua Dearuwa
+pid	CO	LA	Wöthüha
 pid	CO	LA	Wo’tiheh
 pid	VE	L	Piaroa
+pid	VE	LA	Amorua
+pid	VE	LA	Deá’ru’wa
 pid	VE	LA	Dearwa
 pid	VE	LA	Deruwa
 pid	VE	LA	Uhothha
 pid	VE	LA	Uwotjüja
+pid	VE	LA	Wöthüha
 pid	VE	LA	Wo’tiheh
 pif	FM	L	Pingelapese
 pif	FM	LA	Pingelap
@@ -40474,6 +41852,7 @@ pih	NF	L	Pitcairn-Norfolk
 pih	NF	LA	Norfolkese
 pih	NF	LA	Pitcairn English
 pih	NZ	L	Pitcairn-Norfolk
+pih	NZ	LA	Norf’k
 pih	NZ	LA	Pitcairn English
 pih	PN	D	Pitcairn English
 pih	PN	L	Pitcairn-Norfolk
@@ -40498,12 +41877,14 @@ pim	US	LA	Virginia Algonquian
 pin	PG	L	Piame
 pin	PG	LA	Biami
 pio	CO	L	Piapoco
+pio	CO	LA	Wenewika
 pio	VE	L	Piapoco
 pio	VE	LA	Amarizado
 pio	VE	LA	Dzaze
 pio	VE	LA	Enegua
 pio	VE	LA	Kuipaco
 pio	VE	LA	Piapoko Dejá
+pio	VE	LA	Wenewika
 pio	VE	LA	Wenéwika
 pio	VE	LA	Yapoco
 pip	NG	L	Pero
@@ -40624,6 +42005,7 @@ pko	UG	LA	Suk
 pkp	CK	L	Pukapuka
 pkp	CK	LA	Bukabukan
 pkp	CK	LA	Pukapukan
+pkp	CK	LA	Te Leo Wale
 pkr	IN	L	Kurumba, Attapady
 pkr	IN	LA	Kurumba
 pkr	IN	LA	Pal Kurumba
@@ -40703,6 +42085,9 @@ plj	NG	LA	Polchi
 plk	PK	D	Jalkoti
 plk	PK	D	Kolai
 plk	PK	D	Palasi
+plk	PK	DA	Jalkot
+plk	PK	DA	Koli
+plk	PK	DA	Palas
 plk	PK	L	Shina, Kohistani
 plk	PK	LA	Kohistani
 plk	PK	LA	Kohistyo
@@ -40723,6 +42108,10 @@ pln	CO	L	Palenquero
 pln	CO	LA	Lengua
 pln	CO	LA	Palenque
 plo	MX	L	Popoluca, Oluta
+plo	MX	LA	Oluta
+plo	MX	LA	Oluta Mijean
+plo	MX	LA	Olutec
+plo	MX	LA	Popoluca de Oluta
 plp	NP	L	Palpa
 plp	NP	LA	Pahari-Palpa
 plr	CI	L	Sénoufo, Palaka
@@ -40732,15 +42121,21 @@ plr	CI	LA	Palara
 plr	CI	LA	Pallakha
 plr	CI	LA	Pilara
 pls	MX	L	Popoloca, San Marcos Tlacoyalco
+pls	MX	LA	Ngigua
+pls	MX	LA	Ngiwa
 pls	MX	LA	Northern Popoloca
 pls	MX	LA	Popoloca de San Marcos Tlalcoyalco
 pls	MX	LA	Popoluca del Norte
 pls	MX	LA	San Marcos Tlalcoyalco Popoloca
 plt	KM	L	Malagasy
+plt	KM	LA	Ambaniandro
+plt	KM	LA	Borizany
+plt	KM	LA	Hova
 plt	KM	LA	Malgache
 plt	KM	LA	Official Malagasy
 plt	KM	LA	Plateau Malagasy
 plt	KM	LA	Standard Malagasy
+plt	KM	LA	Teny ofisialy
 plt	MG	D	Betsileo
 plt	MG	D	Bezanozano
 plt	MG	D	Merina
@@ -40749,11 +42144,16 @@ plt	MG	D	Tanala
 plt	MG	D	Vakinankaritra
 plt	MG	D	Zafimaniry
 plt	MG	L	Malagasy, Plateau
+plt	MG	LA	Ambaniandro
+plt	MG	LA	Borizany
+plt	MG	LA	Hova
 plt	MG	LA	Malagasy
 plt	MG	LA	Malgache
 plt	MG	LA	Official Malagasy
 plt	MG	LA	Standard Malagasy
+plt	MG	LA	Teny ofisialy
 plu	BR	L	Palikúr
+plu	BR	LA	Pa’ikwaki
 plu	BR	LA	Paikwene
 plu	BR	LA	Palicur
 plu	BR	LA	Palijur
@@ -40764,6 +42164,7 @@ plu	BR	LA	Paricuria
 plu	BR	LA	Parikurene
 plu	BR	LA	Parinkur-lene
 plu	GF	L	Palikúr
+plu	GF	LA	Pa’ikwaki
 plu	GF	LA	Palicur
 plu	GF	LA	Palikour
 plv	PH	L	Palawano, Southwest
@@ -40800,9 +42201,6 @@ pma	VU	LA	Paamese
 pma	VU	LA	Pauma
 pmb	CD	L	Pambia
 pmb	CD	LA	Apambia
-pmc	ID	L	Palumata
-pmc	ID	LA	Balamata
-pmc	ID	LA	Palamata
 pmd	AU	L	Pallanganmiddang
 pmd	AU	LA	Pallangahmiddang
 pmd	AU	LA	Wavaroo
@@ -40903,6 +42301,7 @@ pmt	PF	D	Vahitu
 pmt	PF	DA	Putahi
 pmt	PF	DA	Tupitimoake
 pmt	PF	L	Tuamotuan
+pmt	PF	LA	Paumotu
 pmt	PF	LA	Pa’umotu
 pmw	US	L	Miwok, Plains
 pmw	US	LA	Valley Miwok
@@ -40911,7 +42310,14 @@ pmx	IN	LA	Paumei
 pmx	IN	LA	Pomai
 pmx	IN	LA	Pome
 pmx	IN	LA	Poumei
+pmy	ID	D	Bird’s Head Malay
+pmy	ID	D	North Papua Malay
+pmy	ID	D	Serui Malay
+pmy	ID	D	South Coast Malay
 pmy	ID	L	Malay, Papuan
+pmy	ID	LA	Bahasa Tanah
+pmy	ID	LA	Logat Papua
+pmy	ID	LA	Melayu Papua
 pmz	MX	L	Pame, Southern
 pna	MY	D	Punan Bah
 pna	MY	D	Punan Biau
@@ -40925,13 +42331,25 @@ pnb	IN	LA	Lahanda
 pnb	IN	LA	Lahnda
 pnb	IN	LA	Lahndi
 pnb	IN	LA	Western Panjabi
+pnb	PK	D	Bathi
+pnb	PK	D	Bhatyiana
+pnb	PK	D	Doab
+pnb	PK	D	Lahori
+pnb	PK	D	Majhi
+pnb	PK	D	Malwa
+pnb	PK	D	Powadhi
+pnb	PK	D	Punjabi Proper
+pnb	PK	DA	Bhatneri
+pnb	PK	DA	Bhatti
 pnb	PK	L	Punjabi, Western
 pnb	PK	LA	Lahanda
 pnb	PK	LA	Lahnda
 pnb	PK	LA	Lahndi
-pnb	PK	LA	Lahori
-pnb	PK	LA	Majhi
-pnb	PK	LA	Western Panjabi
+pnb	PK	LA	Panjabi
+pnb	PK	LA	Panjabi Proper
+pnb	PK	LA	Punjabi
+pnb	PK	LA	Punjapi
+pnb	PK	LA	Shahmukhi
 pnc	ID	D	Bulo
 pnc	ID	D	Tapango
 pnc	ID	L	Pannei
@@ -41021,10 +42439,12 @@ pnt	GR	L	Pontic
 pnt	GR	LA	Pontic Greek
 pnt	TR	L	Pontic
 pnu	CN	L	Bunu, Jiongnai
+pnu	CN	LA	Bunu
 pnu	CN	LA	Hualan Yao
 pnu	CN	LA	Jiongnai
 pnu	CN	LA	Jiongnaihua
 pnu	CN	LA	Kiong Nai
+pnu	CN	LA	Kjong Nai
 pnu	CN	LA	Punu
 pnu	CN	LA	Qiungnai
 pnv	AU	L	Pinigura
@@ -41065,11 +42485,13 @@ poc	GT	DA	Palín Pocomam
 poc	GT	L	Poqomam
 poc	GT	LA	Pocomán
 poc	GT	LA	Pokomam
-pod	CO	L	Ponares
+poc	GT	LA	Qaq’oral
 poe	MX	L	Popoloca, San Juan Atzingo
 poe	MX	LA	Atzingo Popoloca
 poe	MX	LA	Eastern Popoloca
+poe	MX	LA	Ngiba
 poe	MX	LA	Ngigua
+poe	MX	LA	Ngiwa
 poe	MX	LA	Popoloca de San Juan Atzingo
 poe	MX	LA	Popoloca del Oriente
 poe	MX	LA	Southern Popoloca
@@ -41190,16 +42612,22 @@ pov	GW	D	Bissau-Bolama Creole
 pov	GW	D	Cacheu-Ziguinchor Creole
 pov	GW	L	Crioulo, Upper Guinea
 pov	GW	LA	Guinea-Bissau Creole
-pov	GW	LA	Kiryol
+pov	GW	LA	Guinea-Bissau Kriyol
 pov	GW	LA	Kriulo
+pov	GW	LA	Kriyol
 pov	GW	LA	Portuguese Creole
 pov	SN	D	Cacheu-Ziguinchor Creole
 pov	SN	L	Crioulo, Upper Guinea
+pov	SN	LA	Casamançais
+pov	SN	LA	Créole afro-portugais de Casamance
+pov	SN	LA	Créole casamançais
 pov	SN	LA	Kriulo
+pov	SN	LA	Kriyol
 pov	SN	LA	Portuguese Creole
 pow	MX	D	Huejonapan
 pow	MX	D	Santa María Nativitas
 pow	MX	L	Popoloca, San Felipe Otlaltepec
+pow	MX	LA	Ngiba
 pow	MX	LA	Popoloca de San Felipe Otlaltepec
 pow	MX	LA	Popoloca del Poniente
 pow	MX	LA	Western Popoloca
@@ -41211,12 +42639,11 @@ poy	TZ	LA	Pogolu
 poy	TZ	LA	Pogora
 poy	TZ	LA	Pogoro
 poy	TZ	LA	Shipogolu
-ppa	IN	L	Pao
-ppa	IN	LA	Pabra
 ppe	PG	L	Papi
 ppe	PG	LA	Paupe
 ppi	MX	L	Paipai
 ppi	MX	LA	Akwa’ala
+ppi	MX	LA	Jaspuy pai
 ppk	ID	D	Bana
 ppk	ID	D	Benggaulu
 ppk	ID	D	Kantewu
@@ -41236,10 +42663,10 @@ ppk	ID	L	Uma
 ppk	ID	LA	Koro
 ppk	ID	LA	Oema
 ppk	ID	LA	Pipikoro
-ppl	SV	L	Pipil
-ppl	SV	LA	Nahuat
+ppl	SV	L	Nahuat
 ppl	SV	LA	Nawat
 ppl	SV	LA	Nicarao
+ppl	SV	LP	Pipil
 ppm	ID	L	Papuma
 ppn	PG	L	Papapana
 ppo	PG	D	Aurei
@@ -41271,6 +42698,9 @@ ppp	CD	L	Pelende
 ppq	PG	L	Pei
 ppq	PG	LA	Pai
 pps	MX	L	Popoloca, San Luís Temalacayuca
+pps	MX	LA	Ngiba
+pps	MX	LA	Ngigua
+pps	MX	LA	Ngiwa
 pps	MX	LA	Popoloca de San Luis Temalacayuca
 ppt	PG	L	Pare
 ppt	PG	LA	Akium-Pare
@@ -41289,6 +42719,7 @@ pqa	NG	LA	Afawa
 pqa	NG	LA	Fa’awa
 pqa	NG	LA	Foni
 pqa	NG	LA	Fucaka
+pqa	NG	LA	Pa’anci
 pqa	NG	LA	Pa’awa
 pqa	NG	LA	Pala
 pqm	CA	D	Malecite
@@ -41323,7 +42754,7 @@ prg	PL	LA	Old Prussian
 prh	PH	L	Porohanon
 prh	PH	LA	Camotes
 pri	NC	L	Paicî
-pri	NC	LA	Ci
+pri	NC	LA	Cî
 pri	NC	LA	Paaci
 pri	NC	LA	Pati
 pri	NC	LA	Ponerihouen
@@ -41430,6 +42861,10 @@ prk	MM	LA	Standard Wa
 prk	MM	LA	Wa
 prk	TH	L	Wa, Parauk
 prl	PE	L	Peruvian Sign Language
+prl	PE	LA	Lengua de Signos Peruana
+prl	PE	LA	Lenguaje de señas peruana
+prl	PE	LA	Lenguaje de señas peruano
+prl	PE	LA	LSP
 prm	PG	D	Aird Hills
 prm	PG	D	Porome
 prm	PG	DA	Kibiri
@@ -41447,14 +42882,15 @@ prn	AF	L	Prasuni
 prn	AF	LA	Parun
 prn	AF	LA	Paruni
 prn	AF	LA	Prasun
+prn	AF	LA	Vasi vari
 prn	AF	LA	Veron
 prn	AF	LA	Verou
 prn	AF	LA	Veruni
 prn	AF	LA	Wasi-Veri
 prp	IN	L	Parsi
 prp	IN	LA	Parsee
-prq	PE	L	Ashéninka Perené
-prq	PE	LA	Ashéninca Perené
+prq	PE	L	Ashéninka, Perené
+prq	PE	LA	Ashéninca, Perené
 prq	PE	LP	Perené Campa
 prr	BR	L	Puri
 prr	BR	LA	Coroado
@@ -41472,14 +42908,20 @@ prs	AF	LA	Tajiki
 prs	PK	L	Dari
 prs	PK	LA	Afghan Persian
 prs	PK	LA	Badakhshi
+prs	PK	LA	Farsi
 prs	PK	LA	Madaglashti
 prs	PK	LA	Tajik
 prt	LA	L	Prai
 prt	LA	LA	Lao Mai
+prt	LA	LA	Lao Prai
+prt	LA	LA	Lua Prai
 prt	TH	D	Ban Wen
 prt	TH	D	Prai
 prt	TH	D	Southern Prai
 prt	TH	L	Prai
+prt	TH	LA	Lao Prai
+prt	TH	LA	Lua Prai
+prt	TH	LA	Pray
 prt	TH	LA	Thin
 pru	ID	L	Puragi
 pru	ID	LA	Mogao
@@ -41489,18 +42931,29 @@ prx	IN	L	Purik
 prx	IN	LA	Burig
 prx	IN	LA	Burigskat
 prx	IN	LA	Purig
+prx	IN	LA	Purig-pa
 prx	IN	LA	Purigskad
 prx	IN	LA	Purik Bhotia
 prx	IN	LA	Purki
-pry	TH	L	Pray 3
 prz	CO	L	Providencia Sign Language
 psa	ID	L	Awyu, Asue
 psa	ID	LA	Miaro
 psa	ID	LA	Miaro Awyu
 psa	ID	LA	Pisa
 psc	IR	L	Persian Sign Language
+psd	CA	D	Far Northern Plains Indian Sign Language
+psd	CA	L	Plains Indian Sign Language
 psd	US	L	Plains Indian Sign Language
+psd	US	LA	Hand Talk
+psd	US	LA	Indian Language of Signs
+psd	US	LA	Indian Sign Language
+psd	US	LA	NAISL
+psd	US	LA	North American Indian Sign Language
+psd	US	LA	PISL
 psd	US	LA	Plains Sign Language
+psd	US	LA	Plains Sign Talk
+psd	US	LA	PST
+psd	US	LA	Sign Talk
 pse	ID	D	Benakat
 pse	ID	D	Bengkulu
 pse	ID	D	Enim
@@ -41545,10 +42998,10 @@ psn	ID	LA	To Panasean
 pso	PL	L	Polish Sign Language
 pso	PL	LA	PJM
 pso	PL	LA	Polski Język Migowy
-psp	PH	L	Philippine Sign Language
-psp	PH	LA	Filipino Sign Language
+psp	PH	L	Filipino Sign Language
 psp	PH	LA	FSL
 psp	PH	LA	Local Sign Language
+psp	PH	LA	Philippine Sign Language
 psq	PG	L	Pasi
 psq	PG	LA	Besi
 psr	PT	D	Lisbon
@@ -41576,6 +43029,7 @@ psy	US	LA	Conoy
 pta	PY	L	Pai Tavytera
 pta	PY	LA	Ava
 pta	PY	LA	Pai
+pta	PY	LA	Pai Tavyterã
 pta	PY	LA	Tavytera
 pth	BR	L	Pataxó Hã-Ha-Hãe
 pth	BR	LA	Patashó
@@ -41602,6 +43056,8 @@ pto	BR	LA	Tupí of Cuminapanema
 ptp	PG	D	Dengalu
 ptp	PG	L	Patep
 ptp	PG	LA	Ptep
+ptq	IN	L	Pattapu
+ptq	IN	LA	Pattapu Bhasha
 ptr	VU	L	Piamatsina
 ptt	ID	D	Enrekang
 ptt	ID	D	Pattinjo
@@ -41648,6 +43104,7 @@ pud	ID	L	Punan Aput
 pud	ID	LA	Aput
 pue	AR	L	Puelche
 pue	AR	LA	Gennaken
+pue	AR	LA	Gününa Küne
 pue	AR	LA	Northern Tehuelche
 pue	AR	LA	Pampa
 puf	ID	L	Punan Merah
@@ -41655,6 +43112,7 @@ pug	BF	L	Phuie
 pug	BF	LA	Buguli
 pug	BF	LA	Buguri
 pug	BF	LA	Phuien
+pug	BF	LA	Phuó
 pug	BF	LA	Pougouli
 pug	BF	LA	Puguli
 pug	BF	LA	Pwa
@@ -41750,12 +43208,10 @@ pwa	PG	LA	Yasa
 pwb	NG	L	Panawa
 pwb	NG	LA	Bugel
 pwb	NG	LA	Bujiye
-pwg	PG	D	East Gapa
-pwg	PG	D	West Paiwa
+pwg	PG	D	Gapa
+pwg	PG	D	Paiwa
 pwg	PG	L	Gapapaiwa
-pwg	PG	LA	Gapa
 pwg	PG	LA	Manape
-pwg	PG	LA	Paiwa
 pwi	US	L	Patwin
 pwi	US	LA	Southern Wintun
 pwi	US	LA	Wintu
@@ -41815,6 +43271,8 @@ pww	TH	L	Karen, Pwo Northern
 pww	TH	LA	Phlong
 pxm	MX	L	Mixe, Quetzaltepec
 pxm	MX	LA	Central Mixe
+pxm	MX	LA	Chuxnabán Mixe
+pxm	MX	LA	Midland Mixe
 pxm	MX	LA	Mixe Alto del Sur
 pye	CI	D	Dugbo
 pye	CI	D	Gbowe-Hran
@@ -41863,16 +43321,18 @@ pyy	MM	LA	Hpinba
 pyy	MM	LA	Hpyin
 pyy	MM	LA	Misu
 pyy	MM	LA	Pyin
-pzn	MM	L	Naga, Para
+pzn	MM	L	Naga, Jejara
 pzn	MM	LA	Bara Naga
-pzn	MM	LA	Jejara Naga
+pzn	MM	LA	Naga
+pzn	MM	LA	Para Naga
 pzn	MM	LA	Parasar
 qua	US	L	Quapaw
 qua	US	LA	Alkansea
 qua	US	LA	Arkansas
 qua	US	LA	Capa
 qua	US	LA	Ogaxpa
-qub	PE	L	Quechua, Huallaga Huánuco
+qub	PE	L	Quechua, Huallaga
+qub	PE	LA	Quechua, Huallaga Huánuco
 quc	GT	D	Cunén Kiché
 quc	GT	D	Eastern Kiché
 quc	GT	D	Joyabaj Kiché
@@ -41907,6 +43367,7 @@ quh	BO	D	Sucre
 quh	BO	L	Quechua, South Bolivian
 quh	BO	LA	Central Bolivian Quechua
 quh	BO	LA	Quechua Boliviano
+quh	CL	L	Quechua, South Bolivian
 qui	US	D	Hoh
 qui	US	D	Quileute
 qui	US	L	Quileute
@@ -41919,11 +43380,13 @@ quk	PE	DA	South Chachapoyas
 quk	PE	DA	West Chachapoyas
 quk	PE	L	Quechua, Chachapoyas
 quk	PE	LA	Amazonas
+quk	PE	LA	Llakwash
 qul	BO	D	Apolo
 qul	BO	D	Charazani
 qul	BO	D	Chuma
 qul	BO	L	Quechua, North Bolivian
 qul	BO	LA	North La Paz Quechua
+qul	BO	LA	Quechua
 qum	GT	L	Sipakapense
 qum	GT	LA	Sipacapa Quiché
 qum	GT	LA	Sipacapeño
@@ -41932,17 +43395,22 @@ qun	US	D	Lower Chehalis
 qun	US	L	Quinault
 qup	PE	L	Quechua, Southern Pastaza
 qup	PE	LA	Inga
+qup	PE	LA	Inka
 quq	ES	L	Quinqui
+quq	ES	LA	Mercheros
 qur	PE	L	Quechua, Chaupihuaranga
 qur	PE	LA	Daniel Carrion
 qur	PE	LA	Yanahuanca Pasco Quechua
 qus	AR	L	Quichua, Santiago del Estero
+qus	AR	LA	Quichua
 qus	AR	LA	Santiagueño Quichua
 quv	GT	L	Sakapulteko
 quv	GT	LA	Sacapulas K’iche’
 quv	GT	LA	Sacapulteco
 quw	EC	L	Quichua, Tena Lowland
 quw	EC	LA	Napo Kichwa
+quw	EC	LA	Quijo
+quw	EC	LA	Quixo
 quw	EC	LA	Yumbo
 qux	PE	D	Apurí
 qux	PE	D	Azángaro-Huangáscar-Chocos
@@ -41962,6 +43430,7 @@ quy	PE	D	Andahuaylas
 quy	PE	D	Huancavelica
 quy	PE	L	Quechua, Ayacucho
 quy	PE	LA	Chanka
+quy	PE	LA	Runasimi
 quz	PE	D	Caylloma Quechua
 quz	PE	D	Eastern Apurímac Quechua
 quz	PE	D	Puno Quechua
@@ -41969,15 +43438,20 @@ quz	PE	L	Quechua, Cusco
 quz	PE	LA	Cuzco
 quz	PE	LA	Cuzco Quechua
 quz	PE	LA	Qheswa
+quz	PE	LA	Qheswasimi
 quz	PE	LA	Quechua Cusco
 quz	PE	LA	Quechua de Cusco-Collao
 quz	PE	LA	Quechua Qosqo-Qollaw
+quz	PE	LA	Runasimi
 quz	PE	LA	Runasimi Qusqu Qullaw
 qva	PE	L	Quechua, Ambo-Pasco
 qva	PE	LA	San Rafael-Huariaca Quechua
 qvc	PE	D	Eastern Cajamarca
 qvc	PE	D	Western Cajamarca
 qvc	PE	L	Quechua, Cajamarca
+qvc	PE	LA	Kichwa
+qvc	PE	LA	Lingwa
+qvc	PE	LA	Lingwa, Kichwa
 qve	PE	D	Abancay
 qve	PE	D	Antabamba
 qve	PE	D	Cotabambas
@@ -42000,20 +43474,25 @@ qvn	PE	L	Quechua, North Junín
 qvn	PE	LA	Junín Quechua
 qvn	PE	LA	Tarma-Junín Quechua
 qvo	CO	L	Quichua, Napo Lowland
+qvo	CO	LA	Kichua
 qvo	CO	LA	Lowland Napo Quechua
+qvo	CO	LA	Runa Shimi
 qvo	EC	D	Santa Rosa Quechua
 qvo	EC	L	Quichua, Napo Lowland
 qvo	EC	LA	Ingano
+qvo	EC	LA	Kichua
 qvo	EC	LA	Lowland Napo Quichua
 qvo	EC	LA	Napo Quichua
-qvo	PE	L	Quechua, Napo Lowland
+qvo	EC	LA	Runa Shimi
+qvo	PE	L	Quichua, Napo
 qvo	PE	LA	Kicho
+qvo	PE	LA	Kichua
 qvo	PE	LA	Lowland Napo Quichua
 qvo	PE	LA	Napo
 qvo	PE	LA	Napo Kichua
+qvo	PE	LA	Napo Kichwa
 qvo	PE	LA	Napo Lowland Quichua
-qvo	PE	LA	Quijo
-qvo	PE	LA	Quixo
+qvo	PE	LA	Quechua, Napo Lowland
 qvo	PE	LA	Runa Shimi
 qvo	PE	LA	Santa Rosa Quechua
 qvo	PE	LA	Santarrosino
@@ -42024,6 +43503,7 @@ qvs	PE	LA	Lama
 qvs	PE	LA	Lamano
 qvs	PE	LA	Lamista
 qvs	PE	LA	Lamisto
+qvs	PE	LA	Llakwash Quechua
 qvs	PE	LA	Motilón
 qvs	PE	LA	Ucayali
 qvw	PE	D	East Waylla
@@ -42055,11 +43535,15 @@ qwh	PE	D	Yungay
 qwh	PE	DA	Huaylas
 qwh	PE	L	Quechua, Huaylas Ancash
 qwh	PE	LA	Huaraz Quechua
+qwh	PE	LA	Quechua
 qws	PE	L	Quechua, Sihuas Ancash
-qxa	PE	L	Quechua, Chiquián Ancash
+qxa	PE	L	Quechua, Chiquián
+qxa	PE	LA	Chiquián Ancash Quechua
 qxc	PE	L	Quechua, Chincha
-qxh	PE	L	Quechua, Panao Huánuco
+qxh	PE	L	Quechua, Panao
 qxh	PE	LA	Pachitea Quechua
+qxh	PE	LA	Panao runacuna
+qxh	PE	LA	Quechua, Panao Huánuco
 qxl	EC	L	Quichua, Salasaca Highland
 qxl	EC	LA	Salasaca Quichua
 qxl	EC	LA	Tungurahua Highland Quichua
@@ -42067,9 +43551,10 @@ qxl	EC	LA	Tungurahua Quichua
 qxn	PE	L	Quechua, Northern Conchucos Ancash
 qxn	PE	LA	Conchucos Quechua
 qxn	PE	LA	Northern Conchucos Quechua
-qxo	PE	L	Quechua, Southern Conchucos Ancash
+qxn	PE	LA	Quechua
+qxo	PE	L	Quechua, Southern Conchucos
 qxo	PE	LA	Conchucos Quechua
-qxo	PE	LA	Southern Conchucos Quechua
+qxo	PE	LA	Quechua, Southern Conchucos Ancash
 qxp	PE	D	Cailloma Quechua
 qxp	PE	D	North Bolivian Quechua
 qxp	PE	L	Quechua, Puno
@@ -42090,6 +43575,7 @@ qxs	CN	D	Taoping
 qxs	CN	DA	Daqishan
 qxs	CN	L	Qiang, Southern
 qxs	CN	LA	Ch’iang
+qxs	CN	LA	Rrmea
 qxt	PE	L	Quechua, Santa Ana de Tusi Pasco
 qxu	PE	D	Antabamba
 qxu	PE	D	Cotahuasi
@@ -42107,10 +43593,12 @@ raa	NP	DA	Khesange
 raa	NP	L	Dungmali
 raa	NP	LA	Arthare
 raa	NP	LA	Arthare-Khesang
+raa	NP	LA	Dungmali Puk
 raa	NP	LA	Dungmali Pûk
 raa	NP	LA	Dungmali-Bantawa
 raa	NP	LA	Khesange
 rab	IN	L	Chamling
+rab	IN	LA	Camling
 rab	NP	D	Balamtali
 rab	NP	D	Halesi
 rab	NP	D	Ratanchhali
@@ -42192,10 +43680,11 @@ rak	PG	LA	Pahavai
 rak	PG	LA	Pelipowai
 rak	PG	LA	Pohuai
 ral	IN	L	Ralte
-ram	BR	D	Apanjekra
+ram	BR	D	Apâniekra
 ram	BR	D	Ramkokamekra
-ram	BR	DA	Apanhecra
-ram	BR	DA	Apaniekra
+ram	BR	DA	Apânhecra
+ram	BR	DA	Apânjekra
+ram	BR	DA	Apânyekra
 ram	BR	L	Canela
 ram	BR	LA	Kanela
 ran	ID	L	Riantana
@@ -42225,12 +43714,13 @@ rar	CK	D	Mangaia
 rar	CK	D	Mauke
 rar	CK	D	Mitiaro
 rar	CK	D	Rarotonga
-rar	CK	L	Rarotongan
+rar	CK	L	Cook Islands Maori
 rar	CK	LA	Cook Island
-rar	CK	LA	Cook Islands Maori
 rar	CK	LA	Kuki Airani
 rar	CK	LA	Maori
-rar	CK	LA	Rarotongan-Mangaian
+rar	CK	LA	Māori Kūki ’Āirani
+rar	CK	LA	Rarotongan
+rar	CK	LA	Te Reo Maori
 ras	SD	D	Rashad
 ras	SD	D	Tegali
 ras	SD	D	Tingal
@@ -42240,16 +43730,19 @@ ras	SD	DA	Kom
 ras	SD	DA	Kome
 ras	SD	DA	Ngakom
 ras	SD	L	Tegali
+ras	SD	LA	Orig
 ras	SD	LA	Tagale
 ras	SD	LA	Tegele
 ras	SD	LA	Tekele
 ras	SD	LA	Togole
+ras	SD	LA	Turjok
 rat	IR	L	Razajerdi
 rau	NP	L	Raute
 rau	NP	LA	Boto boli
 rau	NP	LA	Khamchi
 rau	NP	LA	Raji
 rau	NP	LA	Rajwar
+rau	NP	LA	Ra’te
 rau	NP	LA	Rautya
 rau	NP	LA	Rautye
 rav	NP	D	Khotang
@@ -42293,9 +43786,11 @@ raw	MM	LA	Hkanung
 raw	MM	LA	Kiutze
 raw	MM	LA	Nung
 raw	MM	LA	Nung Rawang
+raw	MM	LA	Qiuze
 rax	NG	L	Rang
 ray	PF	L	Rapa
 ray	PF	LA	Rapan
+ray	PF	LA	Reo Rapa
 raz	ID	L	Rahambuu
 raz	ID	LA	Lellewao
 raz	ID	LA	Lellewau
@@ -42383,6 +43878,7 @@ rej	ID	DA	Curup
 rej	ID	DA	Kebanagung
 rej	ID	L	Rejang
 rej	ID	LA	Djang
+rej	ID	LA	Jang
 rej	ID	LA	Redjang
 rel	KE	L	Rendille
 rel	KE	LA	Randile
@@ -42414,6 +43910,7 @@ rga	VU	L	Roria
 rga	VU	LA	Mores
 rge	GR	L	Romano-Greek
 rge	GR	LA	Hellenoromani
+rge	GR	LA	Romika
 rgk	IN	L	Rangkas
 rgk	IN	LA	Canpa
 rgk	IN	LA	Chyanam
@@ -42423,8 +43920,10 @@ rgk	IN	LA	Saukas
 rgk	IN	LA	Saukiya Khun
 rgk	IN	LA	Shaukas
 rgn	IT	L	Romagnol
+rgn	IT	LA	Rumagnol
 rgn	SM	L	Romagnol
 rgn	SM	LA	Emiliano-Romagnolo
+rgn	SM	LA	Rumagnol
 rgr	PE	L	Resígaro
 rgr	PE	LA	Resígero
 rgs	VN	D	Rai
@@ -42443,8 +43942,10 @@ rgu	ID	LA	Roti
 rgu	ID	LA	Rotinese
 rhg	BD	L	Rohingya
 rhg	BD	LA	Rohinga
+rhg	BD	LA	Ruwainggya
 rhg	MM	L	Rohingya
 rhg	MM	LA	Rohinja
+rhg	MM	LA	Ruwainggya
 rhp	PG	L	Yahang
 rhp	PG	LA	Ruruhi’ip
 rhp	PG	LA	Ruruhip
@@ -42488,6 +43989,7 @@ rif	MA	D	Iqeraayen
 rif	MA	D	Iznasen
 rif	MA	DA	Beni Snassen
 rif	MA	L	Tarifit
+rif	MA	LA	Arrif
 rif	MA	LA	Northern Shilha
 rif	MA	LA	Rif
 rif	MA	LA	Rif Berber
@@ -42495,6 +43997,7 @@ rif	MA	LA	Rifeño
 rif	MA	LA	Riff
 rif	MA	LA	Rifia
 rif	MA	LA	Rifiya
+rif	MA	LA	Ruafa
 rif	MA	LA	Shilha
 rif	MA	LA	Tamazight
 rif	MA	LA	Tamazight n Arrif
@@ -42504,28 +44007,28 @@ ril	CN	D	De’ang
 ril	CN	D	Liang
 ril	CN	D	Liang Palaung
 ril	CN	D	Na’ang
-ril	CN	D	Riang-Lang
 ril	CN	D	Xiaoan’gou
 ril	CN	D	Xiaochanggou
 ril	CN	D	Yang Sek
 ril	CN	D	Yang Wan Kun
 ril	CN	D	Yanglam
 ril	CN	D	Yin
-ril	CN	L	Riang
+ril	CN	L	Riang Lang
+ril	CN	LA	Riang
 ril	MM	D	Black Riang
 ril	MM	D	Red Riang
 ril	MM	D	Yinja
-ril	MM	L	Riang
+ril	MM	L	Riang Lang
 ril	MM	LA	Black Karen
 ril	MM	LA	Black Riang
 ril	MM	LA	Black Yang
-ril	MM	LA	Liang Sek
-ril	MM	LA	Riang-Lang
+ril	MM	LA	Drum
+ril	MM	LA	Riang
 ril	MM	LA	Yang
+ril	MM	LA	Yang Lang
 ril	MM	LA	Yang Wan Kun
 ril	MM	LA	Yanglam
 ril	MM	LA	Yin
-ril	MM	LA	Yin Kya
 ril	MM	LA	Yin Net
 ril	MM	LA	Yinnet
 rim	TZ	D	Chahi
@@ -42575,6 +44078,8 @@ rji	NP	D	Purbiya
 rji	NP	L	Raji
 rji	NP	LA	Ban Raji
 rji	NP	LA	Janggali
+rji	NP	LA	Phaan Bhaasaa
+rji	NP	LA	Phaan Boli
 rji	NP	LA	Rajibar
 rji	NP	LA	Rawati
 rji	NP	LA	Rjya
@@ -42590,10 +44095,15 @@ rjs	NP	LA	Rajbansi
 rjs	NP	LA	Tajpuria
 rka	KH	L	Kraol
 rkb	BR	L	Rikbaktsa
-rkb	BR	LA	Aripaktsa
+rkb	BR	LA	Aripaktsá
 rkb	BR	LA	Canoeiro
-rkb	BR	LA	Erikbatsa
-rkb	BR	LA	Erikpatsa
+rkb	BR	LA	Erigbaagtsá
+rkb	BR	LA	Erigpactsá
+rkb	BR	LA	Erigpatsá
+rkb	BR	LA	Erikbatsá
+rkb	BR	LA	Erikpatsá
+rkb	BR	LA	Rikpakcá
+rkb	BR	LA	Rikpaktsá
 rkh	CK	L	Rakahanga-Manihiki
 rkh	CK	LA	Manihiki-Rakahanga
 rki	BD	D	Rakhine
@@ -42625,6 +44135,7 @@ rkm	BF	D	Gassan
 rkm	BF	D	Nouna
 rkm	BF	D	Safané
 rkm	BF	L	Marka
+rkm	BF	LA	Dafing
 rkm	BF	LA	Marka Dafing
 rkm	ML	L	Marka
 rkm	ML	LA	Dafing
@@ -42667,6 +44178,7 @@ rmc	CZ	D	West Slovakian Romani
 rmc	CZ	L	Romani, Carpathian
 rmc	CZ	LA	Bashaldo
 rmc	CZ	LA	Hungarian-Slovak Romani
+rmc	CZ	LA	Karpacki Roma
 rmc	CZ	LA	Romungro
 rmc	PL	D	Galician
 rmc	PL	D	Transylvanian
@@ -42681,8 +44193,13 @@ rmc	SK	D	West Slovakian Romani
 rmc	SK	L	Romani, Carpathian
 rmc	SK	LA	Bashaldo
 rmc	SK	LA	Hungarian-Slovak Romani
+rmc	SK	LA	Karpacki Roma
+rmc	SK	LA	Romanes
 rmc	SK	LA	Romungro
+rmc	SK	LA	Sárvika Romá
+rmc	SK	LA	Ungrike Romá
 rmc	UA	L	Romani, Carpathian
+rmc	UA	LA	Ungrike Romá
 rmd	DK	L	Traveller Danish
 rmd	DK	LA	Rodi
 rmd	DK	LA	Rotwelsch
@@ -42691,20 +44208,24 @@ rme	GB	LA	Anglo-Romani
 rme	GB	LA	English Romani
 rme	GB	LA	Gypsy Jib
 rme	GB	LA	Pogadi Chib
-rme	GB	LA	Posh ‘N’ Posh
+rme	GB	LA	Posh ’N’ Posh
+rme	GB	LA	Romanes
 rme	GB	LA	Romani
 rme	GB	LA	Romani English
 rme	GB	LA	Romanichal
 rme	GB	LA	Romano Lavo
 rme	GB	LA	Romany
+rme	GB	LA	Rummaness
 rme	US	L	Angloromani
 rme	US	LA	English Romani
+rme	US	LA	Romani
 rme	US	LA	Romani English
 rme	US	LA	Romanichal
 rme	US	LA	Romanis
 rmf	FI	L	Romani, Kalo Finnish
 rmf	FI	LA	Fíntika Rómma
 rmf	FI	LA	Gypsy
+rmf	FI	LA	Kaalo
 rmf	SE	L	Romani, Kalo Finnish
 rmf	SE	LA	Fíntika Rómma
 rmf	SE	LA	Kalé
@@ -42724,8 +44245,18 @@ rmi	SY	LA	Bosa
 rmi	SY	LA	Bosha
 rmk	PG	L	Romkun
 rmk	PG	LA	Romkuin
+rml	BY	L	Romani, Baltic
+rml	BY	LA	Balt Romani
+rml	BY	LA	Balt Slavic Romani
+rml	BY	LA	Baltic Slavic Romani
+rml	BY	LA	White Russian Romani
+rml	EE	L	Romani, Baltic
+rml	EE	LA	Estonian Romani
 rml	LT	D	Lithuanian Romani
 rml	LT	L	Romani, Baltic
+rml	LT	LA	Balt Romani
+rml	LT	LA	Balt Slavic Romani
+rml	LT	LA	Baltic Slavic Romani
 rml	LV	D	Estonian Romani
 rml	LV	D	Latvian Romani
 rml	LV	D	North Russian Romani
@@ -42733,13 +44264,15 @@ rml	LV	D	Polish Romani
 rml	LV	D	White Russian Romani
 rml	LV	DA	Lettish Romani
 rml	LV	L	Romani, Baltic
-rml	PL	D	Estonian Romani
-rml	PL	D	Latvian Romani
-rml	PL	D	North Russian Romani
-rml	PL	D	Polish Romani
-rml	PL	D	White Russian Romani
-rml	PL	DA	Lettish Romani
+rml	LV	LA	Latvian Romani
+rml	LV	LA	Lettish Romani
+rml	LV	LA	Lotfítka Romá
+rml	LV	LA	Lotvitko Romani cib
 rml	PL	L	Romani, Baltic
+rml	PL	LA	Balt Romani
+rml	PL	LA	Balt Slavic Romani
+rml	PL	LA	Baltic Slavic Romani
+rml	PL	LA	Polish Romani
 rml	UA	L	Romani, Baltic
 rmm	ID	L	Roma
 rmm	ID	LA	Romang
@@ -42752,25 +44285,11 @@ rmn	BG	D	Paspatian
 rmn	BG	D	Tinners Romani
 rmn	BG	L	Romani, Balkan
 rmn	BG	LA	Gypsy
-rmn	DE	D	Arli
-rmn	DE	D	Dzambazi
-rmn	DE	DA	Erli
-rmn	DE	L	Romani, Balkan
-rmn	FR	D	Arli
-rmn	FR	D	Dzambazi
-rmn	FR	L	Romani, Balkan
 rmn	GR	D	Arli
 rmn	GR	D	Greek Romani
 rmn	GR	DA	Erli
 rmn	GR	L	Romani, Balkan
-rmn	HU	L	Romani, Balkan
-rmn	HU	LA	Beás
-rmn	HU	LA	Cigány
-rmn	HU	LA	Roma
 rmn	IR	L	Romani, Balkan
-rmn	IT	D	Arli
-rmn	IT	DA	Erli
-rmn	IT	L	Romani, Balkan
 rmn	MD	L	Romani, Balkan
 rmn	MD	LA	Gypsy
 rmn	MK	D	Arli
@@ -42784,20 +44303,19 @@ rmn	RS	D	Arli
 rmn	RS	D	Dzambazi
 rmn	RS	D	Tinners Romani
 rmn	RS	L	Romani, Balkan
-rmn	SE	D	Arli
-rmn	SE	L	Romani, Balkan
 rmn	TR	D	Arli
 rmn	TR	DA	Erli
 rmn	TR	L	Romani, Balkan
 rmn	UA	L	Romani, Balkan
 rmo	AT	L	Romani, Sinte
-rmo	AT	LA	Rommanes
+rmo	AT	LA	Romanes
 rmo	AT	LA	Sinte
 rmo	AT	LA	Sinti
 rmo	CH	L	Romani, Sinte
+rmo	CH	LA	Romanes
 rmo	CZ	D	Lallere
 rmo	CZ	L	Romani, Sinte
-rmo	CZ	LA	Rommanes
+rmo	CZ	LA	Romanes
 rmo	CZ	LA	Sinte
 rmo	CZ	LA	Sinti
 rmo	CZ	LA	Tsigane
@@ -42808,47 +44326,58 @@ rmo	DE	D	Kranaria
 rmo	DE	D	Krantiki
 rmo	DE	D	Praistiki
 rmo	DE	L	Romani, Sinte
-rmo	DE	LA	Rommanes
+rmo	DE	LA	Romanes
 rmo	DE	LA	Sinte
-rmo	DE	LA	Sintí
+rmo	DE	LA	Sinti
+rmo	DE	LA	Sinto-Manush
 rmo	DE	LA	Ziguener
 rmo	FR	D	Manouche
 rmo	FR	DA	Manuche
 rmo	FR	DA	Manush
 rmo	FR	L	Romani, Sinte
-rmo	FR	LA	Rommanes
+rmo	FR	LA	Romanes
 rmo	FR	LA	Sinti
 rmo	FR	LA	Tsigane
 rmo	HR	L	Romani, Sinte
+rmo	HR	LA	Romanes
 rmo	IT	D	Manouche
 rmo	IT	D	Piedmont Sintí
 rmo	IT	D	Slovenian-Croatian
 rmo	IT	L	Romani, Sinte
+rmo	IT	LA	Romanes
 rmo	KZ	L	Romani, Sinte
 rmo	KZ	LA	Manouche
 rmo	KZ	LA	Manuche
+rmo	KZ	LA	Romanes
 rmo	KZ	LA	Sinti
 rmo	KZ	LA	Tsigane
 rmo	NL	D	Manouche
 rmo	NL	L	Romani, Sinte
+rmo	NL	LA	Romanes
 rmo	PL	D	Manuche
 rmo	PL	DA	Manouche
 rmo	PL	L	Romani, Sinte
+rmo	PL	LA	Romanes
 rmo	PL	LA	Sinti
 rmo	PL	LA	Tsigane
 rmo	RS	D	Abbruzzesi
 rmo	RS	D	Serbian Romani
 rmo	RS	D	Slovenian-Croatian Romani
 rmo	RS	L	Romani, Sinte
+rmo	RS	LA	Romanes
+rmo	RS	LA	Sasítka Romá
 rmo	RS	LA	Sinte
 rmo	RS	LA	Sinti
 rmo	SI	L	Romani, Sinte
+rmo	SI	LA	Romanes
 rmp	PG	L	Rempi
 rmp	PG	LA	A’e
+rmp	PG	LA	Aic
 rmp	PG	LA	Erempi
 rmp	PG	LA	Rempin
 rmq	BR	D	Brazilian Calão
 rmq	BR	L	Caló
+rmq	BR	LA	Chibi
 rmq	BR	LA	Gitano
 rmq	BR	LA	Iberian Romani
 rmq	ES	D	Brazilian Calão
@@ -42858,6 +44387,7 @@ rmq	ES	D	Spanish Caló
 rmq	ES	DA	Calão
 rmq	ES	DA	Lusitano-Romani
 rmq	ES	L	Caló
+rmq	ES	LA	Caló Romani
 rmq	ES	LA	Gitano
 rmq	ES	LA	Hispanoromani
 rmq	ES	LA	Iberian Romani
@@ -42882,13 +44412,16 @@ rms	RO	LP	Limbaj Mimico-Gestual Romanesc
 rms	RO	LP	LMGR
 rmt	AF	D	Churi-Wali
 rmt	AF	L	Domari
+rmt	AF	LA	Dom
 rmt	AF	LA	Ghorbati
 rmt	EG	D	Helebi
 rmt	EG	D	Nawar
 rmt	EG	DA	Ghagar
 rmt	EG	L	Domari
+rmt	EG	LA	Dom
 rmt	IL	D	Nawari
 rmt	IL	L	Domari
+rmt	IL	LA	Dom
 rmt	IL	LA	Nawari
 rmt	IL	LA	Near-Eastern Gypsy
 rmt	IN	D	Domaki
@@ -42897,6 +44430,7 @@ rmt	IN	L	Domari
 rmt	IN	LA	Dom
 rmt	IN	LA	Domra Magu Hiya
 rmt	IQ	L	Domari
+rmt	IQ	LA	Dom
 rmt	IQ	LA	Middle Eastern Romani
 rmt	IR	D	Karachi
 rmt	IR	D	Koli
@@ -42908,6 +44442,7 @@ rmt	IR	D	Qinati
 rmt	IR	D	Yürük
 rmt	IR	DA	Ghorbati
 rmt	IR	L	Domari
+rmt	IR	LA	Dom
 rmt	IR	LA	Gypsy
 rmt	IR	LA	Luti
 rmt	IR	LA	Mehtar
@@ -42918,6 +44453,7 @@ rmt	JO	D	Kurbat
 rmt	JO	D	Nawar
 rmt	JO	L	Domari
 rmt	JO	LA	Barake
+rmt	JO	LA	Dom
 rmt	JO	LA	Gypsy
 rmt	JO	LA	Kurbat
 rmt	JO	LA	Middle Eastern Romani
@@ -42925,15 +44461,19 @@ rmt	JO	LA	Nawar
 rmt	JO	LA	Tsigene
 rmt	LY	D	Helebi
 rmt	LY	L	Domari
+rmt	LY	LA	Dom
 rmt	PS	D	Nawari
 rmt	PS	L	Domari
+rmt	PS	LA	Dom
 rmt	PS	LA	Nawari
 rmt	PS	LA	Near-Eastern Gypsy
 rmt	RU	D	Karachi
 rmt	RU	D	Luli
 rmt	RU	D	Maznoug
 rmt	RU	L	Domari
+rmt	RU	LA	Dom
 rmt	SD	L	Domari
+rmt	SD	LA	Dom
 rmt	SY	D	Barake
 rmt	SY	D	Beirut
 rmt	SY	D	Kurbati
@@ -42941,6 +44481,7 @@ rmt	SY	D	Nablos
 rmt	SY	D	Nawar
 rmt	SY	L	Domari
 rmt	SY	LA	Barake
+rmt	SY	LA	Dom
 rmt	SY	LA	Gypsy
 rmt	SY	LA	Kurbat
 rmt	SY	LA	Middle Eastern Romani
@@ -42950,6 +44491,7 @@ rmt	TR	D	Beludji
 rmt	TR	D	Karachi
 rmt	TR	D	Marashi
 rmt	TR	L	Domari
+rmt	TR	LA	Dom
 rmt	TR	LA	Gypsy
 rmt	TR	LA	Middle Eastern Romani
 rmt	TR	LA	Tsigene
@@ -42959,10 +44501,13 @@ rmu	SE	LA	Rommani
 rmu	SE	LA	Svensk Rommani
 rmu	SE	LA	Traveller Swedish
 rmw	GB	L	Romani, Welsh
+rmw	GB	LA	Voshanange Kalá
+rmw	GB	LA	Walsenenge Kale
 rmx	VN	L	Romam
 rmx	VN	LA	Ro Mam
 rmy	AL	D	Southern Vlax Romani
 rmy	AL	L	Romani, Vlax
+rmy	AL	LA	Rom
 rmy	BA	D	Kalderash
 rmy	BA	D	Serbo-Bosnian
 rmy	BA	D	Southern Vlax
@@ -42971,43 +44516,26 @@ rmy	BA	DA	Machwaya
 rmy	BA	L	Romani, Vlax
 rmy	BA	LA	Danubian
 rmy	BA	LA	Gypsy
+rmy	BA	LA	Rom
 rmy	BA	LA	Tsigene
 rmy	BA	LA	Vlax
 rmy	BG	L	Romani, Vlax
-rmy	BR	L	Romani, Vlax
-rmy	CO	L	Romani, Vlax
-rmy	DE	D	Kalderash
-rmy	DE	D	Lovari
-rmy	DE	L	Romani, Vlax
-rmy	FR	D	Kalderash
-rmy	FR	D	Lovari
-rmy	FR	L	Romani, Vlax
-rmy	FR	LA	Rom
-rmy	FR	LA	Romenes
-rmy	FR	LA	Tsigane
-rmy	FR	LA	Vlax
-rmy	GB	D	Kalderash
-rmy	GB	D	Lovari
-rmy	GB	L	Romani, Vlax
-rmy	GB	LA	Rom
-rmy	GB	LA	Romenes
-rmy	GB	LA	Tsigane
+rmy	BG	LA	Rom
 rmy	GR	D	Lovari
 rmy	GR	L	Romani, Vlax
+rmy	GR	LA	Rom
 rmy	GR	LA	Romanés
 rmy	GR	LA	Tsingani
 rmy	IT	D	Kalderash
 rmy	IT	D	Lovari
 rmy	IT	L	Romani, Vlax
-rmy	NL	D	Kalderash
-rmy	NL	D	Lovari
-rmy	NL	L	Romani, Vlax
+rmy	IT	LA	Rom
 rmy	NO	D	Lovari
 rmy	NO	L	Romani, Vlax
+rmy	NO	LA	Rom
 rmy	PL	D	Lovari
 rmy	PL	L	Romani, Vlax
-rmy	PT	D	Kalderash
-rmy	PT	L	Romani, Vlax
+rmy	PL	LA	Rom
 rmy	RO	D	Churari
 rmy	RO	D	Eastern Vlax Romani
 rmy	RO	D	Gabor
@@ -43027,6 +44555,7 @@ rmy	RO	DA	Bisa
 rmy	RO	DA	Churarícko
 rmy	RO	DA	Coppersmith
 rmy	RO	DA	Greco
+rmy	RO	DA	Kalderari
 rmy	RO	DA	Kelderashícko
 rmy	RO	DA	Lovarícko
 rmy	RO	DA	Machvanmcko
@@ -43034,6 +44563,8 @@ rmy	RO	DA	Sievemakers
 rmy	RO	L	Romani, Vlax
 rmy	RO	LA	Danubian
 rmy	RO	LA	Gypsy
+rmy	RO	LA	Rom
+rmy	RO	LA	Roma
 rmy	RO	LA	Romanese
 rmy	RO	LA	Tsigene
 rmy	RO	LA	Vlax Romany
@@ -43041,6 +44572,7 @@ rmy	RU	D	Central Vlax Romani
 rmy	RU	D	Kalderash
 rmy	RU	L	Romani, Vlax
 rmy	RU	LA	Kalderash
+rmy	RU	LA	Rom
 rmy	SE	D	Arli
 rmy	SE	D	Gurbet
 rmy	SE	D	Kalderash
@@ -43048,16 +44580,24 @@ rmy	SE	D	Lovari
 rmy	SE	D	Machvano
 rmy	SE	D	Sinto
 rmy	SE	L	Romani, Vlax
+rmy	SE	LA	Rom
 rmy	SE	LP	Zigenare
 rmy	SK	D	Kalderash
 rmy	SK	D	Lovari
 rmy	SK	DA	Kaldarári
 rmy	SK	L	Romani, Vlax
+rmy	SK	LA	Rom
+rmy	UA	D	Central Vlax Romani
+rmy	UA	D	Kalderash
+rmy	UA	D	Ukrainian Vlax Romani
+rmy	UA	L	Romani, Vlax
+rmy	UA	LA	Rom
 rmz	BD	L	Marma
+rmz	BD	LA	Mraima
 rmz	BD	LP	Mogh
 rmz	IN	L	Marma
+rmz	IN	LA	Mraima
 rmz	IN	LP	Mogh
-rna	CO	L	Runa
 rnd	AO	L	Ruund
 rnd	AO	LA	Chilu Wunda
 rnd	AO	LA	Luunda
@@ -43195,7 +44735,6 @@ ron	MD	DA	Oltean
 ron	MD	DA	Walachian
 ron	MD	L	Romanian
 ron	MD	LA	Moldovan
-ron	MD	LA	Romanian
 ron	MD	LA	Roumanian
 ron	MD	LA	Rumanian
 ron	RO	D	Banat
@@ -43235,6 +44774,8 @@ rou	CF	LA	Aykindang
 rou	CF	LA	Rounga
 rou	CF	LA	Runga de Ndele
 rou	TD	L	Runga
+rou	TD	LA	Aiki
+rou	TD	LA	Ayki
 rou	TD	LA	Aykindang
 rou	TD	LA	Rounga
 rou	TD	LA	Roungo
@@ -43262,15 +44803,20 @@ rro	PG	LA	Roro
 rsb	RS	L	Romano-Serbian
 rsb	RS	LA	Tent Gypsy
 rsi	SB	L	Rennellese Sign Language
-rsl	BG	L	Russian Sign Language
 rsl	EE	L	Russian Sign Language
 rsl	MD	L	Russian Sign Language
 rsl	RU	L	Russian Sign Language
-rsl	RU	LA	Russkij Âzyk Žestov
+rsl	RU	LA	Russkij Žestovyj Âzyk
+rsl	RU	LP	Russkij Âzyk Žestov
+rsm	AU	L	Miriwoong Sign Language
+rsm	AU	LA	Fingertalk
+rsm	AU	LA	MwSL
 rtc	MM	D	Central Rungtu
 rtc	MM	D	Northern Rungtu
 rtc	MM	D	Southern Rungtu
 rtc	MM	L	Chin, Rungtu
+rtc	MM	LA	Chin
+rtc	MM	LA	Rungtu
 rtc	MM	LA	Taungtha
 rth	ID	L	Ratahan
 rth	ID	LA	Bentenan
@@ -43345,6 +44891,7 @@ ruk	NG	LA	Bace
 ruk	NG	LA	Bache
 ruk	NG	LA	Che
 ruk	NG	LA	Inchazi
+ruk	NG	LA	Kuche
 ruk	NG	LA	Rukuba
 ruk	NG	LA	Sale
 run	BI	D	Igisoni
@@ -43356,40 +44903,59 @@ run	BI	D	Ikirundi
 run	BI	D	Ikiyogoma
 run	BI	DA	Urumoso
 run	BI	L	Rundi
+run	BI	LA	Hima
 run	BI	LA	Kirundi
 run	BI	LA	Urundi
 ruo	HR	L	Romanian, Istro
 ruo	HR	LA	Istrio-Romanian
 ruo	HR	LA	Istro-Romanian
 rup	AL	L	Aromanian
+rup	AL	LA	Armani
 rup	AL	LA	Armina
+rup	AL	LA	Armini
 rup	AL	LA	Aromunian
 rup	AL	LA	Arumanian
+rup	AL	LA	Arumanisht
+rup	AL	LA	Arumenian
 rup	AL	LA	Arumun
 rup	AL	LA	Macedo Romanian
 rup	AL	LA	Macedo-Rumanian
 rup	AL	LA	Vlach
+rup	BA	L	Aromanian
+rup	BA	LA	Armani
+rup	BA	LA	Macedo Romanian
 rup	BG	L	Aromanian
+rup	BG	LA	Armani
 rup	BG	LA	Armina
+rup	BG	LA	Armini
 rup	BG	LA	Arumanian
 rup	BG	LA	Macedo
 rup	BG	LA	Macedo-Rumanian
 rup	BG	LA	Romanian
 rup	GR	L	Aromanian
+rup	GR	LA	Armani
 rup	GR	LA	Armina
+rup	GR	LA	Armini
 rup	GR	LA	Arumanian
+rup	GR	LA	Arumenian
 rup	GR	LA	Macedo Romanian
 rup	GR	LA	Macedo-Rumanian
 rup	GR	LA	Vlach
 rup	MK	L	Aromanian
+rup	MK	LA	Armani
 rup	MK	LA	Armina
+rup	MK	LA	Armini
 rup	MK	LA	Aromunian
 rup	MK	LA	Arumanian
+rup	MK	LA	Arumenian
 rup	MK	LA	Macedo Romanian
 rup	MK	LA	Macedo-Rumanian
+rup	MK	LA	Vlav
 rup	RO	L	Aromanian
+rup	RO	LA	Armani
 rup	RO	LA	Macedo Romanian
 rup	RS	L	Aromanian
+rup	RS	LA	Armani
 rup	RS	LA	Macedo Romania
 ruq	GR	L	Romanian, Megleno
 ruq	GR	LA	Meglenite
@@ -43414,6 +44980,7 @@ rus	LV	L	Russian
 rus	MD	L	Russian
 rus	MN	L	Russian
 rus	MN	LA	Russki
+rus	PL	L	Russian
 rus	RU	D	North Russian
 rus	RU	D	South Russian
 rus	RU	L	Russian
@@ -43421,7 +44988,11 @@ rus	RU	LA	Russki
 rus	TJ	L	Russian
 rus	UA	L	Russian
 rus	UZ	L	Russian
+rut	AZ	D	Borsh-Khnov
+rut	AZ	DA	Mykhad
 rut	AZ	L	Rutul
+rut	AZ	LA	Knovtsy
+rut	AZ	LA	Myhadbyr
 rut	RU	D	North Rutul
 rut	RU	D	South Rutul
 rut	RU	DA	Asar-Kala
@@ -43447,6 +45018,8 @@ ruu	MY	DA	Roomarrows
 ruu	MY	DA	Rumanau Alab
 ruu	MY	L	Lobu, Lanas
 ruu	MY	LA	Keningau Lobu
+ruu	MY	LA	Lobu
+ruu	MY	LP	Labou
 ruy	NG	L	Mala
 ruy	NG	LA	Amala
 ruy	NG	LA	Rumaiya
@@ -43476,7 +45049,7 @@ rwm	CD	DA	Lubulebule
 rwm	CD	L	Amba
 rwm	CD	LA	Hambo
 rwm	CD	LA	Humu
-rwm	CD	LA	Kihumu
+rwm	CD	LA	KiHumu
 rwm	CD	LA	Kuamba
 rwm	CD	LA	Kwamba
 rwm	CD	LA	Ruwenzori Kibira
@@ -43492,6 +45065,7 @@ rwm	UG	LA	Humu
 rwm	UG	LA	Kihumu
 rwm	UG	LA	Kuamba
 rwm	UG	LA	Ku-Amba
+rwm	UG	LA	Kwamba
 rwm	UG	LA	Lubulebule
 rwm	UG	LA	Lwamba
 rwm	UG	LA	Ruwenzori Kibira
@@ -43569,6 +45143,12 @@ ryu	JP	D	Torishima
 ryu	JP	L	Okinawan, Central
 ryu	JP	LA	Luchu
 ryu	JP	LA	Okinawan
+rzh	YE	L	Rāziḥī
+rzh	YE	LA	Jabal Razih
+rzh	YE	LA	Rāziḥīt
+rzh	YE	LA	Samrah Rāziḥīt
+rzh	YE	LA	Samrit Rāziḥ
+rzh	YE	LA	S-samrit
 saa	TD	L	Saba
 saa	TD	LA	Jelkung
 sab	PA	D	Bokotá
@@ -43598,6 +45178,7 @@ sad	TZ	LA	Kissandaui
 sad	TZ	LA	Sandaui
 sad	TZ	LA	Sandaweeki
 sad	TZ	LA	Sandawi
+sad	TZ	LA	Sandawso
 sad	TZ	LA	Sandwe
 sae	BR	L	Sabanê
 sae	BR	LA	Sabanês Sabones
@@ -43630,6 +45211,7 @@ sak	GA	L	Sake
 sak	GA	LA	Asake
 sak	GA	LA	Shake
 sam	PS	L	Samaritan Aramaic
+sam	PS	LA	Shamerim
 san	IN	L	Sanskrit
 san	NP	L	Sanskrit
 san	NP	LA	Deva Bhasha
@@ -43664,6 +45246,7 @@ sas	ID	L	Sasak
 sas	ID	LA	Lombok
 sat	BD	L	Santhali
 sat	BD	LA	Har
+sat	BD	LA	Har Rar
 sat	BD	LA	Hor
 sat	BD	LA	Sandal
 sat	BD	LA	Sangtal
@@ -43679,6 +45262,7 @@ sat	IN	D	Paharia
 sat	IN	DA	Khole
 sat	IN	L	Santhali
 sat	IN	LA	Har
+sat	IN	LA	Har Rar
 sat	IN	LA	Hor
 sat	IN	LA	Samtali
 sat	IN	LA	Sandal
@@ -43691,6 +45275,7 @@ sat	IN	LA	Sentali
 sat	IN	LA	Sonthal
 sat	NP	L	Santhali
 sat	NP	LA	Har
+sat	NP	LA	Har Rar
 sat	NP	LA	Hor
 sat	NP	LA	Sainti
 sat	NP	LA	Sandal
@@ -43780,6 +45365,7 @@ sba	TD	LA	Gambaye
 sba	TD	LA	Gamblai
 sba	TD	LA	Ngambai
 sba	TD	LA	Sara Ngambai
+sba	TD	LA	Sara-Ngambay
 sbb	SB	L	Simbo
 sbb	SB	LA	Madeggusu
 sbb	SB	LA	Mandeghughusu
@@ -43834,6 +45420,7 @@ sbl	PH	L	Sambal, Botolan
 sbl	PH	LA	Aeta Negrito
 sbl	PH	LA	Ayta Hambali
 sbl	PH	LA	Botolan Zambal
+sbl	PH	LA	Hambali
 sbm	TZ	D	Itumba
 sbm	TZ	D	Kondoa
 sbm	TZ	D	Kweny
@@ -43871,20 +45458,22 @@ sbp	TZ	LA	Sangi
 sbp	TZ	LA	Sango
 sbp	TZ	LA	Shisango
 sbq	PG	L	Sileibi
-sbr	ID	L	Sembakung Murut
+sbr	ID	L	Murut, Sembakung
 sbr	ID	LA	Sembakoeng
 sbr	ID	LA	Sembakong
 sbr	ID	LA	Simbakong
 sbr	ID	LA	Tingalun
 sbr	ID	LA	Tinggalan
 sbr	ID	LA	Tinggalum
-sbr	MY	L	Sembakung Murut
+sbr	MY	L	Murut, Sembakung
 sbr	MY	LA	Sembakoeng
 sbr	MY	LA	Sembakong
 sbr	MY	LA	Simbakong
+sbr	MY	LA	Tenggalan
 sbr	MY	LA	Tidoeng
 sbr	MY	LA	Tidong
 sbr	MY	LA	Tidung
+sbr	MY	LA	Tingalan
 sbr	MY	LA	Tingalun
 sbr	MY	LA	Tinggalan
 sbr	MY	LA	Tinggalum
@@ -44066,6 +45655,7 @@ scp	NP	D	Western Helambu Sherpa
 scp	NP	L	Helambu Sherpa
 scp	NP	LA	Hyolmo
 scp	NP	LA	Yholmo
+scp	NP	LA	Yohlmo
 scp	NP	LA	Yohlmu Tam
 scp	NP	LA	Yolmo
 scq	KH	L	Sa’och
@@ -44078,6 +45668,7 @@ scs	CA	L	Slavey, North
 scs	CA	LA	Dene
 scs	CA	LA	Dené
 scs	CA	LA	Mackenzian
+scs	CA	LA	Satúotine Yatí
 scs	CA	LP	Slave
 scs	CA	LP	Slavi
 scu	IN	L	Shumcho
@@ -44215,6 +45806,7 @@ sdr	BD	D	Mokkan Tila Sadri
 sdr	BD	D	Nurpur Sadri
 sdr	BD	D	Uchai Sadri
 sdr	BD	L	Sadri, Oraon
+sdr	BD	LA	Pahan
 sds	TN	D	Sened
 sds	TN	D	Tmagourt
 sds	TN	DA	Tmagurt
@@ -44334,9 +45926,13 @@ seh	MZ	L	Sena
 seh	MZ	LA	Chisena
 seh	MZ	LA	Cisena
 sei	MX	L	Seri
+sei	MX	LA	Cmiique Iitom
+sei	MX	LA	Comcáac
 sej	PG	L	Sene
 sek	CA	L	Sekani
+sek	CA	LA	Tsek’ehne
 sek	CA	LA	Tse’khene
+sek	CA	LA	Tsek’hene
 sel	RU	D	Narym
 sel	RU	D	Srednyaya Ob-Ket
 sel	RU	D	Taz
@@ -44360,16 +45956,19 @@ sen	BF	LA	Nandereke
 sen	BF	LA	Nandergé
 sen	BF	LA	Nanergé
 sen	BF	LA	Nanergué
+sen	BF	LA	Nanerige
 seo	PG	L	Suarmin
 seo	PG	LA	Akiapmin
 seo	PG	LA	Duranmin
 sep	BF	L	Sénoufo, Sìcìté
+sep	BF	LA	Sìcijuungé
 sep	BF	LA	Sìcìré
 sep	BF	LA	Sìcìté
 sep	BF	LA	Sìpììté
 sep	BF	LA	Sucite
 sep	BF	LA	Tagba
 sep	ML	L	Sénoufo, Sìcìté
+sep	ML	LA	Sìcijuungé
 sep	ML	LA	Sìcìré
 sep	ML	LA	Sìcìté
 sep	ML	LA	Sìpììté
@@ -44416,11 +46015,14 @@ sew	PG	L	Sewa Bay
 sew	PG	LA	Duau Pwata
 sey	EC	D	Angotero
 sey	EC	D	Ecuadorian Siona
+sey	EC	DA	Angutera
 sey	EC	L	Secoya
 sey	PE	D	Angotero
 sey	PE	D	Piojé
+sey	PE	DA	Angutera
 sey	PE	L	Secoya
 sey	PE	LA	Angotero
+sey	PE	LA	Angutera
 sey	PE	LA	Encabellao
 sez	MM	D	Central Senthang
 sez	MM	D	Sakta
@@ -44437,12 +46039,15 @@ sez	MM	LA	Hsemtang
 sez	MM	LA	Sentang
 sfb	BE	L	French Belgian Sign Language
 sfb	BE	LA	Langue des signes belge francophone
+sfb	BE	LA	Langue des signes de Belgique Francophone
 sfb	BE	LA	LSBF
 sfe	PH	L	Subanen, Eastern
 sfe	PH	LA	Guinselugnen
+sfe	PH	LA	Salugnen
 sfm	CN	L	Miao, Small Flowery
 sfm	CN	LA	Atse
 sfm	CN	LA	Ghab-Mvb Ghab-Svd
+sfm	CN	LA	Gha-Mu
 sfm	CN	LA	Ghuab-Hmongb Ghuab-Soud
 sfm	CN	LA	Hsiao Hwa Miao
 sfm	CN	LA	Xiao Hua Miao
@@ -44466,6 +46071,7 @@ sge	ID	D	Kelai
 sge	ID	D	Segah
 sge	ID	L	Segai
 sge	ID	LA	Ga’ay
+sge	ID	LA	Menggae
 sge	ID	LA	Segayi
 sgg	CH	L	Swiss-German Sign Language
 sgg	CH	LA	Deutschschweizer Gebärdensprache
@@ -44506,8 +46112,10 @@ sgh	TJ	DA	Shighni
 sgh	TJ	DA	Shugan
 sgh	TJ	DA	Shugnan
 sgh	TJ	L	Shughni
+sgh	TJ	LA	Khugnone
 sgh	TJ	LA	Shugnan-Rushan
 sgi	CM	L	Suga
+sgi	CM	LA	Baghap
 sgi	CM	LA	Galim
 sgi	CM	LA	Nizaa
 sgi	CM	LA	Ssuga
@@ -44542,6 +46150,14 @@ sgr	IR	LA	Sängsari
 sgr	IR	LA	Sängsäri
 sgr	IR	LA	Sengiseri
 sgr	IR	LA	Sengsari
+sgs	LT	L	Samogitian
+sgs	LT	LA	Lowland Lithuanian
+sgs	LT	LA	Žemaičiai
+sgs	LT	LA	Žemaičių
+sgs	LT	LA	Žemaitis
+sgs	LT	LA	Žemaitiškai
+sgs	LT	LA	Žemaitiu
+sgs	LT	LA	Zhemaitish
 sgt	BT	L	Brokpake
 sgt	BT	LA	Brokpa
 sgt	BT	LA	Dakpa
@@ -44567,6 +46183,7 @@ sgw	ET	DA	Cheha
 sgw	ET	DA	Eza
 sgw	ET	DA	Gwemarra
 sgw	ET	DA	Izha
+sgw	ET	DA	Muxir
 sgw	ET	L	Sebat Bet Gurage
 sgw	ET	LA	Central West Gurage
 sgw	ET	LA	Gouraghie
@@ -44598,10 +46215,12 @@ shb	VE	L	Ninam
 shb	VE	LA	Shiriana
 shb	VE	LA	Yanam
 shc	CD	L	Sonde
+shc	CD	LA	Kilua
 shc	CD	LA	Kisonde
 shc	CD	LA	Kisoonde
 shc	CD	LA	Soonde
 shd	PK	L	Kundal Shahi
+shd	PK	LA	Apeen Bol
 shd	PK	LP	Rawri
 she	ET	L	Sheko
 she	ET	LA	Shak
@@ -44803,6 +46422,7 @@ shw	SD	D	Ndano
 shw	SD	D	Shabun
 shw	SD	DA	Shirumba
 shw	SD	L	Shwai
+shw	SD	LA	Cwaya
 shw	SD	LA	Ludumor
 shw	SD	LA	Shirumba
 shw	SD	LA	Shuway
@@ -44811,6 +46431,7 @@ shx	CN	D	Luofu
 shx	CN	DA	Eastern She
 shx	CN	DA	Western She
 shx	CN	L	She
+shx	CN	LA	Ho Nte
 shx	CN	LA	Huo Nte
 shy	DZ	L	Tachawit
 shy	DZ	LA	Aurès
@@ -44973,8 +46594,10 @@ siz	LY	L	Siwi
 sja	CO	D	Basurudó
 sja	CO	L	Epena
 sja	CO	LA	Cholo
+sja	CO	LA	Embena
 sja	CO	LA	Embera
 sja	CO	LA	Emberá-Saija
+sja	CO	LA	Epéna Pedée
 sja	CO	LA	Epená Saija
 sja	CO	LA	Saija
 sja	CO	LA	Southern Empera
@@ -45042,6 +46665,7 @@ sjm	MY	LA	Cagayanon
 sjm	MY	LA	Jama Mapun
 sjm	MY	LA	Kagayan
 sjm	MY	LA	Orang Cagayan
+sjm	MY	LA	Pellun Mapun
 sjm	MY	LA	Sama Mapun
 sjm	PH	L	Mapun
 sjm	PH	LA	Bajau Kagayan
@@ -45168,6 +46792,7 @@ skm	PG	D	Kamdaran
 skm	PG	D	Sakam
 skm	PG	L	Kutong
 skm	PG	LA	Dinangat
+skm	PG	LA	Kutong gin
 skm	PG	LA	Sakam
 skn	PH	L	Subanon, Kolibugan
 skn	PH	LA	Calibugan
@@ -45191,11 +46816,8 @@ skr	IN	DA	Bahawalpuri
 skr	IN	DA	Bhawalpuri
 skr	IN	DA	Reasati
 skr	IN	L	Saraiki
-skr	IN	LA	Bahawalpuri
 skr	IN	LA	Multani
 skr	IN	LA	Mutani
-skr	IN	LA	Reasati
-skr	IN	LA	Riasati
 skr	IN	LA	Seraiki
 skr	IN	LA	Siraiki
 skr	PK	D	Dervi
@@ -45209,8 +46831,6 @@ skr	PK	DA	Derawali
 skr	PK	DA	Khatki
 skr	PK	L	Saraiki
 skr	PK	LA	Bahawalpuri
-skr	PK	LA	Multani
-skr	PK	LA	Riasiti
 skr	PK	LA	Seraiki
 skr	PK	LA	Siraiki
 sks	PG	L	Maia
@@ -45260,6 +46880,7 @@ skx	ID	D	Lodang
 skx	ID	DA	Wono
 skx	ID	L	Seko Padang
 skx	ID	LA	Seko
+skx	ID	LA	Sua Tu Padang
 skx	ID	LA	Wono
 sky	SB	L	Sikaiana
 sky	SB	LA	Sikayana
@@ -45277,6 +46898,7 @@ sle	IN	LA	Sholanayika
 sle	IN	LA	Sholiga
 sle	IN	LA	Sholigar
 sle	IN	LA	Solaga
+sle	IN	LA	Solagaru mattu
 sle	IN	LA	Solanayakkans
 sle	IN	LA	Solega
 sle	IN	LA	Soliga
@@ -45286,9 +46908,9 @@ slf	CH	LA	Lingua dei segni della Svizzera italiana
 slf	CH	LA	Lingua dei Segni Italiana
 slf	CH	LA	LIS
 slf	CH	LA	LIS-SI
-slg	ID	L	Selungai Murut
+slg	ID	L	Murut, Selungai
 slg	ID	LA	Murut
-slg	MY	L	Selungai Murut
+slg	MY	L	Murut, Selungai
 slh	US	D	Duwamish
 slh	US	D	Muckleshoot
 slh	US	D	Nisqually
@@ -45303,15 +46925,30 @@ sli	PL	L	Silesian, Lower
 sli	PL	LA	Upper Schlesisch
 slj	BR	L	Salumá
 slk	AT	L	Slovak
+slk	AT	LA	Slovencina
+slk	AT	LA	Slovenský Jazyk
 slk	CZ	L	Slovak
+slk	CZ	LA	Slovencina
+slk	CZ	LA	Slovenský Jazyk
 slk	HR	L	Slovak
+slk	HR	LA	Slovencina
+slk	HR	LA	Slovenský Jazyk
 slk	HU	L	Slovak
+slk	HU	LA	Slovencina
+slk	HU	LA	Slovenský Jazyk
 slk	RO	L	Slovak
+slk	RO	LA	Slovencina
+slk	RO	LA	Slovenský Jazyk
 slk	RS	L	Slovak
+slk	RS	LA	Slovencina
+slk	RS	LA	Slovenský Jazyk
 slk	SK	L	Slovak
 slk	SK	LA	Slovakian
 slk	SK	LA	Slovencina
+slk	SK	LA	Slovenský Jazyk
 slk	UA	L	Slovak
+slk	UA	LA	Slovencina
+slk	UA	LA	Slovenský Jazyk
 sll	PG	L	Salt-Yui
 sll	PG	LA	Iui
 sll	PG	LA	Salt
@@ -45348,6 +46985,8 @@ sls	SG	D	Contact Signing
 sls	SG	D	Natural Sign Language
 sls	SG	DA	Pidgin Signed English
 sls	SG	L	Singapore Sign Language
+sls	SG	LA	Natural Sign Language
+sls	SG	LA	SgSL
 slt	LA	L	Sila
 slt	LA	LA	Asong
 slt	LA	LA	Sida
@@ -45421,6 +47060,7 @@ sme	FI	LA	Davvin
 sme	FI	LA	Northern Lapp
 sme	FI	LA	Saame
 sme	FI	LA	Same
+sme	FI	LA	Sámegiella
 sme	FI	LP	Lapp
 sme	NO	D	Ruija
 sme	NO	D	Sea Lappish
@@ -45442,6 +47082,7 @@ sme	SE	LA	Northern Saami
 sme	SE	LA	Norwegian Saami
 sme	SE	LA	Saame
 sme	SE	LA	Same
+sme	SE	LA	Sámegiella
 sme	SE	LA	Samic
 sme	SE	LP	Lapp
 smf	PG	L	Auwe
@@ -45449,6 +47090,7 @@ smf	PG	LA	Simog
 smg	PG	L	Simbali
 smg	PG	LA	Asimbali
 smh	CN	L	Samei
+smh	CN	LA	Sani
 smj	NO	L	Saami, Lule
 smj	NO	LA	Lule
 smj	NO	LA	Saame
@@ -45457,6 +47099,7 @@ smj	SE	LA	Lule
 smj	SE	LA	Saami
 smj	SE	LP	Lapp
 smk	PH	L	Bolinao
+smk	PH	LA	Binobolinao
 smk	PH	LA	Bino-Bolinao
 smk	PH	LA	Binubolinao
 smk	PH	LA	Binubulinao
@@ -45466,6 +47109,15 @@ smk	PH	LA	Bulinaw
 smk	PH	LA	Sambal Bolinao
 sml	MY	L	Sama, Central
 sml	MY	LA	Badjaw
+sml	MY	LA	Bajau Pela’u
+sml	MY	LA	Sama
+sml	MY	LA	Sama Dilaut
+sml	MY	LA	Sama Kabinga’an
+sml	MY	LA	Sama Mandelaut
+sml	MY	LA	Sama Pala’u
+sml	MY	LA	Sama Siasi
+sml	MY	LA	Sama Sitangkai
+sml	MY	LA	Sama Ubian
 sml	MY	LA	Sinama
 sml	PH	D	Sama Deya
 sml	PH	D	Sama Dilaut
@@ -45496,8 +47148,10 @@ smn	FI	LP	Lapp
 smo	AS	L	Samoan
 smo	AS	LA	Gagana Samoa
 smo	WS	L	Samoan
+smo	WS	LA	Gagana Samoa
 smp	PS	L	Samaritan
 smp	PS	LA	Samaritan Hebrew
+smp	PS	LA	Shamerim
 smq	PG	L	Samo
 smq	PG	LA	Daba
 smq	PG	LA	Nomad
@@ -45686,6 +47340,7 @@ snk	GM	LA	Sarakule
 snk	GM	LA	Sarakulle
 snk	GM	LA	Saraxuli
 snk	GM	LA	Soninke
+snk	GM	LA	Sooninkanxanne
 snk	GW	L	Soninke
 snk	GW	LA	Maraka
 snk	GW	LA	Marka
@@ -45694,6 +47349,7 @@ snk	GW	LA	Sarakolle
 snk	GW	LA	Sarakule
 snk	GW	LA	Sarakulle
 snk	GW	LA	Serahule
+snk	GW	LA	Soninkanxanne
 snk	ML	D	Geriga
 snk	ML	D	Kinbakka
 snk	ML	D	Kinxenna
@@ -45721,7 +47377,7 @@ snk	ML	LA	Saraxuli
 snk	ML	LA	Sebbe
 snk	ML	LA	Serahule
 snk	ML	LA	Serecole
-snk	ML	LA	Soninkanxanne
+snk	ML	LA	Sooninkanxanne
 snk	ML	LA	Sooninke
 snk	ML	LA	Wakkore
 snk	ML	LA	Wankara
@@ -45743,6 +47399,7 @@ snk	MR	LA	Sarakolle
 snk	MR	LA	Sarakule
 snk	MR	LA	Sarakulle
 snk	MR	LA	Serahule
+snk	MR	LA	Soninkanxanne
 snk	SN	D	Kinxenna
 snk	SN	L	Soninke
 snk	SN	LA	Sarakole
@@ -45752,6 +47409,7 @@ snk	SN	LA	Sarakulle
 snk	SN	LA	Sarangkolle
 snk	SN	LA	Saraxuli
 snk	SN	LA	Serahule
+snk	SN	LA	Soninkanxanne
 snl	PH	D	Mindanao
 snl	PH	D	Sarangani
 snl	PH	L	Sangil
@@ -45814,6 +47472,7 @@ snv	ID	LA	Merau
 snv	MY	L	Sa’ban
 snv	MY	LA	Merau
 snw	GH	L	Selee
+snw	GH	LA	Bale
 snw	GH	LA	Santrokofi
 snw	GH	LA	Sele
 snw	GH	LA	Sentrokofi
@@ -45829,9 +47488,12 @@ snz	PG	D	Saipa
 snz	PG	L	Sinsauru
 snz	PG	LA	Kow
 soa	TH	L	Thai Song
+soa	TH	LA	Chao Song
 soa	TH	LA	Lao Song
 soa	TH	LA	Lao Song Dam
 soa	TH	LA	Song
+soa	TH	LA	Tai Song Dam
+soa	TH	LA	Thai Soang
 sob	ID	L	Sobei
 sob	ID	LA	Biga
 sob	ID	LA	Imasi
@@ -45923,6 +47585,7 @@ sop	CD	LA	Yembe
 soq	PG	L	Kanasi
 soq	PG	LA	Sona
 sor	TD	L	Somrai
+sor	TD	LA	Shibne
 sor	TD	LA	Sibine
 sor	TD	LA	Somray
 sor	TD	LA	Somre
@@ -45938,6 +47601,7 @@ sos	BF	DA	Timiku
 sos	BF	L	Seeku
 sos	BF	LA	Sambla
 sos	BF	LA	Samogho
+sos	BF	LA	Seenku
 sos	BF	LA	Sembla
 sos	BF	LA	Southern Samo
 sot	LS	L	Sotho, Southern
@@ -45965,8 +47629,8 @@ sou	TH	LA	Paktay
 sov	PW	D	Merir
 sov	PW	D	Pulo Anna
 sov	PW	D	Sonsorolese
-sov	PW	L	Sonsorol
-sov	PW	LA	Sonsorolese
+sov	PW	L	Sonsorolese
+sov	PW	LA	Sonsorol
 sow	ID	L	Sowanda
 sow	ID	LA	Waina
 sow	ID	LA	Waina-Sowanda
@@ -46012,6 +47676,7 @@ soy	TG	LA	Sorouba
 soy	TG	LA	Soruba
 soy	TG	LA	Uyobe
 soz	TZ	L	Temi
+soz	TZ	LA	Batem
 soz	TZ	LA	GiTemi
 soz	TZ	LA	Kisonjo
 soz	TZ	LA	Kitemi
@@ -46132,6 +47797,7 @@ spm	PG	L	Akukem
 spm	PG	LA	Sepen
 spn	PY	L	Sanapaná
 spn	PY	LA	Kelya’mok
+spn	PY	LA	Nenlhet
 spn	PY	LA	Saapa’ang
 spo	US	L	Spokane
 spo	US	LA	Spokan
@@ -46143,8 +47809,10 @@ spp	ML	L	Sénoufo, Supyire
 spp	ML	LA	Sup’ide
 spp	ML	LA	Suppire
 spp	ML	LA	Supyire
-spq	PE	L	Spanish, Loreto-Ucayali
+spq	PE	L	Spanish, Charapa
+spq	PE	LA	Castellano Sharapa
 spq	PE	LA	Jungle Spanish
+spq	PE	LA	Spanish, Loreto-Ucayali
 spr	ID	D	Iha-Saparua
 spr	ID	D	Iha-Seram
 spr	ID	D	Kulur
@@ -46215,6 +47883,7 @@ sqt	YE	LA	Socotri
 sqt	YE	LA	Sokotri
 sqt	YE	LA	Suqutri
 squ	CA	L	Squamish
+squ	CA	LA	Sḵwx̱wú7mesh sníchim
 squ	CA	LA	Skwxwu’mesh snichim
 sra	PG	L	Saruga
 srb	IN	L	Sora
@@ -46266,10 +47935,11 @@ sri	CO	LA	Chiranga
 sri	CO	LA	Cirnga
 sri	CO	LA	Si-Ra
 sri	CO	LA	Sura Masa
-srk	MY	L	Serudung Murut
+srk	MY	L	Murut, Serudung
 srk	MY	LA	Serudong
+srk	MY	LA	Suudung
 srk	MY	LA	Tawau Murut
-srk	MY	LA	Tidung
+srk	MY	LA	Tawou Murut
 srl	ID	D	Eastern Isirawa
 srl	ID	D	Western Isirawa
 srl	ID	L	Isirawa
@@ -46382,6 +48052,7 @@ ssb	MY	D	Bajau Banaran
 ssb	MY	D	Bajau Darat
 ssb	MY	D	Bajau Laut
 ssb	MY	D	Bajau Semporna
+ssb	MY	D	Denawan
 ssb	MY	D	Laminusa
 ssb	MY	D	Sama
 ssb	MY	D	Sibutu
@@ -46390,6 +48061,8 @@ ssb	MY	D	Simunul
 ssb	MY	D	Ubian
 ssb	MY	DA	A’a Sama
 ssb	MY	DA	Bajau Asli
+ssb	MY	DA	Benadan
+ssb	MY	DA	Binadan
 ssb	MY	DA	Kubang
 ssb	MY	DA	Kubung
 ssb	MY	DA	Laminusa Sinama
@@ -46397,6 +48070,7 @@ ssb	MY	DA	Mandelaut
 ssb	MY	DA	Obian
 ssb	MY	DA	Pala’au
 ssb	MY	DA	Sama’
+ssb	MY	DA	Sama Dilaut
 ssb	MY	DA	Sama Kubang
 ssb	MY	DA	Sama Kubung
 ssb	MY	DA	Sama Laut
@@ -46414,8 +48088,11 @@ ssb	MY	DA	Sea Bajau
 ssb	MY	DA	Sea Gypsies
 ssb	MY	DA	Sibutuq
 ssb	MY	DA	Tau Ubian
+ssb	MY	DP	Pala’u
 ssb	MY	L	Sama, Southern
+ssb	MY	LA	Sinama
 ssb	MY	LA	Southern Bajau
+ssb	MY	LA	Tawi-Tawi Sinama
 ssb	PH	D	Balimbing
 ssb	PH	D	Bongao
 ssb	PH	D	Languyan
@@ -46429,7 +48106,9 @@ ssb	PH	D	Tandubas
 ssb	PH	DA	Sibutu
 ssb	PH	L	Sama, Southern
 ssb	PH	LA	Sama Tawi-Tawi
+ssb	PH	LA	Sinama
 ssb	PH	LA	Southern Sinama
+ssb	PH	LA	Tawi-Tawi Sinama
 ssc	TZ	D	Hacha
 ssc	TZ	D	Iryege
 ssc	TZ	D	Kine
@@ -46449,7 +48128,6 @@ ssc	TZ	DA	Kikine
 ssc	TZ	DA	Kikirone
 ssc	TZ	DA	Kisurwa
 ssc	TZ	DA	Kisweta
-ssc	TZ	DA	Rieri
 ssc	TZ	DA	Ryeri
 ssc	TZ	L	Suba-Simbiti
 ssc	TZ	LA	Kisimbiti
@@ -46457,6 +48135,7 @@ ssc	TZ	LA	Kisuba
 ssc	TZ	LA	Simbiti
 ssd	PG	L	Siroi
 ssd	PG	LA	Suroi
+sse	MY	D	Bajau Balangingih
 sse	MY	L	Sama, Balangingih
 sse	MY	LA	Baangingi’
 sse	MY	LA	Balagnini
@@ -46465,9 +48144,8 @@ sse	MY	LA	Balangingi Bajau
 sse	MY	LA	Balanian
 sse	MY	LA	Balanini
 sse	MY	LA	Balignini
-sse	MY	LA	Banadan
+sse	MY	LA	Bangingih
 sse	MY	LA	Bangingih Sama
-sse	MY	LA	Binadan
 sse	MY	LA	Northern Sinama
 sse	MY	LA	Sama
 sse	MY	LA	Sama Bangingih
@@ -46484,6 +48162,7 @@ sse	PH	L	Sama, Balangingih
 sse	PH	LA	Baangingi’
 sse	PH	LA	Balanguingui
 sse	PH	LA	Bangingi
+sse	PH	LA	Bangingih
 sse	PH	LA	Bangingih Sama
 sse	PH	LA	Northern Sama
 sse	PH	LA	Sama Bangingih
@@ -46681,6 +48360,7 @@ sti	VN	LA	Xtieng
 stj	BF	L	Samo, Matya
 stj	BF	LA	Northwestern Samo
 stj	BF	LA	San
+stj	BF	LA	Sànán
 stj	BF	LA	Sane
 stj	BF	LA	Tougan
 stj	BF	LA	West Central Goe
@@ -46688,6 +48368,7 @@ stj	ML	L	Samo, Matya
 stj	ML	LA	Sã
 stj	ML	LA	Samogho
 stj	ML	LA	San
+stj	ML	LA	Sànán
 stk	PG	L	Arammba
 stk	PG	LA	Aramba
 stk	PG	LA	Serki
@@ -46715,9 +48396,12 @@ sto	CA	L	Stoney
 sto	CA	LA	Nakoda
 sto	CA	LA	Stony
 stp	MX	L	Tepehuan, Southeastern
+stp	MX	LA	O’dam
 stp	MX	LA	Tepehuán del Sureste
 stp	MX	LA	Tepehuano
 stq	DE	L	Saterfriesisch
+stq	DE	LA	Friesen
+stq	DE	LA	Saterfriesen
 stq	DE	LA	Saterfriesiesch
 stq	DE	LA	Saterlandic
 stq	DE	LA	Saterlandic Frisian
@@ -46728,19 +48412,25 @@ str	CA	D	Songish
 str	CA	D	Ts’ooke
 str	CA	DA	Lekwungen
 str	CA	DA	Senčoten
-str	CA	DA	Ts’ooke
 str	CA	L	Salish, Straits
+str	CA	LA	Lkwungen
 str	CA	LA	Malchosen
 str	CA	LA	Northern Straits Salish
+str	CA	LA	Senčoten
 str	CA	LA	Straits
+str	CA	LA	T’Sou-ke
 str	US	D	Lummi
 str	US	D	Samish
 str	US	D	Semiahmoo
 str	US	D	Songish
 str	US	D	Ts’ooke
 str	US	L	Salish, Straits
+str	US	LA	Lkwungen
+str	US	LA	Malchosen
 str	US	LA	Northern Straits Salish
+str	US	LA	Senčoten
 str	US	LA	Straits
+str	US	LA	T’Sou-ke
 sts	AF	L	Shumashti
 sts	AF	LA	Shumasht
 stt	VN	L	Stieng, Budeh
@@ -46765,8 +48455,11 @@ stv	ET	LA	Selti
 stv	ET	LA	Silte
 stv	ET	LA	Silti
 stw	FM	L	Satawalese
+sty	RU	D	Baraba
+sty	RU	D	Tobol-Irtysh
+sty	RU	D	Tom
 sty	RU	L	Tatar, Siberian
-sty	RU	LA	Kazan Tatar
+sty	RU	LA	Eastern Tatar
 sua	PG	L	Sulka
 sub	CD	L	Suku
 sub	CD	LA	Kisuku
@@ -46839,6 +48532,7 @@ suq	ET	DA	Tirma
 suq	ET	DA	Tirmagi
 suq	ET	L	Suri
 suq	ET	LA	Churi
+suq	ET	LA	Dama
 suq	ET	LA	Dhuri
 suq	ET	LA	Eastern Suri
 suq	ET	LA	Shuri
@@ -46849,6 +48543,7 @@ sur	NG	D	Panyam
 sur	NG	DA	Mapan
 sur	NG	DA	Mapun
 sur	NG	L	Mwaghavul
+sur	NG	LA	Maghavul
 sur	NG	LA	Sura
 sus	GN	L	Susu
 sus	GN	LA	Sose
@@ -46877,6 +48572,7 @@ suy	BR	LA	Kisêdjê
 suz	NP	D	Surel
 suz	NP	L	Sunwar
 suz	NP	LA	Bhujuwar
+suz	NP	LA	Kiranti-Kõits Lo
 suz	NP	LA	Kirati-Koits
 suz	NP	LA	Koits Lo
 suz	NP	LA	Mukhiya
@@ -46888,6 +48584,7 @@ sva	GE	D	Lentex
 sva	GE	D	Lower Bal
 sva	GE	D	Upper Bal
 sva	GE	L	Svan
+sva	GE	LA	Lushnu
 sva	GE	LA	Svanuri
 svb	PG	L	Ulau-Suain
 svb	PG	LA	Suain
@@ -46902,9 +48599,9 @@ svm	IT	L	Slavomolisano
 svm	IT	LA	Croato molisano
 svm	IT	LA	Molise Croatian
 svm	IT	LA	Molise Slavic
+svm	IT	LA	Na-našu
 svm	IT	LA	Naš jezik
 svm	IT	LA	Slavic of Molise
-svr	IN	L	Savara
 svs	SB	L	Savosavo
 svs	SB	LA	Savo
 svs	SB	LA	Savo Island
@@ -46923,10 +48620,6 @@ swc	CD	D	Lualaba Kingwana
 swc	CD	L	Swahili, Congo
 swc	CD	LA	Zaïre Swahili
 swc	ZM	L	Swahili, Congo
-swe	DK	D	Scanian
-swe	DK	DA	Skåne
-swe	DK	DA	Skånska
-swe	DK	DA	Southern Swedish
 swe	DK	L	Swedish
 swe	FI	D	Åland Islands Swedish
 swe	FI	D	Österbotten
@@ -46955,6 +48648,7 @@ swe	SE	DA	Övdalian
 swe	SE	DA	Övdalsk
 swe	SE	DA	Scanian
 swe	SE	DA	Skåne
+swe	SE	DA	Skånska
 swe	SE	L	Swedish
 swe	SE	LA	Ruotsi
 swe	SE	LA	Svenska
@@ -46974,12 +48668,12 @@ swg	DE	LA	Schwäbisch
 swg	DE	LA	Schwaebisch
 swg	DE	LA	Suabian
 swh	BI	L	Swahili
+swh	BI	LA	Bajun
 swh	KE	D	Amu
 swh	KE	D	Bajuni
 swh	KE	D	Changamwe
 swh	KE	D	Chitundi
 swh	KE	D	Faza
-swh	KE	D	Gurian
 swh	KE	D	Jomvu
 swh	KE	D	Katwa
 swh	KE	D	Kilifi
@@ -46993,45 +48687,49 @@ swh	KE	D	Pemba
 swh	KE	D	Shaka
 swh	KE	D	Siu
 swh	KE	D	Tangana
-swh	KE	D	Tikuu
 swh	KE	D	Vumba
 swh	KE	DA	Bajun
-swh	KE	DA	Chimbalazi
 swh	KE	DA	Gunya
 swh	KE	DA	Hadimu
 swh	KE	DA	Kimvita
 swh	KE	DA	Malindi
-swh	KE	DA	Mbalazi
 swh	KE	DA	Mombasa
 swh	KE	DA	Ozi
 swh	KE	DA	Phemba
 swh	KE	DA	Siyu
 swh	KE	DA	Tambatu
 swh	KE	DA	Tikulu
+swh	KE	DA	Tikuu
 swh	KE	DA	Tukulu
-swh	KE	L	Kiswahili
+swh	KE	L	Swahili
 swh	KE	LA	Arab-Swahili
+swh	KE	LA	Bajun
 swh	KE	LA	Kisuahili
 swh	KE	LA	Kiswaheli
 swh	KE	LA	Suahili
-swh	KE	LA	Swahili
 swh	MZ	L	Swahili
+swh	MZ	LA	Bajun
 swh	OM	L	Swahili
+swh	OM	LA	Bajun
 swh	SO	D	Bajuni
 swh	SO	D	Mwini
 swh	SO	DA	Af-Bajuun
 swh	SO	DA	Af-Chimwiini
+swh	SO	DA	al-Jaziira
 swh	SO	DA	Bajun
 swh	SO	DA	Barawa
 swh	SO	DA	Barwaani
 swh	SO	DA	Bravanese
 swh	SO	DA	Chimbalazi
 swh	SO	DA	Chimwiini
+swh	SO	DA	Gunya
 swh	SO	DA	Kibajuni
 swh	SO	DA	Mbalazi
 swh	SO	DA	Miini
 swh	SO	DA	Mwiini
+swh	SO	DA	Tikuu
 swh	SO	L	Swahili
+swh	SO	LA	Bajun
 swh	TZ	D	Mgao
 swh	TZ	D	Mrima
 swh	TZ	D	Pemba
@@ -47041,15 +48739,18 @@ swh	TZ	DA	Kiunguja
 swh	TZ	DA	Mtang’ata
 swh	TZ	DA	Zanzibar
 swh	TZ	L	Swahili
+swh	TZ	LA	Bajun
 swh	TZ	LA	Kisuaheli
 swh	TZ	LA	Kiswahili
 swh	UG	D	Shamba
 swh	UG	DA	Kishamba
 swh	UG	L	Swahili
+swh	UG	LA	Bajun
 swh	UG	LA	Kisuaheli
 swh	UG	LA	Kiswahili
 swh	ZA	L	Swahili
 swh	ZA	LA	Arab-Swahili
+swh	ZA	LA	Bajun
 swh	ZA	LA	Kisuahili
 swh	ZA	LA	Kiswaheli
 swh	ZA	LA	Suahili
@@ -47277,7 +48978,10 @@ sys	TD	LA	Symiarta
 sys	TD	LA	Taar Shamyan
 sys	TD	LA	Zimirra
 syw	NP	L	Kagate
+syw	NP	LA	Shuba
 syw	NP	LA	Shuuba
+syw	NP	LA	Shuva
+syw	NP	LA	Shuwa
 syw	NP	LA	Shyuuba
 syw	NP	LA	Syuuba
 syw	NP	LA	Syuwa
@@ -47293,6 +48997,7 @@ syx	GA	LA	Shamay
 syx	GA	LA	Shamayi
 syy	IL	L	Al-Sayyid Bedouin Sign Language
 syy	IL	LA	ABSL
+syy	IL	LA	Bedouin Sign Language
 sza	MY	L	Semelai
 szb	ID	D	Apmisibil
 szb	ID	D	Ngalum
@@ -47350,12 +49055,13 @@ tab	RU	DA	Khanag
 tab	RU	L	Tabassaran
 tab	RU	LA	Ghumghum
 tab	RU	LA	Tabasaran
-tab	RU	LA	Tabasarantsy
+tab	RU	LA	Tabasarantsky
 tac	MX	L	Tarahumara, Western
 tac	MX	LA	Baja Tarahumara
 tac	MX	LA	Lowland Tarahumara
 tac	MX	LA	Ralámuli de la Baja Tarahumara
 tac	MX	LA	Rarámuri
+tac	MX	LA	Rarómari raicha
 tac	MX	LA	Rocoroibo
 tac	MX	LA	Tarahumara del Oeste
 tac	MX	LA	Tarahumara del Poniente
@@ -47380,7 +49086,9 @@ tag	SD	D	Tumale
 tag	SD	L	Tagoi
 tag	SD	LA	Tagoy
 tah	PF	L	Tahitian
+tah	PF	LA	Reo Tahiti
 taj	IN	L	Tamang, Eastern
+taj	IN	LA	Tamang
 taj	NP	D	Central-Eastern Tamang
 taj	NP	D	Outer-Eastern Tamang
 taj	NP	D	Southwestern Tamang
@@ -47399,6 +49107,7 @@ taj	NP	L	Tamang, Eastern
 taj	NP	LA	Ishang
 taj	NP	LA	Murmi
 taj	NP	LA	Sei
+taj	NP	LA	Tamang
 taj	NP	LP	Bhotia
 tak	NG	L	Tala
 tal	NG	L	Tal
@@ -47415,7 +49124,6 @@ tam	IN	D	Madrasi
 tam	IN	D	Madurai
 tam	IN	D	Malaya Tamil
 tam	IN	D	Mandyam Brahmin
-tam	IN	D	Pattapu Bhasha
 tam	IN	D	Sanketi
 tam	IN	D	Secunderabad Brahmin
 tam	IN	D	South Africa Tamil
@@ -47433,6 +49141,7 @@ tam	MU	L	Tamil
 tam	MY	L	Tamil
 tam	RE	L	Tamil
 tam	SG	L	Tamil
+tam	ZA	L	Tamil
 tan	NG	D	Biliri
 tan	NG	D	Kaltungo
 tan	NG	DA	Tangale East
@@ -47443,6 +49152,7 @@ tao	TW	L	Yami
 tao	TW	LA	Botel Tabago
 tao	TW	LA	Botel Tobago
 tao	TW	LA	Lanyu
+tao	TW	LA	Pongso no Tao
 tao	TW	LA	Tao
 tao	TW	LA	Tawu
 tap	CD	D	Shila
@@ -47474,6 +49184,7 @@ taq	ML	DA	Tombouctou
 taq	ML	L	Tamasheq
 taq	ML	LA	Kidal
 taq	ML	LA	Kidal Tamasheq
+taq	ML	LA	Tamachen
 taq	ML	LA	Tamashekin
 taq	ML	LA	Timbuktu
 taq	ML	LA	Tomacheck
@@ -47481,6 +49192,7 @@ taq	ML	LP	Tuareg
 tar	MX	L	Tarahumara, Central
 tar	MX	LA	Alta Tarahumara
 tar	MX	LA	Ralámuli de la Tarahumara Alta
+tar	MX	LA	Ralámuli raicha
 tar	MX	LA	Samachique Tarahumara
 tar	MX	LA	Tarahumara de Cumbres
 tar	MX	LA	Tarahumara del Centro
@@ -47492,12 +49204,12 @@ tat	CN	L	Tatar
 tat	CN	LA	Tartar
 tat	CN	LA	Tata’er
 tat	KZ	L	Tatar
-tat	RU	D	Eastern Tatar
 tat	RU	D	Middle Tatar
 tat	RU	D	Western Tatar
 tat	RU	DA	Kazan
 tat	RU	DA	Misher
 tat	RU	L	Tatar
+tat	RU	LA	Kazan Tatar
 tat	RU	LA	Tartar
 tat	TR	L	Tatar
 tau	CA	L	Tanana, Upper
@@ -47702,6 +49414,8 @@ tbz	TG	D	Eastern Ditammari
 tbz	TG	D	Western Ditammari
 tbz	TG	DA	Tamberma
 tbz	TG	L	Ditammari
+tbz	TG	LA	Bataba
+tbz	TG	LA	Batammarab
 tbz	TG	LA	Soma
 tbz	TG	LA	Some
 tbz	TG	LA	Tamari
@@ -47772,6 +49486,7 @@ tcf	MX	DA	Zilacayotitlán Tlapanec
 tcf	MX	L	Me’phaa, Malinaltepec
 tcf	MX	LA	Malinaltepec Tlapanec
 tcf	MX	LA	Me’phaa
+tcf	MX	LA	Mè’phàà Mañuwìín
 tcf	MX	LA	Tlapaneco
 tcf	MX	LA	Tlapaneco Central Bajo
 tcf	MX	LA	Tlapaneco de Malinaltepec
@@ -47841,11 +49556,13 @@ tcu	MX	D	Chinatú Tarahumara
 tcu	MX	L	Tarahumara, Southeastern
 tcu	MX	LA	Balleza
 tcu	MX	LA	Chinatú
+tcu	MX	LA	Rarámari raicha
 tcu	MX	LA	Tarahumara de Chinatú
 tcu	MX	LA	Tarahumara del Sur
 tcu	MX	LA	Tarahumara del Sureste
 tcu	MX	LA	Turuachi
 tcw	MX	L	Totonac, Tecpatlán
+tcw	MX	LA	Totonaca
 tcx	IN	L	Toda
 tcx	IN	LA	Todi
 tcx	IN	LA	Tuda
@@ -47904,16 +49621,17 @@ tcz	MM	D	Paite
 tcz	MM	D	Sairang
 tcz	MM	D	Thangngen
 tcz	MM	L	Chin, Thado
-tcz	MM	LA	Kuki
-tcz	MM	LA	Kuki-Thado
 tcz	MM	LA	Thado-Pao
 tcz	MM	LA	Thadou
 tcz	MM	LA	Thado-Ubiphei
+tcz	MM	LP	Kuki
+tcz	MM	LP	Kuki-Thado
 tda	NE	D	Air
 tda	NE	D	Azawagh
 tda	NE	DA	Northern Tagdal
 tda	NE	DA	Southern Tagdal
 tda	NE	L	Tagdal
+tda	NE	LA	Igalan
 tdb	IN	L	Panchpargania
 tdb	IN	LA	Bedia
 tdb	IN	LA	Chik Barik
@@ -47927,6 +49645,9 @@ tdb	IN	LA	Temoral
 tdb	IN	LA	Tumariya
 tdc	CO	L	Emberá-Tadó
 tdc	CO	LA	Cholo
+tdc	CO	LA	Embena
+tdc	CO	LA	Embera
+tdc	CO	LA	Epena
 tdc	CO	LA	Êpêra
 tdc	CO	LA	Katío
 tdd	CN	D	Mangshi
@@ -47952,6 +49673,7 @@ tdd	CN	LA	Dai Nuea
 tdd	CN	LA	Daide
 tdd	CN	LA	Dehong
 tdd	CN	LA	Dehong Dai
+tdd	CN	LA	Shan
 tdd	CN	LA	Tai Dehong
 tdd	CN	LA	Tai Le
 tdd	CN	LA	Tai Mao
@@ -47980,9 +49702,17 @@ tde	ML	L	Dogon, Tiranige Diga
 tde	ML	LA	Duleri
 tde	ML	LA	Duleri Dom
 tdf	LA	L	Talieng
+tdf	LA	LA	Caliang
+tdf	LA	LA	Calieng
+tdf	LA	LA	Kaseng
+tdf	LA	LA	Kasseng
+tdf	LA	LA	Koseng
+tdf	LA	LA	Kraseng
 tdf	LA	LA	Taliang
 tdf	LA	LA	Tariang
+tdf	LA	LA	Tarieng
 tdf	LA	LA	Triang
+tdf	LA	LA	Trieng
 tdg	NP	D	Northwestern dialect of Western Tamang
 tdg	NP	D	Rasuwa
 tdg	NP	D	Southwestern dialect of Western Tamang
@@ -47992,6 +49722,8 @@ tdg	NP	DA	Nuwakot
 tdg	NP	L	Tamang, Western
 tdg	NP	LA	Murmi
 tdg	NP	LA	Sain
+tdg	NP	LA	Tamang Gyot
+tdg	NP	LA	Tamang Tam
 tdh	IN	L	Thulung
 tdh	IN	LA	Thulunge Rai
 tdh	NP	D	Central Thulung
@@ -48030,6 +49762,9 @@ tdl	NG	LA	Nsur
 tdl	NG	LA	Suru
 tdl	NG	LA	Tapshin
 tdl	NG	LA	Tapshinawa
+tdm	GY	L	Taruma
+tdm	GY	LA	Aroaqui
+tdm	GY	LA	Taruamá
 tdn	ID	D	Kakas
 tdn	ID	D	Remboken
 tdn	ID	D	Tondano
@@ -48061,13 +49796,6 @@ tdt	TL	LA	Tetum Dili
 tdt	TL	LA	Tetum Praça
 tdt	TL	LA	Tetum Prasa
 tdt	TL	LA	Tetun
-tdu	MY	L	Dusun, Tempasuk
-tdu	MY	LA	Kedamaian Dusun
-tdu	MY	LA	Tampasok
-tdu	MY	LA	Tampassuk
-tdu	MY	LA	Tampasuk
-tdu	MY	LA	Tempasok
-tdu	MY	LA	Tindal
 tdv	NG	L	Toro
 tdv	NG	LA	Turkwam
 tdx	MG	L	Malagasy, Tandroy-Mahafaly
@@ -48240,6 +49968,7 @@ ten	CO	LA	Jabaal
 teo	KE	D	Orom
 teo	KE	DA	Rom
 teo	KE	L	Teso
+teo	KE	LA	Ateso
 teo	UG	D	Orom
 teo	UG	DA	Rom
 teo	UG	L	Teso
@@ -48249,6 +49978,7 @@ teo	UG	LA	Bakidi
 teo	UG	LA	Elgumi
 teo	UG	LA	Etossio
 teo	UG	LA	Ikumama
+teo	UG	LA	Iteso
 teo	UG	LA	Wamia
 tep	MX	L	Tepecano
 teq	SD	L	Temein
@@ -48374,6 +50104,7 @@ tfn	US	LA	Kinayskiy
 tfo	ID	L	Tefaro
 tfo	ID	LA	Demba
 tfr	CR	L	Teribe
+tfr	CR	LA	Naso
 tfr	CR	LA	Terraba
 tfr	PA	L	Teribe
 tfr	PA	LA	Naso
@@ -48394,7 +50125,9 @@ tga	KE	LA	Kisagalla
 tga	KE	LA	Sagala
 tga	KE	LA	Saghala
 tga	KE	LA	Teri
+tgb	MY	D	Minansad
 tgb	MY	L	Tobilung
+tgb	MY	LA	Momogun
 tgb	MY	LA	Tabilong
 tgb	MY	LA	Tebilung
 tgb	MY	LA	Tobilang
@@ -48426,7 +50159,9 @@ tgi	PG	LA	Piva
 tgj	IN	L	Tagin
 tgj	IN	LA	Nil
 tgk	KG	L	Tajiki
+tgk	KG	LA	Tojiki
 tgk	KZ	L	Tajiki
+tgk	KZ	LA	Tojiki
 tgk	TJ	L	Tajiki
 tgk	TJ	LA	Galcha
 tgk	TJ	LA	Tadzhik
@@ -48434,6 +50169,7 @@ tgk	TJ	LA	Tajik
 tgk	TJ	LA	Tajiki Persian
 tgk	TJ	LA	Tojiki
 tgk	UZ	L	Tajiki
+tgk	UZ	LA	Tojiki
 tgl	CA	L	Tagalog
 tgl	PH	D	Bataan
 tgl	PH	D	Batangas
@@ -48504,6 +50240,7 @@ tgw	CI	LA	Tagbana
 tgw	CI	LA	Tagouna
 tgw	CI	LA	Tagwana
 tgx	CA	L	Tagish
+tgx	CA	LA	Dene K’e
 tgy	SS	L	Togoyo
 tgy	SS	LA	Togoy
 tgz	AU	L	Tagalaka
@@ -48521,16 +50258,12 @@ tha	TH	D	Khorat Thai
 tha	TH	DA	Korat
 tha	TH	DA	Thaikorat
 tha	TH	L	Thai
-tha	TH	LA	Central Tai
+tha	TH	LA	Bangkok Thai
+tha	TH	LA	Central Thai
 tha	TH	LA	Siamese
 tha	TH	LA	Standard Thai
+tha	TH	LA	Thai Klang
 tha	TH	LA	Thaiklang
-thc	VN	D	Tai Pao
-thc	VN	D	Tai Yo
-thc	VN	DA	Tai Paw
-thc	VN	L	Tai Hang Tong
-thc	VN	LA	Hàng Tong
-thc	VN	LA	Tày Muòng
 thd	AU	D	Kuuk-Yak
 thd	AU	L	Thayore
 thd	AU	LA	Behran
@@ -48575,6 +50308,7 @@ thk	KE	D	Thagicu
 thk	KE	DA	Central Tharaka
 thk	KE	DA	North Tharaka
 thk	KE	L	Kitharaka
+thk	KE	LA	Atharaka
 thk	KE	LA	Saraka
 thk	KE	LA	Sharoka
 thk	KE	LA	Tharaka
@@ -48586,6 +50320,7 @@ thl	IN	LA	Dang
 thl	IN	LA	Dangali
 thl	IN	LA	Dangora
 thl	IN	LA	Dangura
+thl	IN	LA	Tharu
 thl	NP	D	Dangaha
 thl	NP	DA	Dang
 thl	NP	L	Tharu, Dangaura
@@ -48594,7 +50329,9 @@ thl	NP	LA	Dangali
 thl	NP	LA	Dangauli
 thl	NP	LA	Dangora
 thl	NP	LA	Dangura
+thl	NP	LA	Tharu
 thm	LA	L	Aheu
+thm	LA	LA	Bru
 thm	LA	LA	Kha Tong Luang
 thm	LA	LA	Phon Soung
 thm	LA	LA	Phonsung
@@ -48629,7 +50366,11 @@ thq	NP	L	Tharu, Kochila
 thq	NP	LA	Saptariya Tharu
 thr	IN	L	Tharu, Rana
 thr	IN	LA	Rana Thakur
+thr	IN	LA	Tharu
+thr	IN	LA	Tharuwa
 thr	NP	L	Tharu, Rana
+thr	NP	LA	Tharu
+thr	NP	LA	Tharuwa
 ths	NP	D	Marpha
 ths	NP	D	Syang
 ths	NP	D	Tukuche
@@ -48641,8 +50382,10 @@ ths	NP	DA	Yhulkasom
 ths	NP	L	Thakali
 ths	NP	LA	Barhagaule
 ths	NP	LA	Panchgaunle
+ths	NP	LA	Tapaang
 ths	NP	LA	Thaksya
 tht	CA	L	Tahltan
+tht	CA	LA	Nahanni
 tht	CA	LA	Tāltān
 thu	SS	D	Bodho
 thu	SS	D	Colo
@@ -48669,6 +50412,7 @@ thv	DZ	DA	Ganet
 thv	DZ	DA	Tahaggart
 thv	DZ	L	Tamahaq, Tahaggart
 thv	DZ	LA	Tamachek
+thv	DZ	LA	Tamahaq
 thv	DZ	LA	Tamashekin
 thv	DZ	LA	Tomachek
 thv	DZ	LA	Touareg
@@ -48683,6 +50427,7 @@ thv	LY	DA	Ganet
 thv	LY	DA	Tahaggart
 thv	LY	L	Tamahaq, Tahaggart
 thv	LY	LA	Tamachek
+thv	LY	LA	Tamahaq
 thv	LY	LA	Tamashekin
 thv	LY	LA	Tomachek
 thv	LY	LA	Tourage
@@ -48697,6 +50442,7 @@ thv	NE	DA	Ganet
 thv	NE	DA	Tahaggart
 thv	NE	L	Tamahaq, Tahaggart
 thv	NE	LA	Tamachek
+thv	NE	LA	Tamahaq
 thv	NE	LA	Tamashekin
 thv	NE	LA	Tamasheq
 thv	NE	LA	Tomachek
@@ -48718,6 +50464,7 @@ thz	NE	DA	Tayert
 thz	NE	L	Tamajeq, Tayart
 thz	NE	LA	Amazigh
 thz	NE	LA	Tamachek
+thz	NE	LA	Tamajeq
 thz	NE	LA	Tomacheck
 thz	NE	LA	Touareg
 thz	NE	LA	Tuareg
@@ -48735,42 +50482,6 @@ tic	SD	L	Tira
 tic	SD	LA	Lithiro
 tic	SD	LA	Thiro
 tic	SD	LA	Tiro
-tid	ID	D	Nonukan
-tid	ID	D	Penchangan
-tid	ID	D	Sedalir
-tid	ID	D	Sesayap
-tid	ID	D	Sibuku
-tid	ID	D	Tarakan
-tid	ID	D	Tidung
-tid	ID	DA	Nunukan
-tid	ID	DA	Sadalir
-tid	ID	DA	Salalir
-tid	ID	DA	Saralir
-tid	ID	DA	Selalir
-tid	ID	DA	Sesajap
-tid	ID	DA	Terakan
-tid	ID	L	Tidong
-tid	ID	LA	Camucones
-tid	ID	LA	Tedong
-tid	ID	LA	Tidoeng
-tid	ID	LA	Tidung
-tid	ID	LA	Tiran
-tid	ID	LA	Tirones
-tid	ID	LA	Tiroon
-tid	ID	LA	Zedong
-tid	MY	D	Sesayap
-tid	MY	D	Tarakan
-tid	MY	DA	Sesajap
-tid	MY	DA	Terakan
-tid	MY	L	Tidong
-tid	MY	LA	Camucones
-tid	MY	LA	Nonukan
-tid	MY	LA	Tedong
-tid	MY	LA	Tidoeng
-tid	MY	LA	Tiran
-tid	MY	LA	Tirones
-tid	MY	LA	Tiroon
-tid	MY	LA	Zedong
 tif	PG	D	Asbalmin
 tif	PG	D	Tifal
 tif	PG	L	Tifal
@@ -48807,15 +50518,15 @@ tih	MY	D	Timugon
 tih	MY	DA	Binta’
 tih	MY	DA	Bukow
 tih	MY	DA	Sandewar
-tih	MY	L	Timugon Murut
+tih	MY	L	Murut, Timugon
 tih	MY	LA	Temogun
-tih	MY	LA	Tenom Murut
 tih	MY	LA	Timigan
 tih	MY	LA	Timigun
 tih	MY	LA	Timogon
 tih	MY	LA	Timogun
 tih	MY	LA	Timugon
 tih	MY	LA	Tumugun
+tih	MY	LP	Tenom Murut
 tii	CD	L	Tiene
 tii	CD	LA	Kitiene
 tii	CD	LA	Kitiini
@@ -48869,13 +50580,16 @@ tiq	BF	LA	Kiefo
 tiq	BF	LA	Tyefo
 tiq	BF	LA	Tyeforo
 tir	ER	L	Tigrigna
+tir	ER	LA	Beta Israel
 tir	ER	LA	Habashi
 tir	ER	LA	Tigray
 tir	ER	LA	Tigrinya
 tir	ET	L	Tigrigna
+tir	ET	LA	Beta Israel
 tir	ET	LA	Tigray
 tir	ET	LA	Tigrinya
 tir	IL	L	Tigrigna
+tir	IL	LA	Beta Israel
 tir	IL	LA	Tigrinya
 tir	IL	LP	Falashas
 tis	PH	D	Masadiit Boliney
@@ -48920,6 +50634,7 @@ tjg	ID	LA	Tunjung Dayak
 tji	CN	D	Baojing
 tji	CN	D	Longshan
 tji	CN	L	Tujia, Northern
+tji	CN	LA	pi tsi kha
 tji	CN	LA	Tuchia
 tji	CN	LA	Tudja
 tjl	MM	D	Tai Lai
@@ -48940,6 +50655,7 @@ tjo	DZ	LA	Touggourt
 tjo	DZ	LA	Tougourt
 tjo	DZ	LA	Tugurt
 tjs	CN	L	Tujia, Southern
+tjs	CN	LA	Mong Tsi
 tjs	CN	LA	Tuchia
 tju	AU	L	Tjurruru
 tju	AU	LA	Tjururu
@@ -48996,21 +50712,32 @@ tkg	MG	L	Malagasy, Tesaka
 tkg	MG	LA	Antaisaka
 tkg	MG	LA	Antesaka
 tkg	MG	LA	Atesaka
+tkg	MG	LA	Tesaka Malagasy
 tkl	TK	L	Tokelauan
 tkl	TK	LA	Tokelau
 tkn	JP	D	Kametsu
 tkn	JP	L	Toku-No-Shima
 tkp	SB	L	Tikopia
+tkp	SB	LA	Fakatikopia
 tkq	NG	L	Tee
 tkq	NG	LA	Tai
+tkr	AZ	D	Cinix
+tkr	AZ	D	Kalyal Muxax
+tkr	AZ	D	Mishlesh
+tkr	AZ	D	Muslax
+tkr	AZ	D	Suvagil
 tkr	AZ	L	Tsakhur
 tkr	AZ	LA	Caxur
 tkr	AZ	LA	Sakhur
 tkr	AZ	LA	Tsakhury
+tkr	AZ	LA	Ts’axna Miz
 tkr	AZ	LA	Tsaxur
+tkr	AZ	LA	Yedna Miz
 tkr	AZ	LA	Yikbi
+tkr	AZ	LA	Yiqny Miz
 tkr	RU	D	Gelmets-Mikik
 tkr	RU	D	Tsakh
+tkr	RU	DA	Gelmets
 tkr	RU	DA	Gelmets-kurdul
 tkr	RU	DA	Jinagh
 tkr	RU	DA	Kirmico-Lek
@@ -49020,10 +50747,13 @@ tkr	RU	DA	Mukhakh-Sabunchi
 tkr	RU	DA	Muslakh
 tkr	RU	DA	Suvagil
 tkr	RU	DA	Tsakh-Qum
+tkr	RU	DA	Tsakhur
 tkr	RU	L	Tsakhur
 tkr	RU	LA	Caxur
 tkr	RU	LA	Tsakhury
+tkr	RU	LA	Ts’axna Miz
 tkr	RU	LA	Tsaxur
+tkr	RU	LA	Yedna Miz
 tkr	RU	LA	Yikbi
 tkr	RU	LA	Yiqny Miz
 tks	IR	D	Khalkhal
@@ -49037,10 +50767,13 @@ tks	IR	LA	Takistani
 tkt	IN	L	Tharu, Kathariya
 tkt	IN	LA	Kathoriya Tharu
 tkt	IN	LA	Khatima Tharu
+tkt	IN	LA	Tharu
 tkt	NP	L	Tharu, Kathariya
 tkt	NP	LA	Kathariya
 tkt	NP	LA	Kathoriya Tharu
+tkt	NP	LA	Tharu
 tku	MX	L	Totonac, Upper Necaxa
+tku	MX	LA	Totonaca
 tkv	PG	L	Mur Pano
 tkv	PG	LA	Pano
 tkw	SB	L	Teanu
@@ -49085,13 +50818,16 @@ tlf	PG	LA	Telefomin
 tlg	ID	L	Tofanma
 tlg	ID	LA	Tofamna
 tli	CA	L	Tlingit
+tli	CA	LA	Inland Tlingit
 tli	CA	LA	Kolosch
 tli	CA	LA	Kolosh
+tli	CA	LA	Łingít
 tli	CA	LA	Thlinget
 tli	CA	LA	Tlinkit
 tli	US	L	Tlingit
 tli	US	LA	Kolosch
 tli	US	LA	Kolosh
+tli	US	LA	Łingít
 tli	US	LA	Thlinget
 tli	US	LA	Tlinkit
 tlj	CD	L	Talinga-Bwisi
@@ -49101,7 +50837,9 @@ tlj	CD	LA	Lubwisi
 tlj	CD	LA	Lubwissi
 tlj	CD	LA	Mawissi
 tlj	CD	LA	Olubwisi
+tlj	CD	LA	Talinga
 tlj	UG	L	Talinga-Bwisi
+tlj	UG	LA	Bwisi
 tlj	UG	LA	Bwissi
 tlj	UG	LA	Kitalinga
 tlj	UG	LA	Lubwisi
@@ -49134,7 +50872,7 @@ tlq	LA	LA	Loi
 tlq	LA	LA	Monglwe
 tlq	LA	LA	Tailoi
 tlq	LA	LA	Wakut
-tlq	MM	D	Saneung Muak
+tlq	MM	D	Muak Sa-aak
 tlq	MM	L	Tai Loi
 tlq	MM	LA	Aw-aak
 tlq	MM	LA	Bulang-Su
@@ -49160,15 +50898,16 @@ tlr	SB	LA	Talisi
 tlr	SB	LA	Tolo
 tls	VU	L	Tambotalo
 tlt	ID	D	Laha Serani
-tlt	ID	D	West Teluti
+tlt	ID	D	West Sou Nama
 tlt	ID	DA	Haya
 tlt	ID	DA	Tehoru
 tlt	ID	DA	Tehua
 tlt	ID	DA	Wolu
-tlt	ID	L	Teluti
+tlt	ID	L	Sou Nama
 tlt	ID	LA	Silen
 tlt	ID	LA	Taluti
 tlt	ID	LA	Tehoru
+tlt	ID	LA	Teluti
 tlt	ID	LA	Tihoru
 tlt	ID	LA	Wolu
 tlu	ID	D	Liang
@@ -49295,6 +51034,7 @@ tmk	NP	LA	Murmi
 tmk	NP	LA	Rongba
 tmk	NP	LA	Sain
 tmk	NP	LA	Tamang Gyoi
+tmk	NP	LA	Tamang Gyot
 tmk	NP	LA	Tamang Lengmo
 tmk	NP	LA	Tamang Tam
 tml	ID	L	Citak, Tamnim
@@ -49308,17 +51048,11 @@ tmn	ID	L	Taman
 tmn	ID	LA	Dayak Taman
 tmn	ID	LA	Taman Dayak
 tmo	MY	L	Temoq
-tmp	LA	L	Tai Mène
-tmp	LA	LA	Tai Maen
-tmp	LA	LA	Tai Man
-tmp	LA	LA	Tai Men
-tmp	LA	LA	Tai Mene
-tmp	LA	LA	Tai-Maen
-tmp	LA	LA	Tay Mènè
 tmq	PG	L	Tumleo
 tmr	IL	L	Jewish Babylonian Aramaic
 tmr	IL	LA	Babylonian Talmudic Aramaic
 tms	SD	L	Tima
+tms	SD	LA	Domurik
 tms	SD	LA	Lomorik
 tms	SD	LA	Lomuriki
 tms	SD	LA	Tamanik
@@ -49378,8 +51112,6 @@ tnc	CO	LA	Tanimuca-Letuama
 tnc	CO	LA	Uairã
 tnc	CO	LA	Ufaina
 tnd	CO	L	Tunebo, Angosturas
-tne	PH	L	Kallahan, Tinoc
-tne	PH	LA	Tinoc Kalangoya
 tng	TD	D	Mande
 tng	TD	D	Tobanga
 tng	TD	DA	Deressia
@@ -49458,11 +51190,14 @@ tny	TZ	L	Tongwe
 tny	TZ	LA	Kitongwe
 tny	TZ	LA	Sitongwe
 tnz	MY	D	Satun
-tnz	MY	L	Tonga
+tnz	MY	L	Ten’edn
 tnz	MY	LA	Mos Tean-ean
+tnz	MY	LA	Tonga
 tnz	TH	D	Satun
-tnz	TH	L	Tonga
+tnz	TH	L	Ten’edn
+tnz	TH	LA	Maniq
 tnz	TH	LA	Mos
+tnz	TH	LA	Tonga
 tnz	TH	LA	Tonga-Mos
 tob	AR	D	Northern Toba
 tob	AR	D	Southeast Toba
@@ -49470,13 +51205,18 @@ tob	AR	L	Toba
 tob	AR	LA	Chaco Sur
 tob	AR	LA	Namqom
 tob	AR	LA	Qom
+tob	AR	LA	Qoml’ek
 tob	AR	LA	Toba Qom
 tob	AR	LA	Toba Sur
 tob	BO	L	Toba
+tob	BO	LA	Namqom
 tob	BO	LA	Qom
+tob	BO	LA	Qoml’ek
 tob	PY	L	Toba Qom
 tob	PY	LA	Emok-Lik
+tob	PY	LA	Namqom
 tob	PY	LA	Qom
+tob	PY	LA	Qoml’ek
 tob	PY	LA	Takshika
 tob	PY	LA	Toba-Qom
 toc	MX	D	Cerro Grande Totonac
@@ -49495,8 +51235,6 @@ tod	GN	LA	Toa
 tod	GN	LA	Toale
 tod	GN	LA	Toali
 tod	GN	LA	Tooma
-toe	CO	L	Tomedes
-toe	CO	LA	Tamudes
 tof	PG	D	Waidoro
 tof	PG	D	Western Gizra
 tof	PG	L	Gizrra
@@ -49543,6 +51281,7 @@ toi	ZW	LA	Zambezi
 toj	MX	L	Tojolabal
 toj	MX	LA	Chañabal
 toj	MX	LA	Comiteco
+toj	MX	LA	Tojol-ab’al
 tol	US	L	Tolowa
 tol	US	LA	Smith River
 tom	ID	D	Taratara
@@ -49555,6 +51294,7 @@ tom	ID	LA	Tombula
 tom	ID	LA	Tombulu’
 tom	ID	LA	Toumbulu
 ton	TO	L	Tongan
+ton	TO	LA	Faka Tonga
 ton	TO	LA	Tonga
 too	MX	D	Zihuateutla Totonac
 too	MX	L	Totonac, Xicotepec de Juárez
@@ -49614,6 +51354,7 @@ tpc	MX	L	Me’phaa, Azoyú
 tpc	MX	LA	Azoyú Tlapanec
 tpc	MX	LA	Me’phaa
 tpc	MX	LA	Mè’phàà
+tpc	MX	LA	Mè’pháà Tsìndíì
 tpc	MX	LA	Tlapaneco de Azoyú
 tpc	MX	LA	Tlapaneco del Sur
 tpe	BD	D	Anok
@@ -49685,6 +51426,7 @@ tpl	MX	L	Me’phaa, Tlacoapa
 tpl	MX	LA	Me’phaa
 tpl	MX	LA	Me’phaa de Tlacoapa
 tpl	MX	LA	Mi’phaa
+tpl	MX	LA	Mi’phàà Mí’uíí
 tpl	MX	LA	Tlacoapa Tlapanec
 tpl	MX	LA	Tlapaneco
 tpl	MX	LA	Tlapaneco de Tlacoapa
@@ -49697,9 +51439,17 @@ tpm	GH	LA	Tampolem
 tpm	GH	LA	Tampolense
 tpm	GH	LA	Tamprusi
 tpo	LA	L	Tai Pao
+tpo	VN	L	Tai Pao
+tpo	VN	LA	Hàng Tong
+tpo	VN	LA	Tai Hang Tong
+tpo	VN	LA	Tai Paw
+tpo	VN	LA	Tày Muòng
+tpo	VN	LA	Thai Muong
 tpp	MX	L	Tepehua, Pisaflores
 tpq	IN	L	Tukpa
 tpq	IN	LA	Nesang
+tpq	IN	LA	Nyamkad
+tpq	IN	LA	Nyam-Kad
 tpq	IN	LA	Nyam-kat
 tpr	BR	L	Tuparí
 tpt	MX	L	Tepehua, Tlachichilco
@@ -49736,6 +51486,7 @@ tpx	MX	L	Me’phaa, Acatepec
 tpx	MX	LA	Acatepec Tlapanec
 tpx	MX	LA	Me’pa
 tpx	MX	LA	Me’pa Wí’ìn
+tpx	MX	LA	Me’pàà Wí’ììn
 tpx	MX	LA	Me’phaa
 tpx	MX	LA	Tlapaneco de Acatepec
 tpx	MX	LA	Tlapaneco del Suroeste
@@ -49778,13 +51529,14 @@ tqp	PG	LA	Tumuip
 tqq	SO	L	Tunni
 tqq	SO	LA	Af-Tunni
 tqr	SD	L	Torona
-tqt	MX	L	Totonac, Ozumatlán
+tqt	MX	L	Totonaco del cerro Xinolatépetl
+tqt	MX	LA	Totonac, Ozumatlán
+tqt	MX	LA	Totonac, Xinolatépetl
 tqt	MX	LA	Totonaco de Ozomatlán
-tqt	MX	LA	Totonaco del cerro Xinolate´petl
 tqt	MX	LA	Totonaco Norte de Huauchinango
 tqt	MX	LA	Western Totonac
-tqt	MX	LA	Xinolate´petl Totonac
-tqt	MX	LA	Xinulajgsipij Tutunaku
+tqt	MX	LA	Xinolatépetl Totonac
+tqt	MX	LA	Xinulajgsípij Totonaco
 tqu	SB	L	Touo
 tqu	SB	LA	Baniata
 tqu	SB	LA	Lokuru
@@ -49856,6 +51608,7 @@ trp	IN	D	Jamatia
 trp	IN	D	Noatia
 trp	IN	DA	Tipra
 trp	IN	L	Kok Borok
+trp	IN	LA	Halam
 trp	IN	LA	Kakbarak
 trp	IN	LA	Kokbarak
 trp	IN	LA	Kokborok
@@ -49917,6 +51670,7 @@ trv	TW	LA	Sedek
 trv	TW	LA	Sedeq
 trv	TW	LA	Sediakk
 trv	TW	LA	Sedik
+trv	TW	LA	Sediq Taroko
 trv	TW	LA	Seedek
 trv	TW	LA	Seedeq
 trv	TW	LA	Seedik
@@ -50024,27 +51778,34 @@ tsd	GR	LA	Tsakonia
 tse	TN	L	Tunisian Sign Language
 tsg	ID	L	Tausug
 tsg	ID	LA	Joloano Sulu
+tsg	ID	LA	Jolohano
 tsg	ID	LA	Moro Joloano
+tsg	ID	LA	Sinug Tausug
 tsg	ID	LA	Sooloo
 tsg	ID	LA	Sulu
 tsg	ID	LA	Suluk
 tsg	ID	LA	Taosug
 tsg	ID	LA	Tausog
 tsg	ID	LA	Taw Sug
-tsg	MY	L	Tausug
+tsg	MY	L	Suluk
 tsg	MY	LA	Joloano
 tsg	MY	LA	Joloano Sulu
-tsg	MY	LA	Moro
+tsg	MY	LA	Jolohano
+tsg	MY	LA	Sinug Tausug
 tsg	MY	LA	Sooloo
+tsg	MY	LA	Sug
 tsg	MY	LA	Sulu
-tsg	MY	LA	Suluk
 tsg	MY	LA	Taosug
 tsg	MY	LA	Tausog
+tsg	MY	LA	Tausug
 tsg	MY	LA	Taw Sug
+tsg	MY	LP	Moro
 tsg	PH	L	Tausug
 tsg	PH	LA	Bahasa Sug
+tsg	PH	LA	Jolohano
 tsg	PH	LA	Moro Joloano
 tsg	PH	LA	Sinug
+tsg	PH	LA	Sinug Tausug
 tsg	PH	LA	Sulu
 tsg	PH	LA	Suluk
 tsg	PH	LA	Tausog
@@ -50081,7 +51842,7 @@ tsj	BT	LA	Sarchapkkha
 tsj	BT	LA	Shachobiikha
 tsj	BT	LA	Shachopkha
 tsj	BT	LA	Sharchagpakha
-tsj	BT	LA	Sharchhop-kha
+tsj	BT	LA	Sharchhokpa
 tsj	BT	LA	Tsangla
 tsj	BT	LA	Tshalingpa
 tsj	CN	L	Tshangla
@@ -50254,6 +52015,10 @@ tsp	BF	L	Toussian, Northern
 tsp	BF	LA	Tusia
 tsp	BF	LA	Tusian
 tsq	TH	L	Thai Sign Language
+tsq	TH	LA	Modern Standard Thai Sign Language
+tsq	TH	LA	MSTSL
+tsq	TH	LA	ThSL
+tsq	TH	LA	TSL
 tsr	VU	L	Akei
 tsr	VU	LA	Tasiriki
 tss	TW	D	Kaohsiung
@@ -50262,6 +52027,7 @@ tss	TW	D	Taipei
 tss	TW	L	Taiwan Sign Language
 tss	TW	LA	Taiwan Ziran Shouyu
 tst	ML	L	Tondi Songway Kiini
+tst	ML	LA	Songway Kiini
 tst	ML	LA	TSK
 tsu	TW	D	Duhtu
 tsu	TW	D	Iimutsu
@@ -50269,6 +52035,7 @@ tsu	TW	D	Luhtu
 tsu	TW	D	Tapangu
 tsu	TW	D	Tfuea
 tsu	TW	L	Tsou
+tsu	TW	LA	Cou
 tsu	TW	LA	Namakaban
 tsu	TW	LA	Niitaka
 tsu	TW	LA	Tibola
@@ -50294,6 +52061,7 @@ tsw	NG	LA	Kamberri
 tsw	NG	LA	Salka
 tsx	PG	L	Mubami
 tsx	PG	LA	Dausame
+tsx	PG	LA	Dausuami Mubami
 tsx	PG	LA	Ta
 tsx	PG	LA	Tao-Suamato
 tsx	PG	LA	Tao-Suame
@@ -50312,22 +52080,34 @@ tsz	MX	LA	P’urhe
 tsz	MX	LA	P’urhépecha
 tsz	MX	LA	Phorhépecha
 tsz	MX	LA	Porhé
+tsz	MX	LA	P’orhepecha
 tsz	MX	LA	Purépecha de la Zona Lacustre
+tsz	MX	LA	P’urhepecha
 tsz	MX	LA	Tarascan
 tsz	MX	LA	Tarasco
 tsz	US	L	Purepecha
+tsz	US	LA	P’orhepecha
+tsz	US	LA	P’urhepecha
 ttb	NG	L	Gaa
 ttb	NG	LA	Tiba
 ttc	GT	L	Tektiteko
+ttc	GT	LA	B’a’aj
+ttc	GT	LA	K’onti’l
 ttc	GT	LA	Maya-Tekiteko
+ttc	GT	LA	Qyool
 ttc	GT	LA	Teco
 ttc	GT	LA	Tectitán Mam
 ttc	GT	LA	Tectitec
 ttc	GT	LA	Tectiteco
+ttc	GT	LA	Tujqyol
 ttc	GT	LP	Teko
 ttc	MX	L	Tectitec
+ttc	MX	LA	B’a’aj
+ttc	MX	LA	K’onti’l
+ttc	MX	LA	Qyool
 ttc	MX	LA	Teco
 ttc	MX	LA	Tectitán Mame
+ttc	MX	LA	Tujqyol
 ttd	PG	L	Tauade
 ttd	PG	LA	Tauata
 tte	PG	D	Anagusa
@@ -50359,8 +52139,10 @@ tth	LA	D	Pasoom
 tth	LA	DA	Sa’ang
 tth	LA	L	Ta’oih, Upper
 tth	LA	LA	Kantua
+tth	LA	LA	Katang
 tth	LA	LA	Ta Hoi
 tth	LA	LA	Ta-Oi
+tth	LA	LA	Ta-oiq
 tth	LA	LA	Ta-Oy
 tth	LA	LA	Tau Oi
 tth	VN	D	Ha’aang
@@ -50392,8 +52174,6 @@ ttj	UG	LA	Rutooro
 ttj	UG	LA	Rutoro
 ttj	UG	LA	Toro
 ttk	CO	L	Totoro
-ttl	NA	L	Totela
-ttl	NA	LA	Echitotela
 ttl	ZM	L	Totela
 ttl	ZM	LA	Echitotela
 ttm	CA	L	Tutchone, Northern
@@ -50428,6 +52208,7 @@ ttq	NE	LA	Amazigh
 ttq	NE	LA	Tahoua
 ttq	NE	LA	Tahoua Tamajeq
 ttq	NE	LA	Tamachek
+ttq	NE	LA	Tamajaq
 ttq	NE	LA	Tamashekin
 ttq	NE	LA	Tamasheq
 ttq	NE	LA	Tewellemet
@@ -50440,6 +52221,7 @@ ttq	NG	L	Tamajaq, Tawallammat
 ttq	NG	LA	Azbinawa
 ttq	NG	LA	Buzu
 ttq	NG	LA	Tahoua Tamajeq
+ttq	NG	LA	Tamajaq
 ttq	NG	LA	Tamasheq
 ttq	NG	LA	Tomacheck
 ttq	NG	LA	Tuareg
@@ -50488,6 +52270,7 @@ ttt	IR	LA	Mussulman Tati
 ttt	RU	D	Northern Tats
 ttt	RU	L	Tat, Muslim
 ttt	RU	LA	Mussulman Tati
+ttt	RU	LA	Musulman Tats
 ttu	PG	L	Torau
 ttu	PG	LA	Rorovana
 ttv	PG	L	Titan
@@ -50509,6 +52292,7 @@ tty	ID	LA	Sikari
 tty	ID	LA	Tori
 tty	ID	LA	Tori Aikwakai
 ttz	NP	L	Tsum
+ttz	NP	LA	Tsumba
 ttz	NP	LA	Tsumge
 tua	PG	L	Wiarumus
 tua	PG	LA	Imandi
@@ -50713,6 +52497,7 @@ tuq	NE	LA	Toubou
 tuq	NE	LA	Tubu
 tuq	NG	D	Kecherda
 tuq	NG	L	Tedaga
+tuq	NG	LA	Teda
 tuq	TD	L	Tedaga
 tuq	TD	LA	Tebou
 tuq	TD	LA	Tebu
@@ -50906,6 +52691,7 @@ twh	VN	LA	Tai Lai
 twh	VN	LA	Táy Khao
 twh	VN	LA	Thái Tráng
 twh	VN	LA	White Tai
+twi	GH	L	Twi
 twl	MZ	D	Tawara-Chioco
 twl	MZ	D	Tawara-Daque
 twl	MZ	L	Tawara
@@ -50939,12 +52725,14 @@ twm	IN	LA	Northern Monpa
 twm	IN	LA	Takpa
 twm	IN	LA	Tawan Monba
 twn	CM	L	Twendi
+twn	CM	LA	Cambap
 two	BW	L	Tswapong
 two	BW	LA	Setswapong
 twp	PG	L	Ere
 twp	PG	LA	Londru
 twp	PG	LA	Nane
 twq	NE	L	Tasawaq
+twq	NE	LA	Ingalkoyyu’
 twq	NE	LA	Ingelshi
 twr	MX	L	Tarahumara, Southwestern
 twr	MX	LA	Tarahumara del Suroeste
@@ -50982,7 +52770,9 @@ twy	ID	LA	Tabuyan
 twy	ID	LA	Tawoyan Dayak
 twy	ID	LA	Tewoyan
 txa	MY	D	Lingkabau Sugut
+txa	MY	D	Sugut
 txa	MY	DA	Linkabau
+txa	MY	DA	Sungoi
 txa	MY	L	Tombonuo
 txa	MY	LA	Lobu
 txa	MY	LA	Paitan
@@ -50994,11 +52784,14 @@ txa	MY	LA	Tambanuva
 txa	MY	LA	Tambanwas
 txa	MY	LA	Tambenua
 txa	MY	LA	Tambunwas
+txa	MY	LA	Tangar nu Tombonuo
 txa	MY	LA	Tembenua
 txa	MY	LA	Tombonuva
 txa	MY	LA	Tombonuwo
 txa	MY	LA	Tumbunwha
 txa	MY	LA	Tunbumohas
+txa	MY	LP	Lobou nu Tindal
+txa	MY	LP	Pagan
 txe	ID	L	Totoli
 txe	ID	LA	Gage
 txe	ID	LA	Tolitoli
@@ -51059,6 +52852,9 @@ txu	BR	L	Kayapó
 txu	BR	LA	Cayapo
 txu	BR	LA	Kokraimoro
 txx	MY	L	Tatana
+txx	MY	LA	Dusun Tatana
+txx	MY	LA	Gia Tatana
+txx	MY	LA	Kadazan Tatana
 txx	MY	LA	Tatana’
 txx	MY	LA	Tatanaq
 txy	MG	L	Malagasy, Tanosy
@@ -51080,6 +52876,7 @@ tye	NG	LA	Tyanga
 tye	NG	LA	Tyenga
 tyh	LA	L	O’du
 tyh	LA	LA	’Iduh
+tyh	LA	LA	O Du
 tyh	LA	LA	Oedou
 tyh	LA	LP	Haat
 tyh	LA	LP	Hat
@@ -51097,11 +52894,22 @@ tyi	CG	LA	Tsaya
 tyi	CG	LA	Tsaye
 tyi	CG	LA	Tsayi
 tyi	CG	LA	West Teke
-tyj	VN	L	Tai Do
+tyj	LA	L	Tai Yo
+tyj	LA	LA	Tai Do
+tyj	LA	LA	Tai Maen
+tyj	LA	LA	Tai Man
+tyj	LA	LA	Tai Men
+tyj	LA	LA	Tai Mene
+tyj	LA	LA	Tai Mène
+tyj	LA	LA	Tai Mènè
+tyj	LA	LA	Tai-Maen
+tyj	VN	L	Tai Yo
+tyj	VN	LA	Tai Do
 tyj	VN	LA	Tay Muoi
 tyj	VN	LA	Tay Quy Chau
 tyj	VN	LA	Tay Yo
 tyj	VN	LA	Tay-Jo
+tyj	VN	LA	Thai Muong
 tyl	VN	L	Thu Lao
 tyn	ID	D	Central Kombai
 tyn	ID	D	Tayan
@@ -51212,6 +53020,7 @@ tzh	MX	D	Tzeltal del Sur
 tzh	MX	DA	Lowland Tzeltal
 tzh	MX	DA	Tzeltal de Ocosingo
 tzh	MX	L	Tzeltal
+tzh	MX	LA	Bats’il k’op
 tzh	MX	LA	Cancuc
 tzh	MX	LA	Chanal
 tzh	MX	LA	Highland Tzeltal
@@ -51254,6 +53063,7 @@ tzo	MX	DA	San Pedro Chenalhó
 tzo	MX	DA	Santa Catarina Pantelho
 tzo	MX	DA	Villa Corzo
 tzo	MX	L	Tzotzil
+tzo	MX	LA	Bats’i k’op
 tzo	MX	LA	San Bartolomé Venustiano Carranza Tzotzil
 tzo	MX	LA	Tsotsil
 tzx	PG	L	Tabriak
@@ -51347,6 +53157,7 @@ udu	SD	LA	Korara
 udu	SD	LA	Kumus
 udu	SD	LA	Kwanim Pa
 udu	SD	LA	Othan
+udu	SD	LA	Twampa
 udu	SS	L	Uduk
 udu	SS	LA	Kebeirka
 udu	SS	LA	Korara
@@ -51452,7 +53263,7 @@ ukh	CF	L	Ukhwejo
 ukh	CF	LA	Benkonjo
 ukh	CF	LA	Ukwedjo
 ukl	UA	L	Ukrainian Sign Language
-ukl	UA	LA	Ukrainska Žestovyj Âzyk
+ukl	UA	LA	Ukrayinska Zhestova Mova
 ukl	UA	LA	USL
 ukp	NG	D	Bayobiri
 ukp	NG	D	Ukpe
@@ -51642,6 +53453,7 @@ unr	IN	DA	Sadar Bhumij
 unr	IN	L	Mundari
 unr	IN	LA	Colh
 unr	IN	LA	Horo
+unr	IN	LA	Kolh
 unr	IN	LA	Mandari
 unr	IN	LA	Mondari
 unr	IN	LA	Munari
@@ -51676,6 +53488,7 @@ upv	VU	D	Wala-Rano
 upv	VU	DA	Nale
 upv	VU	L	Uripiv-Wala-Rano-Atchin
 upv	VU	LA	Northeast Malakula
+upv	VU	LA	Tirax
 ura	PE	L	Urarina
 ura	PE	LA	Itucali
 ura	PE	LA	Shimacu
@@ -51826,6 +53639,7 @@ ute	US	D	Chemehuevi
 ute	US	D	Southern Paiute
 ute	US	D	Ute
 ute	US	L	Ute-Southern Paiute
+ute	US	LA	Southern Paiute
 ute	US	LA	Ute-Chemehuevi
 utp	SB	L	Amba
 utp	SB	LA	Aba
@@ -51838,8 +53652,16 @@ utr	NG	LA	Utur
 utu	PG	L	Utu
 uum	GE	L	Urum
 uum	UA	L	Urum
+uun	TW	D	Kaxabu
+uun	TW	D	Kulon
+uun	TW	D	Pazeh
+uun	TW	DA	Kulun
+uun	TW	DA	Pazih
 uun	TW	L	Kulon-Pazeh
 uun	TW	LA	Kulun
+uun	TW	LA	Pazeh
+uun	TW	LA	Pazeh-Kahabu
+uun	TW	LA	Pazih
 uur	VU	L	Ura
 uuu	CN	L	U
 uuu	CN	LA	A’erwa
@@ -51892,10 +53714,12 @@ uzn	UZ	DA	Qarlug
 uzn	UZ	L	Uzbek, Northern
 uzn	UZ	LA	Özbek
 uzs	AF	L	Uzbek, Southern
+uzs	AF	LA	O’zbek
 uzs	AF	LA	Usbeki
 uzs	AF	LA	Uzbak
 uzs	AF	LA	Uzbeki
 uzs	TR	L	Uzbek, Southern
+uzs	TR	LA	O’zbek
 vaa	IN	L	Vaagri Booli
 vaa	IN	LA	Guvvalollu
 vaa	IN	LA	Haki Piki
@@ -51907,6 +53731,7 @@ vaa	IN	LA	Narakureavar
 vaa	IN	LA	Narikkorava
 vaa	IN	LA	Rattiyan
 vaa	IN	LA	Shikarijanam
+vaa	IN	LA	Vagri
 vaa	IN	LA	Wagri Vel
 vaa	IN	LA	Wogri Boli
 vae	CF	D	Tana
@@ -51951,16 +53776,17 @@ vai	SL	LA	Vy
 vaj	AO	L	Northwestern !Kung
 vaj	AO	LA	!O!kung
 vaj	AO	LA	!O!ung
+vaj	AO	LA	!Xun
 vaj	AO	LA	Maligo
 vaj	AO	LA	Northwestern !Xun
 vaj	AO	LA	Sekela
 vaj	AO	LA	Vasekela Bushman
 vaj	AO	LA	Vasekele
-vaj	AO	LA	Xun
 vaj	NA	L	Northwestern !Kung
 vaj	NA	LA	!Ku
 vaj	NA	LA	!Kung
 vaj	NA	LA	!’O-!Khung
+vaj	NA	LA	!Xun
 vaj	NA	LA	Sekela
 vaj	NA	LA	Vasekela Bushman
 vaj	NA	LA	Vasekele
@@ -51981,6 +53807,7 @@ vap	IN	L	Vaiphei
 vap	IN	LA	Bhaipei
 vap	IN	LA	Vaipei
 vap	IN	LA	Veiphei
+vap	IN	LA	Zomi
 var	MX	D	Highland Guarijío
 var	MX	D	Lowland Huarijío
 var	MX	L	Huarijío
@@ -51988,10 +53815,12 @@ var	MX	LA	Guarijío
 var	MX	LA	Maculái
 var	MX	LA	Macurái
 var	MX	LA	Macurawe
+var	MX	LA	Makurawe
 var	MX	LA	Varihío
 var	MX	LA	Varijío
 var	MX	LA	Varohio
 var	MX	LA	Vorijío
+var	MX	LA	Warihó
 vas	IN	D	Ambodi
 vas	IN	D	Dehvali
 vas	IN	D	Dogri
@@ -52041,13 +53870,31 @@ vec	HR	D	Istrian
 vec	HR	D	Tretine
 vec	HR	D	Venetian Proper
 vec	HR	L	Venetian
+vec	HR	LA	Veneto
+vec	IT	D	Belumat
 vec	IT	D	Bisiacco
+vec	IT	D	Buranelo
+vec	IT	D	Caorloto
+vec	IT	D	Ciosoto
 vec	IT	D	Istrian
+vec	IT	D	Liventin
+vec	IT	D	Maranese
+vec	IT	D	Paduan
+vec	IT	D	Pordenonese
+vec	IT	D	Rovigoto
+vec	IT	D	Trentin
+vec	IT	D	Trevisan
 vec	IT	D	Triestino
 vec	IT	D	Venetian Proper
+vec	IT	D	Veronese
+vec	IT	D	Vicentin
+vec	IT	DA	Padovan
+vec	IT	DA	Triestin
+vec	IT	DA	Venessian
 vec	IT	L	Venetian
 vec	IT	LA	Talian
 vec	IT	LA	Venet
+vec	IT	LA	Veneto
 vec	MX	L	Venetian
 vec	MX	LA	Chipileño
 vec	MX	LA	Veneto
@@ -52120,14 +53967,12 @@ vgr	PK	LA	Bavri
 vgr	PK	LA	Salavta
 vgr	PK	LA	Vaghri Koli
 vgt	BE	D	Antwerpen
-vgt	BE	D	Limburg
 vgt	BE	D	Oost-Vlaanderen
 vgt	BE	D	Vlaams-Brabant
 vgt	BE	D	West-Vlaanderen
 vgt	BE	DA	Antwerp
 vgt	BE	DA	East Flanders
 vgt	BE	DA	Flemish Brabant
-vgt	BE	DA	Limburg
 vgt	BE	DA	West Flanders
 vgt	BE	L	Flemish Sign Language
 vgt	BE	LA	VGT
@@ -52171,6 +54016,7 @@ vif	CG	D	Kotchi
 vif	CG	D	Lindji
 vif	CG	D	Woyo
 vif	CG	L	Vili
+vif	CG	LA	Bavili
 vif	CG	LA	Civili
 vif	CG	LA	Fiot
 vif	CG	LA	Fiote
@@ -52248,6 +54094,7 @@ vls	BE	LA	West Vlaams
 vls	FR	L	Vlaams
 vls	FR	LA	Frans Vlaams
 vls	FR	LA	Vlaemsch
+vls	FR	LA	Vlamingen
 vls	NL	D	Frans Vlaams
 vls	NL	D	West Vlaams
 vls	NL	DA	Vlaemsch
@@ -52290,6 +54137,7 @@ vmi	AU	LA	Bagu
 vmj	MX	L	Mixtec, Ixtayutla
 vmj	MX	LA	Mixteco de Santiago Ixtayutla
 vmj	MX	LA	Northeastern Jamiltepec Mixtec
+vmj	MX	LA	Tu’un savi
 vmk	MZ	L	Makhuwa-Shirima
 vmk	MZ	LA	Chirima
 vmk	MZ	LA	Eshirima
@@ -52304,14 +54152,17 @@ vml	AU	LA	Maldjana
 vml	AU	LA	Maljanna
 vml	AU	LA	Malkana
 vmm	MX	L	Mixtec, Mitlatongo
+vmm	MX	LA	Jnu’u lavi
 vmm	MX	LA	Mixteco de Mitlatongo
 vmp	MX	L	Mazatec, Soyaltepec
+vmp	MX	LA	En naxijen
 vmp	MX	LA	Mazateco de San Miguel Soyaltepec
 vmp	MX	LA	Mazateco de Temascal
 vmp	MX	LA	Mazateco del Noreste
 vmq	MX	L	Mixtec, Soyaltepec
 vmq	MX	LA	Mixteco de San Bartolo Soyaltepec
 vmq	MX	LA	Mixteco del Noreste Bajo
+vmq	MX	LA	Tu’un savi
 vmr	MZ	L	Marenje
 vmr	MZ	LA	Emarendje
 vmr	MZ	LA	Marendje
@@ -52358,6 +54209,7 @@ vmw	MZ	LA	Maquoua
 vmx	MX	L	Mixtec, Tamazola
 vmx	MX	LA	Mixteco de San Juan Tamazola
 vmy	MX	L	Mazatec, Ayautla
+vmy	MX	LA	Enre naxinanda nguifi
 vmy	MX	LA	Mazateco del Sureste
 vmz	MX	D	San Antonio Eloxochitlán Mazatec
 vmz	MX	D	San Francisco Huehuetlán Mazatec
@@ -52368,11 +54220,13 @@ vmz	MX	D	San Pedro Ocopetatillo Mazatec
 vmz	MX	D	Santa Ana Ateixtlahuaca Mazatec
 vmz	MX	DA	Mazateco de Eloxochitlán
 vmz	MX	L	Mazatec, Mazatlán
+vmz	MX	LA	Ienra naxinandana nnandia
 vmz	MX	LA	Mazateco de Mazatlán Villa de Flores
 vmz	MX	LA	Mazateco del Suroeste
 vnk	SB	L	Lovono
 vnk	SB	LA	Alavana
 vnk	SB	LA	Alavano
+vnk	SB	LA	Lavana
 vnk	SB	LA	Vanikolo
 vnk	SB	LA	Vanikoro
 vnk	SB	LA	Vano
@@ -52407,6 +54261,7 @@ vro	EE	D	Seto
 vro	EE	D	Western Võro
 vro	EE	L	Võro
 vro	EE	LA	Voro
+vro	EE	LA	Võro kiil
 vro	EE	LA	Võro-Seto
 vro	EE	LA	Voru
 vro	EE	LA	Võru
@@ -52514,10 +54369,17 @@ waa	US	LA	Ichishkíin
 waa	US	LA	Northeast Sahaptin
 wab	PG	L	Wab
 wab	PG	LA	Som
+wac	US	D	Cathlamet
+wac	US	D	Clackama
+wac	US	D	Kiksht
+wac	US	D	Multnomah
+wac	US	DA	Clackamas
+wac	US	DA	Kathlamet
 wac	US	L	Wasco-Wishram
-wac	US	LA	Cathlamet
-wac	US	LA	Kathlamet
+wac	US	LA	Columbia Chinook
+wac	US	LA	Kiksht
 wac	US	LA	Upper Chinook
+wac	US	LA	Wasco
 wac	US	LA	Wishram
 wad	ID	D	Aibondeni
 wad	ID	D	Ambumi
@@ -52582,6 +54444,7 @@ wam	US	L	Wampanoag
 wam	US	LA	Massachusett
 wam	US	LA	Massachusetts
 wam	US	LA	Natick
+wam	US	LA	Wôpanâak
 wan	CI	D	Kemu
 wan	CI	D	Miamu
 wan	CI	L	Wan
@@ -52636,6 +54499,7 @@ waw	BR	D	Katawian
 waw	BR	DA	Cachuena
 waw	BR	DA	Catauian
 waw	BR	DA	Catawian
+waw	BR	DA	Karahawyana
 waw	BR	DA	Katawina
 waw	BR	DA	Katuena
 waw	BR	DA	Katwena
@@ -52723,6 +54587,7 @@ wbh	TZ	LA	Kiwanda
 wbh	TZ	LA	Vanda
 wbh	TZ	LA	Wandia
 wbi	TZ	L	Vwanji
+wbi	TZ	LA	Bavwanji
 wbi	TZ	LA	Kivwanji
 wbi	TZ	LA	Kiwanji
 wbi	TZ	LA	Wanji
@@ -52741,6 +54606,7 @@ wbj	TZ	LA	Wasi
 wbk	AF	D	Chima-Nishey
 wbk	AF	D	Varjan
 wbk	AF	L	Waigali
+wbk	AF	LA	Kalasha ala
 wbk	AF	LA	Suki
 wbk	AF	LA	Wai
 wbk	AF	LA	Wai-Ala
@@ -52757,6 +54623,7 @@ wbl	AF	LA	Wakhigi
 wbl	CN	D	Eastern Wakhi
 wbl	CN	L	Wakhi
 wbl	CN	LA	Khik
+wbl	CN	LA	Khikwar
 wbl	CN	LA	Vakhan
 wbl	CN	LA	Wakhani
 wbl	CN	LA	Wakhigi
@@ -52765,6 +54632,7 @@ wbl	PK	D	Ishkoman
 wbl	PK	D	Yarkhun
 wbl	PK	D	Yasin
 wbl	PK	L	Wakhi
+wbl	PK	LA	Khik
 wbl	PK	LA	Khikwar
 wbl	PK	LA	Vakhan
 wbl	PK	LA	Wakhani
@@ -52775,6 +54643,7 @@ wbl	TJ	D	Western Wakhi
 wbl	TJ	L	Wakhi
 wbl	TJ	LA	Guhjali
 wbl	TJ	LA	Khik
+wbl	TJ	LA	Khikwar
 wbl	TJ	LA	Vakhan
 wbl	TJ	LA	Wakhani
 wbl	TJ	LA	Wakhigi
@@ -52913,6 +54782,7 @@ wec	CI	L	Wè Western
 wec	CI	LA	Gere
 wec	CI	LA	Guéré
 wec	CI	LA	Neyo
+wec	CI	LA	Wèè
 wed	PG	D	Kwamana
 wed	PG	D	Lavora
 wed	PG	D	Topura
@@ -53051,8 +54921,9 @@ wgy	AU	LA	Biyay
 wha	ID	D	Hatuolu
 wha	ID	D	Kanikeh
 wha	ID	D	Maneo
-wha	ID	D	South Manusela
-wha	ID	L	Manusela
+wha	ID	D	South Sou Upaa
+wha	ID	L	Sou Upaa
+wha	ID	LA	Manusela
 wha	ID	LA	Wahai
 wha	ID	LA	Wahinama
 whg	PG	D	Banz-Nondugl
@@ -53133,6 +55004,8 @@ wka	TZ	LA	Ng’omvia
 wka	TZ	LA	Ngomvya
 wka	TZ	LA	Qwadza
 wkb	IN	L	Kumbaran
+wkb	IN	LA	Adi Andhra
+wkb	IN	LA	Kusavan
 wkd	ID	L	Mo
 wkd	ID	LA	Wakde
 wkl	IN	L	Kalanadi
@@ -53172,6 +55045,7 @@ wlk	US	L	Wailaki
 wll	SD	L	Wali
 wll	SD	LA	Walari
 wll	SD	LA	Walarishe
+wll	SD	LA	Wele
 wln	BE	D	Central Walloon
 wln	BE	D	Eastern Walloon
 wln	BE	D	Southern Walloon
@@ -53180,10 +55054,6 @@ wln	BE	L	Walloon
 wln	BE	LA	Wallon
 wlo	ID	L	Wolio
 wlo	ID	LA	Baubau
-wlo	MY	L	Wolio
-wlo	MY	LA	Buton
-wlo	MY	LA	Butonese
-wlo	MY	LA	Butung
 wlr	VU	L	Wailapa
 wls	NC	L	Wallisian
 wls	NC	LA	East Uvean
@@ -53231,6 +55101,7 @@ wmc	PG	L	Wamas
 wmd	BR	D	Negaroté
 wmd	BR	D	Tawende
 wmd	BR	L	Mamaindé
+wmd	BR	LA	Mamainsahai’gidu
 wme	NP	D	Bonu
 wme	NP	D	Hilepane
 wme	NP	D	Jhappali
@@ -53244,10 +55115,13 @@ wme	NP	LA	Chaurasya
 wme	NP	LA	Chourase
 wme	NP	LA	Chourasia
 wme	NP	LA	Ombule
+wme	NP	LA	Radu Yor
 wme	NP	LA	Tsaurasya
 wme	NP	LA	Umbule
 wme	NP	LA	Vambucauras Raduyor
 wme	NP	LA	Vambule
+wme	NP	LA	Vambule Radu Yor
+wme	NP	LA	Vambule Yor
 wmh	TL	L	Waima’a
 wmh	TL	LA	Uai Ma’a
 wmh	TL	LA	Uaimo’a
@@ -53287,6 +55161,8 @@ wmw	MZ	LA	Ibo
 wmw	MZ	LA	Kimwani
 wmw	MZ	LA	Muane
 wmw	MZ	LA	Mwane
+wmw	MZ	LA	Mwaní
+wmw	MZ	LA	Namwaní
 wmw	MZ	LA	Quimuane
 wmx	PG	L	Womo
 wnb	PG	L	Wanambre
@@ -53448,7 +55324,11 @@ woy	ET	LA	Weyt’o
 wpc	VE	L	Maco
 wpc	VE	LA	Itoto
 wpc	VE	LA	Jojod
+wpc	VE	LA	Maco-Piaroa
 wpc	VE	LA	Mako
+wpc	VE	LA	Maku
+wpc	VE	LA	Sáliba-Maco
+wpc	VE	LA	Wirö
 wpc	VE	LA	Wotuja
 wra	PG	L	Warapu
 wra	PG	LA	Barupu
@@ -53465,6 +55345,7 @@ wrb	AU	LA	Wollegara
 wrb	AU	LA	Yunnalinka
 wrd	AF	L	Warduji
 wrg	AU	L	Warungu
+wrg	AU	LA	Gudjal
 wrg	AU	LA	Gudjala
 wrg	AU	LA	Gugu-Badhun
 wrg	AU	LA	Warrongo
@@ -53563,6 +55444,14 @@ wsa	ID	D	Bonoi Buroro
 wsa	ID	L	Warembori
 wsa	ID	LA	Waremboivoro
 wsa	ID	LA	Warenbori
+wsg	IN	D	Rajura
+wsg	IN	D	Utnoor Gondi
+wsg	IN	L	Gondi, Adilabad
+wsg	IN	LA	Gunjala Gondi
+wsg	IN	LA	Koyang
+wsg	IN	LA	Nirmal
+wsg	IN	LA	Raj Gond
+wsg	IN	LA	Telugu Gondi
 wsi	VU	L	Wusi
 wsi	VU	LA	Wusi-Kerepua
 wsk	PG	L	Waskia
@@ -53635,6 +55524,7 @@ wti	ET	LA	Beni Shangul
 wti	ET	LA	Bertha
 wti	ET	LA	Burta
 wti	ET	LA	Jebelawi
+wti	ET	LA	Rotana
 wti	ET	LA	Wetawit
 wti	SD	D	Bake
 wti	SD	D	Fadashi
@@ -53645,6 +55535,7 @@ wti	SD	L	Berta
 wti	SD	LA	Barta
 wti	SD	LA	Burta
 wti	SD	LA	Gwami
+wti	SD	LA	Rotana
 wti	SD	LA	Wetawit
 wti	SD	LP	Beni Shangul
 wtk	PG	L	Watakataui
@@ -53674,6 +55565,8 @@ wub	AU	LA	Yeidji
 wub	AU	LA	Yeithi
 wud	TG	L	Wudu
 wuh	CN	L	Wutunhua
+wuh	CN	LA	Ngandehua
+wuh	CN	LA	Sanggaixiong
 wuh	CN	LA	Wutong
 wuh	CN	LA	Wutun
 wul	ID	D	Lower Samenage
@@ -53699,6 +55592,7 @@ wun	TZ	D	Maleza
 wun	TZ	D	Mwambani
 wun	TZ	D	Udinde
 wun	TZ	L	Bungu
+wun	TZ	LA	Echiungu
 wun	TZ	LA	Iciwungu
 wun	TZ	LA	Kibungu
 wun	TZ	LA	Ungu
@@ -53865,6 +55759,16 @@ xac	IN	LA	Cachari
 xac	IN	LA	Plains Kachari
 xai	BR	L	Kaimbé
 xaj	BR	L	Ararandewára
+xaj	BR	LA	Ararandeuras
+xak	BR	L	Máku
+xak	BR	LA	Macu
+xak	BR	LA	Máko
+xak	BR	LA	Maku
+xak	BR	LA	Makú
+xak	VE	L	Máku
+xak	VE	LA	Máko
+xak	VE	LA	Maku
+xak	VE	LA	Makú
 xal	CN	D	Bayit
 xal	CN	D	Dorbot
 xal	CN	D	Jakhachin
@@ -53924,11 +55828,15 @@ xal	RU	LA	Oirat
 xal	RU	LA	Qalmaq
 xal	RU	LA	Volga Oirat
 xal	RU	LA	Western Mongolian
+xam	ZA	D	Achterveld
+xam	ZA	D	Katkop
+xam	ZA	D	Strandberg
 xam	ZA	L	|Xam
 xam	ZA	LA	|Kamka!e
 xam	ZA	LA	|Kham-Ka-!k’e
 xam	ZA	LA	|Xam-Ka-!k’e
 xan	ET	L	Xamtanga
+xan	ET	LA	Agaw
 xan	ET	LA	Agawinya
 xan	ET	LA	Khamtanga
 xan	ET	LA	Simt’anga
@@ -53967,8 +55875,6 @@ xav	BR	LA	Shavante
 xav	BR	LA	Tapacua
 xaw	US	L	Kawaiisu
 xay	ID	L	Kayan Mahakam
-xba	BR	L	Kamba
-xba	BR	LA	Camba
 xbd	AU	L	Bindal
 xbd	AU	LA	Nyawaygi
 xbe	AU	L	Bigambal
@@ -54023,6 +55929,7 @@ xbi	PG	DA	Wampukuamp
 xbi	PG	DA	Wampurun
 xbi	PG	DA	Yanimoi
 xbi	PG	L	Kombio
+xbi	PG	LA	Akwun
 xbi	PG	LA	Endangen
 xbj	AU	L	Birrpayi
 xbj	AU	LA	Biribi
@@ -54066,9 +55973,6 @@ xbr	ID	LA	Oost-Sumbaas
 xbr	ID	LA	Sumba
 xbr	ID	LA	Sumbanese
 xbw	BR	L	Kambiwá
-xbx	BR	L	Kabixí
-xbx	BR	LA	Cabichí
-xbx	BR	LA	Cabishi
 xby	AU	L	Batyala
 xby	AU	LA	Badjela
 xby	AU	LA	Badtala
@@ -54181,6 +56085,7 @@ xes	PG	LA	Namuya
 xet	BR	L	Xetá
 xet	BR	LA	Aré
 xet	BR	LA	Cheta
+xet	BR	LA	Curutón
 xet	BR	LA	Seta
 xet	BR	LA	Sheta
 xeu	PG	D	Ahia
@@ -54286,8 +56191,6 @@ xii	ZA	LA	Xirikwa
 xii	ZA	LA	Xrikwa
 xin	GT	L	Xinca
 xin	GT	LA	Szinca
-xip	BR	L	Xipináwa
-xip	BR	LA	Shipinahua
 xir	BR	L	Xiriâna
 xis	IN	L	Kisan
 xis	IN	LA	Birhor
@@ -54357,7 +56260,12 @@ xkg	ML	D	Sébékoro
 xkg	ML	D	Séféto
 xkg	ML	L	Kagoro
 xkg	ML	LA	Kakolo
-xkh	BR	L	Karahawyana
+xki	KE	D	Kisumu
+xki	KE	D	Mombasa
+xki	KE	D	Nairobi
+xki	KE	DA	central
+xki	KE	DA	eastern
+xki	KE	DA	western
 xki	KE	L	Kenyan Sign Language
 xki	KE	LA	KSL
 xkj	IR	L	Kajali
@@ -54480,7 +56388,9 @@ xkz	BT	LA	Kurteopkha
 xkz	BT	LA	Kürthöpka
 xkz	BT	LA	Kurthopkha
 xkz	BT	LA	Kurtobikha
+xkz	BT	LA	Kurtöp
 xkz	BT	LA	Kurtopakha
+xkz	BT	LA	Kurtotpikha
 xla	PG	L	Kamula
 xla	PG	LA	Wawoi
 xma	SO	L	Mushungulu
@@ -54500,6 +56410,7 @@ xmc	MZ	LA	Coastal Makhuwa
 xmc	MZ	LA	Emaka
 xmc	MZ	LA	Maca
 xmc	MZ	LA	Maka
+xmc	MZ	LA	Makua-Marevone
 xmc	MZ	LA	Marevone
 xmc	MZ	LA	Marrevone
 xmc	MZ	LA	South Maca
@@ -54511,6 +56422,7 @@ xmd	CM	LA	Ma Mbudum
 xmd	CM	LA	Mbedam
 xmd	CM	LA	Mboudoum
 xmf	GE	L	Mingrelian
+xmf	GE	LA	Margali
 xmf	GE	LA	Margaluri
 xmf	GE	LA	Megrel
 xmf	GE	LA	Megrelian
@@ -54521,6 +56433,7 @@ xmg	CM	DA	Bamendjin
 xmg	CM	L	Mengaka
 xmg	CM	LA	Bamileke-Mengaka
 xmg	CM	LA	Benzing
+xmg	CM	LA	Eghap
 xmg	CM	LA	Ghap
 xmg	CM	LA	Megaka
 xmh	AU	L	Kuku-Muminh
@@ -54547,6 +56460,7 @@ xmj	TD	LA	Mida’a
 xmj	TD	LA	Midah
 xml	MY	L	Malaysian Sign Language
 xml	MY	LA	Bahasa Isyarat Malaysia
+xml	MY	LA	BIM
 xmm	ID	L	Malay, Manado
 xmm	ID	LA	Manadonese
 xmm	ID	LA	Manadonese Malay
@@ -54651,10 +56565,16 @@ xns	IN	LA	Malani
 xnt	US	L	Narragansett
 xnu	AU	L	Nukunul
 xny	AU	L	Nyiyaparli
+xny	AU	LA	Bailko
+xny	AU	LA	Balgu
+xny	AU	LA	Balygu
+xny	AU	LA	Balyku
 xny	AU	LA	Iabali
 xny	AU	LA	Jana
 xny	AU	LA	Janari
+xny	AU	LA	Jauna
 xny	AU	LA	Niabali
+xny	AU	LA	Nijadali
 xny	AU	LA	Njiabadi
 xny	AU	LA	Njiabali
 xny	AU	LA	Njijabadi
@@ -54663,6 +56583,8 @@ xny	AU	LA	Njijapali
 xny	AU	LA	Nyiyabali
 xny	AU	LA	Nyiyapali
 xny	AU	LA	Nyiypali
+xny	AU	LA	Paljgu
+xny	AU	LA	Palyku
 xnz	EG	L	Mattokki
 xnz	EG	LA	Kenuz
 xnz	EG	LA	Kenuzi
@@ -54670,7 +56592,6 @@ xnz	EG	LA	Kenzi
 xnz	EG	LA	Kunuz
 xnz	EG	LA	Kunuz Nubian
 xnz	EG	LA	Kunuzi
-xnz	EG	LA	Mattokki
 xoc	NG	L	O’chi’chi’
 xod	ID	D	Kasuweri
 xod	ID	D	Negri Besar
@@ -54715,7 +56636,13 @@ xoi	PG	L	Kominimung
 xok	BR	L	Xokleng
 xok	BR	LA	Aweikoma
 xok	BR	LA	Botocudos
-xok	BR	LA	Bugre
+xok	BR	LA	Bugré
+xok	BR	LA	Kaingang
+xok	BR	LA	Shokléng
+xok	BR	LA	Xakléng
+xok	BR	LA	Xogléng
+xok	BR	LA	Xokré
+xok	BR	LA	Xokréng
 xom	ET	D	Koma of Begi
 xom	ET	D	Koma of Daga
 xom	ET	L	Komo
@@ -54735,6 +56662,7 @@ xom	SD	LA	Madiin
 xom	SS	L	Komo
 xom	SS	LA	Aru
 xom	SS	LA	Koma
+xon	GH	D	Komba
 xon	GH	D	Lichabool
 xon	GH	D	Ligbeln
 xon	GH	D	Likoonli
@@ -54745,7 +56673,9 @@ xon	GH	DA	Likonl
 xon	GH	DA	Liquan
 xon	GH	L	Konkomba
 xon	GH	LA	Kpankpamba
+xon	GH	LA	Likpakpaanl
 xon	TG	L	Konkomba
+xon	TG	LA	Likpakpaanl
 xoo	BR	L	Xukurú
 xoo	BR	LA	Kirirí
 xoo	BR	LA	Kirirí-Xokó
@@ -54832,6 +56762,7 @@ xsb	PH	D	Masinloc
 xsb	PH	D	Santa Cruz
 xsb	PH	L	Sambal
 xsb	PH	LA	Sambali
+xsb	PH	LA	Sambalì
 xsb	PH	LP	Tina
 xsb	PH	LP	Tina Sambal
 xse	ID	L	Sempan
@@ -54842,8 +56773,11 @@ xsh	NG	LA	Samban
 xsi	PG	L	Sio
 xsi	PG	LA	Sigawa
 xsl	CA	L	Slavey, South
+xsl	CA	LA	Acha’otinne
+xsl	CA	LA	Deh Gáh Ghotie Zhatie
 xsl	CA	LA	Dene
 xsl	CA	LA	Dené
+xsl	CA	LA	Dene Tha’
 xsl	CA	LA	Denetha
 xsl	CA	LA	Mackenzian
 xsl	CA	LP	Slave
@@ -54885,11 +56819,13 @@ xsr	CN	L	Sherpa
 xsr	CN	LA	Serwa
 xsr	CN	LA	Sharpa
 xsr	CN	LA	Sharpa Bhotia
+xsr	CN	LA	Sherwi tamnye
 xsr	CN	LA	Xiaerba
 xsr	IN	L	Sherpa
 xsr	IN	LA	Serwa
 xsr	IN	LA	Sharpa
 xsr	IN	LA	Sharpa Bhotia
+xsr	IN	LA	Sherwi tamnye
 xsr	IN	LA	Xarba
 xsr	IN	LA	Xiaerba
 xsr	NP	D	Central Sherpa
@@ -54904,6 +56840,7 @@ xsr	NP	DA	South Sherpa
 xsr	NP	L	Sherpa
 xsr	NP	LA	Serwa
 xsr	NP	LA	Sharpa
+xsr	NP	LA	Sherwi tamnye
 xsr	NP	LA	Xiaerba
 xsr	NP	LP	Sharpa Bhotia
 xsu	BR	D	Auaris
@@ -54950,6 +56887,7 @@ xta	MX	L	Mixtec, Alcozauca
 xta	MX	LA	Mixteco de Alocozauca
 xta	MX	LA	Mixteco de Xochapa
 xtb	MX	L	Mixtec, Chazumba
+xtb	MX	LA	Da’an davi
 xtb	MX	LA	Mixteco de Chazumba
 xtb	MX	LA	Mixteco de la Frontera Puebla-Oaxaca
 xtb	MX	LA	Northern Oaxaca Mixtec
@@ -54971,6 +56909,7 @@ xtd	MX	L	Mixtec, Diuxi-Tilantongo
 xtd	MX	LA	Central Nochistlán Mixtec
 xtd	MX	LA	Mixteco de Diuxi-Tilantongo
 xtd	MX	LA	Mixteco del Este Central
+xtd	MX	LA	Tnu’un dau
 xte	ID	D	Bime
 xte	ID	D	Okbap
 xte	ID	D	Omban
@@ -54991,17 +56930,20 @@ xth	AU	LA	Yitsa
 xth	AU	LA	Yit-tha
 xti	MX	L	Mixtec, Sinicahua
 xti	MX	LA	Mixteco de San Antonio Sinicahua
+xti	MX	LA	Tu’un savi
 xtj	MX	L	Mixtec, San Juan Teita
+xtj	MX	LA	Dañudavi
 xtj	MX	LA	Mixteco de San Juan Teita
 xtj	MX	LA	Teita Mixtec
 xtl	MX	L	Mixtec, Tijaltepec
 xtl	MX	LA	Mixteco de San Pablo Tijaltepec
 xtl	MX	LA	Mixteco de Santa María Yosoyúa
+xtl	MX	LA	Tu’un savi
 xtm	MX	D	San Agustín Tlacotepec Mixtec
 xtm	MX	D	San Cristóbal Amoltepec Mixtec
 xtm	MX	D	San Mateo Peñasco Mixtec
 xtm	MX	L	Mixtec, Magdalena Peñasco
-xtn	MX	D	San Antonio Monte Verde
+xtn	MX	D	San Antonino Monte Verde
 xtn	MX	D	San Antonio Nduaxico
 xtn	MX	D	San Sebastian Nicananduta
 xtn	MX	D	Santiago Nundiche
@@ -55010,8 +56952,11 @@ xtn	MX	L	Mixtec, Northern Tlaxiaco
 xtn	MX	LA	Mixteco de San Juan Ñumí
 xtn	MX	LA	Mixteco del Norte de Tlaxiaco
 xtn	MX	LA	Ñumí Mixtec
+xtn	MX	LA	Sa’an nda’u
+xtn	MX	LA	Sa’an savi
 xtp	MX	L	Mixtec, San Miguel Piedras
 xtp	MX	LA	Mixteco de San Miguel Piedras
+xtp	MX	LA	Tu’un savi
 xts	MX	L	Mixtec, Sindihui
 xtt	MX	L	Mixtec, Tacahua
 xtt	MX	LA	Mixteco de Santa Cruz Tacahua
@@ -55020,6 +56965,7 @@ xtu	MX	L	Mixtec, Cuyamecalco
 xtu	MX	LA	Cuicatlán Mixtec
 xtu	MX	LA	Mixteco de Cañada central
 xtu	MX	LA	Mixteco de Cuyamecalco
+xtu	MX	LA	Tu’un savi
 xtv	AU	L	Thawa
 xtv	AU	LA	Baianga
 xtv	AU	LA	Guyanagal
@@ -55036,6 +56982,7 @@ xtw	BR	LA	Da’wan’du
 xtw	BR	LA	Tawaindê
 xty	MX	L	Mixtec, Yoloxóchitl
 xty	MX	LA	Mixteco de Yoloxóchitl
+xty	MX	LA	Tu’un savi
 xua	IN	L	Kurumba, Alu
 xua	IN	LA	Alu Kurumba Nonstandard Kannada
 xua	IN	LA	Hal Kurumba
@@ -55122,13 +57069,15 @@ xuu	BW	LA	Kxoe
 xuu	BW	LA	Xun
 xuu	BW	LP	Mbarakwena
 xuu	BW	LP	Water Bushmen
-xuu	NA	D	||Anikhwe
+xuu	NA	D	||Ani
 xuu	NA	D	||Xo-Kxoe
 xuu	NA	D	||Xom-Kxoe
 xuu	NA	D	Buga-Kxoe
 xuu	NA	D	Buma-Kxoe
+xuu	NA	DA	||Anikhwe
 xuu	NA	L	Khwe
 xuu	NA	LA	Khoe
+xuu	NA	LA	Khwe-||Ani
 xuu	NA	LA	Kxoe
 xuu	NA	LA	Kxoedam
 xuu	NA	LA	Xun
@@ -55136,18 +57085,6 @@ xuu	NA	LP	Barakwena
 xuu	NA	LP	Barakwengo
 xuu	NA	LP	Mbarakwena
 xuu	NA	LP	Water Bushmen
-xuu	ZA	D	||Ani
-xuu	ZA	D	Kxoedam
-xuu	ZA	L	Khwe
-xuu	ZA	LA	Barakwena
-xuu	ZA	LA	Barakwengo
-xuu	ZA	LA	Basarwa
-xuu	ZA	LA	Khoe
-xuu	ZA	LA	Kxoe
-xuu	ZA	LA	Mbarakwena
-xuu	ZA	LA	Mbarakwengo
-xuu	ZA	LA	Water Bushmen
-xuu	ZA	LA	Xun
 xuu	ZM	D	||Xo-Kxoe
 xuu	ZM	L	Khwe
 xuu	ZM	LA	!Hukwe
@@ -55397,6 +57334,7 @@ yab	BR	LA	Makú-Yahup
 yab	BR	LA	Yahup
 yab	BR	LA	Yahup Makú
 yab	BR	LA	Yëhup
+yab	BR	LA	Yuhupdeh
 yab	BR	LP	Maku
 yac	ID	D	Apahapsili
 yac	ID	D	Landikma
@@ -55409,6 +57347,7 @@ yac	ID	LA	Western Yali
 yac	ID	LA	Yaly
 yad	PE	L	Yagua
 yad	PE	LA	Llagua
+yad	PE	LA	Nijyamii
 yad	PE	LA	Nijyamïï Nikyejaada
 yad	PE	LA	Yahua
 yad	PE	LA	Yava
@@ -55431,8 +57370,10 @@ yaf	CD	LA	Iaka
 yaf	CD	LA	Iyaka
 yaf	CD	LA	Kiyaka
 yag	AR	L	Yámana
+yag	AR	LA	Háusi Kúta
 yag	AR	LA	Yahgan
 yag	CL	L	Yámana
+yag	CL	LA	Háusi Kúta
 yag	CL	LA	Tequenica
 yag	CL	LA	Yagán
 yag	CL	LA	Yaghan
@@ -55444,9 +57385,11 @@ yah	TJ	LA	Iazgulem
 yah	TJ	LA	Yazghulomi
 yah	TJ	LA	Yazgulam
 yah	TJ	LA	Yazgulyami
+yah	TJ	LA	Yuzdomi zavég
 yai	TJ	D	Eastern Yagnobi
 yai	TJ	D	Western Yagnobi
 yai	TJ	L	Yagnobi
+yai	TJ	LA	Soghdi
 yai	TJ	LA	Yaghnabi
 yai	TJ	LA	Yaghnobi
 yai	TJ	LA	Yaghnubi
@@ -55459,6 +57402,7 @@ yaj	CF	LA	Yanguere
 yak	US	D	Klikitat
 yak	US	L	Yakama
 yak	US	LA	Ichishkíin
+yak	US	LA	Waptailmim
 yak	US	LA	Yakima
 yal	GN	D	Firia
 yal	GN	D	Sulima
@@ -55468,8 +57412,11 @@ yal	GN	LA	Djallonke
 yal	GN	LA	Dyalonke
 yal	GN	LA	Jalonke
 yal	GN	LA	Jalunga
+yal	GN	LA	Jalunga xuwiina’
+yal	GN	LA	Jalungas
 yal	GN	LA	Yalunke
 yal	ML	D	Bafing
+yal	ML	D	Fontofa
 yal	ML	D	Jalunga
 yal	ML	D	Yalunka
 yal	ML	L	Jalunga
@@ -55477,6 +57424,9 @@ yal	ML	LA	Dialonke
 yal	ML	LA	Djallonke
 yal	ML	LA	Dyalonke
 yal	ML	LA	Jalonke
+yal	ML	LA	Jalunga xuwiina’
+yal	ML	LA	Jalunganéé
+yal	ML	LA	Jalungas
 yal	ML	LA	Yalunka
 yal	ML	LA	Yalunke
 yal	SL	D	Firia
@@ -55487,6 +57437,8 @@ yal	SL	LA	Dialonke
 yal	SL	LA	Djallonke
 yal	SL	LA	Jalonke
 yal	SL	LA	Jalunga
+yal	SL	LA	Jalunga xuwiina’
+yal	SL	LA	Jalungas
 yal	SL	LA	Kjalonke
 yal	SL	LA	Yalunke
 yal	SN	L	Jalunga
@@ -55494,6 +57446,8 @@ yal	SN	LA	Dialonké
 yal	SN	LA	Djallonke
 yal	SN	LA	Dyalonke
 yal	SN	LA	Jalonké
+yal	SN	LA	Jalunga xuwiina’
+yal	SN	LA	Jalungas
 yal	SN	LA	Yalunka
 yal	SN	LA	Yalunke
 yam	CM	D	Bom
@@ -55621,7 +57575,11 @@ yao	ZM	LA	Veiao
 yao	ZM	LA	Wajao
 yap	FM	L	Yapese
 yaq	MX	L	Yaqui
+yaq	MX	LA	Hiak-nooki
+yaq	MX	LA	Yoeme
 yaq	US	L	Yaqui
+yaq	US	LA	Hiak-nooki
+yaq	US	LA	Yoeme
 yar	VE	D	Curasicana
 yar	VE	D	Wokiare
 yar	VE	DA	Guaiquiare
@@ -55731,6 +57689,7 @@ ybe	CN	LA	Yugu
 ybe	CN	LA	Yuku
 ybh	IN	L	Yakkha
 ybh	IN	LA	Yakha
+ybh	IN	LA	Yakkha Ceya
 ybh	IN	LA	Yakkhaba
 ybh	NP	D	Eastern Yakkha
 ybh	NP	D	Northern Yakkha
@@ -55742,6 +57701,7 @@ ybh	NP	DA	Sankhuwasabha
 ybh	NP	L	Yakkha
 ybh	NP	LA	Dewansala
 ybh	NP	LA	Yakha
+ybh	NP	LA	Yakkha Ceya
 ybh	NP	LA	Yakkhaba
 ybh	NP	LA	Yakkhaba Cea
 ybh	NP	LA	Yakkhaba Sala
@@ -55813,18 +57773,50 @@ ycp	LA	L	Chepya
 yda	AU	L	Yanda
 yda	AU	LA	Janda
 yda	AU	LA	Yunda
+ydd	AR	L	Yiddish, Eastern
+ydd	BE	L	Yiddish, Eastern
+ydd	BY	D	Northeastern Yiddish
+ydd	BY	DA	Litvish
+ydd	BY	L	Yiddish, Eastern
+ydd	CA	L	Yiddish, Eastern
+ydd	CR	L	Yiddish, Eastern
+ydd	HU	L	Yiddish, Eastern
 ydd	IL	D	Mideastern Yiddish
 ydd	IL	D	Northeastern Yiddish
 ydd	IL	D	Southeastern Yiddish
+ydd	IL	DA	Litvish
 ydd	IL	L	Yiddish, Eastern
 ydd	IL	LA	Judeo-German
 ydd	IL	LA	Yiddish
+ydd	LT	D	Northeastern Yiddish
+ydd	LT	DA	Lithuanian Yiddish
+ydd	LT	DA	Litvish
+ydd	LT	L	Yiddish, Eastern
+ydd	LV	D	Northeastern Yiddish
 ydd	LV	L	Yiddish, Eastern
 ydd	LV	LA	Judeo-German
+ydd	MD	D	Southeastern Yiddish
+ydd	MD	DA	Bessarabian-Romanian
 ydd	MD	L	Yiddish, Eastern
+ydd	PA	L	Yiddish, Eastern
+ydd	PL	D	Mideastern Yiddish
+ydd	PL	D	Northeastern Yiddish
+ydd	PL	DA	Litvish
+ydd	PL	DA	Polish Yiddish
+ydd	PL	L	Yiddish, Eastern
+ydd	RO	D	Southeastern Yiddish
+ydd	RO	DA	Bessarabian-Romanian
 ydd	RO	L	Yiddish, Eastern
-ydd	SE	L	Yiddish, Eastern
+ydd	RU	L	Yiddish, Eastern
+ydd	UA	D	Southeastern Yiddish
+ydd	UA	DA	Podolian
+ydd	UA	DA	Volhynian
 ydd	UA	L	Yiddish, Eastern
+ydd	US	L	Yiddish, Eastern
+ydd	UY	D	Northeastern Yiddish
+ydd	UY	DA	Litvish
+ydd	UY	L	Yiddish, Eastern
+ydd	ZA	L	Yiddish, Eastern
 yde	PG	L	Yangum Dey
 ydg	PK	L	Yidgha
 ydg	PK	LA	Lutkuhwar
@@ -55997,8 +57989,13 @@ ygw	PG	D	Hiqwaye
 ygw	PG	D	Iwalaqamalje
 ygw	PG	D	Yeqwangilje
 ygw	PG	L	Yagwoia
+ygw	PG	LA	Gwase
+ygw	PG	LA	Hiqwase
+ygw	PG	LA	Hiqwaye
+ygw	PG	LA	Iwalaqamalhe
 ygw	PG	LA	Kokwaiyakwa
 ygw	PG	LA	Yeghuye
+ygw	PG	LA	Yeqwangilje
 yha	CN	D	Ecun
 yha	CN	D	Langjia
 yha	CN	D	Yalang
@@ -56038,6 +58035,7 @@ yhl	CN	LA	Shaoji Phula
 yhl	CN	LA	Sifter Basket Phula
 yhl	CN	LA	Thrice Striped Red Phula
 yhl	CN	LA	Xiuba
+yhs	AU	L	Yan-nhangu Sign Language
 yia	AU	L	Yinggarda
 yia	AU	LA	Ingara
 yia	AU	LA	Ingarda
@@ -56050,6 +58048,7 @@ yia	AU	LA	Kakarakala
 yia	AU	LA	Yingkarta
 yid	IL	L	Yiddish
 yif	CN	L	Ache
+yif	CN	LA	Azhe
 yig	CN	D	Bijie
 yig	CN	D	Dafang
 yig	CN	D	Qian Xi
@@ -56096,9 +58095,11 @@ yij	AU	L	Yindjibarndi
 yij	AU	LA	Jindjibandi
 yij	AU	LA	Yinjtjipartnti
 yik	CN	L	Lalo, Dongshanba
+yik	CN	LA	Jiantou
 yik	CN	LA	Lalu
 yik	CN	LA	Lalupa
 yik	CN	LA	Lalupu
+yik	CN	LA	Maganfang
 yil	AU	L	Yindjilandji
 yil	AU	LA	Bularnu
 yil	AU	LA	Dhidhanu
@@ -56116,13 +58117,16 @@ yim	IN	LA	Yanchunger
 yim	IN	LA	Yimchunger
 yim	IN	LA	Yimchungre
 yim	IN	LA	Yimchungru
-yin	MM	L	Yinchia
-yin	MM	LA	Black Riang
+yin	MM	L	Riang Lai
+yin	MM	LA	Ban Roi
+yin	MM	LA	Liang Sek
 yin	MM	LA	Ranei
+yin	MM	LA	Riang Seak
 yin	MM	LA	Striped Karen
+yin	MM	LA	Yang
+yin	MM	LA	Yang Lai
 yin	MM	LA	Yin Kya
-yin	MM	LA	Yin Net
-yin	MM	LA	Yinnet
+yin	MM	LA	Yinchia
 yip	CN	L	Pholo
 yip	CN	LA	Black Phula
 yip	CN	LA	Flowery Phula
@@ -56140,6 +58144,7 @@ yir	ID	LA	Jair
 yir	ID	LA	Yair
 yis	PG	L	Yis
 yit	CN	L	Lalu, Eastern
+yit	CN	LA	Lalu
 yiu	CN	D	Northern Awu
 yiu	CN	D	Southern Awu
 yiu	CN	L	Awu
@@ -56149,32 +58154,12 @@ yiv	CN	D	Nasu
 yiv	CN	D	Nisu
 yiv	CN	L	Nisu, Northern
 yiv	CN	LA	E-Xin Yi
+yiv	CN	LA	Nasupho
+yiv	CN	LA	Nisupho
 yix	CN	L	Axi
 yix	CN	LA	Ahi
 yix	CN	LA	Axibo
 yix	CN	LA	Axipo
-yiy	AU	D	Dangedl
-yiy	AU	D	Gorminang
-yiy	AU	D	Jir’jorond
-yiy	AU	DA	Dhanu’un
-yiy	AU	DA	Djudjan
-yiy	AU	DA	Dudjym
-yiy	AU	DA	Jirmel Mel-Jir
-yiy	AU	DA	Ngamba’wandh
-yiy	AU	DA	Yir Thangedl
-yiy	AU	DA	Yirmel
-yiy	AU	DA	Yirtangettle
-yiy	AU	DA	Yirtutiym
-yiy	AU	L	Yir Yoront
-yiy	AU	LA	Gwandera
-yiy	AU	LA	Jir Joront
-yiy	AU	LA	Kokomindjen
-yiy	AU	LA	Mandjoen
-yiy	AU	LA	Millera
-yiy	AU	LA	Mind’jana
-yiy	AU	LA	Mundjun
-yiy	AU	LA	Myunduno
-yiy	AU	LA	Yir Yiront
 yiz	CN	L	Azhe
 yka	PH	L	Yakan
 yka	PH	LA	Yacan
@@ -56270,6 +58255,7 @@ yle	PG	LA	Rossel
 yle	PG	LA	Yela
 yle	PG	LA	Yelejong
 yle	PG	LA	Yeletnye
+yle	PG	LA	Yélî Dnye
 yle	PG	LA	Yelidnye
 ylg	PG	L	Yelogu
 ylg	PG	LA	Buiamanambu
@@ -56287,6 +58273,7 @@ yln	CN	LA	Buyang Zhuang
 yln	CN	LA	Eastern Buyang
 yln	CN	LA	E’cun Buyang
 ylo	CN	L	Naluo
+ylo	CN	LA	Aluo Naluo
 ylo	CN	LA	Gan Yi
 ylo	CN	LA	Laluo
 ylo	CN	LA	Naruo
@@ -56311,6 +58298,7 @@ yly	NC	LA	Nielaiu
 yly	NC	LA	Nyalayu
 yly	NC	LA	Puma
 yly	NC	LA	Yalasu
+yly	NC	LA	Yalayu
 ymb	PG	D	East Yambes
 ymb	PG	D	West Yambes
 ymb	PG	L	Yambes
@@ -56404,11 +58392,14 @@ yng	CD	LA	Gbendere
 ynk	RU	L	Yupik, Naukan
 ynk	RU	LA	Naukan
 ynk	RU	LA	Naukanski
+ynk	RU	LA	Nevuqaq
 ynl	PG	L	Yangulam
 yno	TH	L	Yong
 yno	TH	LA	Nyong
 ynq	NG	L	Yendang
 ynq	NG	LA	Kuseki
+ynq	NG	LA	Nya Korok
+ynq	NG	LA	Nya Yendang
 ynq	NG	LA	Nyandang
 ynq	NG	LA	Yadang
 ynq	NG	LA	Yandang
@@ -56445,6 +58436,7 @@ yok	US	D	Yowlumne
 yok	US	DA	Choinimne
 yok	US	DA	Choynumne
 yok	US	DA	Northern Foothill Yokuts
+yok	US	DA	Wukchumni
 yok	US	L	Yokuts
 yom	AO	D	Mbala
 yom	AO	D	Vungunya
@@ -56512,6 +58504,7 @@ yor	NG	L	Yoruba
 yor	NG	LA	Yariba
 yor	NG	LA	Yooba
 yot	NG	L	Yotti
+yot	NG	LA	Wonkorok
 yot	NG	LA	Yoti
 yox	JP	L	Yoron
 yoy	LA	L	Yoy
@@ -56613,7 +58606,6 @@ yre	CI	L	Yaouré
 yre	CI	LA	Yaure
 yre	CI	LA	Yohowré
 yre	CI	LA	Youré
-yri	CO	L	Yarí
 yrk	RU	D	Forest Yurak
 yrk	RU	D	Tundra Yurak
 yrk	RU	L	Nenets
@@ -56645,6 +58637,14 @@ yrl	VE	LA	Geral
 yrl	VE	LA	Modern Tupi
 yrl	VE	LA	Waengatu
 yrl	VE	LA	Yeral
+yrm	AU	L	Yirrk-Mel
+yrm	AU	LA	Kok-Cel
+yrm	AU	LA	Kok-Wap
+yrm	AU	LA	Yir Mel
+yrm	AU	LA	Yirmel
+yrm	AU	LA	Yirrk-Thangalki
+yrm	AU	LA	Yirr-Mel
+yrm	AU	LA	Yirr-Thangell
 yrn	CN	L	Yerong
 yrn	CN	LA	Ban Yao
 yrn	CN	LA	Da Ia
@@ -56662,6 +58662,9 @@ yrn	CN	LA	Tu Yao Indigenous Yao
 yrn	CN	LA	Yalang
 yrn	CN	LA	Yang Khyung
 yrn	CN	LA	Yerong Buyang
+yro	BR	L	Yaroamë
+yro	BR	LA	Jawari
+yro	BR	LA	Yawari
 yrs	ID	L	Yarsun
 yrw	PG	L	Yarawata
 yry	AU	L	Yarluyandi
@@ -56687,7 +58690,9 @@ ysl	SI	LA	Yugoslavian Sign Language
 ysn	CN	D	Northern Sani
 ysn	CN	D	Southern Sani
 ysn	CN	L	Sani
+ysn	CN	LA	Gni Ni
 yso	CN	L	Nisi
+yso	CN	LA	Lolo
 yso	CN	LA	Southeastern Lolo Yi
 ysp	CN	L	Lolopo, Southern
 ysr	RU	L	Yupik, Sirenik
@@ -56728,10 +58733,16 @@ ytw	PG	L	Yout Wam
 yty	AU	L	Yatay
 yty	AU	LA	Iataj
 yua	BZ	L	Maya, Yucatec
+yua	BZ	LA	Maaya
+yua	BZ	LA	Maaya t’aan
+yua	BZ	LA	Maayáa
 yua	BZ	LA	Maya
 yua	BZ	LA	Yucantán Maya
 yua	BZ	LA	Yucateco
 yua	MX	L	Maya, Yucatec
+yua	MX	LA	Maaya
+yua	MX	LA	Maaya t’aan
+yua	MX	LA	Maayáa
 yua	MX	LA	Peninsular Maya
 yua	MX	LA	Yucatan Maya
 yub	AU	L	Yugambal
@@ -56751,10 +58762,13 @@ yud	IL	LA	Jewish Tripolitanian-Libyan Arabic
 yud	IL	LA	Tripolita’it
 yud	IL	LA	Tripolitanian Judeo-Arabic
 yud	IL	LA	Yudi
+yue	AU	L	Chinese, Yue
 yue	BN	L	Chinese, Yue
 yue	BN	LA	Cantonese
 yue	BN	LA	Yue
 yue	BN	LA	Yueh
+yue	CA	D	Vancouver Cantonese
+yue	CA	L	Chinese, Yue
 yue	CN	D	Bobai
 yue	CN	D	Cangwu
 yue	CN	D	Gaolei
@@ -56841,6 +58855,7 @@ yui	BR	L	Wajiara
 yui	BR	LA	Juruti
 yui	BR	LA	Juruti-Tapuia
 yui	BR	LA	Luruty-Tapuya
+yui	BR	LA	Wajiaraye
 yui	BR	LA	Yuriti-Tapuia
 yui	CO	L	Wajiara
 yui	CO	LA	Juriti
@@ -56853,6 +58868,7 @@ yui	CO	LA	Wadzana
 yui	CO	LA	Waijiara masa-wadyana
 yui	CO	LA	Waikana
 yui	CO	LA	Waimasá
+yui	CO	LA	Wajiaraye
 yui	CO	LA	Wayhara
 yui	CO	LA	Yuriti
 yui	CO	LA	Yuruti
@@ -56960,6 +58976,7 @@ yuz	BO	D	Mansinyo
 yuz	BO	D	Soloto
 yuz	BO	L	Yuracare
 yuz	BO	LA	Yura
+yuz	BO	LA	Yurakaré
 yva	ID	D	Central Yawa
 yva	ID	D	East Yawa
 yva	ID	D	North Yawa
@@ -56979,7 +58996,17 @@ yvt	VE	LA	Paraene
 ywa	PG	L	Kalou
 ywa	PG	LA	Yawa
 ywg	AU	L	Yinhawangka
+ywg	AU	LA	Inawangga
+ywg	AU	LA	Inawonga
+ywg	AU	LA	Inawongga
+ywg	AU	LA	Nalawonga
+ywg	AU	LA	Ngalawonga
+ywg	AU	LA	Ngalawongga
+ywg	AU	LA	Ngarla-warngga
+ywg	AU	LA	Ngaunmardi
+ywg	AU	LA	Ninanu
 ywl	CN	L	Lalu, Western
+ywl	CN	LA	Lalu
 ywn	BR	L	Yawanawa
 ywn	BR	LA	Iauanauá
 ywn	BR	LA	Jawanaua
@@ -56991,6 +59018,7 @@ ywq	CN	LA	Black Yi
 ywq	CN	LA	Dian Dongbei Yi
 ywq	CN	LA	Hei Yi
 ywq	CN	LA	Nasu
+ywq	CN	LA	Nasupho
 ywq	CN	LA	Wu-Lu Yi
 ywr	AU	D	Eastern Inland Yawuru
 ywr	AU	D	Northern Yawuru
@@ -57000,6 +59028,7 @@ ywt	CN	L	Lalo, Central
 ywt	CN	LA	Lalaw
 ywt	CN	LA	Lalo
 ywt	CN	LA	Lalopa
+ywt	CN	LA	Lalu
 ywt	CN	LA	Laluo
 ywt	CN	LA	Misapa
 ywt	CN	LA	Western Yi
@@ -57008,6 +59037,7 @@ ywu	CN	D	Hen-Ke Yi
 ywu	CN	D	Hezhang Yi
 ywu	CN	D	Weining Yi
 ywu	CN	L	Nasu, Wumeng
+ywu	CN	LA	Nesu
 ywu	CN	LA	Wumeng Yi
 ywu	CN	LA	Wusa Yi
 ywu	CN	LA	Yuan-Mo Yi
@@ -57086,6 +59116,24 @@ yxy	AU	LA	Waningotbun
 yxy	AU	LA	Yabala-Yabala
 yxy	AU	LA	Yoorta
 yxy	AU	LA	Yurt
+yyr	AU	L	Yir-Yoront
+yyr	AU	LA	Jir Joront
+yyr	AU	LA	Jirjiront
+yyr	AU	LA	Jir’jorond
+yyr	AU	LA	Koka-mungin
+yyr	AU	LA	Koko-majoen
+yyr	AU	LA	KokoMandjoen
+yyr	AU	LA	Kokomindjan
+yyr	AU	LA	Kokomindjen
+yyr	AU	LA	KokoMindjin
+yyr	AU	LA	Kokominjan
+yyr	AU	LA	KokoMinjen
+yyr	AU	LA	Mandjoen
+yyr	AU	LA	Mind’jana
+yyr	AU	LA	Mundjun
+yyr	AU	LA	Yir Yiront
+yyr	AU	LA	Yir Yoront
+yyr	AU	LA	Yir-yiront
 yyu	PG	L	Yau
 yyz	CN	L	Ayizi
 yzg	CN	L	Buyang, E’ma
@@ -57113,11 +59161,16 @@ zaa	MX	LA	Zapoteco de Atepec
 zab	MX	D	Jalieza Zapotec
 zab	MX	D	San Lucas Quiavini Zapotec
 zab	MX	D	San Martín Tilcajete Zapotec
+zab	MX	D	Santa Ana del Valle Zapotec
 zab	MX	D	Teotitlán del Valle Zapotec
-zab	MX	L	Zapotec, San Juan Guelavía
+zab	MX	DA	San Marcos Tlapazola Zapotec
+zab	MX	DA	Tlacolula Valley Zapotec
+zab	MX	L	Zapotec, Western Tlacolula Valley
 zab	MX	LA	Guelavía
+zab	MX	LA	San Juan Guelavía Zapotec
 zab	MX	LA	Western Tlacolula Zapotec
 zab	MX	LA	Zapoteco de San Juan
+zab	MX	LA	Zapoteco de Tlacolula occidental
 zac	MX	L	Zapotec, Ocotlán
 zac	MX	LA	Ocotlán Oeste Zapotec
 zac	MX	LA	Zapoteco del Poniente de Ocotlán
@@ -57147,6 +59200,7 @@ zag	SD	LA	Beri
 zag	SD	LA	Beria
 zag	SD	LA	Beri-Aa
 zag	SD	LA	Berri
+zag	SD	LA	Bideyat
 zag	SD	LA	Kebadi
 zag	SD	LA	Kuyuk
 zag	SD	LA	Merida
@@ -57185,6 +59239,7 @@ zah	NG	L	Zangwal
 zah	NG	LA	Twar
 zah	NG	LA	Zwangal
 zai	MX	L	Zapotec, Isthmus
+zai	MX	LA	diidxazá
 zai	MX	LA	Zapoteco del Istmo
 zaj	TZ	L	Zaramo
 zaj	TZ	LA	Dzalamo
@@ -57215,10 +59270,12 @@ zaq	MX	L	Zapotec, Aloápam
 zaq	MX	LA	Zapoteco de Aloápam
 zar	MX	L	Zapotec, Rincón
 zar	MX	LA	Northern Villa Alta Zapotec
+zar	MX	LA	San Juan Yaee Zapotec
 zar	MX	LA	Zapoteco de Yagallo
 zar	MX	LA	Zapoteco del Rincón
 zas	MX	L	Zapotec, Santo Domingo Albarradas
 zas	MX	LA	Albarradas Zapotec
+zas	MX	LA	Dihidx Bilyáhab
 zas	MX	LA	Zapoteco de Santo Domingo Albarradas
 zat	MX	L	Zapotec, Tabaa
 zat	MX	LA	Central Villa Alta Zapotec
@@ -57263,8 +59320,10 @@ zbc	MY	D	Long Teru Berawan
 zbc	MY	L	Berawan, Central
 zbc	MY	LA	Batu Belah
 zbc	MY	LA	Long Teru
+zbc	MY	LA	Melawan
 zbe	MY	L	Berawan, East
 zbe	MY	LA	Long Jegan Berawan
+zbe	MY	LA	Melawan
 zbt	ID	L	Batui
 zbt	ID	LA	Baha
 zbw	MY	L	Berawan, West
@@ -57297,6 +59356,7 @@ zga	TZ	D	Kinga
 zga	TZ	D	Mahanji
 zga	TZ	DA	Mahanzi
 zga	TZ	L	Kinga
+zga	TZ	LA	Bakinga
 zga	TZ	LA	Ekikinga
 zga	TZ	LA	Kikinga
 zgb	CN	L	Zhuang, Guibei
@@ -57342,6 +59402,7 @@ zhd	CN	DA	Pian Tou Tu
 zhd	CN	DA	Ping Tou Tu
 zhd	CN	L	Zhuang, Dai
 zhd	CN	LA	Bu Dai
+zhd	CN	LA	bu6 daai2
 zhd	CN	LA	Kau Ndae
 zhd	CN	LA	Khaau Daai
 zhd	CN	LA	Thu Lao
@@ -57352,6 +59413,7 @@ zhd	CN	LA	Wen-Ma Southern Zhuang
 zhd	CN	LA	Zhuangyu Nanbu fangyan Dejing tuyu
 zhd	CN	LA	Zhuangyu Nanbu Fangyan Wen-Ma Tuyu
 zhd	VN	L	Zhuang, Dai
+zhd	VN	LA	bu6 daai2
 zhd	VN	LA	Thu Lao
 zhd	VN	LA	Tu
 zhd	VN	LA	Tuliao
@@ -57371,6 +59433,7 @@ zhn	CN	LA	Noangx
 zhn	CN	LA	Nong hua
 zhn	CN	LA	Phu Nong
 zhn	CN	LA	Phu Tei
+zhn	CN	LA	Tei Nong
 zhn	CN	LA	Yan-Guang Southern Zhuang
 zhn	CN	LA	Zhuangyu Nanbu fanyan Yan-Guang tuyu
 zho	CN	L	Chinese
@@ -57409,10 +59472,12 @@ zim	TD	D	Zamre
 zim	TD	L	Mesme
 zim	TD	LA	Djime
 zim	TD	LA	Djiwe
+zim	TD	LA	Zime
 zim	TD	LA	Zime of Kélo
 zin	TZ	D	Kula
 zin	TZ	D	Longo
 zin	TZ	L	Zinza
+zin	TZ	LA	Abazinza
 zin	TZ	LA	Binza
 zin	TZ	LA	Dzinda
 zin	TZ	LA	Dzindza
@@ -57479,12 +59544,42 @@ zkn	MM	LA	Genan
 zkn	MM	LA	Kana
 zkp	BR	L	Kaingáng, São Paulo
 zkr	CN	L	Zakhring
+zkr	CN	LA	Charumba
 zkr	CN	LA	Zaiwa
 zkr	CN	LA	Zha
 zkr	IN	L	Zakhring
+zkr	IN	LA	Charumba
 zkr	IN	LA	Eastern Mishmi
 zkr	IN	LA	Meyor
 zkr	IN	LA	Zaiwa
+zku	AU	L	Kaurna
+zku	AU	LA	Coorna
+zku	AU	LA	Gaurna
+zku	AU	LA	Jaitjawarra
+zku	AU	LA	Karnuwarra
+zku	AU	LA	Kaura
+zku	AU	LA	Koornawarra
+zku	AU	LA	Kurumidlanta
+zku	AU	LA	Medaindi
+zku	AU	LA	Medaindie
+zku	AU	LA	Meljurna
+zku	AU	LA	Merelde
+zku	AU	LA	Merildekald
+zku	AU	LA	Meyu
+zku	AU	LA	Midlanta
+zku	AU	LA	Milipitingara
+zku	AU	LA	Nantuwara
+zku	AU	LA	Nantuwaru
+zku	AU	LA	Nganawara
+zku	AU	LA	Padnaindi
+zku	AU	LA	Padnayndie
+zku	AU	LA	Wakanuwan
+zku	AU	LA	Warra
+zku	AU	LA	Warrah
+zku	AU	LA	Widninga
+zku	AU	LA	Winaini
+zku	AU	LA	Winnaynie
+zku	AU	LA	Winnay-nie
 zlj	CN	L	Zhuang, Liujiang
 zlm	ID	D	Akit
 zlm	ID	D	Belitung
@@ -57508,6 +59603,7 @@ zlm	ID	L	Malay
 zlm	ID	LA	Bahasa Daerah
 zlm	ID	LA	Bahasa Melayu
 zlm	ID	LA	Malayu
+zlm	ID	LA	Melayu
 zlm	MY	D	Akit
 zlm	MY	D	Belitung
 zlm	MY	D	coastal Jambi
@@ -57536,11 +59632,13 @@ zlm	MY	LA	Colloquial Malay
 zlm	MY	LA	Informal Malay
 zlm	MY	LA	Local Malay
 zlm	MY	LA	Malayu
+zlm	MY	LA	Melayu
 zlm	SG	D	Jugra-Muar-Melaka-Johor
 zlm	SG	L	Malay
 zlm	SG	LA	Colloquial Malay
 zlm	SG	LA	Local Malay
 zlm	SG	LA	Malayu
+zlm	SG	LA	Melayu
 zln	CN	L	Zhuang, Lianshan
 zlq	CN	L	Zhuang, Liuqian
 zma	AU	L	Manda
@@ -57613,6 +59711,7 @@ zmn	GA	LA	M’bahouin
 zmn	GA	LA	Mbaouin
 zmo	SD	L	Molo
 zmo	SD	LA	Malkan
+zmo	SD	LA	Tura-Ka-Molo
 zmp	CD	D	Mpuono
 zmp	CD	D	Mpuun
 zmp	CD	DA	Ambuun
@@ -57644,6 +59743,7 @@ zmt	AU	LA	Maringa
 zmu	AU	L	Muruwari
 zmu	AU	LA	Murawari
 zmu	AU	LA	Muruwarri
+zmu	AU	LA	Muruwurri
 zmv	AU	L	Mbariman-Gudhinma
 zmv	AU	LA	Rimang-Gudinhma
 zmw	CD	L	Mbo
@@ -57740,6 +59840,7 @@ zom	MM	L	Zo
 zom	MM	LA	Jou
 zom	MM	LA	Yo
 zom	MM	LA	Yos
+zom	MM	LA	Zohâm
 zom	MM	LA	Zokam
 zom	MM	LA	Zome
 zom	MM	LA	Zomi
@@ -57887,12 +59988,14 @@ zsa	PG	LA	Sirasira
 zsl	ZM	L	Zambian Sign Language
 zsl	ZM	LA	ZAMSL
 zsm	BN	L	Malay, Standard
+zsm	BN	LA	Bahasa Malaysia
 zsm	BN	LA	Formal Malay
 zsm	BN	LA	Malay
 zsm	BN	LA	Malayu
 zsm	BN	LA	Melayu
 zsm	BN	LA	Melayu Baku
 zsm	MY	L	Malay, Standard
+zsm	MY	LA	Bahasa Malaysia
 zsm	MY	LA	Bahasa Malayu
 zsm	MY	LA	Formal Malay
 zsm	MY	LA	Informal Malay
@@ -57901,6 +60004,7 @@ zsm	MY	LA	Malayu
 zsm	MY	LA	Melayu
 zsm	MY	LA	Melayu Baku
 zsm	SG	L	Malay, Standard
+zsm	SG	LA	Bahasa Malaysia
 zsm	SG	LA	Formal Malay
 zsm	SG	LA	Malay
 zsm	SG	LA	Malayu
@@ -57940,6 +60044,7 @@ ztt	MX	L	Zapotec, Tejalapan
 ztt	MX	LA	Zapoteco de San Felipe Tejalapan
 ztt	MX	LA	Zapoteco de Tejalápam
 ztu	MX	L	Zapotec, Güilá
+ztu	MX	LA	San Dionisio Ocotepec Zapotec
 ztu	MX	LA	Zapoteco de San Dionisio Ocotepec
 ztu	MX	LA	Zapoteco de San Pablo Güilá
 ztx	MX	L	Zapotec, Zaachila
@@ -57989,10 +60094,16 @@ zul	ZA	D	Transvaal Zulu
 zul	ZA	L	Zulu
 zul	ZA	LA	Isizulu
 zul	ZA	LA	Zunda
-zum	IR	L	Kumzari
+zum	IR	L	Laraki
+zum	IR	LA	Komzari
+zum	IR	LA	Komzāri
+zum	IR	LA	Kumzari
+zum	IR	LA	Lāraki
+zum	IR	LA	Rāraki
 zum	OM	L	Kumzari
 zum	OM	LA	Kumzai
 zun	US	L	Zuni
+zun	US	LA	Shiwi’ma
 zun	US	LA	Zuñi
 zuy	CM	L	Zumaya
 zwa	ET	L	Zay
@@ -58015,35 +60126,54 @@ zyg	CN	DA	Tuhua
 zyg	CN	DA	Yangyu
 zyg	CN	DA	Zouzhou
 zyg	CN	L	Zhuang, Yang
+zyg	CN	LA	Caj coux
+zyg	CN	LA	Can Yang
 zyg	CN	LA	Dejing Zhuang
+zyg	CN	LA	Dianbao
+zyg	CN	LA	Fouh
 zyg	CN	LA	Gen Yang
 zyg	CN	LA	Jingxi Zhuang
 zyg	CN	LA	Lang
 zyg	CN	LA	Nong
 zyg	CN	LA	Nung Giang
 zyg	CN	LA	Tianbao
+zyg	CN	LA	Tianpao
 zyg	CN	LA	Tuhua
+zyg	CN	LA	Yangx
 zyg	CN	LA	Yangyu
 zyg	CN	LA	Yangzhou
 zyg	CN	LA	Zhuangyu Nanbu fangyan Dejing tuyu
 zyg	VN	L	Zhuang, Yang
-zyg	VN	LA	Thu Lao
-zyg	VN	LA	Tu
-zyg	VN	LA	Tuliao
-zyg	VN	LA	Tuzu
-zyg	VN	LA	Wen-Ma Southern Zhuang
+zyg	VN	LA	Caj coux
+zyg	VN	LA	Can Yang
+zyg	VN	LA	Dejing Zhuang
+zyg	VN	LA	Dianbao
+zyg	VN	LA	Fouh
+zyg	VN	LA	Jingxi Zhuang
+zyg	VN	LA	Nong
+zyg	VN	LA	Nung Giang
+zyg	VN	LA	Tianpao
+zyg	VN	LA	Tuhua
+zyg	VN	LA	Yangx
+zyg	VN	LA	Yangyu
+zyg	VN	LA	Zhuangyu Nanbu fangyan Dejing tuyu
 zyj	CN	L	Zhuang, Youjiang
 zyn	CN	L	Zhuang, Yongnan
 zyn	CN	LA	Bou Rau
+zyn	CN	LA	Boux Toj
 zyn	CN	LA	Long An
 zyn	CN	LA	Long’an
+zyn	CN	LA	Nongz Anx
 zyn	CN	LA	Nung An
 zyn	CN	LA	Southern Zhuang
 zyn	CN	LA	Yongnan Vernacular of the Southern Dialect of the Zhuang Language
 zyn	CN	LA	Zhuangyu nanbu fangyan Yongnan tuyu
 zyn	VN	L	Zhuang, Yongnan
+zyn	VN	LA	Boux Toj
 zyn	VN	LA	Long An
 zyn	VN	LA	Long’an
+zyn	VN	LA	Nongz Anx
+zyn	VN	LA	Nung An
 zyn	VN	LA	Southern Zhuang
 zyn	VN	LA	Yongnan Vernacular of the Southern Dialect of the Zhuang Language
 zyn	VN	LA	Zhuangyu nanbu fangyan Yongnan tuyu
@@ -58063,12 +60193,20 @@ zyp	MM	LA	Zoptei
 zyp	MM	LA	Zyphe
 zza	TR	L	Zaza
 zzj	CN	L	Zhuang, Zuojiang
+zzj	CN	LA	Canto
 zzj	CN	LA	Ken Tho
 zzj	CN	LA	Longyin
 zzj	CN	LA	Longzhou
+zzj	CN	LA	Nongz Anx
 zzj	CN	LA	Pho Thai
+zzj	CN	LA	Potai
 zzj	CN	LA	Pu Tho
+zzj	CN	LA	Puto
 zzj	CN	LA	Southern Zhuang
 zzj	CN	LA	Zhuangyu nanbu fangyan Zuojiang tuyu
 zzj	VN	L	Zhuang, Zuojiang
+zzj	VN	LA	Canto
+zzj	VN	LA	Nongz Anx
 zzj	VN	LA	Nung Chao
+zzj	VN	LA	Potai
+zzj	VN	LA	Puto

--- a/SIL.WritingSystems/Resources/ianaSubtagRegistry.txt
+++ b/SIL.WritingSystems/Resources/ianaSubtagRegistry.txt
@@ -1,4 +1,4 @@
-File-Date: 2015-03-06
+File-Date: 2016-07-19
 %%
 Type: language
 Subtag: aa
@@ -792,6 +792,7 @@ Scope: macrolanguage
 Type: language
 Subtag: or
 Description: Oriya (macrolanguage)
+Description: Odia (macrolanguage)
 Added: 2005-10-16
 Suppress-Script: Orya
 Scope: macrolanguage
@@ -2740,7 +2741,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: aot
-Description: Atong
+Description: Atong (India)
 Description: A'tong
 Added: 2009-07-29
 %%
@@ -3264,7 +3265,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: ato
-Description: Atong
+Description: Atong (Cameroon)
 Added: 2009-07-29
 %%
 Type: language
@@ -4107,7 +4108,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: bcg
-Description: Baga Binari
+Description: Baga Pokur
 Added: 2009-07-29
 %%
 Type: language
@@ -4641,6 +4642,8 @@ Type: language
 Subtag: bgm
 Description: Baga Mboteni
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: bcg
 %%
 Type: language
 Subtag: bgn
@@ -6281,6 +6284,7 @@ Type: language
 Subtag: btl
 Description: Bhatola
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: btm
@@ -7268,6 +7272,7 @@ Type: language
 Subtag: cbe
 Description: Chipiajes
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: cbg
@@ -7278,6 +7283,7 @@ Type: language
 Subtag: cbh
 Description: Cagua
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: cbi
@@ -8071,6 +8077,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: cnh
+Description: Hakha Chin
 Description: Haka Chin
 Added: 2009-07-29
 %%
@@ -8230,6 +8237,8 @@ Type: language
 Subtag: coy
 Description: Coyaima
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: pij
 %%
 Type: language
 Subtag: coz
@@ -8320,6 +8329,8 @@ Type: language
 Subtag: cqu
 Description: Chilean Quechua
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: quh
 Macrolanguage: qu
 %%
 Type: language
@@ -8700,6 +8711,7 @@ Type: language
 Subtag: cum
 Description: Cumeral
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: cuo
@@ -9320,6 +9332,7 @@ Macrolanguage: mwr
 %%
 Type: language
 Subtag: dhg
+Description: Dhangu-Djangu
 Description: Dhangu
 Description: Djangu
 Added: 2009-07-29
@@ -9958,7 +9971,7 @@ Preferred-Value: khk
 %%
 Type: language
 Subtag: dri
-Description: C'lela
+Description: C'Lela
 Added: 2009-07-29
 %%
 Type: language
@@ -10090,12 +10103,18 @@ Description: Tomo Kan Dogon
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dtn
+Description: Daatsʼíin
+Added: 2016-05-30
+%%
+Type: language
 Subtag: dto
 Description: Tommo So Dogon
 Added: 2012-08-12
 %%
 Type: language
 Subtag: dtp
+Description: Kadazan Dusun
 Description: Central Dusun
 Added: 2009-07-29
 %%
@@ -10176,6 +10195,8 @@ Type: language
 Subtag: duj
 Description: Dhuwal
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Comments: see dwu, dwy
 %%
 Type: language
 Subtag: duk
@@ -10250,7 +10271,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: duz
-Description: Duli
+Description: Duli-Gey
 Added: 2009-07-29
 %%
 Type: language
@@ -10281,9 +10302,19 @@ Description: Dutton World Speedwords
 Added: 2009-07-29
 %%
 Type: language
+Subtag: dwu
+Description: Dhuwal
+Added: 2016-05-30
+%%
+Type: language
 Subtag: dww
 Description: Dawawa
 Added: 2009-07-29
+%%
+Type: language
+Subtag: dwy
+Description: Dhuwaya
+Added: 2016-05-30
 %%
 Type: language
 Subtag: dya
@@ -10818,6 +10849,12 @@ Description: Ese Ejja
 Added: 2009-07-29
 %%
 Type: language
+Subtag: esg
+Description: Aheri Gondi
+Added: 2016-05-30
+Macrolanguage: gon
+%%
+Type: language
 Subtag: esh
 Description: Eshtehardi
 Added: 2009-07-29
@@ -11212,6 +11249,11 @@ Type: language
 Subtag: fmu
 Description: Far Western Muria
 Added: 2009-07-29
+%%
+Type: language
+Subtag: fnb
+Description: Fanbak
+Added: 2016-05-30
 %%
 Type: language
 Subtag: fng
@@ -11898,7 +11940,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: gek
-Description: Yiwom
+Description: Ywom
 Added: 2009-07-29
 %%
 Type: language
@@ -12003,12 +12045,15 @@ Type: language
 Subtag: ggn
 Description: Eastern Gurung
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: gvr
 %%
 Type: language
 Subtag: ggo
 Description: Southern Gondi
 Added: 2009-07-29
-Macrolanguage: gon
+Deprecated: 2016-05-30
+Comments: see esg, wsg
 %%
 Type: language
 Subtag: ggr
@@ -12210,6 +12255,11 @@ Type: language
 Subtag: gjn
 Description: Gonja
 Added: 2009-07-29
+%%
+Type: language
+Subtag: gjr
+Description: Gurindji Kriol
+Added: 2016-05-30
 %%
 Type: language
 Subtag: gju
@@ -12791,6 +12841,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: gsn
+Description: Nema
 Description: Gusan
 Added: 2009-07-29
 %%
@@ -12942,6 +12993,8 @@ Type: language
 Subtag: guv
 Description: Gey
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: duz
 %%
 Type: language
 Subtag: guw
@@ -13011,7 +13064,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: gvr
-Description: Western Gurung
+Description: Gurung
 Added: 2009-07-29
 %%
 Type: language
@@ -14195,6 +14248,7 @@ Type: language
 Subtag: iap
 Description: Iapama
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: iar
@@ -14581,11 +14635,23 @@ Type: language
 Subtag: ill
 Description: Iranun
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Comments: see ilm, ilp
+%%
+Type: language
+Subtag: ilm
+Description: Iranun (Malaysia)
+Added: 2016-05-30
 %%
 Type: language
 Subtag: ilo
 Description: Iloko
 Added: 2005-10-16
+%%
+Type: language
+Subtag: ilp
+Description: Iranun (Philippines)
+Added: 2016-05-30
 %%
 Type: language
 Subtag: ils
@@ -14899,6 +14965,11 @@ Subtag: itc
 Description: Italic languages
 Added: 2009-07-29
 Scope: collection
+%%
+Type: language
+Subtag: itd
+Description: Southern Tidung
+Added: 2016-05-30
 %%
 Type: language
 Subtag: ite
@@ -15416,6 +15487,11 @@ Description: Bankal
 Added: 2012-08-12
 %%
 Type: language
+Subtag: jka
+Description: Kaera
+Added: 2016-05-30
+%%
+Type: language
 Subtag: jkm
 Description: Mobwa Karen
 Added: 2012-08-12
@@ -15549,6 +15625,11 @@ Type: language
 Subtag: jod
 Description: Wojenaka
 Added: 2009-07-29
+%%
+Type: language
+Subtag: jog
+Description: Jogi
+Added: 2015-05-27
 %%
 Type: language
 Subtag: jor
@@ -15791,6 +15872,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kak
+Description: Kalanguya
 Description: Kayapa Kallahan
 Added: 2009-07-29
 %%
@@ -16445,7 +16527,8 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: kfr
-Description: Kachchi
+Description: Kachhi
+Description: Kutchi
 Added: 2009-07-29
 %%
 Type: language
@@ -16502,6 +16585,8 @@ Type: language
 Subtag: kgc
 Description: Kasseng
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: tdf
 %%
 Type: language
 Subtag: kgd
@@ -17616,6 +17701,7 @@ Type: language
 Subtag: kox
 Description: Coxima
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: koy
@@ -18233,6 +18319,8 @@ Type: language
 Subtag: ktr
 Description: Kota Marudu Tinagas
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: dtp
 %%
 Type: language
 Subtag: kts
@@ -18491,6 +18579,8 @@ Type: language
 Subtag: kvs
 Description: Kunggara
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: gdj
 %%
 Type: language
 Subtag: kvt
@@ -18974,6 +19064,8 @@ Type: language
 Subtag: kzj
 Description: Coastal Kadazan
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: dtp
 %%
 Type: language
 Subtag: kzk
@@ -19024,6 +19116,8 @@ Type: language
 Subtag: kzt
 Description: Tambunan Dusun
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: dtp
 %%
 Type: language
 Subtag: kzu
@@ -19301,6 +19395,7 @@ Added: 2009-07-29
 Type: language
 Subtag: lce
 Description: Loncong
+Description: Sekak
 Added: 2009-07-29
 Macrolanguage: ms
 %%
@@ -20315,7 +20410,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: lou
-Description: Louisiana Creole French
+Description: Louisiana Creole
 Added: 2009-07-29
 %%
 Type: language
@@ -21919,6 +22014,11 @@ Subtag: mja
 Description: Mahei
 Added: 2009-07-29
 Deprecated: 2011-08-16
+%%
+Type: language
+Subtag: mjb
+Description: Makalero
+Added: 2016-05-30
 %%
 Type: language
 Subtag: mjc
@@ -24088,6 +24188,8 @@ Type: language
 Subtag: nad
 Description: Nijadali
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: xny
 %%
 Type: language
 Subtag: nae
@@ -26057,6 +26159,11 @@ Description: Nisenan
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ntd
+Description: Northern Tidung
+Added: 2016-05-30
+%%
+Type: language
 Subtag: nte
 Description: Nathembo
 Added: 2009-07-29
@@ -26105,6 +26212,8 @@ Type: language
 Subtag: nts
 Description: Natagaimas
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: pij
 %%
 Type: language
 Subtag: ntu
@@ -26913,6 +27022,11 @@ Description: Old Lithuanian
 Added: 2014-02-28
 %%
 Type: language
+Subtag: olu
+Description: Kuvale
+Added: 2016-05-30
+%%
+Type: language
 Subtag: oma
 Description: Omaha-Ponca
 Added: 2009-07-29
@@ -26931,6 +27045,7 @@ Type: language
 Subtag: ome
 Description: Omejes
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: omg
@@ -27214,6 +27329,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: ory
+Description: Odia (individual language)
 Description: Oriya (individual language)
 Added: 2012-08-12
 Macrolanguage: or
@@ -27391,6 +27507,12 @@ Description: !O!ung
 Added: 2009-07-29
 Deprecated: 2015-02-12
 Preferred-Value: vaj
+%%
+Type: language
+Subtag: ovd
+Description: Övdalian
+Description: Elfdalian
+Added: 2016-06-16
 %%
 Type: language
 Subtag: owi
@@ -27936,6 +28058,11 @@ Added: 2009-07-29
 Deprecated: 2012-08-12
 %%
 Type: language
+Subtag: pgz
+Description: Papua New Guinean Sign Language
+Added: 2016-05-30
+%%
+Type: language
 Subtag: pha
 Description: Pa-Hng
 Added: 2009-07-29
@@ -28338,6 +28465,8 @@ Type: language
 Subtag: pmc
 Description: Palumata
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: huw
 %%
 Type: language
 Subtag: pmd
@@ -28575,6 +28704,7 @@ Type: language
 Subtag: pod
 Description: Ponares
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: poe
@@ -28671,6 +28801,8 @@ Type: language
 Subtag: ppa
 Description: Pao
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: bfy
 %%
 Type: language
 Subtag: ppe
@@ -28880,6 +29012,8 @@ Type: language
 Subtag: pry
 Description: Pray 3
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: prt
 %%
 Type: language
 Subtag: prz
@@ -30094,6 +30228,7 @@ Type: language
 Subtag: rna
 Description: Runa
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: rnd
@@ -30241,6 +30376,11 @@ Type: language
 Subtag: rsl
 Description: Russian Sign Language
 Added: 2009-07-29
+%%
+Type: language
+Subtag: rsm
+Description: Miriwoong Sign Language
+Added: 2016-05-30
 %%
 Type: language
 Subtag: rtc
@@ -30394,6 +30534,11 @@ Type: language
 Subtag: ryu
 Description: Central Okinawan
 Added: 2009-07-29
+%%
+Type: language
+Subtag: rzh
+Description: Rāziḥī
+Added: 2016-05-30
 %%
 Type: language
 Subtag: saa
@@ -32705,6 +32850,7 @@ Type: language
 Subtag: svr
 Description: Savara
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: svs
@@ -33453,6 +33599,11 @@ Description: Sur
 Added: 2009-07-29
 %%
 Type: language
+Subtag: tdm
+Description: Taruma
+Added: 2016-05-30
+%%
+Type: language
 Subtag: tdn
 Description: Tondano
 Added: 2009-07-29
@@ -33486,6 +33637,8 @@ Type: language
 Subtag: tdu
 Description: Tempasuk Dusun
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: dtp
 %%
 Type: language
 Subtag: tdv
@@ -33766,6 +33919,8 @@ Type: language
 Subtag: thc
 Description: Tai Hang Tong
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: tpo
 %%
 Type: language
 Subtag: thd
@@ -33886,6 +34041,8 @@ Type: language
 Subtag: tid
 Description: Tidong
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Comments: see itd, ntd
 %%
 Type: language
 Subtag: tie
@@ -34241,6 +34398,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: tlt
+Description: Sou Nama
 Description: Teluti
 Added: 2009-07-29
 %%
@@ -34353,6 +34511,8 @@ Type: language
 Subtag: tmp
 Description: Tai Mène
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: tyj
 %%
 Type: language
 Subtag: tmq
@@ -34424,6 +34584,8 @@ Type: language
 Subtag: tne
 Description: Tinoc Kallahan
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: kak
 %%
 Type: language
 Subtag: tnf
@@ -34524,7 +34686,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: tnz
-Description: Tonga (Thailand)
+Description: Ten'edn
 Added: 2009-07-29
 %%
 Type: language
@@ -34546,6 +34708,7 @@ Type: language
 Subtag: toe
 Description: Tomedes
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: tof
@@ -35591,6 +35754,7 @@ Added: 2009-07-29
 Type: language
 Subtag: tyj
 Description: Tai Do
+Description: Tai Yo
 Added: 2009-07-29
 %%
 Type: language
@@ -37164,6 +37328,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: wha
+Description: Sou Upaa
 Description: Manusela
 Added: 2009-07-29
 %%
@@ -37734,6 +37899,12 @@ Description: Warembori
 Added: 2009-07-29
 %%
 Type: language
+Subtag: wsg
+Description: Adilabad Gondi
+Added: 2016-05-30
+Macrolanguage: gon
+%%
+Type: language
 Subtag: wsi
 Description: Wusi
 Added: 2009-07-29
@@ -37966,6 +38137,11 @@ Description: Ararandewára
 Added: 2014-02-28
 %%
 Type: language
+Subtag: xak
+Description: Máku
+Added: 2016-05-30
+%%
+Type: language
 Subtag: xal
 Description: Kalmyk
 Description: Oirat
@@ -38036,6 +38212,8 @@ Type: language
 Subtag: xba
 Description: Kamba (Brazil)
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: cax
 %%
 Type: language
 Subtag: xbb
@@ -38106,6 +38284,7 @@ Type: language
 Subtag: xbx
 Description: Kabixí
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: xby
@@ -38403,6 +38582,7 @@ Type: language
 Subtag: xip
 Description: Xipináwa
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: xir
@@ -38473,6 +38653,8 @@ Type: language
 Subtag: xkh
 Description: Karahawyana
 Added: 2009-07-29
+Deprecated: 2016-05-30
+Preferred-Value: waw
 %%
 Type: language
 Subtag: xki
@@ -39868,6 +40050,11 @@ Description: Hlepho Phowa
 Added: 2009-07-29
 %%
 Type: language
+Subtag: yhs
+Description: Yan-nhaŋu Sign Language
+Added: 2015-04-17
+%%
+Type: language
 Subtag: yia
 Description: Yinggarda
 Added: 2009-07-29
@@ -40384,6 +40571,7 @@ Type: language
 Subtag: yri
 Description: Yarí
 Added: 2009-07-29
+Deprecated: 2016-05-30
 %%
 Type: language
 Subtag: yrk
@@ -40404,6 +40592,11 @@ Type: language
 Subtag: yrn
 Description: Yerong
 Added: 2009-07-29
+%%
+Type: language
+Subtag: yro
+Description: Yaroamë
+Added: 2016-05-30
 %%
 Type: language
 Subtag: yrs
@@ -40730,6 +40923,7 @@ Macrolanguage: zap
 %%
 Type: language
 Subtag: zab
+Description: Western Tlacolula Valley Zapotec
 Description: San Juan Guelavía Zapotec
 Added: 2009-07-29
 Macrolanguage: zap
@@ -42623,6 +42817,7 @@ Prefix: sgn
 Type: extlang
 Subtag: lce
 Description: Loncong
+Description: Sekak
 Added: 2009-07-29
 Preferred-Value: lce
 Prefix: ms
@@ -42943,6 +43138,13 @@ Prefix: ar
 Macrolanguage: ar
 %%
 Type: extlang
+Subtag: pgz
+Description: Papua New Guinean Sign Language
+Added: 2016-05-30
+Preferred-Value: pgz
+Prefix: sgn
+%%
+Type: extlang
 Subtag: pks
 Description: Pakistan Sign Language
 Added: 2009-07-29
@@ -43047,6 +43249,13 @@ Subtag: rsl
 Description: Russian Sign Language
 Added: 2009-07-29
 Preferred-Value: rsl
+Prefix: sgn
+%%
+Type: extlang
+Subtag: rsm
+Description: Miriwoong Sign Language
+Added: 2016-05-30
+Preferred-Value: rsm
 Prefix: sgn
 %%
 Type: extlang
@@ -43383,6 +43592,13 @@ Preferred-Value: ygs
 Prefix: sgn
 %%
 Type: extlang
+Subtag: yhs
+Description: Yan-nhaŋu Sign Language
+Added: 2015-04-17
+Preferred-Value: yhs
+Prefix: sgn
+%%
+Type: extlang
 Subtag: ysl
 Description: Yugoslavian Sign Language
 Added: 2009-07-29
@@ -43506,6 +43722,11 @@ Type: script
 Subtag: Beng
 Description: Bengali
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Bhks
+Description: Bhaiksuki
+Added: 2015-07-24
 %%
 Type: script
 Subtag: Blis
@@ -43673,6 +43894,11 @@ Description: Gurmukhi
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Hanb
+Description: Han with Bopomofo (alias for Han + Bopomofo)
+Added: 2016-02-08
+%%
+Type: script
 Subtag: Hang
 Description: Hangul
 Description: Hangŭl
@@ -43751,6 +43977,11 @@ Type: script
 Subtag: Ital
 Description: Old Italic (Etruscan, Oscan, etc.)
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Jamo
+Description: Jamo (alias for Jamo subset of Hangul)
+Added: 2016-02-08
 %%
 Type: script
 Subtag: Java
@@ -43847,6 +44078,11 @@ Type: script
 Subtag: Latn
 Description: Latin
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Leke
+Description: Leke
+Added: 2015-07-24
 %%
 Type: script
 Subtag: Lepc
@@ -43991,6 +44227,14 @@ Description: Nabataean
 Added: 2010-04-10
 %%
 Type: script
+Subtag: Newa
+Description: Newa
+Description: Newar
+Description: Newari
+Description: Nepāla lipi
+Added: 2016-01-04
+%%
+Type: script
 Subtag: Nkgb
 Description: Nakhi Geba
 Description: 'Na-'Khi ²Ggŏ-¹baw
@@ -44081,6 +44325,11 @@ Type: script
 Subtag: Phnx
 Description: Phoenician
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Piqd
+Description: Klingon (KLI pIqaD)
+Added: 2016-01-04
 %%
 Type: script
 Subtag: Plrd
@@ -44336,6 +44585,11 @@ Type: script
 Subtag: Zmth
 Description: Mathematical notation
 Added: 2007-12-05
+%%
+Type: script
+Subtag: Zsye
+Description: Symbols (Emoji variant)
+Added: 2016-01-04
 %%
 Type: script
 Subtag: Zsym
@@ -44760,6 +45014,11 @@ Type: region
 Subtag: EU
 Description: European Union
 Added: 2009-07-29
+%%
+Type: region
+Subtag: EZ
+Description: Eurozone
+Added: 2016-07-14
 %%
 Type: region
 Subtag: FI
@@ -45620,6 +45879,11 @@ Description: United States Minor Outlying Islands
 Added: 2005-10-16
 %%
 Type: region
+Subtag: UN
+Description: United Nations
+Added: 2016-07-14
+%%
+Type: region
 Subtag: US
 Description: United States
 Added: 2005-10-16
@@ -45938,6 +46202,15 @@ Added: 2005-10-16
 Prefix: de
 %%
 Type: variant
+Subtag: abl1943
+Description: Orthographic formulation of 1943 - Official in Brazil
+  (Formulário Ortográfico de 1943 - Oficial no Brasil)
+Added: 2015-05-06
+Prefix: pt-BR
+Comments: Denotes conventions established by the Academia Brasileira de
+  Letras in 1943 and generally used in Brazil until 2009
+%%
+Type: variant
 Subtag: alalc97
 Description: ALA-LC Romanization, 1997 edition
 Added: 2009-12-09
@@ -45954,6 +46227,16 @@ Added: 2009-09-05
 Prefix: djk
 Comments: Aluku dialect of the "Busi Nenge Tongo" English-based Creole
   continuum in Eastern Suriname and Western French Guiana
+%%
+Type: variant
+Subtag: ao1990
+Description: Portuguese Language Orthographic Agreement of 1990 (Acordo
+  Ortográfico da Língua Portuguesa de 1990)
+Added: 2015-05-06
+Prefix: pt
+Prefix: gl
+Comments: Portuguese orthography conventions established in 1990 but
+  not brought into effect until 2009
 %%
 Type: variant
 Subtag: arevela
@@ -46004,6 +46287,12 @@ Comments: Barlavento is one of the two main dialect groups of
 Added: 2013-12-10
 %%
 Type: variant
+Subtag: basiceng
+Description: Basic English
+Added: 2015-12-29
+Prefix: en
+%%
+Type: variant
 Subtag: bauddha
 Description: Buddhist Hybrid Sanskrit
 Added: 2010-07-28
@@ -46041,6 +46330,24 @@ Prefix: en
 Comments: Jargon embedded in American English
 %%
 Type: variant
+Subtag: colb1945
+Description: Portuguese-Brazilian Orthographic Convention of 1945
+  (Convenção Ortográfica Luso-Brasileira de 1945)
+Added: 2015-05-06
+Prefix: pt
+Comments: Portuguese orthography conventions established in 1945,
+  generally in effect until 2009. This reform was not ratified in
+  Brazil.
+%%
+Type: variant
+Subtag: cornu
+Description: Cornu-English
+Description: Cornish English
+Description: Anglo-Cornish
+Added: 2015-12-07
+Prefix: en
+%%
+Type: variant
 Subtag: dajnko
 Description: Slovene in Dajnko alphabet
 Added: 2012-06-27
@@ -46067,6 +46374,12 @@ Type: variant
 Subtag: fonipa
 Description: International Phonetic Alphabet
 Added: 2006-12-11
+%%
+Type: variant
+Subtag: fonnapa
+Description: North American Phonetic Alphabet
+Description: Americanist Phonetic Notation
+Added: 2016-06-24
 %%
 Type: variant
 Subtag: fonupa
@@ -46206,6 +46519,12 @@ Added: 2005-10-16
 Prefix: sl
 %%
 Type: variant
+Subtag: newfound
+Description: Newfoundland English
+Added: 2015-11-25
+Prefix: en-CA
+%%
+Type: variant
 Subtag: njiva
 Description: The Gniva dialect of Resian
 Description: The Njiva dialect of Resian
@@ -46234,6 +46553,12 @@ Added: 2007-07-05
 Prefix: sl-rozaj
 Comments: The dialect of Oseacco/Osojane is one of the four major local
   dialects of Resian
+%%
+Type: variant
+Subtag: oxendict
+Description: Oxford English Dictionary spelling
+Added: 2015-04-17
+Prefix: en
 %%
 Type: variant
 Subtag: pamaka
@@ -46308,6 +46633,11 @@ Description: Scouse
 Added: 2006-09-18
 Prefix: en
 Comments: English Liverpudlian dialect known as 'Scouse'
+%%
+Type: variant
+Subtag: simple
+Description: Simplified form
+Added: 2015-12-29
 %%
 Type: variant
 Subtag: solba
@@ -46429,11 +46759,15 @@ Type: grandfathered
 Tag: cel-gaulish
 Description: Gaulish
 Added: 2001-05-25
+Deprecated: 2015-03-29
+Comments: see xcg, xga, xtg
 %%
 Type: grandfathered
 Tag: en-GB-oed
 Description: English, Oxford English Dictionary spelling
 Added: 2003-07-09
+Deprecated: 2015-04-17
+Preferred-Value: en-GB-oxendict
 %%
 Type: grandfathered
 Tag: i-ami
@@ -46458,6 +46792,7 @@ Type: grandfathered
 Tag: i-enochian
 Description: Enochian
 Added: 2002-07-03
+Deprecated: 2015-03-29
 %%
 Type: grandfathered
 Tag: i-hak
@@ -46574,6 +46909,7 @@ Tag: zh-min
 Description: Min, Fuzhou, Hokkien, Amoy, or Taiwanese
 Added: 1999-12-18
 Deprecated: 2009-07-29
+Comments: see cdo, cpx, czo, mnp, nan
 %%
 Type: grandfathered
 Tag: zh-min-nan


### PR DESCRIPTION
This PR updates the following: 
- I noticed the IANA subtag registry was out of date; I updated it to the latest version. 
- Updated LanguageIndex.txt and LanguageCodes.txt to latest from the Ethnologue site, but fixing some incompatibilities with ISO 639-3:
- `[aka] Akan` and `[nor] Norwegian` removed from LanguageCodes.txt, which are macrolanguages according to ISO 639-3.
- Added the following ISO 639-3 sub-languages of the above to both LanguageCodes.txt and LanguageIndex.txt:
  - `[nob] Norwegian Bokmål`
  - `[nno] Norwegian Nynorsk`
  - `[fat] Fanti`
  - `[twi] Twi`
- Removes the unit test related to Akan, which broke (since Akan is no longer listed in LanguageCodes.txt)

There are many languages from ISO 639-3 missing in these files.  It would be good if the other missing codes were added as well.  But these changes should at least be a stopgap measure until that happens.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/382)

<!-- Reviewable:end -->
