### PR TITLE
PTX-50439 character sets for crossrefs and versesegments need to be to reated same as footnotes since order needs to be preserved

### DIFF
--- a/SIL.WritingSystems/CharacterSetDefinition.cs
+++ b/SIL.WritingSystems/CharacterSetDefinition.cs
@@ -7,6 +7,7 @@ namespace SIL.WritingSystems
 {
 	public class CharacterSetDefinition : DefinitionBase<CharacterSetDefinition>
 	{
+		private static readonly string[] _sequenceTypes = {"footnotes", "crossrefs", "verseSegments" };
 		private readonly string _type;
 		private readonly ObservableList<string> _characters; 
 
@@ -39,6 +40,11 @@ namespace SIL.WritingSystems
 			get { return _type; }
 		}
 
+		public bool IsSequenceType
+		{
+			get { return _sequenceTypes.Contains(_type); }
+		}
+
 		public IObservableList<string> Characters
 		{
 			get { return _characters; }
@@ -48,7 +54,7 @@ namespace SIL.WritingSystems
 		{
 			if (other == null || _type != other._type)
 				return false;
-			if (_type == "footnotes")
+			if (IsSequenceType)
 				return _characters.SequenceEqual(other._characters);
 			return _characters.SetEquals(other._characters);
 		}

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -554,7 +554,7 @@ namespace SIL.WritingSystems
 			string type = (string) exemplarCharactersElem.Attribute("type") ?? "main";
 			var csd = new CharacterSetDefinition(type);
 			var unicodeSet = (string) exemplarCharactersElem;
-			csd.Characters.AddRange(type == "footnotes" ? unicodeSet.Trim('[', ']').Split(' ').Select(c => c.Trim('{', '}')) : UnicodeSet.ToCharacters(unicodeSet));
+			csd.Characters.AddRange(csd.IsSequenceType ? unicodeSet.Trim('[', ']').Split(' ').Select(c => c.Trim('{', '}')) : UnicodeSet.ToCharacters(unicodeSet));
 			ws.CharacterSets.Add(csd);
 		}
 
@@ -1001,7 +1001,7 @@ namespace SIL.WritingSystems
 						break;
 					// All others go to special Sil:exemplarCharacters
 					default:
-						string unicodeSet = csd.Type == "footnotes" ? string.Format("[{0}]", string.Join(" ", csd.Characters.Select(c => c.Length > 1 ? string.Format("{{{0}}}", c) : c)))
+						string unicodeSet = csd.IsSequenceType ? string.Format("[{0}]", string.Join(" ", csd.Characters.Select(c => c.Length > 1 ? string.Format("{{{0}}}", c) : c)))
 							: UnicodeSet.ToPattern(csd.Characters);
 						exemplarCharactersElem = new XElement(Sil + "exemplarCharacters", unicodeSet);
 						exemplarCharactersElem.SetAttributeValue("type", csd.Type);


### PR DESCRIPTION
The cross reference callers and verse segments need to be ordered sequences, so I changed the CharacterSetDefinition code to treat these the same way as it was already treating footnote callers.

Main change is to replace the hard coded check for "footnotes" to a new boolean IsSequenceType property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/437)
<!-- Reviewable:end -->
