### PR TITLE
If the IGO option is chosen for a CC license, use version number "3.0"

### DIFF
--- a/SIL.Windows.Forms.Tests/ClearShare/CreativeCommonsLicenseTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/CreativeCommonsLicenseTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 using SIL.Windows.Forms.ClearShare;
 
@@ -7,6 +9,12 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 	[TestFixture]
 	public class CreativeCommonsLicenseTests
 	{
+		[SetUp]
+		public void Setup()
+		{
+			Thread.CurrentThread.CurrentCulture = new CultureInfo("sv-SE"); //sweden, which uses commas for decimal  point (regression test)
+		}
+
 		[Test]
 		public void RoundTrip_BY()
 		{
@@ -108,6 +116,16 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 				IntergovernmentalOriganizationQualifier = true
 			};
 			Assert.IsTrue(l.HasChanges);
+		}
+
+		[Test]
+		public void SetIGO_VersionNumerIsAppropriate()
+		{
+			var l = new CreativeCommonsLicense(true, true, CreativeCommonsLicense.DerivativeRules.Derivatives)
+			{
+				IntergovernmentalOriganizationQualifier = true
+			};
+			Assert.AreEqual("3.0", l.Version, "The igo version of CC did not have a version beyond 3.0 as of Nov 2016");
 		}
 
 		[Test]

--- a/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
+++ b/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 
 namespace SIL.Windows.Forms.ClearShare
 {
@@ -143,8 +144,10 @@ namespace SIL.Windows.Forms.ClearShare
 				var urlWithoutTrailingSlash = value.TrimEnd(new char[] {'/'});
 				var parts = urlWithoutTrailingSlash.Split(new char[] { '/' });
 				var version=  parts[5];
+
+				//just a sanity check on the version
 				decimal result;
-				if (decimal.TryParse(version, out result))
+				if (decimal.TryParse(version, NumberStyles.AllowDecimalPoint, new CultureInfo("en-US"), out result))
 					Version = version;
 
 				if(parts.Length > 6)
@@ -310,6 +313,10 @@ namespace SIL.Windows.Forms.ClearShare
 					HasChanges = true;
 				}
 				_qualifier = newValue;
+				if(value)
+				{
+					_version = "3.0";// as of November 2016, igo only had a 3.0 version, while normal cc licenses were up to 4.0
+				}
 			}
 		}
 


### PR DESCRIPTION
Also specify what we think a version number should look like, regardless of locale. Sorry, kinda two-in-one here, but both version related.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/417)
<!-- Reviewable:end -->
