### PR TITLE
PTX-48214 move IsDeprecated property to SubTag

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -785,8 +785,8 @@ namespace SIL.WritingSystems.Tests
 				adaptor.Read(tempFile.Path, wsFromLdml);
 				Assert.That(wsFromLdml.Variants, Is.EqualTo(new[]
 				{
-					new VariantSubtag("private", "private", true, new List<string>()),
-					new VariantSubtag("use", "", true, new List<string>())
+					new VariantSubtag("private", "private", true, false, new List<string>()),
+					new VariantSubtag("use", "", true, false, new List<string>())
 				}));
 			}
 		}

--- a/SIL.WritingSystems/LanguageSubtag.cs
+++ b/SIL.WritingSystems/LanguageSubtag.cs
@@ -15,7 +15,7 @@ namespace SIL.WritingSystems
 		/// <param name="code">The code.</param>
 		/// <param name="name">The name.</param>
 		public LanguageSubtag(string code, string name = null)
-			: base(code, name, true)
+			: base(code, name, true, false)
 		{
 			 Names = new List<string>();
 		}
@@ -31,12 +31,11 @@ namespace SIL.WritingSystems
 		/// <param name="isMacroLanguage">if set to <c>true</c> this is a macrolanguage.</param>
 		/// <param name="isDeprecated">if set to <c>true</c> this subtag is deprecated and should not be used.</param>
 		internal LanguageSubtag(string code, string name, bool isPrivateUse, string iso3Code, List<string> descriptions, bool isMacroLanguage, bool isDeprecated)
-			: base(code, name, isPrivateUse)
+			: base(code, name, isPrivateUse, isDeprecated)
 		{
 			_iso3Code = iso3Code;
 			Names = descriptions;
 			IsMacroLanguage = isMacroLanguage;
-			IsDeprecated = isDeprecated;
 		}
 
 		/// <summary>
@@ -47,7 +46,7 @@ namespace SIL.WritingSystems
 		/// <param name="isPrivateUse">if set to <c>true</c> this is a private use subtag.</param>
 		/// <param name="iso3Code">The ISO 639-3 language code.</param>
 		internal LanguageSubtag(string code, string name, bool isPrivateUse, string iso3Code)
-			: base(code, name, isPrivateUse)
+			: base(code, name, isPrivateUse, false)
 		{
 			Names = new List<string>();
 			_iso3Code = iso3Code;
@@ -84,12 +83,6 @@ namespace SIL.WritingSystems
 		/// </summary>
 		/// <c>true</c> if this is a macrolanguage; otherwise, <c>false</c>.
 		public bool IsMacroLanguage { get; private set; }
-
-		/// <summary>
-		/// Gets a value indicating whether this tag is deprecated.
-		/// </summary>
-		/// <c>true</c> if this tag is deprecated and should not be used; otherwise, <c>false</c>.
-		public bool IsDeprecated { get; private set; }
 
 		public static implicit operator LanguageSubtag(string code)
 		{

--- a/SIL.WritingSystems/RegionSubtag.cs
+++ b/SIL.WritingSystems/RegionSubtag.cs
@@ -8,17 +8,17 @@
 		/// <param name="code">The code.</param>
 		/// <param name="name">The name.</param>
 		public RegionSubtag(string code, string name = null)
-			: base(code, name, true)
+			: base(code, name, true, false)
 		{
 		}
 
-		internal RegionSubtag(string code, string name, bool isPrivateUse)
-			: base(code, name, isPrivateUse)
+		internal RegionSubtag(string code, string name, bool isPrivateUse, bool isDeprecated)
+			: base(code, name, isPrivateUse, isDeprecated)
 		{
 		}
 
 		public RegionSubtag(RegionSubtag subtag, string name)
-			: this(subtag.Code, name, subtag.IsPrivateUse)
+			: this(subtag.Code, name, subtag.IsPrivateUse, subtag.IsDeprecated)
 		{
 		}
 

--- a/SIL.WritingSystems/ScriptSubtag.cs
+++ b/SIL.WritingSystems/ScriptSubtag.cs
@@ -8,17 +8,17 @@
 		/// <param name="code">The code.</param>
 		/// <param name="name">The name.</param>
 		public ScriptSubtag(string code, string name = null)
-			: base(code, name, true)
+			: base(code, name, true, false)
 		{
 		}
 
-		internal ScriptSubtag(string code, string name, bool isPrivateUse)
-			: base(code, name, isPrivateUse)
+		internal ScriptSubtag(string code, string name, bool isPrivateUse, bool isDeprecated)
+			: base(code, name, isPrivateUse, isDeprecated)
 		{
 		}
 
 		public ScriptSubtag(ScriptSubtag subtag, string name)
-			: this(subtag.Code, name, subtag.IsPrivateUse)
+			: this(subtag.Code, name, subtag.IsPrivateUse, subtag.IsDeprecated)
 		{
 		}
 

--- a/SIL.WritingSystems/StandardSubtags.cs
+++ b/SIL.WritingSystems/StandardSubtags.cs
@@ -129,13 +129,13 @@ namespace SIL.WritingSystems
 						languages.Add(new LanguageSubtag(subtag, description, false, iso3Code, descriptions, macrolanguage, deprecated));
 						break;
 					case "script":
-						scripts.Add(new ScriptSubtag(subtag, description, false));
+						scripts.Add(new ScriptSubtag(subtag, description, false, deprecated));
 						break;
 					case "region":
-						regions.Add(new RegionSubtag(subtag, description, false));
+						regions.Add(new RegionSubtag(subtag, description, false, deprecated));
 						break;
 					case "variant":
-						variants.Add(new VariantSubtag(subtag, description, false, GetVariantPrefixes(subTagComponents)));
+						variants.Add(new VariantSubtag(subtag, description, false, deprecated, GetVariantPrefixes(subTagComponents)));
 						break;
 				}
 			}

