### PR TITLE
Change OpenFileDialogWithViews to use DialogAdapters

### DIFF
--- a/SIL.Windows.Forms/ImageToolbox/OpenFileDialogWithViews.cs
+++ b/SIL.Windows.Forms/ImageToolbox/OpenFileDialogWithViews.cs
@@ -56,7 +56,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 		private bool m_IsWatching = false;
 		private DialogViewTypes m_DialogViewTypes;
 		private const int WM_COMMAND = 0x0111;
-		private OpenFileDialog m_OpenFileDialog;
+		private DialogAdapters.OpenFileDialogAdapter m_OpenFileDialog;
 
 		public OpenFileDialogWithViews()
 		{
@@ -73,24 +73,16 @@ namespace SIL.Windows.Forms.ImageToolbox
 		private DialogViewTypes DialogViewType
 		{
 			get { return m_DialogViewTypes; }
-			set
-			{
-				m_DialogViewTypes = value;
-				if (!Platform.IsWindows && m_DialogViewTypes == DialogViewTypes.Large_Icons)
-				{
-					// on Mono for now we support only setting large icons
-					SelectLargeIconView(OpenFileDialog);
-				}
-			}
+			set { m_DialogViewTypes = value; }	// not used for Linux/Mono with GTK dialog
 		}
 
-		private OpenFileDialog OpenFileDialog
+		private DialogAdapters.OpenFileDialogAdapter OpenFileDialog
 		{
 			get
 			{
 				if (m_OpenFileDialog == null)
 				{
-					m_OpenFileDialog = new OpenFileDialog();
+					m_OpenFileDialog = new DialogAdapters.OpenFileDialogAdapter();
 				}
 
 				return m_OpenFileDialog;
@@ -277,41 +269,6 @@ namespace SIL.Windows.Forms.ImageToolbox
 				}
 			}
 		}
-
-		/// <summary>
-		/// Select the large icon view in the open file dialog.
-		/// </summary>
-		/// <remarks>
-		/// This totally depends on the internal implementation of the file dialogs in Mono.  Since that has
-		/// remained stable for several years, it should work for us.  The worst that can happen for a new
-		/// version of Mono is that it silently stops working.
-		/// </remarks>
-		private static void SelectLargeIconView(OpenFileDialog dlg)
-		{
-			// Accessing a private member variable of FileDialog, so if the
-			// implementation changes, give up immediately.
-			if (!(dlg is FileDialog))
-				return;
-			Type dlgType = typeof(FileDialog);
-			var dlgViewField = dlgType.GetField("mwfFileView", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
-			if (dlgViewField == null)
-				return;
-			var fileView = dlgViewField.GetValue(dlg);
-			if (fileView == null)
-				return;
-			var viewType = fileView.GetType();
-			var viewItemField = viewType.GetField("largeIconMenutItem", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
-			if (viewItemField == null)
-				return;
-			var largeIcon = viewItemField.GetValue(fileView) as MenuItem;
-			if (largeIcon == null)
-				return;
-			var viewOnClickMethod = viewType.GetMethod("OnClickViewMenuSubItem", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public,
-				null, new Type[] { typeof(Object), typeof(EventArgs) }, null);
-			if (viewOnClickMethod != null)
-				viewOnClickMethod.Invoke(fileView, new Object[] { largeIcon, new EventArgs() });
-		}
-
 	}
 
 }

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -386,6 +386,9 @@
     <Reference Include="MarkdownDeep, Version=1.5.4615.26275, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
+    </Reference>
+    <Reference Include="DialogAdapters">
+      <HintPath>..\packages\DialogAdapters.0.1.1.32530\lib\net45\DialogAdapters.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" Condition="'$(OS)'=='Windows_NT'" />
     <Reference Include="System" />

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40" />
   <package id="NAudio" version="1.8.3" />
+  <package id="DialogAdapters" version="0.1.1.32530" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This uses the GTK dialog on Linux/Mono while still using the normal
.Net dialog on Windows.  Both Paratext and FieldWorks have switched
to doing this in their code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/614)
<!-- Reviewable:end -->
