### PR TITLE
Cope with excel-exported csv cells in image index

### DIFF
--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageGallery/ImageCollectionTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageGallery/ImageCollectionTests.cs
@@ -33,7 +33,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_OnKeyWordHasManyMatches_GetManyMatches()
 		{
-			bool foundExactMatches;
 			var matches = _collection.GetMatchingImages("duck");
 		    Assert.AreEqual(kDuckPicturesInArtOfReading, matches.Count());
 		}
@@ -41,7 +40,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_OnKeyWordHasNoMatches_GetNoMatches()
 		{
-			bool foundExactMatches;
 			var matches = _collection.GetMatchingImages("xy3z");
 			Assert.AreEqual(0, matches.Count());
 		}
@@ -49,7 +47,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_TwoKeyWords_GetMatchesOnBoth()
 		{
-			bool foundExactMatches;
 			var duckMatches = _collection.GetMatchingImages("duck");
 			var bothMatches = _collection.GetMatchingImages("duck sheep");
 			Assert.Greater(bothMatches.Count(), duckMatches.Count());
@@ -58,7 +55,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_UpperCaseQuery_GetsMatches()
 		{
-			bool foundExactMatches;
 			var treesMatches = _collection.GetMatchingImages("trees");
 			var TREESMatches = _collection.GetMatchingImages("TREES");
 			Assert.AreEqual(treesMatches.Count(), TREESMatches.Count());
@@ -68,7 +64,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_WordsFollowedByPunctuation_StillMatches()
 		{
-			bool foundExactMatches;
 			var duckMatches = _collection.GetMatchingImages("duck,");
 			Assert.AreEqual(kDuckPicturesInArtOfReading, duckMatches.Count());
 		}
@@ -76,7 +71,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_HasExtraNonMatchingWords_StillMatches()
 		{
-			bool foundExactMatches;
 			var duckMatches = _collection.GetMatchingImages("duck blah");
 			Assert.AreEqual(kDuckPicturesInArtOfReading, duckMatches.Count());
 		}
@@ -84,7 +78,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 		[Test]
 		public void GetMatchingPictures_KeyWordsMatchSamePicture_PictureOnlyListedOnce()
 		{
-			bool foundExactMatches;
 			var batMatches = _collection.GetMatchingImages("bat");
 			var bothMatches = _collection.GetMatchingImages("bat bat");
 			Assert.AreEqual(bothMatches.Count(), batMatches.Count());

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageGallery/ImageIndexLayoutTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageGallery/ImageIndexLayoutTests.cs
@@ -50,5 +50,21 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox.ImageGallery
 				Assert.AreEqual("мальчик,ребёнок,голова,люди,плечо", layout.GetCSVOfKeywordsOrEmpty("ru", rowparts));
 			}
 		}
+
+
+		/// <summary>
+		/// When you export a cell in Excel that has items separated by a comma, it sticks quotes around it. We want to ignore those quotes.
+		/// </summary>
+		[Test]
+		public void Constructor_KeyWordsFieldSurroundedByQuotes_QuotesIgnored()
+		{
+			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("filename\ten")))
+			using (var reader = new StreamReader(stream))
+			{
+				var layout = new ImageIndexReader(reader);
+				var rowparts = "filename	\"boy,child\"".Split('\t');
+				Assert.AreEqual("boy,child", layout.GetCSVOfKeywordsOrEmpty("en", rowparts), "Should strip off quotation marks");
+			}
+		}
 	}
 }

--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageIndexReader.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageIndexReader.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using SIL.Code;
+using SIL.Extensions;
 
 namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 {
@@ -72,7 +73,13 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 
 		public virtual string GetCSVOfKeywordsOrEmpty(string languageId, string[] fields)
 		{
-			return GetFieldOrEmpty(languageId, fields);
+			var csv = GetFieldOrEmpty(languageId, fields).Trim();
+
+			// When you export a cell in Excel that has items separated by a comma, it sticks quotes around it. We want to ignore those quotes.
+			if (csv.StartsWith("\"") && csv.EndsWith("\""))
+				csv = csv.Trim('"');
+
+			return csv;
 		}
 
 		private string GetFieldOrEmpty(string key, string[] fields)

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -1170,9 +1170,6 @@
   <ItemGroup>
     <None Include="Resources\cc0.png" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ImageToolbox\Collection\" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
When you export a cell in Excel that has items separated by a comma, it sticks quotes around it. We want to ignore those quotes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/567)
<!-- Reviewable:end -->
