### PR TITLE
Fix broken implementation of irrKLang

### DIFF
--- a/SIL.Media.Tests/AudioRecorderTests.cs
+++ b/SIL.Media.Tests/AudioRecorderTests.cs
@@ -46,7 +46,7 @@ namespace SIL.Media.Tests
 			var path = Path.GetRandomFileName();
 			// ReSharper disable once UnusedVariable
 			using (var x = AudioFactory.CreateAudioSession(path)) { }
-			Assert.IsFalse(File.Exists(path));
+			Assert.IsFalse(File.Exists(path)); // File doesn't exist after disposal
 		}
 
 		[Test]
@@ -271,11 +271,6 @@ namespace SIL.Media.Tests
 				get { return _recorder; }
 			}
 
-			//public void Stop()
-			//{
-			//	_recorder.StopRecordingAndSaveAsWav();
-			//}
-
 			public void Dispose()
 			{
 				try
@@ -285,14 +280,11 @@ namespace SIL.Media.Tests
 						_recorder.StopRecordingAndSaveAsWav();
 					}
 				}
-				catch (Exception)
+				finally
 				{
 					_recorder.Dispose();
 					_tempFile.Dispose();
-					throw;
 				}
-				_recorder.Dispose();
-				_tempFile.Dispose();
 			}
 		}
 
@@ -432,6 +424,7 @@ namespace SIL.Media.Tests
 		}
 
 		[Test]
+		[NUnit.Framework.Category("ByHand")]
 		[Ignore("this test is to be run manually to test long recordings. Recite John 3:16")]
 		public void Record_LongRecording()
 		{
@@ -443,16 +436,16 @@ namespace SIL.Media.Tests
 					SystemSounds.Beep.Play();
 					Assert.DoesNotThrow(() => x.StartRecording());
 					Assert.IsTrue(x.IsRecording);
-					Thread.Sleep(10000);
+					Thread.Sleep(10000); // Records 10 seconds
 					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
 					SystemSounds.Beep.Play();
 					Assert.IsTrue(x.CanPlay);
 					Assert.DoesNotThrow(() => x.Play());
-					Thread.Sleep(4000);
+					Thread.Sleep(4000); // Plays the first 4 seconds
 					Assert.DoesNotThrow(() => x.StopPlaying());
 					Thread.Sleep(500); // Pause
 					Assert.DoesNotThrow(() => x.Play());
-					Thread.Sleep(6000);
+					Thread.Sleep(6000); // Plays the first 6 seconds
 					Assert.DoesNotThrow(() => x.StopPlaying());
 				}
 			}

--- a/SIL.Media.Tests/AudioRecorderTests.cs
+++ b/SIL.Media.Tests/AudioRecorderTests.cs
@@ -15,7 +15,7 @@ namespace SIL.Media.Tests
 	/// and the project that builds libpalaso on TeamCity (build/Palaso.proj, task Test) invokes RunNUnitTC which
 	/// selects the test assemblies using Include="$(RootDir)/output/$(Configuration)/*.Tests.dll" which excludes exes.
 	/// I have not tried to verify that all of these tests would actually have problems on TeamCity, but it seemed
-	/// helpful to document in the usual way that they are not, in fact, run there. 
+	/// helpful to document in the usual way that they are not, in fact, run there.
 	/// </summary>
 	[NUnit.Framework.Category("SkipOnTeamCity")]
 	[TestFixture]
@@ -25,7 +25,8 @@ namespace SIL.Media.Tests
 		[Test]
 		public void Construct_FileDoesNotExist_OK()
 		{
-			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
+			// ReSharper disable once UnusedVariable
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName())) { }
 		}
 
 		[Test]
@@ -33,7 +34,8 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.CreateAudioSession(f.Path);
+				// ReSharper disable once UnusedVariable
+				using (var x = AudioFactory.CreateAudioSession(f.Path)) { }
 			}
 		}
 
