### PR TITLE
empty spans in empty text cause parsing to fail

### DIFF
--- a/Palaso.Lift.Tests/Parsing/ParserTests.cs
+++ b/Palaso.Lift.Tests/Parsing/ParserTests.cs
@@ -177,6 +177,14 @@ namespace Palaso.Lift.Tests.Parsing
 			SimpleCheckGetOrMakeEntry_InsertVersion("<lift V />", 0);
 		}
 
+		[Test]
+		public void EmptySpanOk()
+		{
+			_doc.LoadXml("<example><form lang='en-US-fonipa'><text><span lang='en-US'></span></text></form></example>");
+			LiftMultiText t = _parser.ReadMultiText(_doc.FirstChild);
+			Assert.AreEqual(0, _parsingWarnings.Count);
+		}
+
 
 
 		[Test]

--- a/Palaso.Lift/Parsing/LiftMultiText.cs
+++ b/Palaso.Lift/Parsing/LiftMultiText.cs
@@ -405,7 +405,8 @@ namespace Palaso.Lift.Parsing
 			LiftString alternative;
 			if (!TryGetValue(key, out alternative))
 			{
-				alternative = new LiftString();
+				// When you get to here you know that textNode.InnerText.Length=0
+				alternative = new LiftString("");
 				this[key] = alternative;
 			}
 			int start = alternative.Text.Length;


### PR DESCRIPTION
WS-451 this causes WeSay to fail to load a project and exit

fix makes alternative an empty string instead of null text object
TryGetValue only fails if there is no text in the <span> or <text>

alternative = new LiftString(); creates a LiftString with Text = null
so alternative.Text.Length throws an exception

Also adds a test to comfirm that empty spans pass parsing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/564)
<!-- Reviewable:end -->
