### PR TITLE
Fixed a couple issues found with the Versification.Table class

### DIFF
--- a/SIL.Scripture.Tests/ScrVersTests.cs
+++ b/SIL.Scripture.Tests/ScrVersTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using SIL.Reflection;
@@ -183,9 +184,14 @@ namespace SIL.Scripture.Tests
 		[SetUp]
 		public void Setup()
 		{
-			versification = new ScrVers("DummyScrVers");
-			// Defaults to the eng.vrs file but without a common name
-			versification.ClearAllInfo();
+			versification = new ScrVers("DummyScrVers"); // Defaults to the eng.vrs file but without a common name
+			versification.ClearAllInfo(); // Clear all mappings, etc. from the versification so we can test with a clean slate
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Versification.Table.Implementation.RemoveAllUnknownVersifications();
 		}
 		#endregion
 
@@ -903,6 +909,38 @@ namespace SIL.Scripture.Tests
 			ScrVers vers = new ScrVers("Blah");
 			Assert.AreEqual("Blah", vers.Name);
 			Assert.IsFalse(vers.IsPresent);
+		}
+
+		[Test]
+		public void Get_BuiltInVersificationsCached()
+		{
+			ScrVers english1 = ScrVers.English;
+			ScrVers english2 = new ScrVers(ScrVersType.English);
+			ScrVers english3 = new ScrVers("English");
+			Assert.IsTrue(ReferenceEquals(english1.VersInfo, english2.VersInfo));
+			Assert.IsTrue(ReferenceEquals(english2.VersInfo, english3.VersInfo));
+		}
+
+		[Test]
+		public void Get_UnknownVersificationsCached()
+		{
+			ScrVers monkey1 = new ScrVers("Monkey");
+			ScrVers monkey2 = new ScrVers("Monkey");
+			Assert.IsTrue(ReferenceEquals(monkey1.VersInfo, monkey2.VersInfo));
+		}
+
+		[Test]
+		public void VersificationTables_AlwaysIncludesAllBuiltInVersifications()
+		{
+			List<ScrVers> foundVersifications = Versification.Table.Implementation.VersificationTables().ToList();
+			Assert.AreEqual(7, foundVersifications.Count);
+			Assert.IsTrue(foundVersifications.Contains(versification));
+			Assert.IsTrue(foundVersifications.Contains(ScrVers.English), "missing English");
+			Assert.IsTrue(foundVersifications.Contains(ScrVers.Original), "missing Original");
+			Assert.IsTrue(foundVersifications.Contains(ScrVers.RussianOrthodox), "missing RussianOrthodox");
+			Assert.IsTrue(foundVersifications.Contains(ScrVers.Septuagint), "missing Septuagint");
+			Assert.IsTrue(foundVersifications.Contains(ScrVers.Vulgate), "missing Vulgate");
+			Assert.IsTrue(foundVersifications.Contains(ScrVers.RussianProtestant), "missing RussianProtestant");
 		}
 		#endregion
 

--- a/SIL.Scripture/Versification.cs
+++ b/SIL.Scripture/Versification.cs
@@ -506,13 +506,18 @@ namespace SIL.Scripture
 			/// </summary>
 			public IEnumerable<ScrVers> VersificationTables()
 			{
+				yield return ScrVers.English;
+				yield return ScrVers.Original;
+				yield return ScrVers.Septuagint;
+				yield return ScrVers.Vulgate;
+				yield return ScrVers.RussianOrthodox;
+				yield return ScrVers.RussianProtestant;
+
 				List<Versification> versificationList;
 				lock (versifications)
-				{
 					versificationList = versifications.Values.ToList();
-				}
 
-				foreach (var versification in versificationList)
+				foreach (var versification in versificationList.Where(v => v.Type == ScrVersType.Unknown))
 					yield return new ScrVers(versification);
 			}
 
@@ -642,6 +647,7 @@ namespace SIL.Scripture
 					versification = new Versification(type.ToString(), null);
 					using (TextReader fallbackVersificationStream = new StringReader(resourceFileText))
 						ReadVersificationFile(fallbackVersificationStream, null, type, ref versification);
+					versifications[key] = versification;
 					return versification;
 				}
 			}


### PR DESCRIPTION
Fixed not all versifications being returned by the VersificationTables method (i.e. no built-in versifications were ever being included).

Fixed built-in versifications not being cached so a new one was created each time. This resulted in significantly increased memory usage and decreased performance (because a deep-compare was then necessary).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/545)
<!-- Reviewable:end -->
