### PR TITLE
[API] Mark XmlUtils.AppendAttribute as obsolete

### DIFF
--- a/SIL.Core/Xml/XmlUtils.cs
+++ b/SIL.Core/Xml/XmlUtils.cs
@@ -550,16 +550,10 @@ namespace SIL.Xml
 		/// <summary>
 		/// Append an attribute with the specified name and value to parent.
 		/// </summary>
-		/// <param name="parent"></param>
-		/// <param name="attrName"></param>
-		/// <param name="attrVal"></param>
+		[Obsolete("Use SetAttribute instead")]
 		public static void AppendAttribute(XmlNode parent, string attrName, string attrVal)
 		{
-			Debug.Assert(parent.OwnerDocument != null, "parent.OwnerDocument != null");
-			XmlAttribute xa = parent.OwnerDocument.CreateAttribute(attrName);
-			xa.Value = attrVal;
-			Debug.Assert(parent.Attributes != null, "parent.Attributes != null");
-			parent.Attributes.Append(xa);
+			SetAttribute(parent, attrName, attrVal);
 		}
 
 		/// <summary>

--- a/build/Palaso.proj
+++ b/build/Palaso.proj
@@ -4,7 +4,7 @@
 		<RootDir Condition="'$(teamcity_build_checkoutDir)' != ''">$(teamcity_build_checkoutDir)</RootDir>
 		<BUILD_NUMBER Condition="'$(BUILD_NUMBER)'==''">1.2.3.4</BUILD_NUMBER>
 		<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies). -->
-		<Version>4.0</Version>
+		<Version>4.1</Version>
 	</PropertyGroup>
 
 	<UsingTask TaskName="StampAssemblies" AssemblyFile="$(RootDir)/build/SIL.BuildTasks.dll" />


### PR DESCRIPTION
The preferred way is to use `SetAttribute` which deals with both
setting an attribute and replacing an existing one.

`AppendAttribute` always appended the attribute to the end of
the collection (and the collection removed an already existing one
with the same name). `SetAttribute` will keep an existing attribute
and just change its value, thus keeping the order of attributes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/550)
<!-- Reviewable:end -->
