### PR TITLE
allows StripFilePrefix to handle windows paths

### DIFF
--- a/Palaso.Tests/IO/FileUtilsTests.cs
+++ b/Palaso.Tests/IO/FileUtilsTests.cs
@@ -268,7 +268,7 @@ namespace Palaso.Tests.IO
 		}
 
 		[Test]
-		[Platform(Include = "Windows")]
+		[Platform(Include = "Win", Reason = "Windows specific test")]
 		public void StripFilePrefix_EnsureFilePrefixIsRemoved_Windows()
 		{
 			var prefix = Uri.UriSchemeFile + ":";
@@ -278,10 +278,18 @@ namespace Palaso.Tests.IO
 			var reducedPathname = FileUtils.StripFilePrefix(fullPathname);
 			Assert.IsFalse(reducedPathname.StartsWith(prefix));
 			Assert.IsFalse(reducedPathname.StartsWith("/"));
+
+			var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase);
+			Assert.IsTrue(baseDir.StartsWith(prefix));
+
+			var reducedDirname = FileUtils.StripFilePrefix(baseDir);
+			Assert.IsFalse(reducedDirname.StartsWith(prefix));
+			Assert.IsFalse(reducedDirname.StartsWith("/"));
+			Assert.IsFalse(reducedDirname.StartsWith("\\"));
 		}
 
 		[Test]
-		[Platform(Include = "Linux")]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
 		public void StripFilePrefix_EnsureFilePrefixIsRemoved_Linux()
 		{
 			var prefix = Uri.UriSchemeFile + ":";
@@ -291,6 +299,13 @@ namespace Palaso.Tests.IO
 			var reducedPathname = FileUtils.StripFilePrefix(fullPathname);
 			Assert.IsFalse(reducedPathname.StartsWith(prefix));
 			Assert.IsTrue(reducedPathname.StartsWith("/"));
+
+			var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase);
+			Assert.IsTrue(baseDir.StartsWith(prefix));
+
+			var reducedDirname = FileUtils.StripFilePrefix(baseDir);
+			Assert.IsFalse(reducedDirname.StartsWith(prefix));
+			Assert.IsFalse(reducedDirname.StartsWith("/"));
 		}
 	}
 }

--- a/Palaso.Tests/IO/FileUtilsTests.cs
+++ b/Palaso.Tests/IO/FileUtilsTests.cs
@@ -305,7 +305,7 @@ namespace Palaso.Tests.IO
 
 			var reducedDirname = FileUtils.StripFilePrefix(baseDir);
 			Assert.IsFalse(reducedDirname.StartsWith(prefix));
-			Assert.IsFalse(reducedDirname.StartsWith("/"));
+			Assert.IsTrue(reducedDirname.StartsWith("/"));
 		}
 	}
 }

--- a/Palaso.Tests/reporting/ErrorReportTests.cs
+++ b/Palaso.Tests/reporting/ErrorReportTests.cs
@@ -33,7 +33,7 @@ namespace Palaso.Tests.reporting
 #endif
 
 		[Test]
-		[Platform(Include = "Windows", Reason = "Windows specific test")]
+		[Platform(Include = "Win", Reason = "Windows specific test")]
 		public void Properties_WindowsDoesNotContainDesktopEnvironment()
 		{
 			// SUT
@@ -45,7 +45,7 @@ namespace Palaso.Tests.reporting
 		}
 
 		[Test]
-		[Platform(Include = "Windows", Reason = "Windows specific test")]
+		[Platform(Include = "Win", Reason = "Windows specific test")]
 		public void GetStandardProperties_WindowsDoesNotContainDesktopEnvironment()
 		{
 			// SUT

--- a/Palaso/IO/FileUtils.cs
+++ b/Palaso/IO/FileUtils.cs
@@ -362,6 +362,7 @@ namespace Palaso.IO
 			var path = fileString.Substring(prefix.Length);
 			// Trim any number of beginning slashes
 			path = path.TrimStart('/');
+			path = path.TrimStart('\\');
 			// Prepend slash on Linux
 			if (Platform.IsUnix)
 				path = '/' + path;


### PR DESCRIPTION
enable some windows specific tests that were disabled because
Platform should be "Win" not "Windows"
add to StripFilePrefix tests to check windows path handling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/573)
<!-- Reviewable:end -->
