### PR TITLE
Normalize line endings when writing XML files

### DIFF
--- a/Palaso.DictionaryServices.Tests/Lift/LiftWriterTests.cs
+++ b/Palaso.DictionaryServices.Tests/Lift/LiftWriterTests.cs
@@ -1744,6 +1744,8 @@ namespace Palaso.DictionaryServices.Tests.Lift
 		[Test]
 		public void Add_TextWithSpanAndMeaningfulWhiteSpace_FormattingAndWhitespaceIsUntouched()
 		{
+			// REVIEW (EberhardB): does it really make sense to preserve the line endings? It seems
+			// that for a text node line endings should be standardized.
 			const string formattedText = "\rThis's <span href=\"reference\">\n is a\t\t\n\r\t span</span> with annoying whitespace!\r\n";
 			const string expected = "<form\r\n\tlang=\"de\">\r\n\t<text>" + formattedText + "</text>\r\n</form>";
 			using (var session = new LiftExportAsFragmentTestSession())

--- a/Palaso.DictionaryServices/Lift/LiftWriter.cs
+++ b/Palaso.DictionaryServices/Lift/LiftWriter.cs
@@ -46,7 +46,7 @@ namespace Palaso.DictionaryServices.Lift
 		///
 		/// </summary>
 		/// <param name="path"></param>
-		/// <param name="includeByteOrderMark">PrinceXML (at least v7 chokes if given a BOM, Lexique Pro chokes without it) </param>
+		/// <param name="byteOrderStyle">PrinceXML (at least v7 chokes if given a BOM, Lexique Pro chokes without it) </param>
 		public LiftWriter(string path, ByteOrderStyle byteOrderStyle)
 			: this()
 		{
@@ -61,7 +61,7 @@ namespace Palaso.DictionaryServices.Lift
 		public LiftWriter(StringBuilder builder, bool produceFragmentOnly): this()
 		{
 			_writer = XmlWriter.Create(builder, CanonicalXmlSettings.CreateXmlWriterSettings(
-				produceFragmentOnly ? ConformanceLevel.Fragment : ConformanceLevel.Document)
+				produceFragmentOnly ? ConformanceLevel.Fragment : ConformanceLevel.Document, NewLineHandling.None)
 			);
 			if (!produceFragmentOnly)
 			{

--- a/Palaso.Tests/Xml/CanonicalXmlSettingsTests.cs
+++ b/Palaso.Tests/Xml/CanonicalXmlSettingsTests.cs
@@ -32,11 +32,7 @@ namespace Palaso.Tests.Xml
 		private static void CheckReaderSettings(XmlReaderSettings settings, ConformanceLevel expectedConformanceLevel)
 		{
 			Assert.IsFalse(settings.CheckCharacters);
-#if NET_4_0 && !__MonoCS__
 			Assert.AreEqual(DtdProcessing.Parse, settings.DtdProcessing);
-#else
-			Assert.IsTrue(settings.ProhibitDtd);
-#endif
 			Assert.AreEqual(ValidationType.None , settings.ValidationType);
 			Assert.IsTrue(settings.CloseInput);
 			Assert.IsTrue(settings.IgnoreWhitespace);

--- a/Palaso.Tests/Xml/CanonicalXmlSettingsTests.cs
+++ b/Palaso.Tests/Xml/CanonicalXmlSettingsTests.cs
@@ -75,5 +75,42 @@ namespace Palaso.Tests.Xml
 				Assert.AreEqual(expected, result);
 			}
 		}
+
+		[Test]
+		public void WriteReadWithFile_WithCanonicalXmlWriterSettings_NormalizesLineEndings()
+		{
+			const string xmlInput = "<a><b>\nContent</b><b>\r\nOther</b></a>";
+			const string expected = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<a>\r\n\t<b>\r\nContent</b>\r\n\t<b>\r\nOther</b>\r\n</a>";
+			using (var tempFile = TempFile.CreateAndGetPathButDontMakeTheFile())
+			{
+				using (var reader = XmlReader.Create(new StringReader(xmlInput)))
+				{
+					using (var writer = XmlWriter.Create(tempFile.Path, CanonicalXmlSettings.CreateXmlWriterSettings()))
+					{
+						writer.WriteNode(reader, false);
+					}
+				}
+				string result = File.ReadAllText(tempFile.Path);
+				Console.WriteLine(result);
+				Assert.AreEqual(expected, result);
+			}
+		}
+
+		[Test]
+		public void Write_WithCanonicalXmlWriterSettingsNoNormalize_KeepLineEndings()
+		{
+			const string content = "\nContent\rmore\r\nOther\n\rfinal";
+			const string expected = "<a>" + content + "</a>";
+			var bldr = new StringBuilder();
+			using (var writer = XmlWriter.Create(bldr, CanonicalXmlSettings.CreateXmlWriterSettings(ConformanceLevel.Fragment, NewLineHandling.None)))
+			{
+				writer.WriteStartElement("a");
+				writer.WriteRaw(content);
+				writer.WriteEndElement();
+			}
+			var result = bldr.ToString();
+			Console.WriteLine(result);
+			Assert.AreEqual(expected, result);
+		}
 	}
 }

