### PR TITLE
Merge pull request #435 from sillsdev/DelDirRobustWithReadOnlyFiles

### DIFF
--- a/SIL.Core.Tests/IO/DirectoryUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/DirectoryUtilitiesTests.cs
@@ -589,5 +589,31 @@ namespace SIL.Tests.IO
 				File.Delete(fileName);
 			}
 		}
+
+		[Test]
+		public void DeleteDirectoryRobust_ContainsReadOnlyFile_StillRemoves()
+		{
+			using (var tempDir = new TemporaryFolder("DeleteDirectoryRobust_ContainsReadOnlyFile_StillRemoves"))
+			{
+				var fileName = tempDir.Combine("tempFile.txt");
+				File.WriteAllText(fileName, @"Some test text");
+				new System.IO.FileInfo(fileName).IsReadOnly = true;
+				DirectoryUtilities.DeleteDirectoryRobust(tempDir.Path);
+				Assert.IsFalse(Directory.Exists(tempDir.Path), "Did not delete directory");
+			}
+		}
+
+		[Test]
+		public void DeleteDirectoryRobust_NoOverrideContainsReadOnlyFile_ReturnsFalse()
+		{
+			using (var tempDir = new TemporaryFolder("DeleteDirectoryRobust_NoOverrideContainsReadOnlyFile_ReturnsFalse"))
+			{
+				var fileName = tempDir.Combine("tempFile.txt");
+				File.WriteAllText(fileName, @"Some test text");
+				new System.IO.FileInfo(fileName).IsReadOnly = true;
+				Assert.IsFalse(DirectoryUtilities.DeleteDirectoryRobust(tempDir.Path, overrideReadOnly:false));
+				Assert.IsTrue(Directory.Exists(tempDir.Path), "Did not expect it to delete directory because of the readonly file");
+			}
+		}
 	}
 }

--- a/SIL.Core/IO/RobustIO.cs
+++ b/SIL.Core/IO/RobustIO.cs
@@ -25,8 +25,12 @@ namespace SIL.IO
 
 		public static void DeleteDirectory(string path, bool recursive)
 		{
-			if (recursive)
-				DirectoryUtilities.DeleteDirectoryRobust(path);
+			if(recursive)
+			{
+				var succeeded = DirectoryUtilities.DeleteDirectoryRobust(path);
+				if(!succeeded)
+					throw new IOException("Could not delete directory "+path);
+			}
 			else
 				RetryUtility.Retry(() => Directory.Delete(path, false));
 		}

--- a/SIL.TestUtilities/TestUtilities.cs
+++ b/SIL.TestUtilities/TestUtilities.cs
@@ -29,6 +29,7 @@ namespace SIL.TestUtilities
 						string[] files = Directory.GetFiles(folder, "*.*", SearchOption.AllDirectories);
 						foreach (string s in files)
 						{
+							File.SetAttributes(s, FileAttributes.Normal); //get past readonly
 							File.Delete(s);
 						}
 						//sleep and try again (seems to work)


### PR DESCRIPTION
Make DeleteDirectoryRobust mow down readonly files, by default
(cherry picked from commit dee8eafe72fb9c370470cf332e2dd5eaf7a72175)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/444)
<!-- Reviewable:end -->