@@ -42,15 +44,18 @@ namespace SIL.Media.Tests
 		public void Construct_FileDoesNotExist_DoesNotCreateFile()
 		{
 			var path = Path.GetRandomFileName();
-			var x = AudioFactory.CreateAudioSession(path);
+			// ReSharper disable once UnusedVariable
+			using (var x = AudioFactory.CreateAudioSession(path)) { }
 			Assert.IsFalse(File.Exists(path));
 		}
 
 		[Test]
 		public void StopRecording_NotRecording_Throws()
 		{
-			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
-			Assert.Throws<ApplicationException>(() => x.StopRecordingAndSaveAsWav());
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.Throws<ApplicationException>(() => x.StopRecordingAndSaveAsWav());
+			}
 		}
 
 		[Test]
@@ -87,15 +92,19 @@ namespace SIL.Media.Tests
 		[Test]
 		public void CanRecord_FileDoesNotExist_True()
 		{
-			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
-			Assert.IsTrue(x.CanRecord);
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.IsTrue(x.CanRecord);
+			}
 		}
 
 		[Test]
 		public void CanStop_NonExistantFile_False()
 		{
-			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
-			Assert.IsFalse(x.CanStop);
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.IsFalse(x.CanStop);
+			}
 		}
 
 		[Test]
@@ -103,44 +112,34 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.CreateAudioSession(f.Path);
-				Assert.IsTrue(x.CanRecord);
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					Assert.IsTrue(x.CanRecord);
+				}
 			}
 		}
 
 		[Test]
-		[Platform(Exclude ="Windows", Reason="IrrKlang doesn't throw, so we don't really know")]
 		public void Play_FileEmpty_Throws()
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.CreateAudioSession(f.Path);
-				Assert.Throws<Exception>(() => x.Play());
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					Assert.Throws<Exception>(() => x.Play());
+				}
 			}
 		}
 
 		[Test]
 		public void Play_FileDoesNotExist_Throws()
 		{
-			var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName());
-			Assert.Throws<FileNotFoundException>(() => x.Play());
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.Throws<FileNotFoundException>(() => x.Play());
+			}
 		}
 
-		// It's not completely reproducible, but typically including one of the tests marked like this
-		// will cause aborting the whole test sequence (or cause it to lock up, if you aren't using a
-		// test runner with a time limit). As near as I can make out, things fail at so high a level
-		// that no useful stack trace emerges. The problem seems to be the one described at
-		// http://lambert.geek.nz/2007/05/unmanaged-appdomain-callback/. Specifically, something
-		// in IrrKlang's unmanaged code calls a managed-code function. The common case appears to be
-		// to report that Play has stopped, but there may be other callbacks. This works fine in an
-		// app that is only running in one AppDomain, but NUnit uses two, one for the test management
-		// code and one for the SUT. Apparently unmanaged code has no way to know which AppDomain to
-		// make the call-back in and guesses the first and that is wrong, leading to an exception
-		// "Cannot pass a GCHandle across AppDomains". Somehow this is at such a high level that
-		// it freezes up the whole test sequence, possibly because the exception is thrown in
-		// NUnit's management AppDomain. There doesn't seem to be any way to fix this in our code
-		// (the link above suggests something IrrKlang could do) so I've disabled the offending tests.
-		[Ignore("Aborts with 'GC across AppDomain not allowed' IrrKlang.Play/Nunit incompatibility")]
 		[Test]
 		public void CanStop_WhilePlaying_True()
 		{
@@ -158,15 +157,16 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var old = File.GetLastWriteTimeUtc(f.Path);
 				var oldInfo = new FileInfo(f.Path);
 				var oldLength = oldInfo.Length;
 				Assert.AreEqual(0, oldLength);
 				var oldTimestamp = oldInfo.LastWriteTimeUtc;
-				var x = AudioFactory.CreateAudioSession(f.Path);
-				x.StartRecording();
-				Thread.Sleep(1000);
-				x.StopRecordingAndSaveAsWav();
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					x.StartRecording();
+					Thread.Sleep(1000);
+					x.StopRecordingAndSaveAsWav();
+				}
 				var newInfo = new FileInfo(f.Path);
 				Assert.Greater(newInfo.LastWriteTimeUtc, oldTimestamp);
 				Assert.Greater(newInfo.Length, oldLength);