--- a/Palaso/Text/MultiTextBase.cs
+++ b/Palaso/Text/MultiTextBase.cs
@@ -292,7 +292,6 @@ namespace Palaso.Text
 		/// just for deserialization
 		/// </summary>
 		[XmlElement(typeof (LanguageForm), ElementName="form")]
-
 		public LanguageForm[] Forms
 		{
 			get

--- a/Palaso/Xml/CanonicalXmlSettings.cs
+++ b/Palaso/Xml/CanonicalXmlSettings.cs
@@ -61,22 +61,25 @@ namespace Palaso.Xml
 		/// This formats with new line on attributes, indents with tab, and encoded in UTF8 with no BOM.
 		/// </remarks>
 		/// <param name="conformanceLevel">Document|Fragment</param>
+		/// <param name = "newLineHandling">Indicates how to normalize line breaks in the output.</param>
 		///<returns>XmlWriterSettings</returns>
-		public static XmlWriterSettings CreateXmlWriterSettings(ConformanceLevel conformanceLevel)
+		public static XmlWriterSettings CreateXmlWriterSettings(ConformanceLevel conformanceLevel,
+			NewLineHandling newLineHandling = NewLineHandling.Replace)
 		{
-			var settings = new XmlWriterSettings
-							   {
-								   NewLineOnAttributes = true,              // New line for each attribute, saves space on a typical Chorus changeset.
-								   Indent = true,                           // Indent entities
-								   IndentChars = "\t",                      // Tabs for the indent
-								   CheckCharacters = false,
-								   Encoding = new UTF8Encoding(false),      // UTF8 without a BOM.
-								   CloseOutput = true,                      // Close the underlying stream on Close.  This is not the default.
-								   ConformanceLevel = conformanceLevel,
-								   NewLineChars = "\r\n",                   // Use /r/n for our end of lines
-								   NewLineHandling = NewLineHandling.None,  // Assume that the input is as written /r/n
-								   OmitXmlDeclaration = false               // The default, an xml declaration is written
-							   };
+			var settings = new XmlWriterSettings {
+				NewLineOnAttributes = true,              // New line for each attribute, saves space on a typical Chorus changeset.
+				Indent = true,                           // Indent entities
+				IndentChars = "\t",                      // Tabs for the indent
+				CheckCharacters = false,
+				Encoding = new UTF8Encoding(false),      // UTF8 without a BOM.
+				CloseOutput = true,                      // Close the underlying stream on Close.  This is not the default.
+				ConformanceLevel = conformanceLevel,
+				NewLineChars = "\r\n",                   // Use /r/n for our end of lines
+				// NOTE: .NET and Mono (3.4) behave differently with NewLineHandling.Replace when calling XmlWriter.WriteRaw():
+				// .NET will still replace line endings whereas Mono will write the data as-is.
+				NewLineHandling = newLineHandling,  // Normalize line endings
+				OmitXmlDeclaration = false               // The default, an xml declaration is written
+			};
 			return settings;
 		}
 

--- a/Palaso/Xml/CanonicalXmlSettings.cs
+++ b/Palaso/Xml/CanonicalXmlSettings.cs
@@ -28,11 +28,7 @@ namespace Palaso.Xml
 			{
 				CheckCharacters = false,
 				ConformanceLevel = conformanceLevel,
-#if NET_4_0 && !__MonoCS__
 				DtdProcessing = DtdProcessing.Parse,
-#else
-				ProhibitDtd = true,
-#endif
 				ValidationType = ValidationType.None,
 				CloseInput = true,
 				IgnoreWhitespace = true


### PR DESCRIPTION
The previous code assumed that all line endings are written as \r\n. However that was not the case when the data that we wrote contained line endings. This change forces line ending normalization so that line endings always end up as \r\n even when in the data we write. That helps with FW and LfMerge S/R where the ParserParameters contain line endings which will otherwise introduce a difference between Windows and Linux.

This change also allows to pass a `NewLineHandling` parameter when calling `CreateXmlWriterSettings`. Passing `NewLineHandling.None` will keep the previous behavior and is needed for Lift where one test expects that the line endings stay as they are.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/440)
<!-- Reviewable:end -->
