### PR TITLE
Added code to disable/hide controls that are no longer relevant once

### DIFF
--- a/SIL.Archiving/ArchivingDlg.Designer.cs
+++ b/SIL.Archiving/ArchivingDlg.Designer.cs
@@ -85,6 +85,8 @@ namespace SIL.Archiving
 			this._buttonCreatePackage.TabIndex = 0;
 			this._buttonCreatePackage.Text = "&1) Create Package";
 			this._buttonCreatePackage.UseVisualStyleBackColor = true;
+			this._buttonCreatePackage.Click += new System.EventHandler(this.CreatePackage);
+
 			// 
 			// _linkOverview
 			// 

--- a/SIL.Archiving/ArchivingDlg.cs
+++ b/SIL.Archiving/ArchivingDlg.cs
@@ -100,20 +100,24 @@ namespace SIL.Archiving
 				model.Cancel();
 				WaitCursor.Hide();
 			};
+		}
 
-			_buttonCreatePackage.Click += delegate
-			{
-				Focus();
-				_buttonCreatePackage.Enabled = false;
-				_progressBar.Visible = true;
-				WaitCursor.Show();
-				_logBox.Clear();
-				_buttonLaunchRamp.Enabled = model.CreatePackage();
-				_buttonCreatePackage.Enabled = false;
-				_chkMetadataOnly.Enabled = false;
-				_progressBar.Visible = false;
-				WaitCursor.Hide();
-			};
+		private void CreatePackage(object sender, EventArgs eventArgs)
+		{
+			Focus();
+			DisableControlsDuringPackageCreation();
+			_progressBar.Visible = true;
+			WaitCursor.Show();
+			_logBox.Clear();
+			_buttonLaunchRamp.Enabled = _viewModel.CreatePackage();
+			_progressBar.Visible = false;
+			WaitCursor.Hide();
+		}
+
+		protected virtual void DisableControlsDuringPackageCreation()
+		{
+			_buttonCreatePackage.Enabled = false;
+			_chkMetadataOnly.Enabled = false;
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/SIL.Archiving/IMDI/IMDIArchivingDlg.cs
+++ b/SIL.Archiving/IMDI/IMDIArchivingDlg.cs
@@ -80,6 +80,12 @@ namespace SIL.Archiving.IMDI
 			_flowLayoutExtra.Controls.Add(_destinationFolderTable);
 		}
 
+		protected override void DisableControlsDuringPackageCreation()
+		{
+			base.DisableControlsDuringPackageCreation();
+			_destinationFolderTable.Visible = false;
+		}
+
 		void SetDestinationLabelText()
 		{
 			var labelText = ((IMDIArchivingDlgViewModel)_viewModel).OutputFolder;
@@ -108,6 +114,7 @@ namespace SIL.Archiving.IMDI
 				((IMDIArchivingDlgViewModel)_viewModel).OutputFolder = chooseFolder.SelectedPath;
 
 				SetDestinationLabelText();
+				SetControlProperties();
 			}
 		}
 

--- a/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
+++ b/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
@@ -22,6 +22,7 @@ namespace SIL.Archiving.IMDI
 		private string _programPreset;
 		private string _otherProgramPath;
 		private readonly string _configFileName = Path.Combine(ArchivingFileSystem.SilCommonArchivingDataFolder, "IMDIProgram.config");
+		private string m_outputFolder;
 
 		#region Properties
 		internal override string ArchiveType
@@ -126,8 +127,6 @@ namespace SIL.Archiving.IMDI
 			: base(appName, title, id, appSpecificArchivalProcessInfo, setFilesToArchive)
 		{
 			OutputFolder = outputFolder;
-
-			PackagePath = Path.Combine(OutputFolder, CorpusDirectoryName);
 
 			_imdiData = new IMDIPackage(corpus, PackagePath)
 			{
@@ -611,6 +610,16 @@ namespace SIL.Archiving.IMDI
 		}
 
 		/// <summary />
-		public string OutputFolder { get; set; }
+		public string OutputFolder
+		{
+			get { return m_outputFolder; }
+			set
+			{
+				m_outputFolder = value;
+				PackagePath = Path.Combine(value, CorpusDirectoryName);
+				if (_imdiData != null)
+					_imdiData.PackagePath = "";
+			}
+		}
 	}
 }

--- a/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
+++ b/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
@@ -22,7 +22,7 @@ namespace SIL.Archiving.IMDI
 		private string _programPreset;
 		private string _otherProgramPath;
 		private readonly string _configFileName = Path.Combine(ArchivingFileSystem.SilCommonArchivingDataFolder, "IMDIProgram.config");
-		private string m_outputFolder;
+		private string _outputFolder;
 
 		#region Properties
 		internal override string ArchiveType