@@ -178,35 +178,38 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				var x = AudioFactory.CreateAudioSession(f.Path);
-				x.StartRecording();
-				Thread.Sleep(100);
-				Assert.IsTrue(x.IsRecording);
-				x.StopRecordingAndSaveAsWav();
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					x.StartRecording();
+					Thread.Sleep(100);
+					Assert.IsTrue(x.IsRecording);
+					x.StopRecordingAndSaveAsWav();
+				}
 			}
 		}
 
-		[Ignore("Aborts with 'GC across AppDomain not allowed' IrrKlang.Play/Nunit incompatibility")]
 		[Test]
 		public void RecordThenPlay_SmokeTest()
 		{
 			using (var f = new TempFile())
 			{
 				var w = new BackgroundWorker();
-				w.DoWork+=new DoWorkEventHandler((o,args)=> SystemSounds.Exclamation.Play());
+				// ReSharper disable once RedundantDelegateCreation
+				w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
 
-				var x = AudioFactory.CreateAudioSession(f.Path);
-				x.StartRecording();
-				w.RunWorkerAsync();
-				Thread.Sleep(1000);
-				x.StopRecordingAndSaveAsWav();
-				x.Play();
-				Thread.Sleep(1000);
-				x.StopPlaying();
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					x.StartRecording();
+					w.RunWorkerAsync();
+					Thread.Sleep(1000);
+					x.StopRecordingAndSaveAsWav();
+					x.Play();
+					Thread.Sleep(1000);
+					x.StopPlaying();
+				}
 			}
 		}
 
-		[Ignore("Aborts with 'GC across AppDomain not allowed' IrrKlang.Play/Nunit incompatibility")]
 		[Test]
 		public void Play_GiveThaiFileName_ShouldHearTwoSounds()
 		{
@@ -217,18 +220,23 @@ namespace SIL.Media.Tests
 				using (var f = TempFile.TrackExisting(soundPath))
 				{
 					var w = new BackgroundWorker();
+					// ReSharper disable once RedundantDelegateCreation
 					w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
 
-					var x = AudioFactory.CreateAudioSession(f.Path);
-					x.StartRecording();
-					w.RunWorkerAsync();
-					Thread.Sleep(1000);
-					x.StopRecordingAndSaveAsWav();
+					using (var x = AudioFactory.CreateAudioSession(f.Path))
+					{
+						x.StartRecording();
+						w.RunWorkerAsync();
+						Thread.Sleep(2000);
+						x.StopRecordingAndSaveAsWav();
+					}
 
-					var y = AudioFactory.CreateAudioSession(f.Path);
-					y.Play();
-					Thread.Sleep(1000);
-					y.StopPlaying();
+					using (var y = AudioFactory.CreateAudioSession(f.Path))
+					{
+						y.Play();
+						Thread.Sleep(1000);
+						y.StopPlaying();
+					}
 				}
 			}
 		}
@@ -237,7 +245,7 @@ namespace SIL.Media.Tests
 		/// <summary>
 		/// for testing things while recording is happening
 		/// </summary>
-		class RecordingSession:IDisposable
+		class RecordingSession : IDisposable
 		{
 			private TempFile _tempFile;
 			private ISimpleAudioSession _recorder;
@@ -253,7 +261,8 @@ namespace SIL.Media.Tests
 			public RecordingSession(int millisecondsToRecordBeforeStopping)
 				: this()
 			{
-				Thread.Sleep(1000);//record a second
+				if (millisecondsToRecordBeforeStopping == 0) millisecondsToRecordBeforeStopping = 1000;
+				Thread.Sleep(millisecondsToRecordBeforeStopping);
 				_recorder.StopRecordingAndSaveAsWav();
 			}
 
@@ -262,16 +271,27 @@ namespace SIL.Media.Tests
 				get { return _recorder; }
 			}
 
-			public void Stop()
-			{
-				_recorder.StopRecordingAndSaveAsWav();
-			}
+			//public void Stop()
+			//{
+			//	_recorder.StopRecordingAndSaveAsWav();
+			//}
+
 			public void Dispose()
 			{
-				if (_recorder.IsRecording)
+				try
 				{
-					_recorder.StopRecordingAndSaveAsWav();
+					if (_recorder.IsRecording)
+					{
+						_recorder.StopRecordingAndSaveAsWav();
+					}
 				}
+				catch (Exception)
+				{
+					_recorder.Dispose();
+					_tempFile.Dispose();
+					throw;
+				}
+				_recorder.Dispose();
 				_tempFile.Dispose();
 			}
 		}
