### PR TITLE
Handle creative commons urls with missing version number (BL-4108)

### DIFF
--- a/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
+++ b/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
@@ -143,7 +143,19 @@ namespace SIL.Windows.Forms.ClearShare
 
 				var urlWithoutTrailingSlash = value.TrimEnd(new char[] {'/'});
 				var parts = urlWithoutTrailingSlash.Split(new char[] { '/' });
-				var version=  parts[5];
+
+				string version;
+				try
+				{
+					version = parts[5];
+				}
+				catch (IndexOutOfRangeException)
+				{
+					// We had a problem with some urls getting saved without a version.
+					// We fixed the save problem, but now we need to handle that bad data.
+					// See http://issues.bloomlibrary.org/youtrack/issue/BL-4108.
+					version = kDefaultVersion;
+				}
 
 				//just a sanity check on the version
 				decimal result;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/443)
<!-- Reviewable:end -->
