### PR TITLE
Moved ReflectionHelper to SIL.Core so it doesn't depend on System.Windows.Forms

### DIFF
--- a/SIL.Core/Reflection/ReflectionHelper.cs
+++ b/SIL.Core/Reflection/ReflectionHelper.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Windows.Forms;
 
-namespace SIL.Windows.Forms
+namespace SIL.Reflection
 {
 	public static class ReflectionHelper
 	{
@@ -20,7 +18,8 @@ namespace SIL.Windows.Forms
 				if (!File.Exists(dllPath))
 				{
 					string dllFile = Path.GetFileName(dllPath);
-					dllPath = Path.Combine(Application.StartupPath, dllFile);
+					string startingDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+					dllPath = Path.Combine(startingDir, dllFile);
 					if (!File.Exists(dllPath))
 						return null;
 				}

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -488,6 +488,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
+    <Compile Include="Reflection\ReflectionHelper.cs" />
     <Compile Include="Reporting\AnalyticsEventSender.cs" />
     <Compile Include="Reporting\ConfigurationException.cs" />
     <Compile Include="Reporting\ConsoleErrorReporter.cs" />

--- a/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
+++ b/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
@@ -341,10 +341,6 @@
       <Project>{F71BA7B9-D9DC-4F8C-A307-87B503D0E05B}</Project>
       <Name>SIL.Scripture</Name>
     </ProjectReference>
-    <ProjectReference Include="..\SIL.Windows.Forms\SIL.Windows.Forms.csproj">
-      <Project>{db44f49c-d8c6-434f-81ed-28ea5c9e8195}</Project>
-      <Name>SIL.Windows.Forms</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\eng.vrs" />

--- a/SIL.Scripture.Tests/ScrVersTests.cs
+++ b/SIL.Scripture.Tests/ScrVersTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 using System.IO;
 using System.Reflection;
 using System.Text;
-using SIL.Windows.Forms;
+using SIL.Reflection;
 
 namespace SIL.Scripture.Tests
 {

--- a/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
+++ b/SIL.Windows.Forms/AppColorPalette/AppColorPaletteExtender.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
+using SIL.Reflection;
 
 namespace SIL.Windows.Forms.AppColorPalette
 {

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -46,7 +46,8 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\output\Debug\SIL.Windows.Forms.xml</DocumentationFile>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <NoWarn>1591</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
@@ -637,7 +638,6 @@
     </Compile>
     <Compile Include="PropertyBag-NoTests\FilePathEditor.cs" />
     <Compile Include="PropertyBag-NoTests\PropertyBag.cs" />
-    <Compile Include="ReflectionHelper.cs" />
     <Compile Include="Registration\Registration.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>


### PR DESCRIPTION
Moved **ReflectionHelper** to **SIL.Core** so it doesn't depend on **System.Windows.Forms** (and it makes more sense there).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/526)
<!-- Reviewable:end -->