@@ -312,7 +332,6 @@ namespace SIL.Media.Tests
 			}
 		}
 
-		[Ignore("IrrKlang Play not compatible with NUnit")]
 		[Test]
 		public void CanRecord_WhilePlaying_False()
 		{
@@ -325,7 +344,6 @@ namespace SIL.Media.Tests
 			}
 		}
 
-		[Ignore("Aborts with 'GC across AppDomain not allowed' IrrKlang.Play/Nunit incompatibility")]
 		[Test]
 		public void CanPlay_WhilePlaying_False()
 		{
@@ -342,8 +360,10 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				ISimpleAudioSession x = RecordSomething(f);
-				Assert.IsFalse(x.IsRecording);
+				using (ISimpleAudioSession x = RecordSomething(f))
+				{
+					Assert.IsFalse(x.IsRecording);
+				}
 			}
 		}
 
@@ -352,21 +372,24 @@ namespace SIL.Media.Tests
 		{
 			using (var f = new TempFile())
 			{
-				ISimpleAudioSession x = RecordSomething(f);
-				Assert.IsTrue(x.CanPlay);
+				using (ISimpleAudioSession x = RecordSomething(f))
+				{
+					Assert.IsTrue(x.CanPlay);
+				}
 			}
 		}
 
-		[Ignore("Aborts with 'GC across AppDomain not allowed' IrrKlang.Play/Nunit incompatibility")]
 		[Test]
 		public void RecordThenPlay_OK()
 		{
 			using (var f = new TempFile())
 			{
-				ISimpleAudioSession x = RecordSomething(f);
-				x.Play();
-				Thread.Sleep(100);	// Ensure file exists to be played.
-				x.StopPlaying();
+				using (ISimpleAudioSession x = RecordSomething(f))
+				{
+					x.Play();
+					Thread.Sleep(100);
+				   x.StopPlaying();
+				}
 			}
 		}
 
@@ -379,30 +402,59 @@ namespace SIL.Media.Tests
 			return x;
 		}
 
-		[Ignore("Aborts with 'GC across AppDomain not allowed' IrrKlang.Play/Nunit incompatibility")]
 		[Test]
 		public void Play_DoesPlay ()
 		{
 			using (var file = TempFile.FromResource(Resources.finished, ".wav"))
 			{
-				var x = AudioFactory.CreateAudioSession(file.Path);
-				Assert.DoesNotThrow( () => x.Play() );
-				Assert.DoesNotThrow( () => x.StopPlaying() );
+				using (var x = AudioFactory.CreateAudioSession(file.Path))
+				{
+					Assert.DoesNotThrow(() => x.Play());
+					Assert.DoesNotThrow(() => x.StopPlaying());
+				}
 			}
 		}
 
 		[Test]
 		public void Record_DoesRecord ()
 		{
-
 			using (var folder = new TemporaryFolder("Record_DoesRecord"))
 			{
 				string fpath = Path.Combine(folder.Path, "dump.ogg");
-				var x = AudioFactory.CreateAudioSession(fpath);
-				Assert.DoesNotThrow(() => x.StartRecording());
-				Assert.IsTrue(x.IsRecording);
-				Thread.Sleep(1000);
-				Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
+				using (var x = AudioFactory.CreateAudioSession(fpath))
+				{
+					Assert.DoesNotThrow(() => x.StartRecording());
+					Assert.IsTrue(x.IsRecording);
+					Thread.Sleep(1000);
+					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
+				}
+			}
+		}
+
+		[Test]
+		[Ignore("this test is to be run manually to test long recordings. Recite John 3:16")]
+		public void Record_LongRecording()
+		{
+			using (var folder = new TemporaryFolder("Record_LongRecording"))
+			{
+				string fpath = Path.Combine(folder.Path, "long.wav");
+				using (var x = AudioFactory.CreateAudioSession(fpath))
+				{
+					SystemSounds.Beep.Play();
+					Assert.DoesNotThrow(() => x.StartRecording());
+					Assert.IsTrue(x.IsRecording);
+					Thread.Sleep(10000);
+					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
+					SystemSounds.Beep.Play();
+					Assert.IsTrue(x.CanPlay);
+					Assert.DoesNotThrow(() => x.Play());
+					Thread.Sleep(4000);
+					Assert.DoesNotThrow(() => x.StopPlaying());
+					Thread.Sleep(500); // Pause
+					Assert.DoesNotThrow(() => x.Play());
+					Thread.Sleep(6000);
+					Assert.DoesNotThrow(() => x.StopPlaying());
+				}
 			}
 		}
 	}

