### PR TITLE
Improve error reporting from KeyboardController and remove unneeded code in WSTests

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -467,7 +467,10 @@ namespace SIL.Windows.Forms.Keyboarding
 			KeyboardDescription keyboard;
 			if (!_keyboards.TryGet(id, out keyboard))
 			{
-				keyboard = _adaptors.Values.First(adaptor => adaptor.CanHandleFormat(format)).CreateKeyboardDefinition(id);
+				var firstCompatibleAdapter = _adaptors.Values.FirstOrDefault(adaptor => adaptor.CanHandleFormat(format));
+				if(firstCompatibleAdapter == null)
+					throw new ArgumentException(string.Format("Did not find {0} in {1} adapters", format, _adaptors.Count), "format");
+				keyboard = firstCompatibleAdapter.CreateKeyboardDefinition(id);
 				_keyboards.Add(keyboard);
 			}
 

--- a/SIL.Windows.Forms.WritingSystems.Tests/WritingSystemSetupPMTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/WritingSystemSetupPMTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Windows.Forms;
 using NUnit.Framework;
 using SIL.Reporting;
-using SIL.Windows.Forms.Keyboarding;
 using SIL.WritingSystems;
 using SIL.WritingSystems.Tests;
 
@@ -77,7 +76,6 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		[TestFixtureSetUp]
 		public void FixtureSetup()
 		{
-			KeyboardController.Initialize();
 			if (!Sldr.IsInitialized)
 				Sldr.Initialize();
 		}
@@ -85,7 +83,6 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		[TestFixtureTearDown]
 		public void FixtureTearDown()
 		{
-			KeyboardController.Shutdown();
 		}
 
 		[SetUp]


### PR DESCRIPTION
* Investigation into failing tests revealed some dead code in the WS tests
* Added improved error messages when a keyboard isn't found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/500)
<!-- Reviewable:end -->
