### PR TITLE
Allow Sldr to be used in offline mode without resorting to reflection…

### DIFF
--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -100,9 +100,9 @@ namespace SIL.WritingSystems
 		/// <summary>
 		/// Initializes the SLDR. This should be called before calling other methods or properties.
 		/// </summary>
-		public static void Initialize()
+		public static void Initialize(bool offlineMode = false)
 		{
-			Initialize(false, DefaultSldrCachePath);
+			Initialize(offlineMode, DefaultSldrCachePath);
 		}
 
 		/// <summary>


### PR DESCRIPTION
…. Allows programs that operate in sensitive areas to keep from accessing online SIL resources. This is needed by Paratext. We've been using reflection to set a property that was used to set the member variable, but this property seems to have been deleted. This seemed like a good time to actually make an official change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/411)
<!-- Reviewable:end -->
