### PR TITLE
changes to allow gloss meaning field in WeSay

### DIFF
--- a/Palaso.DictionaryServices.Tests/Model/LexEntryTests.cs
+++ b/Palaso.DictionaryServices.Tests/Model/LexEntryTests.cs
@@ -114,11 +114,8 @@ namespace Palaso.DictionaryServices.Tests.Model
 			_entry = new LexEntry();
 			_sense = new LexSense();
 			_entry.Senses.Add(_sense);
-#if GlossMeaning
-			this._sense.Gloss["th"] = "sense";
-#else
+			_sense.Gloss["th"] = "sense";
 			_sense.Definition["th"] = "sense";
-#endif
 			MultiText customFieldInSense =
 				_sense.GetOrCreateProperty<MultiText>("customFieldInSense");
 			customFieldInSense["th"] = "custom";
@@ -378,11 +375,8 @@ namespace Palaso.DictionaryServices.Tests.Model
 
 		private void ClearSenseMeaning()
 		{
-#if GlossMeaning
-			this._sense.Gloss["th"] = string.Empty;
-#else
 			_sense.Definition["th"] = string.Empty;
-#endif
+			_sense.Gloss["th"] = string.Empty;
 		}
 
 		private void ClearSenseExample()
@@ -534,16 +528,25 @@ namespace Palaso.DictionaryServices.Tests.Model
 		[Test]
 		public void GetOrCreateSenseWithMeaning_SenseDoesNotExist_NewSenseWithMeaning()
 		{
+			_sense.Gloss["th"] = string.Empty;
 			MultiText meaning = new MultiText();
 			meaning.SetAlternative("th", "new");
 
 			LexSense sense = _entry.GetOrCreateSenseWithMeaning(meaning);
 			Assert.AreNotSame(_sense, sense);
-#if GlossMeaning
-			Assert.AreEqual("new", sense.Gloss.GetExactAlternative("th"));
-#else
 			Assert.AreEqual("new", sense.Definition.GetExactAlternative("th"));
-#endif
+		}
+
+		[Test]
+		public void GetOrCreateSenseWithMeaning_SenseDoesNotExist_NewSenseWithMeaning_Gloss()
+		{
+			_sense.Definition["th"] = string.Empty;
+			MultiText meaning = new MultiText();
+			meaning.SetAlternative("th", "new");
+
+			LexSense sense = _entry.GetOrCreateSenseWithMeaning(meaning, false);
+			Assert.AreNotSame(_sense, sense);
+			Assert.AreEqual("new", sense.Gloss.GetExactAlternative("th"));
 		}
 
 		[Test]
@@ -559,14 +562,40 @@ namespace Palaso.DictionaryServices.Tests.Model
 		}
 
 		[Test]
+		public void GetOrCreateSenseWithMeaning_SenseWithEmptyStringExists_ExistingSense_Gloss()
+		{
+			ClearSenseMeaning();
+
+			MultiText meaning = new MultiText();
+			meaning.SetAlternative("th", string.Empty);
+
+			LexSense sense = _entry.GetOrCreateSenseWithMeaning(meaning, false);
+			Assert.AreSame(_sense, sense);
+		}
+
+
+		[Test]
 		public void GetOrCreateSenseWithMeaning_SenseDoesExists_ExistingSense()
 		{
+			_sense.Gloss["th"] = string.Empty;
 			MultiText meaning = new MultiText();
 			meaning.SetAlternative("th", "sense");
 
 			LexSense sense = _entry.GetOrCreateSenseWithMeaning(meaning);
 			Assert.AreSame(_sense, sense);
 		}
+
+		[Test]
+		public void GetOrCreateSenseWithMeaning_SenseDoesExists_ExistingSense_Gloss()
+		{
+			_sense.Definition["th"] = string.Empty;
+			MultiText meaning = new MultiText();
+			meaning.SetAlternative("th", "sense");
+
+			LexSense sense = _entry.GetOrCreateSenseWithMeaning(meaning, false);
+			Assert.AreSame(_sense, sense);
+		}
+
 
 		[Test]
 		public void GetHeadword_EmptyEverything_ReturnsEmptyString()

--- a/Palaso.DictionaryServices/Model/LexEntry.cs
+++ b/Palaso.DictionaryServices/Model/LexEntry.cs
@@ -427,46 +427,57 @@ namespace Palaso.DictionaryServices.Model
 			}
 		}
 
-		public LexSense GetOrCreateSenseWithMeaning(MultiText meaning) //Switch to meaning
+		public LexSense GetOrCreateSenseWithMeaning(MultiText meaning, bool definition_meaningfield) //Switch to meaning
 		{
 			foreach (LexSense sense in Senses)
 			{
-#if GlossMeaning
-				if (meaning.HasFormWithSameContent(sense.Gloss))
-#else
-				if (meaning.HasFormWithSameContent(sense.Definition))
-#endif
+				if (meaning.HasFormWithSameContent(definition_meaningfield ? sense.Definition : sense.Gloss))
 				{
 					return sense;
 				}
 			}
 			LexSense newSense = new LexSense();
 			Senses.Add(newSense);
-#if GlossMeaning
-			newSense.Gloss.MergeIn(meaning);
-#else
-			newSense.Definition.MergeIn(meaning);
-#endif
+			if (definition_meaningfield)
+			{
+				newSense.Definition.MergeIn(meaning);
+			}
+			else
+			{
+				newSense.Gloss.MergeIn(meaning);
+			}
 			return newSense;
 		}
 
-		public string GetToolTipText()
+		// meaning field is definition by default
+		public LexSense GetOrCreateSenseWithMeaning(MultiText meaning) //Switch to meaning
 		{
-			string s = "";
+			return GetOrCreateSenseWithMeaning(meaning, true);
+		}
+
+		public string GetToolTipText(bool definition_meaningfield)
+		{
+			List<string> meanings = new List<string>();
 			foreach (LexSense sense in Senses)
 			{
-				string x = sense.Definition.GetFirstAlternative();
+				string x = definition_meaningfield ? sense.Definition.GetFirstAlternative() : sense.Gloss.GetFirstAlternative();
 				if (string.IsNullOrEmpty(x))
 				{
-					x = sense.Gloss.GetFirstAlternative();
+					x = definition_meaningfield ? sense.Gloss.GetFirstAlternative() : sense.Definition.GetFirstAlternative();
 				}
-				s += x + ", ";
+				meanings.Add(x);
 			}
-			if (s == "")
+			if (meanings.Count==0)
 			{
 				return StringCatalog.Get("~No Senses");
 			}
-			return s.Substring(0, s.Length - 2); // chop off the trailing separator
+			return string.Join(", ", meanings);
+		}
+
+		// meaning field is definition by default
+		public string GetToolTipText()
+		{
+			return GetToolTipText(true);
 		}
 
 		/// <summary>


### PR DESCRIPTION
these 2 parts of LexEntry currently return stuff for the definition, hard coded. This allows you to pass in a bool to specify what the meaning field is (true: definition, false: gloss)

used by WeSay GatherWordsBySemanticDomains

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/559)
<!-- Reviewable:end -->
