### PR TITLE
PTX-51943 ignore content of bad existing ldml file when writing new file

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -895,8 +895,9 @@ namespace SIL.WritingSystems.Tests
 			}
 		}
 
-		[Test]
-		public void Write_LdmlIsNicelyFormatted()
+		[TestCase(null)]
+		[TestCase("\u0000\u0000")]
+		public void Write_LdmlIsNicelyFormatted(string curentContent)
 		{
 			using (var file = new TempFile())
 			{
@@ -904,7 +905,8 @@ namespace SIL.WritingSystems.Tests
 				var adaptor = new LdmlDataMapper(new TestWritingSystemFactory());
 				var ws = new WritingSystemDefinition("en-Zxxx-x-audio");
 				ws.DateModified = new DateTime(01, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-				adaptor.Write(file.Path, ws, null);
+				Stream existingDataStream = curentContent == null ? null : new MemoryStream(Encoding.UTF8.GetBytes(curentContent));
+				adaptor.Write(file.Path, ws, existingDataStream);
 
 				//change the read writing system and write it out again
 				var ws2 = new WritingSystemDefinition();

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -763,11 +763,11 @@ namespace SIL.WritingSystems
 		{
 			if (element != null)
 			{
-                if (element.IsEmpty || (string.IsNullOrEmpty((string)element) && !element.HasElements && !element.HasAttributes))
-                {
-                    element.Remove();
-                    element = null;
-                }
+				if (element.IsEmpty || (string.IsNullOrEmpty((string)element) && !element.HasElements && !element.HasAttributes))
+				{
+					element.Remove();
+					element = null;
+				}
 			}
 		}
 		
@@ -806,7 +806,15 @@ namespace SIL.WritingSystems
 						DtdProcessing = DtdProcessing.Parse
 					};
 					reader = XmlReader.Create(oldFile, readerSettings);
-					element = XElement.Load(reader);
+					try
+					{
+						element = XElement.Load(reader);
+					}
+					catch
+					{
+						// ignore content of old file since it can't be read
+						element = new XElement("ldml");
+					}
 				}
 				else
 				{
@@ -819,6 +827,7 @@ namespace SIL.WritingSystems
 				using (var writer = XmlWriter.Create(filePath, writerSettings))
 				{
 					WriteLdml(writer, element, ws);
+					writer.Flush();
 					writer.Close();
 				}
 			}


### PR DESCRIPTION
Paratext got errors when trying to update an existing ldml file when the existing file was invalid because the content was not actually written to disk.

Added a try/catch block so invalid existing content will be ignored.

Added a Flush call to the writer to hopefully force the written data to disk and prevent this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/553)
<!-- Reviewable:end -->
