### PR TITLE
Fixed bug in LogBox.SetFont that was keeping it from setting the new font chosen by the user.

### DIFF
--- a/SIL.Windows.Forms/Progress/LogBox.cs
+++ b/SIL.Windows.Forms/Progress/LogBox.cs
@@ -149,7 +149,7 @@ namespace SIL.Windows.Forms.Progress
 			var name = LogBoxSettings.Default.FontName;
 			var size = LogBoxSettings.Default.FontSize;
 
-			if (string.IsNullOrEmpty(name) && size > 0f)
+			if (!string.IsNullOrEmpty(name) && size > 0f)
 				fnt = new Font(name, size);
 
 			Font = fnt;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/465)
<!-- Reviewable:end -->
