### PR TITLE
Update Build tests to fix after restructuring

### DIFF
--- a/BuildTaskTests/Palaso.BuildTask.Tests.Helper/Palaso.BuildTask.Tests.Helper.csproj
+++ b/BuildTaskTests/Palaso.BuildTask.Tests.Helper/Palaso.BuildTask.Tests.Helper.csproj
@@ -94,7 +94,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>..\..\output\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/BuildTaskTests/UnitTestTasks/NUnitTests.cs
+++ b/BuildTaskTests/UnitTestTasks/NUnitTests.cs
@@ -35,7 +35,7 @@ namespace Palaso.BuildTask.Tests.UnitTestTasks
 </Project>",
 				Path.Combine(OutputDirectory, "Palaso.BuildTasks.dll"),
 				Path.Combine(OutputDirectory, "Palaso.BuildTask.Tests.Helper.dll"),
-				Path.Combine(OutputDirectory, "..", "..", "packages", "NUnit.Runners.Net4.2.6.4", "tools"),
+				Path.Combine(OutputDirectory, "..", "..", "..", "packages", "NUnit.Runners.Net4.2.6.4", "tools"),
 				category, Platform.IsWindows));
 
 			return buildFile;


### PR DESCRIPTION
It appears that the Palaso.BuildTask.Tests.Helper was moved but test
not updated to allow it to work after the move. This corrects the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/483)
<!-- Reviewable:end -->
