### PR TITLE
Improve failure message options in FluentAssert

### DIFF
--- a/Palaso.TestUtilities/FluentAssertXml.cs
+++ b/Palaso.TestUtilities/FluentAssertXml.cs
@@ -199,26 +199,23 @@ namespace Palaso.TestUtilities
 		}
 
 
-		public  void HasNoMatchForXpath(string xpath, XmlNamespaceManager nameSpaceManager)
+		public void HasNoMatchForXpath(string xpath, XmlNamespaceManager nameSpaceManager = null, string message = null, bool print = true)
 		{
-			XmlNode node = GetNode( xpath, nameSpaceManager);
+			if (nameSpaceManager == null)
+			{
+				nameSpaceManager = new XmlNamespaceManager(new NameTable());
+			}
+			var node = GetNode(xpath, nameSpaceManager);
 			if (node != null)
 			{
-				Console.WriteLine("Was not supposed to match " + xpath);
-				PrintNodeToConsole(NodeOrDom);
+				if (message != null)
+					Console.WriteLine(message);
+				Console.WriteLine(@"Was not supposed to match " + xpath);
+				if (print)
+					PrintNodeToConsole(NodeOrDom);
 			}
-			Assert.IsNull(node, "Should not have matched: " + xpath);
-		}
 
-		public  void HasNoMatchForXpath(string xpath)
-		{
-			XmlNode node = GetNode( xpath, new XmlNamespaceManager(new NameTable()));
-			if (node != null)
-			{
-				Console.WriteLine("Was not supposed to match " + xpath);
-				PrintNodeToConsole(NodeOrDom);
-			}
-			Assert.IsNull(node, "Should not have matched: " + xpath);
+			Assert.IsNull(node, "Should not have matched: {0}{1}{2}", xpath, Environment.NewLine, message);
 		}
 
 		private XmlNode GetNode(string xpath)


### PR DESCRIPTION
* Add an option to skip printing the xml to the console
for tests which are working with very large files
* Add the option for an informative message to help
debugging assert failures

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/391)
<!-- Reviewable:end -->
