### PR TITLE
Made WriteMinorEvent more robust

### DIFF
--- a/SIL.Core/Reporting/Logger.cs
+++ b/SIL.Core/Reporting/Logger.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using SIL.IO;
 
@@ -481,7 +482,19 @@ namespace SIL.Reporting
 						m_minorEvents.Remove(0, cutoff);
 					}
 					m_minorEvents.Append(DateTime.Now.ToLongTimeString() + "\t");
-					m_minorEvents.AppendFormat(message, args);
+					if (args.Any())
+					{
+						try
+						{
+							m_minorEvents.AppendFormat(message, args);
+						}
+						catch (Exception)
+						{
+							m_minorEvents.AppendFormat("Error formatting message with {0} args: {1}", args.Length, message);
+						}
+					}
+					else
+						m_minorEvents.Append(message);
 					m_minorEvents.AppendLine();
 #if !DEBUG
 					}


### PR DESCRIPTION
Do not attempt to treat the message as a format string if no args are supplied. Report the problem if the format is attempted and fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/418)
<!-- Reviewable:end -->