--- a/SIL.Media/AlsaAudio/AudioAlsaSession.cs
+++ b/SIL.Media/AlsaAudio/AudioAlsaSession.cs
@@ -182,6 +182,11 @@ namespace SIL.Media.AlsaAudio
 		{
 			_device.DesiredInputDevice = device;
 		}
+
+		public void Dispose()
+		{
+			// There is nothing to dispose
+		}
 	}
 }
 #endif

--- a/SIL.Media/AudioIrrKlangSession.cs
+++ b/SIL.Media/AudioIrrKlangSession.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) 2015 SIL International
+﻿// Copyright (c) 2015-2017 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
 #if !MONO
 using System;
 using System.Diagnostics;
@@ -118,8 +119,15 @@ namespace SIL.Media
 
 			if (_sound != null)
 			{
-				_engine.RemoveAllSoundSources();
-				_engine.StopAllSounds();
+				try
+				{
+					_engine.RemoveAllSoundSources(); // Stops sounds currently playing
+				}
+				catch (Exception)
+				{
+					// The most likely exception is that the sound has finished playing
+				}
+				_engine.StopAllSounds(); // Stops sounds after playing
 				_sound.Dispose();
 				_sound = null;
 			}
@@ -149,7 +157,7 @@ namespace SIL.Media
 			}
 
 			// myFile doesn't retain unicode characters so we capture it when the object is created
