### PR TITLE
Fix LT-18647: Restoring (Maba) project leads to crash

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -771,7 +771,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 
 			string[] parts = id.Split('_');
 			string locale = parts[0];
-			string layout = parts[1];
+			string layout = parts.Length > 1 ? parts[1] : string.Empty;
 
 			IInputLanguage inputLanguage;
 			string cultureName;


### PR DESCRIPTION
* Handled Index was outside the bounds of the array

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/575)
<!-- Reviewable:end -->
