### PR TITLE
Work around "Could not set X locale modifiers" error

### DIFF
--- a/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using Ionic.Zip;
 using NUnit.Framework;
-using SIL.Archiving.Generic;
 using SIL.IO;
 using SIL.Reporting;
 using SIL.TestUtilities;
@@ -15,7 +14,7 @@ namespace SIL.Archiving.Tests
 {
 	[TestFixture]
 	[Category("Archiving")]
-	public class SessionArchivingTests
+	public class RampArchivingDlgViewModelTests
 	{
 		private RampArchivingDlgViewModel _helper;
 		private Dictionary<string, Tuple<IEnumerable<string>, string>> _filesToAdd;

--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -716,7 +716,6 @@ namespace SIL.Archiving
 		}
 
 		/// ------------------------------------------------------------------------------------
-// ReSharper disable once UnusedParameter.Local
 		private void PreventInvalidAudienceTypeForWorkStage(Enum invalidAudience, WorkStage stage)
 		{
 			if ((invalidAudience != null) && (invalidAudience.HasFlag(_metsAudienceType)))

--- a/environ
+++ b/environ
@@ -9,3 +9,4 @@ export PKG_CONFIG_PATH=${MONO_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH}
 export MONO_GAC_PREFIX=${MONO_PREFIX}:${MONO_GAC_PREFIX}
 export MONO_MWF_SCALING=disable
 export PATH=${MONO_PREFIX}/bin:$PATH
+export MONO_WINFORMS_XIM_STYLE=disabled


### PR DESCRIPTION
At least locally on my machine this resolved most of the "Could not set X locale modifiers" that we
often see on TC. I still get one error from an Archiving test, but that doesn't get run on TC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/554)
<!-- Reviewable:end -->
