### PR TITLE
Fix RobustFile.Copy to handle empty files without crashing

### DIFF
--- a/SIL.Core.Tests/IO/RobustFileTests.cs
+++ b/SIL.Core.Tests/IO/RobustFileTests.cs
@@ -202,5 +202,28 @@ namespace SIL.Tests.IO
 				RobustFile.BufferSize = oldBufSize;
 			}
 		}
+
+		[Test]
+		public void CopyEmptyFile()
+		{
+			// Create an empty file.
+			var emptyFile = Path.GetTempFileName();
+			Assert.IsTrue(RobustFile.Exists(emptyFile));
+			var info = new FileInfo(emptyFile);
+			Assert.AreEqual(0, info.Length);
+
+			var destName = emptyFile + "-xyzzy";
+			// This was throwing a System.ArgumentOutOfRangeException exception before being fixed.
+			RobustFile.Copy(emptyFile, destName, true);
+			Assert.IsTrue(RobustFile.Exists(destName));
+			var infoDest = new FileInfo(destName);
+			Assert.AreEqual(0, infoDest.Length);
+
+			// Clean up after ourselves.
+			RobustFile.Delete(emptyFile);
+			Assert.IsFalse(RobustFile.Exists(emptyFile));
+			RobustFile.Delete(destName);
+			Assert.IsFalse(RobustFile.Exists(destName));
+		}
 	}
 }

--- a/SIL.Core/IO/RobustFile.cs
+++ b/SIL.Core/IO/RobustFile.cs
@@ -33,15 +33,14 @@ namespace SIL.IO
 
 		// This is just a guess at a buffer size that should make copying reasonably efficient without
 		// being too hard to allocate.
-		internal static int BufferSize = 1024 * 256; // internal so we can tweak in unit tests
+		internal static int BufferSize = FileStreamBufferSize; // internal so we can tweak in unit tests
 
 		public static void Copy(string sourceFileName, string destFileName, bool overwrite = false)
 		{
 			RetryUtility.Retry(() =>
 			{
 				// This is my own implementation; the .NET library uses a native windows function.
-				var bufSize = (int)Math.Min(BufferSize, new FileInfo(sourceFileName).Length);
-				var buffer = new byte[bufSize];
+				var buffer = new byte[BufferSize];
 				using (var input = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read))
 				{
 					using (
@@ -51,11 +50,11 @@ namespace SIL.IO
 						var output = new FileStream(destFileName,
 							(overwrite ? FileMode.Create : FileMode.CreateNew),
 							FileAccess.Write,
-							FileShare.None, bufSize,
+							FileShare.None, BufferSize,
 							FileOptions.SequentialScan))
 					{
 						int count;
-						while ((count = input.Read(buffer, 0, bufSize)) > 0)
+						while ((count = input.Read(buffer, 0, BufferSize)) > 0)
 						{
 							output.Write(buffer, 0, count);
 						}


### PR DESCRIPTION
See https://issues.bloomlibrary.org/youtrack/issue/BL-5191 for an
example of this actually happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/588)
<!-- Reviewable:end -->
