### PR TITLE
Add new PathUtilities.PathContainsDirectory() method

### DIFF
--- a/SIL.Core.Tests/IO/PathUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/PathUtilitiesTests.cs
@@ -323,6 +323,18 @@ namespace SIL.Tests.IO
 			}
 			PathUtilities.OpenDirectoryInExplorer(path);
 		}
+
+		[TestCase(null, Result = false)]
+		[TestCase("", Result = false)]
+		[TestCase("rect", Result = false)]
+		[TestCase("none", Result = false)]
+		[TestCase("directory", Result = true)]
+		[TestCase("subdir", Result = true)]
+		public bool PathContainsDirectory(string directory)
+		{
+			var path = Path.Combine(Path.GetTempPath(), "some", "directory", "and", "other", "subdir");
+			return PathUtilities.PathContainsDirectory(path, directory);
+		}
 	}
 }
 

--- a/SIL.Core/IO/PathUtilities.cs
+++ b/SIL.Core/IO/PathUtilities.cs
@@ -419,6 +419,23 @@ namespace SIL.IO
 			}
 		}
 
+		public static bool PathContainsDirectory(string path, string directory)
+		{
+			if (string.IsNullOrEmpty(directory))
+				return false;
+
+			if (path.Contains(directory))
+			{
+				while (!string.IsNullOrEmpty(path))
+				{
+					var subdir = Path.GetFileName(path);
+					if (subdir == directory)
+						return true;
+					path = Path.GetDirectoryName(path);
+				}
+			}
+			return false;
+		}
 	}
 }
 


### PR DESCRIPTION
This method checks that the path contains a subdirectory named
'subdir' instead of checking that path contains the string
'subdir'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/407)
<!-- Reviewable:end -->
