### PR TITLE
Add TempFile.InFolderOf method

### DIFF
--- a/SIL.Core/IO/TempFile.cs
+++ b/SIL.Core/IO/TempFile.cs
@@ -197,5 +197,19 @@ namespace SIL.IO
 			File.Move(Path, path);
 			_path = path;
 		}
+
+
+		/// <summary>
+		/// Used to create a temporary filename in the same folder as another file.
+		/// </summary>
+		/// <param name="inputPath">path to an (existing) file</param>
+		public static TempFile InFolderOf(string inputPath)
+		{
+			var folder = System.IO.Path.GetDirectoryName(inputPath);
+			if (String.IsNullOrEmpty(folder))
+				folder = ".";
+			var path = System.IO.Path.Combine(folder, System.IO.Path.GetRandomFileName());
+			return TempFile.TrackExisting(path);
+		}
 	}
 }


### PR DESCRIPTION
This is useful for Bloom and other programs whose users may want
to ensure that temporary files retain the same permissions as as
current files when shared over the network.
(See http://issues.bloomlibrary.org/youtrack/issue/BL-3954.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/415)
<!-- Reviewable:end -->
