### PR TITLE
Report exact class of exception in crash reports

### DIFF
--- a/SIL.Core/Reporting/ExceptionHelper.cs
+++ b/SIL.Core/Reporting/ExceptionHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2015 SIL International
+﻿// Copyright (c) 2002-2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections;
@@ -160,6 +160,8 @@ namespace SIL.Reporting
 
 			strBldr.Append("Msg: ");
 			strBldr.AppendLine(error.Message);
+			strBldr.Append("Class: ");
+			strBldr.AppendLine(error.GetType().ToString());
 
 			try
 			{


### PR DESCRIPTION
This is extremely helpful in making a precise try...catch if the error cannot be reproduced but needs to be suppressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/561)
<!-- Reviewable:end -->
