### PR TITLE
Fixed a few bugs found in the Versification.Table class

### DIFF
--- a/SIL.Scripture/ScrVers.cs
+++ b/SIL.Scripture/ScrVers.cs
@@ -201,8 +201,8 @@ namespace SIL.Scripture
 			get { return VersInfo.Name; }
 			set
 			{
-				ScrVersType knownType;
-				if (Enum.TryParse(value, out knownType))
+				ScrVersType knownType = Versification.Table.GetVersificationType(value);
+				if (knownType != ScrVersType.Unknown)
 				{
 					type = knownType;
 					versInfo = null;


### PR DESCRIPTION
Fixed not all versifications being returned by the VersificationTables method (i.e. no built-in versifications were ever being included).

Fixed built-in versifications not being cached so a new one was created each time. This resulted in significantly increased memory usage and decreased performance (because a deep-compare was then necessary).

Fixed a versification named a number (e.g. "30") throwing an exception (caused by **Enum.TryParse** accepting the string representation of a number as a valid value)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/546)
<!-- Reviewable:end -->
