### PR TITLE
Tweak MinimalCredits() output, always include rights statement

### DIFF
--- a/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
@@ -441,7 +441,7 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 			};
 
 			string idOfLanguageUsedForLicense;
-			Assert.AreEqual("Jane Doe, My Collection, Please attribute nicely, © 2014 SIL", m.MinimalCredits(new[] {"en"}, out idOfLanguageUsedForLicense));
+			Assert.AreEqual("Jane Doe, My Collection, © 2014 SIL. Please attribute nicely", m.MinimalCredits(new[] {"en"}, out idOfLanguageUsedForLicense));
 		}
 		[Test]
 		public void MinimalCredits_OnlyCopyright()
@@ -465,7 +465,24 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 			};
 
 			string idOfLanguageUsedForLicense;
-			Assert.AreEqual("My Collection, CC-BY-SA IGO 3.0, © 2014 SIL", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
+			Assert.AreEqual("My Collection, © 2014 SIL. CC-BY-SA IGO 3.0", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
+		}
+
+		[Test]
+		public void MinimalCredits_CreativeCommonsWithExtraRightsStatement()
+		{
+			var m = new Metadata
+			{
+				CopyrightNotice = "Copyright © 2014 SIL",
+				License = new CreativeCommonsLicense(true, true, CreativeCommonsLicense.DerivativeRules.DerivativesWithShareAndShareAlike)
+				{
+					IntergovernmentalOriganizationQualifier = true,
+					RightsStatement = "Only people named Fred can use this."
+				}
+			};
+
+			string idOfLanguageUsedForLicense;
+			Assert.AreEqual("© 2014 SIL. CC-BY-SA IGO 3.0. Only people named Fred can use this.", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
 		}
 	}
 }

--- a/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
+++ b/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
@@ -249,7 +249,9 @@ namespace SIL.Windows.Forms.ClearShare
 			}
 			form = form.TrimEnd(new char[] { '-' });
 
-			return form + " " + (IntergovernmentalOriganizationQualifier ? "IGO " : "") + Version ;
+			var additionalRights = (RightsStatement != null ? ". " + RightsStatement : "");
+			return (form + " " + (IntergovernmentalOriganizationQualifier ? "IGO " : "") + Version + additionalRights).Trim();
+			;
 		}
 
 		/// <summary>

--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -828,8 +828,8 @@ namespace SIL.Windows.Forms.ClearShare
 
 		/// <summary>
 		/// A super compact form of credits that doesn't introduce any English.
-		/// Jane Doe, CC-BY-NC, © 2008 SIL International
-		/// "International Illustrations: Art Of Reading", CC-ND, © 2009 SIL International
+		/// Jane Doe, © 2008 SIL International, CC-BY-NC 3.0
+		/// "International Illustrations: Art Of Reading", © 2009 SIL International, CC-ND
 		/// </summary>
 		public string MinimalCredits(IEnumerable<string> languagePriorityIds, out string idOfLanguageUsedForLicense)
 		{
@@ -842,22 +842,23 @@ namespace SIL.Windows.Forms.ClearShare
 			{
 				notice += string.Format(" {0},", CollectionName);
 			}
-			if(License != null)
+			if (!string.IsNullOrWhiteSpace(CopyrightNotice))
+			{
+				notice += string.Format(" © {0} {1}", GetCopyrightYear(), GetCopyrightBy());
+			}
+			if (License != null)
 			{
 				var minimalFormForCredits = License.GetMinimalFormForCredits(languagePriorityIds, out idOfLanguageUsedForLicense);
-				if(!string.IsNullOrWhiteSpace(minimalFormForCredits))
+				if (!string.IsNullOrWhiteSpace(minimalFormForCredits))
 				{
-					notice += string.Format(" {0},", minimalFormForCredits);
+					notice += string.Format(". {0}", minimalFormForCredits);
 				}
 			}
 			else
 			{
 				idOfLanguageUsedForLicense = "*";
 			}
-			if (!string.IsNullOrWhiteSpace(CopyrightNotice))
-			{
-				notice += string.Format(" © {0} {1}", GetCopyrightYear(), GetCopyrightBy());
-			}
+
 			return notice.Trim();
 		}
 	}


### PR DESCRIPTION
Moves license to *after* the copyright. Creative Commons licenses now also emit the optional extra rights statement, if present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/462)
<!-- Reviewable:end -->
