### PR TITLE
Made copying of versification file more robust

### DIFF
--- a/SIL.DblBundle/Text/TextBundle.cs
+++ b/SIL.DblBundle/Text/TextBundle.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using L10NSharp;
 using SIL.DblBundle.Usx;
+using SIL.IO;
 using SIL.Reporting;
 using SIL.WritingSystems;
 
@@ -188,7 +189,7 @@ namespace SIL.DblBundle.Text
 				throw new ApplicationException(
 					string.Format("Attempted to copy {0} from the bundle but {0} does not exist in this bundle.", DblBundleFileUtils.kVersificationFileName));
 
-			File.Copy(versificationPath, destinationPath, true);
+			RobustFile.Copy(versificationPath, destinationPath, true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This is an attempt to prevent occasional spurious test failures, like this:
Test(s) failed. System.UnauthorizedAccessException : Access to the path 'C:\ProgramData\FCBH-SIL\Glyssen\ach-CM\test~~ProjectTeststmp7320\Test Bundle Publication Audio\versification.vrs' is denied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/473)
<!-- Reviewable:end -->
