### PR TITLE
Enhance copyright string parsing methods

### DIFF
--- a/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
@@ -349,6 +349,32 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 			Assert.AreEqual("SIL International", m.GetCopyrightBy());
 		}
 
+		[Test]
+		public void GetCopyrightInfo_ArtOfReading_ReturnsCopyrightInfo()
+		{
+			var m = new Metadata();
+			m.CopyrightNotice = "Copyright, SIL International 2009. ";	// (from AOR_Cat3.png)
+			Assert.AreEqual("SIL International", m.GetCopyrightBy());
+			Assert.AreEqual("2009", m.GetCopyrightYear());
+		}
+
+		[Test]
+		public void GetCopyrightInfo_Vaccinations_ReturnsCopyrightInfo()
+		{
+			var m = new Metadata();
+			m.CopyrightNotice = "Copyright SIL Papua New Guinea 1996";
+			Assert.AreEqual("SIL Papua New Guinea", m.GetCopyrightBy());
+			Assert.AreEqual("1996", m.GetCopyrightYear());
+		}
+
+		[Test]
+		public void GetCopyrightInfo_StoryPrimer_ReturnsCopyrightInfo()
+		{
+			var m = new Metadata();
+			m.CopyrightNotice = "Copyright SIL Australia and the Literacy Association of the Solomon Islands (LASI) 2014";
+			Assert.AreEqual("SIL Australia and the Literacy Association of the Solomon Islands (LASI)", m.GetCopyrightBy());
+			Assert.AreEqual("2014", m.GetCopyrightYear());
+		}
 
 		[Test]
 		public void GetCopyrightYear_HasCopyrightAndSymbolAndComma_ReturnsCopyrightYear()

--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -783,7 +783,7 @@ namespace SIL.Windows.Forms.ClearShare
 		}
 
 		const string kCopyrightPattern = @"\D*(?<year>\d\d\d\d)?(,\s)?(?<by>.+)?";
-		const string kNoYearPattern = @"([cC]opyright\s+)?(COPYRIGHT\s+)?\©?\s*(?<by>.+)";
+		const string kNoYearPattern = @"([cC]opyright,?\s+)?(COPYRIGHT,?\s+)?\©?\s*(?<by>.+)";
 		private const string kNsCollections = "http://www.metadataworkinggroup.com/schemas/collections/";
 		private const string kNsCc = "http://creativecommons.org/ns#";
 
@@ -807,8 +807,21 @@ namespace SIL.Windows.Forms.ClearShare
 			{
 				m = Regex.Match(CopyrightNotice, kNoYearPattern);
 			}
+			var trimChars = new char[] { ' ', '\t', ',', '.', ':', ';' };
+			var by0 = m.Groups["by"].Value.Trim(trimChars);
+			if (!String.IsNullOrEmpty(by0))
+				return by0;
 
-			return m.Groups["by"].Value.Trim();
+			// Okay, maybe we can get this by deleting the Copyright word or symbol and the year.
+			m = Regex.Match(CopyrightNotice, kNoYearPattern);
+			var by1 = m.Groups["by"].Value.Trim();
+			if (String.IsNullOrEmpty(by1))
+				by1 = CopyrightNotice;
+			m = Regex.Match(by1, @"(?<year>\d\d\d\d)");
+			if (m.Groups["year"].Success)
+				by1 = by1.Replace(m.Groups["year"].Value, "");
+			by1 = by1.Trim(trimChars);
+			return by1;
 		}
 
 		/// <summary>


### PR DESCRIPTION
The code can now handle strings like

   "Copyright, SIL International 2009."
or
   "Copyright SIL Papua New Guinea 1996"

as well as what it could handle before.  This fixes a couple of Bloom
related issues: http://issues.bloomlibrary.org/youtrack/issue/BL-3552
and http://issues.bloomlibrary.org/youtrack/issue/BL-4254.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/456)
<!-- Reviewable:end -->
