### PR TITLE
Move RetryUtility from SIL.Retry to SIL.Code

### DIFF
--- a/SIL.Core/Code/RetryUtility.cs
+++ b/SIL.Core/Code/RetryUtility.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace SIL.Retry
+namespace SIL.Code
 {
 	/// <summary>
 	/// This utility can be used to wrap any call and retry it in a loop

--- a/SIL.Core/IO/RobustFile.cs
+++ b/SIL.Core/IO/RobustFile.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
-using SIL.Retry;
+using SIL.Code;
 
 namespace SIL.IO
 {

--- a/SIL.Core/IO/RobustIO.cs
+++ b/SIL.Core/IO/RobustIO.cs
@@ -4,7 +4,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Xml.Linq;
-using SIL.Retry;
+using SIL.Code;
 
 namespace SIL.IO
 {

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -413,7 +413,7 @@
     <Compile Include="IO\SFMReader.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Retry\RetryUtility.cs" />
+    <Compile Include="Code\RetryUtility.cs" />
     <Compile Include="Settings\CrossPlatformSettingsProvider.cs" />
     <Compile Include="Annotations\Annotation.cs" />
     <Compile Include="Annotations\IAnnotatable.cs" />


### PR DESCRIPTION
I'm making the assumption that no other code is using this yet besides Bloom.
I will fix Bloom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/393)
<!-- Reviewable:end -->
