### PR TITLE
Exclude a test that always fails on Linux

### DIFF
--- a/LanguageData.Tests/GetAndCheckSourcesTests.cs
+++ b/LanguageData.Tests/GetAndCheckSourcesTests.cs
@@ -116,6 +116,7 @@ namespace LanguageData.Tests
 		}
 
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "Mono WebClient code cannot access files on www.ethnologue.com")]
 		public void GetNewSources_Ok()
 		{
 			GetAndCheckSources getcheck = new GetAndCheckSources();

--- a/LanguageData/GetAndCheckSources.cs
+++ b/LanguageData/GetAndCheckSources.cs
@@ -113,8 +113,9 @@ namespace LanguageData
 				_newtwotothree = GenerateTwoToThreeCodes(newiso693);
 				return true;
 			}
-			catch (WebException)
+			catch (WebException we)
 			{
+				Console.WriteLine("Downloading {0} caused a WebException: {1}", (we.Response != null && we.Response.ResponseUri != null ? we.Response.ResponseUri.ToString() : "???"), we.Message);
 				return false;
 			}
 		}


### PR DESCRIPTION
The failure is caused by www.ethnologue.com's relatively recent
paranoia about Denial Of Service attacks.  The Mono WebClient code
cannot cope with the defense mechanism.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/569)
<!-- Reviewable:end -->
