### PR TITLE
missed GetToolTipText()

### DIFF
--- a/SIL.DictionaryServices/Model/LexEntry.cs
+++ b/SIL.DictionaryServices/Model/LexEntry.cs
@@ -473,6 +473,11 @@ namespace SIL.DictionaryServices.Model
 			return string.Join(", ", meanings);
 		}
 
+		public string GetToolTipText()
+		{
+			return GetToolTipText(true);
+		}
+
 		/// <summary>
 		/// checks if it looks like the user has added info. this is used when changing spelling
 		/// in a word-gathering task


### PR DESCRIPTION
I missed an API that needed to be put in with the earlier changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/595)
<!-- Reviewable:end -->
