### PR TITLE
Fix two issues with copying directories

### DIFF
--- a/SIL.Core/IO/DirectoryUtilities.cs
+++ b/SIL.Core/IO/DirectoryUtilities.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) 2017 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
 using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
@@ -8,7 +10,7 @@ using SIL.Reporting;
 
 namespace SIL.IO
 {
-	public class DirectoryUtilities
+	public static class DirectoryUtilities
 	{
 
 		/// <summary>
@@ -96,7 +98,7 @@ namespace SIL.IO
 			return true;
 		}
 
-		public static void CopyDirectoryWithException(string sourcePath, string destinationPath)
+		public static void CopyDirectoryWithException(string sourcePath, string destinationPath, bool overwrite = false)
 		{
 			if (!Directory.Exists(destinationPath))
 				Directory.CreateDirectory(destinationPath);
@@ -105,14 +107,14 @@ namespace SIL.IO
 			foreach (var filepath in Directory.GetFiles(sourcePath))
 			{
 				var filename = Path.GetFileName(filepath);
-				File.Copy(filepath, Path.Combine(destinationPath, filename));
+				File.Copy(filepath, Path.Combine(destinationPath, filename), overwrite);
 			}
 
-			// Copy all the sub directorys.
+			// Copy all the sub directories.
 			foreach (var directorypath in Directory.GetDirectories(sourcePath))
 			{
 				var directoryname = Path.GetFileName(directorypath);
-				CopyDirectoryContents(directorypath, Path.Combine(destinationPath, directoryname));
+				CopyDirectoryWithException(directorypath, Path.Combine(destinationPath, directoryname), overwrite);
 			}
 		}
 


### PR DESCRIPTION
- pass `true` to File.Copy so that existant files get overwritten
- don't hide exceptions for subdirectories but do as the method
  name promises and throw the exception

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/471)
<!-- Reviewable:end -->
