### PR TITLE
Fix a test that started failing on Linux

### DIFF
--- a/LanguageData.Tests/GetAndCheckSourcesTests.cs
+++ b/LanguageData.Tests/GetAndCheckSourcesTests.cs
@@ -116,7 +116,6 @@ namespace LanguageData.Tests
 		}
 
 		[Test]
-		[Platform(Exclude = "Linux", Reason = "Mono WebClient code cannot access files on www.ethnologue.com")]
 		public void GetNewSources_Ok()
 		{
 			GetAndCheckSources getcheck = new GetAndCheckSources();

--- a/LanguageData/GetAndCheckSources.cs
+++ b/LanguageData/GetAndCheckSources.cs
@@ -85,11 +85,11 @@ namespace LanguageData
 				string lastmod_iso693 = client.ResponseHeaders["Last-Modified"];
 
 				client.Encoding = Encoding.UTF8; // ethnologue site currently doesn't specify encoding 2017-01-24
-				_newlanguageindex = client.DownloadString("https://www.ethnologue.com/codes/LanguageIndex.tab");
+				_newlanguageindex = client.DownloadString("https://www.ethnologue.com/sites/default/files/LanguageIndex.tab");
 				_newlanguageindex = _newlanguageindex.Replace("\r\n", "\n");
 				string lastmod_languageindex = client.ResponseHeaders["Last-Modified"];
 
-				_newlanguagecodes = client.DownloadString("https://www.ethnologue.com/codes/LanguageCodes.tab");
+				_newlanguagecodes = client.DownloadString("https://www.ethnologue.com/sites/default/files/LanguageCodes.tab");
 				_newlanguagecodes = _newlanguagecodes.Replace("\r\n", "\n");
 				string lastmod_languagecodes = client.ResponseHeaders["Last-Modified"];
 


### PR DESCRIPTION
www.ethnologue.com's has apparently moved their data files recently
(like today?).  These new URLs (as reported by wget) seem to work okay.
The older URLs were failing on Linux but working on Windows earlier.

This also restores the test that was excluded earlier today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/570)
<!-- Reviewable:end -->