--- a/SIL.WritingSystems/Subtag.cs
+++ b/SIL.WritingSystems/Subtag.cs
@@ -11,10 +11,11 @@ namespace SIL.WritingSystems
 		private readonly string _code;
 		private readonly string _name;
 		private readonly bool _isPrivateUse;
+		private readonly bool _isDeprecated;
 		private readonly int _hashCode;
 
-		protected Subtag(string code, bool isPrivateUse)
-			: this(code, null, isPrivateUse)
+		protected Subtag(string code, bool isPrivateUse, bool isDeprecated)
+			: this(code, null, isPrivateUse, isDeprecated)
 		{
 		}
 
@@ -24,7 +25,8 @@ namespace SIL.WritingSystems
 		/// <param name="code">The code.</param>
 		/// <param name="name">The name.</param>
 		/// <param name="isPrivateUse">if set to <c>true</c> this is a private use subtag.</param>
-		protected Subtag(string code, string name, bool isPrivateUse)
+		/// <param name="isDeprecated">if set to <c>true</c> this is a deprecated subtag.</param>
+		protected Subtag(string code, string name, bool isPrivateUse, bool isDeprecated)
 		{
 			if (code == null)
 				throw new ArgumentNullException("code");
@@ -34,6 +36,7 @@ namespace SIL.WritingSystems
 			_code = code;
 			_name = name;
 			_isPrivateUse = isPrivateUse;
+			_isDeprecated = isDeprecated;
 
 			_hashCode = 23;
 			_hashCode = _hashCode * 31 + _code.ToLowerInvariant().GetHashCode();
@@ -76,6 +79,12 @@ namespace SIL.WritingSystems
 		{
 			get { return _isPrivateUse; }
 		}
+
+		/// <summary>
+		/// Gets a value indicating whether this tag is deprecated.
+		/// </summary>
+		/// <c>true</c> if this tag is deprecated and should not be used; otherwise, <c>false</c>.
+		public bool IsDeprecated { get {return _isDeprecated;} }
 
 		/// <summary>
 		/// Determines whether the specified <see cref="T:System.Object"/> is equal to this instance.

--- a/SIL.WritingSystems/VariantSubtag.cs
+++ b/SIL.WritingSystems/VariantSubtag.cs
@@ -16,7 +16,7 @@ namespace SIL.WritingSystems
 		/// <param name="code">The code.</param>
 		/// <param name="name">The name.</param>
 		public VariantSubtag(string code, string name = null)
-			: this(code, name, true, Enumerable.Empty<string>())
+			: this(code, name, true, false, Enumerable.Empty<string>())
 		{
 		}
 
@@ -26,9 +26,10 @@ namespace SIL.WritingSystems
 		/// <param name="code">The code.</param>
 		/// <param name="name">The name.</param>
 		/// <param name="isPrivateUse">if set to <c>true</c> this is a private use subtag.</param>
+		/// <param name="isDeprecated">if set to <c>true</c> this is a deprecated subtag.</param>
 		/// <param name="prefixes">The prefixes.</param>
-		internal VariantSubtag(string code, string name, bool isPrivateUse, IEnumerable<string> prefixes)
-			: base(code, name, isPrivateUse)
+		internal VariantSubtag(string code, string name, bool isPrivateUse, bool isDeprecated, IEnumerable<string> prefixes)
+			: base(code, name, isPrivateUse, isDeprecated)
 		{
 			_prefixes = new HashSet<string>(prefixes);
 		}
@@ -39,7 +40,7 @@ namespace SIL.WritingSystems
 		/// <param name="subtag">The subtag.</param>
 		/// <param name="name">The name.</param>
 		public VariantSubtag(VariantSubtag subtag, string name)
-			: this(subtag.Code, name, subtag.IsPrivateUse, subtag._prefixes)
+			: this(subtag.Code, name, subtag.IsPrivateUse, subtag.IsDeprecated, subtag._prefixes)
 		{
 		}
 


### PR DESCRIPTION
move IsDeprecated property to SubTag to allow filtering of regions, scripts and variants

This is a revised pull request with 2 changes requested by Eberhard. Tried just amending previous one, but something went wrong in the process.

The deprecated flag was already being set from tag data, but it was only being saved on the LanguageSubTag. This change makes the setting available on all subtags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/459)
<!-- Reviewable:end -->
