### PR TITLE
Make code more robust in handling downloaded data

### DIFF
--- a/LanguageData/GetAndCheckSources.cs
+++ b/LanguageData/GetAndCheckSources.cs
@@ -250,6 +250,8 @@ namespace LanguageData
 			foreach (string line in iso693.Replace("\r\n", "\n").Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries))
 			{
 				string[] items = line.Split('\t');
+				if (items.Length < 4)
+					continue;	// protect against garbage downloaded from the web
 				if (items[3].Trim().Length == 2) {
 					twoToThreeLetter.Add (items[3].Trim(), items[0].Trim());
 				}


### PR DESCRIPTION
This fixes some test failures that are happening today.  The
downloaded data contained one line in the middle consisting of
a single tab character.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/599)
<!-- Reviewable:end -->
