### PR TITLE
Remove superflous reference to SIL.Core in Palaso.BuildTasks

### DIFF
--- a/Palaso.MSBuildTasks/Palaso.BuildTasks.csproj
+++ b/Palaso.MSBuildTasks/Palaso.BuildTasks.csproj
@@ -332,10 +332,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <ProjectReference Include="..\SIL.Core\SIL.Core.csproj">
-      <Project>{3527da1d-1e25-48be-a71e-9ebf7f9208d4}</Project>
-      <Name>SIL.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
 </Project>

--- a/Palaso.MSBuildTasks/Properties/AssemblyInfo.cs
+++ b/Palaso.MSBuildTasks/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using SIL.Acknowledgements;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -19,7 +18,3 @@ using System.Runtime.InteropServices;
 [assembly: Guid("8a17ca29-630a-4869-8a66-aa05cf5538ba")]
 
 [assembly: InternalsVisibleTo("Palaso.BuildTask.Tests")]
-
-[assembly: Acknowledgement("MarkdownDeep", Url = "https://www.nuget.org/packages/MarkdownDeep.NET/",
-	LicenseUrl = "https://opensource.org/licenses/Apache-2.0", Copyright = "Copyright © 2010-2011 Topten Software",
-	Location = "./MarkdownDeep.dll")]


### PR DESCRIPTION
The acknowledgment can be safely removed because it will never be read regardless