### PR TITLE
BL-4184 Fix IGO license unset (on Bloom3.7)

### DIFF
--- a/SIL.Windows.Forms.Tests/ClearShare/CreativeCommonsLicenseTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/CreativeCommonsLicenseTests.cs
@@ -129,6 +129,34 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 		}
 
 		[Test]
+		public void UnSetIGO_VersionNumberIsHighestDefault()
+		{
+			var l = new CreativeCommonsLicense(true, true, CreativeCommonsLicense.DerivativeRules.Derivatives)
+			{
+				IntergovernmentalOriganizationQualifier = true,
+				Version = "3.0"
+			};
+			// SUT
+			l.IntergovernmentalOriganizationQualifier = false;
+			Assert.AreEqual(CreativeCommonsLicense.kDefaultVersion, l.Version,
+				"Setting igo to false when it was true should change version to the current default version.");
+		}
+
+		[Test]
+		public void UnSetIGO_IGOAlreadyUnset_DoesntAffectPreviousVersionNumber()
+		{
+			var l = new CreativeCommonsLicense(true, true, CreativeCommonsLicense.DerivativeRules.Derivatives)
+			{
+				IntergovernmentalOriganizationQualifier = false,
+				Version = "3.0"
+			};
+			// SUT
+			l.IntergovernmentalOriganizationQualifier = false;
+			Assert.AreEqual("3.0", l.Version,
+				"Setting igo to false when it was already false should not change an older version.");
+		}
+
+		[Test]
 		public void ChangeAttributionRequired_HasChanges_True()
 		{
 			var l = new CreativeCommonsLicense(true, true, CreativeCommonsLicense.DerivativeRules.DerivativesWithShareAndShareAlike);

--- a/SIL.Windows.Forms.Tests/ClearShare/MetadataEditorControlTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/MetadataEditorControlTests.cs
@@ -90,5 +90,41 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 			dlg.Controls.Add(c);
 			dlg.ShowDialog();
 		}
+
+		[Test]
+		public void MetadataSetter_WasIGO_UncheckingProducesCurrentDefaultLicense()
+		{
+			var m = new Metadata();
+			m.CopyrightNotice = "test1";
+			m.Creator = "test2";
+			var ccLicense = new CreativeCommonsLicense(true, false, CreativeCommonsLicense.DerivativeRules.DerivativesWithShareAndShareAlike);
+			ccLicense.IntergovernmentalOriganizationQualifier = true;
+			m.License = ccLicense;
+			Assert.That(m.License.Url, Is.StringEnding("3.0/igo/"));
+			// SUT
+			ccLicense.IntergovernmentalOriganizationQualifier = false;
+			m.License = ccLicense;
+			Assert.That(m.License.Url, Is.StringEnding(CreativeCommonsLicense.kDefaultVersion+"/"));
+		}
+
+		[Test]
+		public void MetadataSetter_WasCC3_thenIGO_UncheckingStillProducesCurrentDefaultLicense()
+		{
+			var m = new Metadata();
+			m.CopyrightNotice = "test1";
+			m.Creator = "test2";
+			var ccLicense = new CreativeCommonsLicense(true, false, CreativeCommonsLicense.DerivativeRules.DerivativesWithShareAndShareAlike);
+			ccLicense.Version = "3.0"; // set old version (but non-IGO)
+			m.License = ccLicense;
+			Assert.That(m.License.Url, Is.StringEnding("3.0/"));
+			ccLicense.IntergovernmentalOriganizationQualifier = true;
+			m.License = ccLicense;
+			Assert.That(m.License.Url, Is.StringEnding("3.0/igo/"));
+			// SUT
+			ccLicense.IntergovernmentalOriganizationQualifier = false;
+			m.License = ccLicense;
+			// Considered an acceptable loss of information, since the user was messing with the IGO setting.
+			Assert.That(m.License.Url, Is.StringEnding(CreativeCommonsLicense.kDefaultVersion + "/"));
+		}
 	}
 }

--- a/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
+++ b/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
@@ -323,6 +323,10 @@ namespace SIL.Windows.Forms.ClearShare
 				if (newValue != _qualifier)
 				{
 					HasChanges = true;
+					if (!value)
+					{
+						_version = kDefaultVersion; // Undo the switch to 3.0 below
+					}
 				}
 				_qualifier = newValue;
 				if(value)


### PR DESCRIPTION
* setting IGO changes license version to 3.0
* unsetting IGO should give us back the default
   version (currently 4.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/447)
<!-- Reviewable:end -->
