### PR TITLE
Add 3 properties to allow more general use of Palaso.proj

### DIFF
--- a/build/Palaso.proj
+++ b/build/Palaso.proj
@@ -2,16 +2,19 @@
 	<PropertyGroup>
 		<RootDir Condition="'$(teamcity_build_checkoutDir)' == '' And '$(RootDir)'==''">$(MSBuildProjectDirectory)/..</RootDir>
 		<RootDir Condition="'$(teamcity_build_checkoutDir)' != ''">$(teamcity_build_checkoutDir)</RootDir>
+		<BuilTaskDir Condition="'$(BuilTaskDir)'==''">build</BuilTaskDir>
+		<TestNamePat Condition="'$(TestNamePat)'==''">*.Tests</TestNamePat>
+		<StampIt Condition="'$(StampIt)'==''">true</StampIt>
 		<BUILD_NUMBER Condition="'$(BUILD_NUMBER)'==''">1.2.3.4</BUILD_NUMBER>
 		<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies). -->
 		<Version>3.0</Version>
 	</PropertyGroup>
 
-	<UsingTask TaskName="StampAssemblies" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll" />
-	<UsingTask TaskName="Archive" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll" />
-	<UsingTask TaskName="Split" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll" />
-	<UsingTask TaskName="FileUpdate" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll" />
-	<UsingTask TaskName="NUnit" AssemblyFile="$(RootDir)/build/Palaso.BuildTasks.dll" />
+	<UsingTask TaskName="StampAssemblies" AssemblyFile="$(RootDir)/$(BuilTaskDir)/Palaso.BuildTasks.dll" />
+	<UsingTask TaskName="Archive" AssemblyFile="$(RootDir)/$(BuilTaskDir)/Palaso.BuildTasks.dll" />
+	<UsingTask TaskName="Split" AssemblyFile="$(RootDir)/$(BuilTaskDir)/Palaso.BuildTasks.dll" />
+	<UsingTask TaskName="FileUpdate" AssemblyFile="$(RootDir)/$(BuilTaskDir)/Palaso.BuildTasks.dll" />
+	<UsingTask TaskName="NUnit" AssemblyFile="$(RootDir)/$(BuilTaskDir)/Palaso.BuildTasks.dll" />
 	<UsingTask TaskName="NUnitTeamCity"
 		AssemblyFile="$(teamcity_dotnet_nunitlauncher_msbuild_task)"
 		Condition=" '$(teamcity_version)' != '' And '$(OS)'=='Windows_NT'"/>
@@ -66,7 +69,7 @@
 
 	<Target Name="Build">
 		<CallTarget Targets="Clean"/>
-		<CallTarget Targets="SetAssemblyVersion"/>
+		<CallTarget Targets="SetAssemblyVersion" Condition="'$(StampIt)'=='true'"/>
 		<CallTarget Targets="Compile"/>
 		<Message Text="Build Complete"/>
 	</Target>
@@ -103,7 +106,7 @@
 
 	<Target Name="RunNUnitTC" Condition="'$(teamcity_version)' != ''">
 		<ItemGroup>
-			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/*.Tests.dll"/>
+			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/$(TestNamePat).dll"/>
 		</ItemGroup>
 
 		<NUnitTeamCity
@@ -114,7 +117,7 @@
 
 	<Target Name="RunNUnit" Condition="'$(teamcity_version)' == ''">
 		<ItemGroup>
-			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/*.Tests.dll"/>
+			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/$(TestNamePat).dll"/>
 		</ItemGroup>
 
 		<NUnit Assemblies="@(TestAssemblies)"


### PR DESCRIPTION
Rather than making a copy and editing the Palaso.proj file so the versions diverge, I added the properties that would allow the same Palaso.proj file to be used in the Pathway project. In Pathway the build folder is called Build. The Tests are all contained in a file called Test.dll and when running the unit tests, it is not necessary to stamp the version number on the files. With these additional parameters it is possible to use this file as you can see from the https://github.com/sillsdev/pathway/blob/develop/buildTest.sh file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/394)

<!-- Reviewable:end -->
