### PR TITLE
Disable a test hanging on TeamCity for Linux

### DIFF
--- a/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
+++ b/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
@@ -8,6 +8,7 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 	{
 		private Windows.Forms.Progress.LogBox progress;
 		[Test]
+		[Category("KnownMonoIssue")] // this test hangs on TeamCity for Linux
 		public void ShowLogBox()
 		{
 			Console.WriteLine("Showing LogBox");


### PR DESCRIPTION
Building libpalaso for Linux on the master branch has been hanging on this test.  It seems to pass okay for Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/574)
<!-- Reviewable:end -->
