### PR TITLE
Add Platform.MonoVersion property

### DIFF
--- a/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
+++ b/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
@@ -204,6 +204,19 @@ namespace SIL.Tests.PlatformUtilities
 			return Platform.DesktopEnvironmentInfoString;
 		}
 
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		public void MonoPlatform_Linux()
+		{
+			Assert.That(Platform.MonoVersion, Is.Not.Empty);
+		}
+
+		[Test]
+		[Platform(Exclude = "Linux", Reason = "Windows specific test")]
+		public void MonoPlatform_Windows()
+		{
+			Assert.That(Platform.MonoVersion, Is.Empty);
+		}
 	}
 }
 

--- a/SIL.Core.Tests/SIL.Core.Tests.csproj
+++ b/SIL.Core.Tests/SIL.Core.Tests.csproj
@@ -285,6 +285,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -186,10 +186,23 @@ namespace SIL.PlatformUtilities
 			}
 		}
 
-		[System.Runtime.InteropServices.DllImport ("libc")]
-		static extern int uname (IntPtr buf);
+		[System.Runtime.InteropServices.DllImport("libc")]
+		private static extern int uname(IntPtr buf);
 
-		[System.Runtime.InteropServices.DllImport ("libc")]
-		static extern int readlink(string path, IntPtr buf, int bufsiz);
+		[System.Runtime.InteropServices.DllImport("libc")]
+		private static extern int readlink(string path, IntPtr buf, int bufsiz);
+
+		[System.Runtime.InteropServices.DllImport("__Internal", EntryPoint = "mono_get_runtime_build_info")]
+		private static extern string GetMonoVersion();
+
+		/// <summary>
+		/// Gets the version of the currently running Mono (e.g.
+		/// "5.0.1.1 (2017-02/5077205 Thu May 25 09:16:53 UTC 2017)"), or the empty string
+		/// on Windows.
+		/// </summary>
+		public static string MonoVersion
+		{
+			get { return IsMono ? GetMonoVersion() : string.Empty; }
+		}
 	}
 }

--- a/TestApps/ReportingTest/Reporting.TestApp.csproj
+++ b/TestApps/ReportingTest/Reporting.TestApp.csproj
@@ -325,7 +325,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -52,6 +52,7 @@ namespace SIL.Windows.Forms.TestApp
 				return;
 			}
 
+#if !MONO
 			using (var form = new Form())
 			{
 				var browser = new FolderBrowserControl.FolderBrowserControl();
@@ -65,6 +66,7 @@ namespace SIL.Windows.Forms.TestApp
 				form.Controls.Add(browser);
 				form.ShowDialog();
 			}
+#endif
 		}
 
 		private void OnLanguageLookupDialogClicked(object sender, EventArgs e)


### PR DESCRIPTION
The new property returns the version of the currently running Mono (e.g. 5.0.1.1 (2017-02/5077205 Thu May 25 09:16:53 UTC 2017)), or the empty string when run on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/538)
<!-- Reviewable:end -->
