### PR TITLE
PTX-49759 prevent corrupted .ldml file in global repository from stopping initialization

### DIFF
--- a/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
@@ -21,6 +21,24 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
+		public void Initialize_SkipsBadFile()
+		{
+			using (var e = new TemporaryFolder("GlobalWritingSystemRepositoryTests"))
+			{
+				string versionPath = Path.Combine(e.Path, LdmlDataMapper.CurrentLdmlVersion.ToString());
+				Directory.CreateDirectory(versionPath);
+				string badFile = Path.Combine(versionPath, "en.ldml");
+				File.WriteAllBytes(badFile, new byte[100]); // 100 nulls
+				var repo = GlobalWritingSystemRepository.InitializeWithBasePath(e.Path, null);
+				// main part of test is that we don't get any exception.
+				Assert.That(repo.Count, Is.EqualTo(0));
+				// original .ldml file should have been renamed
+				Assert.That(File.Exists(badFile), Is.False);
+				Assert.That(File.Exists(badFile + ".bad"), Is.True);
+			}
+		}
+
+		[Test]
 		public void PathConstructor_HasCorrectPath()
 		{
 			using (var e = new TemporaryFolder("GlobalWritingSystemRepositoryTests"))

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Xml;
 using SIL.IO;
 using SIL.PlatformUtilities;
 using SIL.Threading;
@@ -108,12 +109,20 @@ namespace SIL.WritingSystems
 				else
 				{
 					// new writing system
-					ws = WritingSystemFactory.Create();
-					ldmlDataMapper.Read(file, ws);
-					ws.Id = ws.LanguageTag;
-					ws.AcceptChanges();
-					WritingSystems[id] = ws;
-					_lastFileStats[id] = Tuple.Create(fi.LastWriteTime, fi.Length);
+					try
+					{
+						ws = WritingSystemFactory.Create();
+						ldmlDataMapper.Read(file, ws);
+						ws.Id = ws.LanguageTag;
+						ws.AcceptChanges();
+						WritingSystems[id] = ws;
+						_lastFileStats[id] = Tuple.Create(fi.LastWriteTime, fi.Length);
+					}
+					catch (XmlException)
+					{
+						// ldml file is not valid, rename it so it is no longer used
+						RobustFile.Move(file, file + ".bad");
+					}
 				}
 			}
 


### PR DESCRIPTION
A bad .ldml file was stopping the global repository from initializing. The bad file was most likely caused by a system crash since it was all nulls.

Changed code to catch XmlException's that occur when reading the .ldml file and to rename the file to be a .ldml.bad file (thought renaming was betting than deleting in case the file was needed for investigation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/422)
<!-- Reviewable:end -->
