### PR TITLE
BL-4243 Don't show license url again if embedded in description

### DIFF
--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -726,9 +726,11 @@ namespace SIL.Windows.Forms.ClearShare
 				b.AppendLine(CollectionName);
 			if (!string.IsNullOrEmpty(CollectionUri))
 				b.AppendLine(CollectionUri);
-			if (!string.IsNullOrEmpty(License.Url))
+			var description = License.GetDescription(languagePriorityIds, out idOfLanguageUsed);
+			// BL-4243, Description for CC usually contains the url already.
+			if (!string.IsNullOrEmpty(License.Url) && !description.Contains(License.Url))
 				b.AppendLine(License.Url);
-			b.AppendLine(License.GetDescription(languagePriorityIds, out idOfLanguageUsed));
+			b.AppendLine(description);
 			if (!String.IsNullOrWhiteSpace(License.RightsStatement))
 				b.AppendLine(License.RightsStatement);
 			return b.ToString();


### PR DESCRIPTION
Removes duplication in MetaData.GetSummaryParagraph()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/461)
<!-- Reviewable:end -->