@@ -612,10 +612,10 @@ namespace SIL.Archiving.IMDI
 		/// <summary />
 		public string OutputFolder
 		{
-			get { return m_outputFolder; }
+			get { return _outputFolder; }
 			set
 			{
-				m_outputFolder = value;
+				_outputFolder = value;
 				PackagePath = Path.Combine(value, CorpusDirectoryName);
 				if (_imdiData != null)
 					_imdiData.PackagePath = "";

--- a/SIL.Archiving/IMDI/IMDIPackage.cs
+++ b/SIL.Archiving/IMDI/IMDIPackage.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using SIL.Archiving.Generic;
 using SIL.Archiving.IMDI.Lists;
@@ -19,7 +20,8 @@ namespace SIL.Archiving.IMDI
 		public string MainExportFile { get; private set; }
 
 		private readonly bool _corpus;
-		private readonly string _packagePath;
+		private bool _creationStarted;
+		private string m_packagePath;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>Constructor</summary>
@@ -30,7 +32,7 @@ namespace SIL.Archiving.IMDI
 		public IMDIPackage(bool corpus, string packagePath)
 		{
 			_corpus = corpus;
-			_packagePath = packagePath;
+			PackagePath = packagePath;
 
 			BaseImdiFile = new MetaTranscript(MetatranscriptValueType.CORPUS);
 
@@ -46,9 +48,15 @@ namespace SIL.Archiving.IMDI
 		/// <summary>The path where the corpus imdi file and corpus directory will be created</summary>
 		public string PackagePath
 		{
-			get { return _packagePath;  }
+			get { return m_packagePath; }
+			set
+			{
+				if (_creationStarted)
+					throw new InvalidOperationException("Cannot change package path after package creation has already begun.");
+				m_packagePath = value;
+			}
 		}
-#endregion
+		#endregion
 
 		// **** Corpus Layout ****
 		//
@@ -65,6 +73,8 @@ namespace SIL.Archiving.IMDI
 		/// <returns></returns>
 		public bool CreateIMDIPackage()
 		{
+			_creationStarted = true;
+
 			// list of session files for the corpus
 			List<string> sessionFiles = new List<string>();
 
@@ -73,12 +83,12 @@ namespace SIL.Archiving.IMDI
 			foreach (var session in Sessions)
 			{
 				var sessImdi = new MetaTranscript { Items = new object[] { session }, Type = MetatranscriptValueType.SESSION };
-				sessionFiles.Add(sessImdi.WriteImdiFile(_packagePath, Name));
+				sessionFiles.Add(sessImdi.WriteImdiFile(PackagePath, Name));
 			}
 
 			if (!_corpus)
 			{
-				MainExportFile = sessionFiles[0];
+				MainExportFile = Path.Combine(PackagePath, sessionFiles[0]);
 				return true;
 			}
 
@@ -92,7 +102,7 @@ namespace SIL.Archiving.IMDI
 			corpus.CatalogueLink = CreateCorpusCatalogue();
 
 			//  Create the corpus imdi file
-			MainExportFile = BaseImdiFile.WriteImdiFile(_packagePath, Name);
+			MainExportFile = BaseImdiFile.WriteImdiFile(PackagePath, Name);
 
 			return true;
 		}
@@ -159,7 +169,7 @@ namespace SIL.Archiving.IMDI
 
 			// write the xml file
 			var catImdi = new MetaTranscript { Items = new object[] { catalogue }, Type = MetatranscriptValueType.CATALOGUE };
-			return catImdi.WriteImdiFile(_packagePath, Name).Replace("\\", "/");
+			return catImdi.WriteImdiFile(PackagePath, Name).Replace("\\", "/");
 		}
 
 		/// <summary>Add a description of the package/corpus</summary>

--- a/SIL.Archiving/IMDI/IMDIPackage.cs
+++ b/SIL.Archiving/IMDI/IMDIPackage.cs
@@ -21,7 +21,7 @@ namespace SIL.Archiving.IMDI
 
 		private readonly bool _corpus;
 		private bool _creationStarted;
-		private string m_packagePath;
+		private string _packagePath;
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>Constructor</summary>
@@ -48,12 +48,12 @@ namespace SIL.Archiving.IMDI
 		/// <summary>The path where the corpus imdi file and corpus directory will be created</summary>
 		public string PackagePath
 		{
-			get { return m_packagePath; }
+			get { return _packagePath; }
 			set
 			{
 				if (_creationStarted)
 					throw new InvalidOperationException("Cannot change package path after package creation has already begun.");
-				m_packagePath = value;
+				_packagePath = value;
 			}
 		}
 		#endregion


### PR DESCRIPTION
the package creation begins.
Fixed the logic for changing the destination folder for an IMDI archive so that it takes effect immediately and not the NEXT time the data is archived.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/481)
<!-- Reviewable:end -->