-			public Stream openFile(string myFile)
+			public Stream openFile(string dummy)
 			{
 				CloseFile();
 				// Ensure that the file is not locked from other users

--- a/SIL.Media/AudioIrrKlangSession.cs
+++ b/SIL.Media/AudioIrrKlangSession.cs
@@ -8,17 +8,16 @@ using IrrKlang;
 
 namespace SIL.Media
 {
-	public class AudioIrrKlangSession : ISimpleAudioSession, ISimpleAudioWithEvents, IDisposable
+	public class AudioIrrKlangSession : ISimpleAudioSession, ISimpleAudioWithEvents
 	{
 		private readonly IAudioRecorder _recorder;
-		private readonly ISoundEngine _engine;
+		private readonly ISoundEngine _engine = new ISoundEngine();
 		private ISound _sound;
 		private bool _thinkWeAreRecording;
 		private DateTime _startRecordingTime;
 		private DateTime _stopRecordingTime;
 		private readonly string _path;
 		private readonly ISoundStopEventReceiver _irrklangEventProxy;
-		private ISoundSource _soundSource;
 
 		/// <summary>
 		/// Will be raised when playing is over
@@ -28,7 +27,7 @@ namespace SIL.Media
 
 		public AudioIrrKlangSession(string filePath)
 		{
-			_engine = new ISoundEngine();
+			_engine.AddFileFactory(new SoundFile(filePath));
 			_recorder = new IAudioRecorder(_engine);
 			_path = filePath;
 			_irrklangEventProxy = new ProxyForIrrklangEvents(this);
@@ -59,6 +58,7 @@ namespace SIL.Media
 			_startRecordingTime = DateTime.Now;
 
 		}
+
 		public void StopRecordingAndSaveAsWav()
 		{
 			if (!_thinkWeAreRecording)
@@ -86,18 +86,12 @@ namespace SIL.Media
 
 		public bool IsRecording
 		{
-			get
-			{
-				//doesn't work: return _recorder.IsRecording; (bug has been reported)
-				//TODO: reportedly fixed in  irrKlang 1.1.3
-
-				return _thinkWeAreRecording;
-			}
+			get { return _recorder != null && _recorder.IsRecording; }
 		}
 
 		public bool IsPlaying
 		{
-			get { return (_sound != null && !_sound.Finished); }
+			get { return _sound != null && !_sound.Finished; }
 		}
 
 		public bool CanRecord
@@ -122,42 +116,45 @@ namespace SIL.Media
 
 			if (_sound != null)
 			{
+				_engine.RemoveAllSoundSources();
 				_engine.StopAllSounds();
+				Dispose();
 			}
 
 			if (!File.Exists(_path))
 				throw new FileNotFoundException("Could not find sound file", _path);
 
-			//turns out, the silly engine will keep playing the same recording, even
-			//after we've chaned the contents of the file or even delete it.
-			//so, we need to make a new engine.
-			//   NO   _sound = _engine.Play2D(path, false);
-
-			var engine = new IrrKlang.ISoundEngine();
-
-
-			// we have to read it into memory and then play from memory,
-			// because the built-in Irrklang play from file function keeps
-			// the file open and locked
-			byte[] audioData = File.ReadAllBytes(_path);    //REVIEW: will this leak?
-			_soundSource = engine.AddSoundSourceFromMemory(audioData, _path);
+			_sound = _engine.Play2D(_path);
 			if (_sound != null)
-				_sound.Dispose();
-			if (_soundSource.AudioFormat.BytesPerSecond != 0)
 			{
-				_sound = engine.Play2D(_soundSource, false, false, false);
-				if (_sound != null)
-				{
-					_sound.setSoundStopEventReceiver(_irrklangEventProxy, engine);
-					return;
-				}
+				_sound.setSoundStopEventReceiver(_irrklangEventProxy, _engine);
+				return;
 			}
+			if (new FileInfo(_path).Length == 0) throw new Exception("Empty File");
 			// if BytesPerSecond is 0 or _sound is null, it's probably a format we don't recognize. See if the OS knows how to play it.
 			Process.Start(_path);
 		}
 
+		private class SoundFile : IFileFactory
+		{
+			private readonly string _fileSoundPath;
+
+			public SoundFile(string filePath)
+			{
+				_fileSoundPath= filePath;
+			}
+
+			// myFile doesn't retain unicode characters so we capture it when the object is created
+			public Stream openFile(string myFile)
+			{
+				// Ensure that the file is not locked from other users
+				return File.Open(_fileSoundPath, FileMode.Open, FileAccess.Read);
+			}
+		}
+
 		/// <summary>
-		/// This is better than putting the ISoundStopEventReceiver on our class, because doing *that* requires clients then to reference the irrklang assembly, where it is defined.
+		/// This is better than putting the ISoundStopEventReceiver on our class, because doing *that*
+		/// requires clients then to reference the irrklang assembly, where it is defined.
 		/// And this is just a private mater, since we expose the event through a normal .net event handler
 		/// </summary>
 		private class ProxyForIrrklangEvents : ISoundStopEventReceiver
@@ -177,17 +174,7 @@ namespace SIL.Media
 
 		private void OnSoundStopped(ISound sound, StopEventCause reason, object userData)
 		{
-			if (_soundSource != null)
-				_soundSource.Dispose();
-			_soundSource = null;
-
-			//this dispose is here because sometimes sounds (over 4 seconds) were getting left in a locked state
-			//but this didn't actually help.
-			((IrrKlang.ISoundEngine)userData).Dispose();
-
-
-			var handler = PlaybackStopped;
-			if (handler != null) handler(this, EventArgs.Empty);
+			Dispose();
 		}
 
 		public void SaveAsWav(string path)
@@ -199,7 +186,7 @@ namespace SIL.Media
 			short formatType = 1;
 			var numChannels = _recorder.AudioFormat.ChannelCount;
 			var sampleRate = _recorder.AudioFormat.SampleRate;
-			var bitsPerChannel = _recorder.AudioFormat.SampleSize * 8;
+			var bitsPerChannel = _recorder.AudioFormat.SampleSize*8;
 			var bytesPerSample = _recorder.AudioFormat.FrameSize;
 			var bytesPerSecond = _recorder.AudioFormat.BytesPerSecond;
 			var dataLen = _recorder.AudioFormat.SampleDataSize;
@@ -214,26 +201,26 @@ namespace SIL.Media
 
 				using (BinaryWriter bw = new BinaryWriter(fs))
 				{
-					bw.Write(new char[4] { 'R', 'I', 'F', 'F' });
+					bw.Write(new char[4] {'R', 'I', 'F', 'F'});
 
 					bw.Write(totalLen);
 
-					bw.Write(new char[8] { 'W', 'A', 'V', 'E', 'f', 'm', 't', ' ' });
+					bw.Write(new [] {'W', 'A', 'V', 'E', 'f', 'm', 't', ' '});
 
-					bw.Write((int)fmtChunkLen);
+					bw.Write((int) fmtChunkLen);
 
-					bw.Write((short)formatType);
-					bw.Write((short)numChannels);
+					bw.Write((short) formatType);
+					bw.Write((short) numChannels);
 
-					bw.Write((int)sampleRate);
+					bw.Write((int) sampleRate);
 
-					bw.Write((int)bytesPerSecond);
+					bw.Write((int) bytesPerSecond);
 
-					bw.Write((short)bytesPerSample);
+					bw.Write((short) bytesPerSample);
 
-					bw.Write((short)bitsPerChannel);
+					bw.Write((short) bitsPerChannel);
 
-					bw.Write(new char[4] { 'd', 'a', 't', 'a' });
+					bw.Write(new [] {'d', 'a', 't', 'a'});
 					bw.Write(_recorder.RecordedAudioData.Length);
 
 					bw.Write(_recorder.RecordedAudioData);
@@ -249,18 +236,24 @@ namespace SIL.Media
 		{
 			if (_sound != null && !_sound.Finished)
 				_sound.Stop();
+			try
+			{
+				_engine.RemoveAllSoundSources();
+			}
+			catch (Exception)
+			{
+				// We'll just ignore any errors on stopping the sounds (they probably aren't playing).
+			}
 			_engine.StopAllSounds();
+			Dispose();
 		}
 
 		public void Dispose()
 		{
-			_engine.Dispose();
 			_recorder.Dispose();
 			if (_sound != null)
-			{
 				_sound.Dispose();
-				_sound = null;
-			}
+			_sound = null;
 		}
 	}
 }

--- a/SIL.Media/AudioNullSession.cs
+++ b/SIL.Media/AudioNullSession.cs
@@ -64,6 +64,11 @@ namespace SIL.Media
 			ReportNotImplemented();
 		}
 
+		public void Dispose()
+		{
+			// There is nothing to dispose
+		}
+
 		/// <Summary>
 		/// MessageBoxes are much less destructive than exceptions, but almost as intrusive.
 		/// </Summary>

--- a/SIL.Media/ISimpleAudioSession.cs
+++ b/SIL.Media/ISimpleAudioSession.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace SIL.Media
 {
-	public interface ISimpleAudioSession
+	public interface ISimpleAudioSession : IDisposable
 	{
 		string FilePath { get; }
 		void StartRecording();

--- a/SIL.Media/ShortSoundFieldControl.cs
+++ b/SIL.Media/ShortSoundFieldControl.cs
@@ -96,6 +96,7 @@ namespace SIL.Media
 			set
 			{
 				_path = value;
+				if (_recorder != null) _recorder.Dispose();
 				_recorder = AudioFactory.CreateAudioSession(Path);
 				toolTip1.SetToolTip(_deleteButton, _deleteButtonInstructions +"\r\n"+_path);
 				UpdateScreen();

--- a/SIL.Media/SoundFieldControl.cs
+++ b/SIL.Media/SoundFieldControl.cs
@@ -26,6 +26,7 @@ namespace SIL.Media
 			set
 			{
 				_path = value;
+				if (_recorder != null) _recorder.Dispose();
 				_recorder = AudioFactory.CreateAudioSession(Path);
 				_timer.Enabled = true;
 			}


### PR DESCRIPTION
make disposable
use IFileFactory to avoid locking file
Allow Thread.Sleep() logic to work.
Create test for longer sound playing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/532)
<!-- Reviewable:end -->
