### PR TITLE
Make DeleteDirectoryRobust mow down readonly files, by default

### DIFF
--- a/SIL.Core.Tests/IO/DirectoryUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/DirectoryUtilitiesTests.cs
@@ -589,5 +589,31 @@ namespace SIL.Tests.IO
 				File.Delete(fileName);
 			}
 		}
+
+		[Test]
+		public void DeleteDirectoryRobust_ContainsReadOnlyFile_StillRemoves()
+		{
+			using (var tempDir = new TemporaryFolder("DeleteDirectoryRobust_ContainsReadOnlyFile_StillRemoves"))
+			{
+				var fileName = tempDir.Combine("tempFile.txt");
+				File.WriteAllText(fileName, @"Some test text");
+				new System.IO.FileInfo(fileName).IsReadOnly = true;
+				DirectoryUtilities.DeleteDirectoryRobust(tempDir.Path);
+				Assert.IsFalse(Directory.Exists(tempDir.Path), "Did not delete directory");
+			}
+		}
+
+		[Test]
+		public void DeleteDirectoryRobust_NoOverrideContainsReadOnlyFile_ReturnsFalse()
+		{
+			using (var tempDir = new TemporaryFolder("DeleteDirectoryRobust_NoOverrideContainsReadOnlyFile_ReturnsFalse"))
+			{
+				var fileName = tempDir.Combine("tempFile.txt");
+				File.WriteAllText(fileName, @"Some test text");
+				new System.IO.FileInfo(fileName).IsReadOnly = true;
+				Assert.IsFalse(DirectoryUtilities.DeleteDirectoryRobust(tempDir.Path, overrideReadOnly:false));
+				Assert.IsTrue(Directory.Exists(tempDir.Path), "Did not expect it to delete directory because of the readonly file");
+			}
+		}
 	}
 }

--- a/SIL.Core/IO/DirectoryUtilities.cs
+++ b/SIL.Core/IO/DirectoryUtilities.cs
@@ -210,7 +210,7 @@ namespace SIL.IO
 		/// This method uses all the tricks to do its best.
 		/// </summary>
 		/// <returns>returns true if the directory is fully deleted</returns>
-		public static bool DeleteDirectoryRobust(string path)
+		public static bool DeleteDirectoryRobust(string path, bool overrideReadOnly=true)
 		{
 			// ReSharper disable EmptyGeneralCatchClause
 
@@ -239,9 +239,10 @@ namespace SIL.IO
 					{
 						try
 						{
-							/* we could do this too, but it's dangerous
-							 *  File.SetAttributes(filePath, FileAttributes.Normal);
-							 */
+							if(overrideReadOnly)
+							{
+								File.SetAttributes(filePath, FileAttributes.Normal);
+							}
 							File.Delete(filePath);
 						}
 						catch (Exception)
@@ -254,7 +255,7 @@ namespace SIL.IO
 					}
 
 				}
-				catch (Exception)//yes, even these simple queries can throw exceptions, as stuff suddenly is deleted base on our prior request
+				catch (Exception)//yes, even these simple queries can throw exceptions, as stuff suddenly is deleted based on our prior request
 				{
 				}
 				//sleep and let some OS things catch up

--- a/SIL.Core/IO/DirectoryUtilities.cs
+++ b/SIL.Core/IO/DirectoryUtilities.cs
@@ -213,7 +213,12 @@ namespace SIL.IO
 		public static bool DeleteDirectoryRobust(string path, bool overrideReadOnly=true)
 		{
 			// ReSharper disable EmptyGeneralCatchClause
-
+#if __MonoCS__
+			// The Mono runtime deletes readonly files and directories that contain readonly files.
+			// This violates the MSDN specification of Directory.Delete and File.Delete.
+			if (!overrideReadOnly && DirectoryContainsReadOnly(path))
+					return false;
+#endif
 			for (int i = 0; i < 40; i++) // each time, we sleep a little. This will try for up to 2 seconds (40*50ms)
 			{
 				if (!Directory.Exists(path))
@@ -286,6 +291,34 @@ namespace SIL.IO
 			}
 			return Path.Combine(parent, name + suffix);
 		}
+
+#if __MonoCS__
+		/// <summary>
+		/// Check whether the given directory is readonly, or contains files or subdirectories that are readonly.
+		/// </summary>
+		/// <remarks>
+		/// Using this check could be considered a workaround for a bug in the Mono runtime, but that bug goes so
+		/// deep that it's safer and easier to work around it here.
+		/// </remarks>
+		static bool DirectoryContainsReadOnly(string path)
+		{
+			var dirInfo = new DirectoryInfo(path);
+			if ((dirInfo.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+				return true;
+			foreach (var file in Directory.GetFiles(path))
+			{
+				var fileInfo = new FileInfo(file);
+				if ((fileInfo.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+					return true;
+			}
+			foreach (var dir in Directory.GetDirectories(path))
+			{
+				if (DirectoryContainsReadOnly(dir))
+					return true;
+			}
+			return false;
+		}
+#endif
 
 		/// <summary>
 		/// Checks if there are any entries in a directory

--- a/SIL.Core/IO/RobustIO.cs
+++ b/SIL.Core/IO/RobustIO.cs
@@ -25,8 +25,12 @@ namespace SIL.IO
 
 		public static void DeleteDirectory(string path, bool recursive)
 		{
-			if (recursive)
-				DirectoryUtilities.DeleteDirectoryRobust(path);
+			if(recursive)
+			{
+				var succeeded = DirectoryUtilities.DeleteDirectoryRobust(path);
+				if(!succeeded)
+					throw new IOException("Could not delete directory "+path);
+			}
 			else
 				RetryUtility.Retry(() => Directory.Delete(path, false));
 		}

--- a/SIL.TestUtilities/TestUtilities.cs
+++ b/SIL.TestUtilities/TestUtilities.cs
@@ -29,6 +29,7 @@ namespace SIL.TestUtilities
 						string[] files = Directory.GetFiles(folder, "*.*", SearchOption.AllDirectories);
 						foreach (string s in files)
 						{
+							File.SetAttributes(s, FileAttributes.Normal); //get past readonly
 							File.Delete(s);
 						}
 						//sleep and try again (seems to work)


### PR DESCRIPTION
Also make the TestUtilities equivalent do the same, and make the RobustIO version notice if DeleteDirectoryRobust fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/435)
<!-- Reviewable:end -->
