### PR TITLE
SLDR redirect changed recently

### DIFF
--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -11,6 +11,7 @@ using System.Security.Principal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SIL.Extensions;
+using SIL.Network;
 using SIL.ObjectModel;
 using SIL.PlatformUtilities;
 using SIL.Threading;
@@ -244,8 +245,8 @@ namespace SIL.WritingSystems
 							else if (webResponse.StatusCode == HttpStatusCode.MovedPermanently)
 							{
 								// Extract ietfLanguageTag from the response header
-								string responseString = webResponse.Headers["Location"].Replace(SldrRepository, "");
-								sldrLanguageTag = responseString.Split('?')[0];
+								var parsedresponse = HttpUtilityFromMono.ParseQueryString(webResponse.Headers["Location"]);
+								sldrLanguageTag = parsedresponse.Get("ws_id").Split('?')[0];
 								redirected = true;
 							}
 							else


### PR DESCRIPTION
I noticed that the SIL.WritingSystems test GetLdmlFile_LanguageTagWithSuppressedScript_DownloadsFile started failing on local builds (it isn't run on teamcity). I couldn't see anything that I'd done that broke it so I dug deeper. 

If the language tag that you ask for the ldml file for has a suppressed script or region then Sldr::GetLdmlFile will notice that the webResponse is a redirect so it generates a new request and tries again. The current codes assumes that the redirection URL is the same form as the original request.

https://staging.scriptsource.org/ldml/TAG?...

but now it is 

https://staging.scriptsource.org/cms_staging/scripts/module.php?module_id=ldml_server&ws_id=TAG?...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/436)
<!-- Reviewable:end -->
