### PR TITLE
Maintain backwards compatibility in SILAboutBox

### DIFF
--- a/SIL.Windows.Forms.Tests/Miscellaneous/SILAboutBoxTests.cs
+++ b/SIL.Windows.Forms.Tests/Miscellaneous/SILAboutBoxTests.cs
@@ -1,13 +1,58 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using SIL.Windows.Forms.Miscellaneous;
 
 namespace SIL.Windows.Forms.Tests.Miscellaneous
 {
+	/// <summary>
+	/// The SILAboutBox class has different behavior depending on whether it is run
+	/// in Debug or Release mode, therefore different test results depending on which version is running.
+	/// </summary>
 	[TestFixture]
 	public class SILAboutBoxTests
 	{
+
 		[Test]
-		public void ValidateHtml_ValidHtmlNotOverriden()
+		public void ValidateHtml_MissingBodyTagHandled()
+		{
+			const string htmlInput =
+				@"<html>
+					<meta charset='UTF-16' />
+					<some>stuff</some>
+				</html>";
+#if DEBUG
+			var ex = Assert.Throws<ApplicationException>(() => SILAboutBox.ValidateHtml(htmlInput));
+			Assert.That(ex.Message, Is.EqualTo("Html has no head or body and needs a charset meta tag."));
+#else
+			var result = SILAboutBox.ValidateHtml(htmlInput);
+			Assert.That(result, Is.EqualTo(htmlInput));
+#endif
+		}
+
+		[Test]
+		public void ValidateHtml_InvalidHtmlHandled()
+		{
+			const string htmlInput =
+				@"<html>
+					ad>
+					</head>
+					<body>
+						<some>stuff</some>
+					</body>
+				</html>";
+#if DEBUG
+			var ex = Assert.Throws<ApplicationException>(() => SILAboutBox.ValidateHtml(htmlInput));
+			Assert.That(ex.Message, Is.EqualTo("Start tag <head> was not found at line 3"));
+#else
+			var result = SILAboutBox.ValidateHtml(htmlInput);
+			Assert.That(result, Is.EqualTo(htmlInput));
+#endif
+		}
+
+		// These tests should behave the same whether in Debug or Release mode
+
+		[Test]
+		public void ValidateHtml_ValidHtml_CharsetNotOverriden()
 		{
 			const string htmlInput =
 				@"<html>
@@ -23,31 +68,33 @@ namespace SIL.Windows.Forms.Tests.Miscellaneous
 		}
 
 		[Test]
-		public void ValidateHtml_InvalidHtml_ReturnsMinimalHtml()
+		public void ValidateHtml_ValidHtmlNoHead_GetsHeadAndMeta()
 		{
 			const string htmlInput =
 				@"<html>
-					ad>
+					<body>
+						<some>stuff</some>
+					</body>
+				</html>";
+			var result = SILAboutBox.ValidateHtml(htmlInput);
+			Assert.That(result, Is.StringContaining("<head><meta charset=\"UTF-8\"></head>"));
+		}
+
+		[Test]
+		public void ValidateHtml_ValidHtmlMetaTagHasNoCharsetAttribute_GetsOne()
+		{
+			const string htmlInput =
+				@"<html>
+					<head>
+						<meta content='text/html' />
 					</head>
 					<body>
 						<some>stuff</some>
 					</body>
 				</html>";
 			var result = SILAboutBox.ValidateHtml(htmlInput);
-			Assert.That(result, Is.EqualTo(SILAboutBox.MinimalHtmlContents));
-		}
-
-		[Test]
-		public void ValidateHtml_ValidHtmlNoMetaTag_GetsOne()
-		{
-			const string htmlInput =
-				@"<html>
-					<body>
-						<some>stuff</some>
-					</body>
-				</html>";
-			var result = SILAboutBox.ValidateHtml(htmlInput);
-			Assert.That(result, Is.StringContaining("<head><meta charset=\"UTF-8\" /></head>"));
+			var trimmedResult = result.Replace(Environment.NewLine, string.Empty).Replace("\t", string.Empty);
+			Assert.That(trimmedResult, Is.StringContaining("<head><meta content='text/html' charset=\"UTF-8\"></head>"));
 		}
 	}
 }

--- a/SIL.Windows.Forms/Properties/AssemblyInfo.cs
+++ b/SIL.Windows.Forms/Properties/AssemblyInfo.cs
@@ -43,3 +43,6 @@ using SIL.Acknowledgements;
 	Location = "./taglib-sharp.dll", LicenseUrl = "https://opensource.org/licenses/LGPL-2.1")]
 [assembly: Acknowledgement("gtk-sharp", Name = "gtk-sharp", Url = "http://www.mono-project.com/docs/gui/gtksharp/",
 	Location = "./gtk-sharp.dll", LicenseUrl = "https://opensource.org/licenses/MIT")]
+[assembly: Acknowledgement("HtmlAgilityPack", Name = "HtmlAgilityPack",
+	Url = "https://www.nuget.org/packages/HtmlAgilityPack/", LicenseUrl = "https://opensource.org/licenses/MS-PL",
+	Location = "./HtmlAgilityPack.dll")]

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -381,6 +381,10 @@
     <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net45\HtmlAgilityPack.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="MarkdownDeep, Version=1.5.4615.26275, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net461" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
* handle parsing failures differently for Debug
   or Release builds
* uses HtmlAgilityPack to load AboutBox html and
   validate/manipulate it.
* do more returning of original html on error
   to maintain backwards compatibility
* do better job of ensuring correct meta tag

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/528)
<!-- Reviewable:end -->
