### PR TITLE
separate init of LiftDataMapper from constructor

### DIFF
--- a/Palaso.DictionaryServices.Tests/Lift/LiftRepositoryTests.cs
+++ b/Palaso.DictionaryServices.Tests/Lift/LiftRepositoryTests.cs
@@ -64,9 +64,11 @@ namespace Palaso.DictionaryServices.Tests.Lift
 
 		public static LiftDataMapper CreateDataMapper(string filePath)
 		{
-			return new LiftDataMapper(
-				filePath, null, new string[] {}, new ProgressState()
-			).Init();
+
+			LiftDataMapper mapper = new LiftDataMapper(
+				filePath, null, new string[] { }, new ProgressState());
+			mapper.Init();
+			return mapper;
 		}
 
 		[Test]

--- a/Palaso.DictionaryServices.Tests/Lift/LiftRepositoryTests.cs
+++ b/Palaso.DictionaryServices.Tests/Lift/LiftRepositoryTests.cs
@@ -66,7 +66,7 @@ namespace Palaso.DictionaryServices.Tests.Lift
 		{
 			return new LiftDataMapper(
 				filePath, null, new string[] {}, new ProgressState()
-			);
+			).Init();
 		}
 
 		[Test]

--- a/Palaso.DictionaryServices/Lift/LiftDataMapper.cs
+++ b/Palaso.DictionaryServices/Lift/LiftDataMapper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Palaso.DictionaryServices.Lift;
 using Palaso.DictionaryServices.Model;
 using Palaso.Lift;
 using Palaso.Lift.Options;
@@ -56,6 +55,11 @@ namespace Palaso.DictionaryServices.Lift
 		{
 		}
 
+		public void Init()
+		{
+			base.Init();
+		}
+
 
 	}
 
@@ -64,9 +68,13 @@ namespace Palaso.DictionaryServices.Lift
 	/// </summary>
 	public class WeSayLiftDataMapper : LiftDataMapper
 	{
-		public WeSayLiftDataMapper(string filePath, OptionsList semanticDomainsList, IEnumerable<string> idsOfSingleOptionFields, ProgressState progressState)
-			:base(filePath,semanticDomainsList,idsOfSingleOptionFields,progressState)
-		{}
+		private bool _glossMeaningField;
+		public WeSayLiftDataMapper(string filePath, OptionsList semanticDomainsList, IEnumerable<string> idsOfSingleOptionFields, ProgressState progressState, bool glossMeaningField)
+			: base(filePath,semanticDomainsList,idsOfSingleOptionFields,progressState)
+		{
+			_glossMeaningField = glossMeaningField;
+			base.Init();
+		}
 
 		protected override void CustomizeReader(ILiftReader<LexEntry> reader)
 		{
@@ -86,7 +94,10 @@ namespace Palaso.DictionaryServices.Lift
 			var entry = (LexEntry) entryObj;
 			foreach (LexSense sense in entry.Senses)
 			{
-				CopyOverGlossesIfDefinitionsMissing(sense);
+				if (!_glossMeaningField)
+				{
+					CopyOverGlossesIfDefinitionsMissing(sense);
+				}
 				FixUpOldLiteralMeaningMistake(entry, sense);
 			}
 		}

--- a/Palaso.DictionaryServices/Lift/LiftDataMapper.cs
+++ b/Palaso.DictionaryServices/Lift/LiftDataMapper.cs
@@ -55,11 +55,11 @@ namespace Palaso.DictionaryServices.Lift
 		{
 		}
 
-		public void Init()
+		public LiftDataMapper Init()
 		{
 			base.Init();
+			return this;
 		}
-
 
 	}
 
@@ -73,7 +73,7 @@ namespace Palaso.DictionaryServices.Lift
 			: base(filePath,semanticDomainsList,idsOfSingleOptionFields,progressState)
 		{
 			_glossMeaningField = glossMeaningField;
-			base.Init();
+			Init();
 		}
 
 		protected override void CustomizeReader(ILiftReader<LexEntry> reader)

--- a/Palaso.DictionaryServices/Lift/LiftDataMapper.cs
+++ b/Palaso.DictionaryServices/Lift/LiftDataMapper.cs
@@ -54,13 +54,6 @@ namespace Palaso.DictionaryServices.Lift
 			: this(filePath, new OptionsList(), new string[] { }, new ProgressState())
 		{
 		}
-
-		public LiftDataMapper Init()
-		{
-			base.Init();
-			return this;
-		}
-
 	}
 
 	/// <summary>

--- a/Palaso.DictionaryServices/LiftLexEntryRepository.cs
+++ b/Palaso.DictionaryServices/LiftLexEntryRepository.cs
@@ -61,7 +61,7 @@ namespace Palaso.DictionaryServices
 #if DEBUG
 			_constructionStackTrace = new StackTrace();
 #endif
-			_decoratedDataMapper = new LiftDataMapper(path, null, new string[] {}, new ProgressState());
+			_decoratedDataMapper = new LiftDataMapper(path, null, new string[] {}, new ProgressState()).Init();
 			_disposed = false;
 		}
 
@@ -73,6 +73,7 @@ namespace Palaso.DictionaryServices
 #if DEBUG
 			_constructionStackTrace = new StackTrace();
 #endif
+			decoratedDataMapper.Init();
 			_decoratedDataMapper = decoratedDataMapper;
 			_disposed = false;
 		}

--- a/Palaso.DictionaryServices/LiftLexEntryRepository.cs
+++ b/Palaso.DictionaryServices/LiftLexEntryRepository.cs
@@ -61,7 +61,9 @@ namespace Palaso.DictionaryServices
 #if DEBUG
 			_constructionStackTrace = new StackTrace();
 #endif
-			_decoratedDataMapper = new LiftDataMapper(path, null, new string[] {}, new ProgressState()).Init();
+			LiftDataMapper mapper = new LiftDataMapper(path, null, new string[] { }, new ProgressState());
+			mapper.Init();
+			_decoratedDataMapper = mapper;
 			_disposed = false;
 		}
 


### PR DESCRIPTION
this allows WeSay to choose whether to copy glosses or not
depending on which is the meaning field

part of the fix for WS-465

If you use LiftDataMapper you will now need to call Init() on it after constructing it.

As far as I can tell (ie from some quick project searches on github) the only other thing apart from WeSay that uses it is Solid, which I can fix once this gets to master. I don't know if PT uses it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/579)
<!-- Reviewable:end -->
