### PR TITLE
Fix Linux non-strongname builds

### DIFF
--- a/Palaso.Tests/Palaso.Tests.csproj
+++ b/Palaso.Tests/Palaso.Tests.csproj
@@ -139,6 +139,12 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'DebugMono' Or '$(Configuration)' == 'DebugMonoStrongName' Or '$(Configuration)' == 'ReleaseMono' Or '$(Configuration)' == 'ReleaseMonoStrongName'">
+    <Reference Include="NDesk.DBus, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f6716e4f9b2ed099, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NDesk.DBus.0.15.0\lib\NDesk.DBus.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Annotations\AnnotatableTests.cs" />
     <Compile Include="Base32Tests\Base32HexTests.cs" />
@@ -197,8 +203,8 @@
     <Compile Include="Text\ApproximateMatcherTests.cs" />
     <Compile Include="Text\LanguageFormTest.cs" />
     <Compile Include="Text\MultiTextBase.Tests.cs" />
-    <Compile Condition="'$(Configuration)' == 'DebugMono' Or '$(Configuration)' == 'ReleaseMono' " Include="UsbDrive\Linux\UDiskDeviceTests.cs" />
-    <Compile Condition="'$(Configuration)' == 'DebugMono' Or '$(Configuration)' == 'ReleaseMono' " Include="UsbDrive\Linux\UDisksTests.cs" />
+    <Compile Include="UsbDrive\Linux\UDiskDeviceTests.cs" />
+    <Compile Include="UsbDrive\Linux\UDisksTests.cs" />
     <Compile Include="UsbDrive\UsbDeviceInfoTests.cs" />
     <Compile Include="WritingSystems\Collation\AddSortKeysToXmlTests.cs" />
     <Compile Include="WritingSystems\Collation\IcuRulesParserTests.cs" />
@@ -271,6 +277,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\build\platform.targets" />
+  <Import Project="..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets" Condition="Exists('..\packages\NDesk.DBus.0.15.0\build\NDesk.DBus.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Palaso.Tests/UsbDrive/Linux/UDiskDeviceTests.cs
+++ b/Palaso.Tests/UsbDrive/Linux/UDiskDeviceTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if MONO
+using System;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -73,3 +74,4 @@ namespace Palaso.Tests.UsbDrive.Linux
 
 	}
 }
+#endif

--- a/Palaso.Tests/UsbDrive/Linux/UDisksTests.cs
+++ b/Palaso.Tests/UsbDrive/Linux/UDisksTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if MONO
+using System;
 using System.Linq;
 using NUnit.Framework;
 using Palaso.UsbDrive.Linux;
@@ -82,3 +83,4 @@ namespace Palaso.Tests.UsbDrive.Linux
 
 	}
 }
+#endif

--- a/Palaso.Tests/packages.config
+++ b/Palaso.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NDesk.DBus" version="0.15.0" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/PalasoUIWindowsForms/PalasoUIWindowsForms.csproj
+++ b/PalasoUIWindowsForms/PalasoUIWindowsForms.csproj
@@ -128,10 +128,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\$(Configuration)\irrKlang.NET4.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio, Version=1.8.3.0, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NAudio.1.8.3\lib\NAudio.dll</HintPath>
-    </Reference>
     <Reference Include="Keyman7Interop">
       <HintPath>..\lib\Debug\Keyman7Interop.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
@@ -160,10 +156,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\Release\irrKlang.NET4.dll</HintPath>
     </Reference>
-    <Reference Include="NAudio, Version=1.8.3.0, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NAudio.1.8.3\lib\NAudio.dll</HintPath>
-    </Reference>
     <Reference Include="Keyman7Interop">
       <HintPath>..\lib\Release\Keyman7Interop.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
@@ -188,7 +180,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\DebugMono\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Posix" />
     <Reference Include="taglib-sharp, Version=2.1.1.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\DebugMono\taglib-sharp.dll</HintPath>
@@ -199,47 +190,30 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\ReleaseMono\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Posix" />
     <Reference Include="taglib-sharp, Version=2.1.1.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\ReleaseMono\taglib-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Enchant.Net">
-      <HintPath>..\lib\common\Enchant.Net.dll</HintPath>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug' Or '$(Configuration)' == 'DebugStrongName' Or '$(Configuration)' == 'Release' Or '$(Configuration)' == 'ReleaseStrongName'">
+    <Reference Include="NAudio, Version=1.8.3.0, Culture=neutral, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NAudio.1.8.3\lib\NAudio.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'DebugMono' Or '$(Configuration)' == 'DebugMonoStrongName' Or '$(Configuration)' == 'ReleaseMono' Or '$(Configuration)' == 'ReleaseMonoStrongName'">
+    <Reference Include="Mono.Posix" />
     <Reference Include="NDesk.DBus">
       <HintPath>..\packages\NDesk.DBus.0.15.0\lib\NDesk.DBus.dll</HintPath>
     </Reference>
     <Reference Include="ibusdotnet">
       <HintPath>..\packages\ibusdotnet.2.0.0.20771\lib\ibusdotnet.dll</HintPath>
     </Reference>
-    <None Include="icu4c.readme.txt" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Progress\LogBoxSettings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>LogBoxSettings.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="Registration\Registration.settings">
-      <Generator>PublicSettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Registration.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="SettingProtection\SettingsProtection1.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>SettingsProtection1.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="SettingProtection\SettingsProtectionSettings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>SettingsProtectionSettings.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="..\lib\common\Enchant.Net.dll.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Reference Include="Enchant.Net">
+      <HintPath>..\lib\common\Enchant.Net.dll</HintPath>
+    </Reference>
     <Reference Include="MarkdownDeep, Version=1.5.4615.26275, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
@@ -260,6 +234,29 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="icu4c.readme.txt" />
+    <None Include="packages.config" />
+    <None Include="Progress\LogBoxSettings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>LogBoxSettings.Designer.cs</LastGenOutput>
+    </None>
+    <None Include="Registration\Registration.settings">
+      <Generator>PublicSettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Registration.Designer.cs</LastGenOutput>
+    </None>
+    <None Include="SettingProtection\SettingsProtection1.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>SettingsProtection1.Designer.cs</LastGenOutput>
+    </None>
+    <None Include="SettingProtection\SettingsProtectionSettings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>SettingsProtectionSettings.Designer.cs</LastGenOutput>
+    </None>
+    <None Include="..\lib\common\Enchant.Net.dll.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClearShare\ClearShareResources.Designer.cs" />


### PR DESCRIPTION
Non-strongname builds on Linux only work when we add a reference to
NDesk.DBus to Palaso.Tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/615)
<!-- Reviewable:end -->
