### PR TITLE
Do not crash if no compatible adapters are found

### DIFF
--- a/SIL.Windows.Forms.Keyboarding.Tests/WindowsKeyboardControllerTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/WindowsKeyboardControllerTests.cs
@@ -44,7 +44,8 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 			get
 			{
 				WinKeyboardDescription[] keyboards = Keyboard.Controller.AvailableKeyboards.OfType<WinKeyboardDescription>().ToArray();
-				Assert.Greater(keyboards.Length, 0, "This test requires that the Windows IME has at least one language installed.");
+				if (keyboards.Length < 2)
+					Assert.Ignore("This test requires that the Windows IME has at least two languages installed.");
 				WinKeyboardDescription d = keyboards.FirstOrDefault(x => x != Keyboard.Controller.ActiveKeyboard);
 				if (d == null)
 					return keyboards.First(); // Some tests have some value even if it is an active keyboard.
@@ -66,7 +67,8 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 		public void WindowsIME_DeActivateKeyboard_RevertsToDefault()
 		{
 			IKeyboardDefinition[] keyboards = Keyboard.Controller.AvailableKeyboards.Where(kd => kd is WinKeyboardDescription).ToArray();
-			Assert.Greater(keyboards.Length, 1, "This test requires that the Windows IME has at least two languages installed.");
+			if(keyboards.Length < 2)
+				Assert.Ignore("This test requires that the Windows IME has at least two languages installed.");
 			IKeyboardDefinition d = GetNonDefaultKeyboard(keyboards);
 			d.Activate();
 			Assert.AreEqual(d, Keyboard.Controller.ActiveKeyboard);
@@ -97,7 +99,8 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 		public void WindowsIME_GetKeyboards_GivesSeveralButOnlyWindowsOnes()
 		{
 			WinKeyboardDescription[] keyboards = Keyboard.Controller.AvailableKeyboards.OfType<WinKeyboardDescription>().ToArray();
-			Assert.Greater(keyboards.Length, 1, "This test requires that the Windows IME has at least two languages installed.");
+			if (keyboards.Length < 2)
+				Assert.Ignore("This test requires that the Windows IME has at least two languages installed.");
 
 			Assert.That(keyboards.Select(keyboard => keyboard.Engine), Is.All.TypeOf<WinKeyboardAdaptor>());
 		}

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -471,8 +472,11 @@ namespace SIL.Windows.Forms.Keyboarding
 			if (!_keyboards.TryGet(id, out keyboard))
 			{
 				var firstCompatibleAdapter = _adaptors.Values.FirstOrDefault(adaptor => adaptor.CanHandleFormat(format));
-				if(firstCompatibleAdapter == null)
-					throw new ArgumentException(string.Format("Did not find {0} in {1} adapters", format, _adaptors.Count), "format");
+				if (firstCompatibleAdapter == null)
+				{
+					Debug.Fail(string.Format("Could not load keyboard for {0}. Did not find {1} in {2} adapters", id, format, _adaptors.Count));
+					return NullKeyboard;
+				}
 				keyboard = firstCompatibleAdapter.CreateKeyboardDefinition(id);
 				_keyboards.Add(keyboard);
 			}


### PR DESCRIPTION
* Uninstalling Keyman updating your linux distro
  or other yet undiscovered things could result in ldml
  files containing unusable keyboard adapters. Don't crash.
* Set most Windows IME tests to be ignored if the system is
  not configured to run them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/591)
<!-- Reviewable:end -->
