### PR TITLE
Fix WritingSystem to always have a DefaultCollation

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlContentForTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlContentForTests.cs
@@ -9,7 +9,7 @@ namespace SIL.WritingSystems.Tests
 <noLdml>
 </noLdml>
 ".Replace("'", "\"");
-		
+
 		public static string Version99Default()
 		{
 			return
@@ -90,7 +90,7 @@ namespace SIL.WritingSystems.Tests
 
 		internal static string Version0WithSystemCollationInfo()
 		{
-			return 
+			return
 				@"<?xml version='1.0' encoding='utf-8'?>
 <ldml>
 <identity>
@@ -321,7 +321,7 @@ namespace SIL.WritingSystems.Tests
 </special>
 </ldml>".Replace('\'', '"'), language, script, region, variant, bogus);
 		}
-		
+
 		public static string Version0(string language, string script, string region, string variant, string abbreviation)
 		{
 			return string.Format(
@@ -411,7 +411,7 @@ namespace SIL.WritingSystems.Tests
 </ldml>".Replace('\'', '"'), language, script, region, variant);
 		}
 
-	#region Version 2 LDML
+		#region Version 2 LDML
 		public static string Version2(string language, string script, string region, string variant)
 		{
 			return
@@ -459,7 +459,7 @@ namespace SIL.WritingSystems.Tests
 		}
 
 
-	#endregion
+		#endregion
 
 		#region Version 3 
 
@@ -473,7 +473,7 @@ namespace SIL.WritingSystems.Tests
 			string collationString = string.Empty;
 			switch (sortType)
 			{
-				case "standard" :
+				case "standard":
 					collationString = @"
 	<collations>
 		<defaultCollation>standard</defaultCollation>
@@ -487,8 +487,8 @@ namespace SIL.WritingSystems.Tests
 			]]></cr>
 		</collation>
 	</collations>".Replace("'", "\"");
-				break;
-				case "simple" :
+					break;
+				case "simple":
 					collationString = @"
 	<collations>
 		<defaultCollation>standard</defaultCollation>
@@ -532,8 +532,8 @@ namespace SIL.WritingSystems.Tests
 			</special>
 		</collation>
 	</collations>".Replace("'", "\"");
-				break;
-				case "simpleNeedsCompiling" :
+					break;
+				case "simpleNeedsCompiling":
 					collationString = @"
 	<collations>
 		<defaultCollation>standard</defaultCollation>
@@ -570,8 +570,8 @@ namespace SIL.WritingSystems.Tests
 			</special>
 		</collation>
 	</collations>".Replace("'", "\"");
-				break;
-				case "inherited" :
+					break;
+				case "inherited":
 					collationString = @"
 	<collations>
 		<defaultCollation>standard</defaultCollation>
@@ -588,11 +588,11 @@ namespace SIL.WritingSystems.Tests
 			</special>
 		</collation>
 	</collations>".Replace("'", "\"");
-				break;
+					break;
 			}
 			return collationString;
 		}
-		
+
 		public static string FontElem = @"
 	<special xmlns:sil='urn://www.sil.org/ldml/0.1'>
 		<sil:external-resources>
@@ -602,7 +602,7 @@ namespace SIL.WritingSystems.Tests
 			</sil:font>
 		</sil:external-resources>
 	</special>".Replace("'", "\"");
-		
+
 		public static string SpellCheckerElem = @"
 	<special xmlns:sil='urn://www.sil.org/ldml/0.1'>
 		<sil:external-resources>
@@ -612,7 +612,7 @@ namespace SIL.WritingSystems.Tests
 			</sil:spellcheck>
 		</sil:external-resources>
 	</special>".Replace("'", "\"");
-		
+
 		public static string KeyboardElem = @"
 	<special xmlns:sil='urn://www.sil.org/ldml/0.1'>
 		<sil:external-resources>
@@ -622,7 +622,7 @@ namespace SIL.WritingSystems.Tests
 			</sil:kbd>
 		</sil:external-resources>
 	</special>".Replace("'", "\"");
-		
+
 		/// <summary>
 		/// Minimal LDML for version 3
 		/// </summary>
@@ -651,16 +651,6 @@ namespace SIL.WritingSystems.Tests
 		/// <summary>
 		/// Minimal LDML for version 3 along with sil:identity element
 		/// </summary>
-		/// <param name="language"></param>
-		/// <param name="script"></param>
-		/// <param name="region"></param>
-		/// <param name="variant"></param>
-		/// <param name="uid"></param>
-		/// <param name="windowsLCID"></param>
-		/// <param name="variantName"></param>
-		/// <param name="defaultRegion"></param>
-		/// <param name="revid"></param>
-		/// <returns></returns>
 		public static string Version3Identity(string language, string script, string region, string variant,
 											string uid, string windowsLCID, string variantName, string defaultRegion, string revid)
 		{
@@ -678,9 +668,9 @@ namespace SIL.WritingSystems.Tests
 			<sil:identity uid='{4}' windowsLCID='{5}' variantName='{6}' defaultRegion='{7}' revid='{8}'></sil:identity>
 		</special>
 	</identity>
-</ldml>".Replace("'", "\""), language, script, region, variant, uid, windowsLCID, variantName, defaultRegion, revid );
+</ldml>".Replace("'", "\""), language, script, region, variant, uid, windowsLCID, variantName, defaultRegion, revid);
 		}
-		 #endregion
+		#endregion
 
 		public static string CurrentVersion(string language, string script, string region, string variant, string otherElement = null)
 		{
@@ -692,7 +682,7 @@ namespace SIL.WritingSystems.Tests
 			string language, script, region, variant;
 			IetfLanguageTag.TryGetParts(languageTag, out language, out script, out region, out variant);
 			return CurrentVersion(language, script, region, variant);
-			
+
 		}
 	}
 }

--- a/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
@@ -1025,6 +1025,10 @@ namespace SIL.WritingSystems.Tests.Migration
 				WritingSystemDefinition ws = repo.Get("de");
 				var scd = new SystemCollationDefinition {LanguageTag = "de"};
 				Assert.That(ws.DefaultCollation.ValueEquals(scd), Is.True);
+
+				var fromFile = new WritingSystemDefinition();
+				new LdmlDataMapper(new TestWritingSystemFactory()).Read(environment.MappedFilePath("test.ldml"), fromFile);
+				Assert.NotNull(fromFile.DefaultCollation);
 			}
 		}
 

--- a/SIL.WritingSystems/DefinitionBase.cs
+++ b/SIL.WritingSystems/DefinitionBase.cs
@@ -22,7 +22,7 @@ namespace SIL.WritingSystems
 		protected bool Set(Expression<Func<string>> propertyExpression, ref string field, string value)
 		{
 			//count null as same as ""
-			if (String.IsNullOrEmpty(field) && String.IsNullOrEmpty(value))
+			if (string.IsNullOrEmpty(field) && string.IsNullOrEmpty(value))
 				return false;
 
 			return base.Set(propertyExpression, ref field, value);

--- a/SIL.WritingSystems/Migration/WritingSystemsLdmlV2To3Migration/LdmlVersion2MigrationStrategy.cs
+++ b/SIL.WritingSystems/Migration/WritingSystemsLdmlV2To3Migration/LdmlVersion2MigrationStrategy.cs
@@ -407,16 +407,16 @@ namespace SIL.WritingSystems.Migration.WritingSystemsLdmlV2To3Migration
 				var layoutElement = ldmlElem.Element("layout");
 				WriteLayoutElement(layoutElement);
 
-				if (staging.CharacterSets.ContainsKey("numeric"))
-				{
-					XElement numbersElem = ldmlElem.GetOrCreateElement("numbers");
-					WriteNumbersElement(numbersElem, staging);
-				}
-
 				if (staging.CharacterSets.ContainsKey("main") || staging.CharacterSets.ContainsKey("punctuation"))
 				{
 					XElement charactersElem = ldmlElem.GetOrCreateElement("characters");
 					WriteCharactersElement(charactersElem, staging);
+				}
+
+				if (staging.CharacterSets.ContainsKey("numeric"))
+				{
+					XElement numbersElem = ldmlElem.GetOrCreateElement("numbers");
+					WriteNumbersElement(numbersElem, staging);
 				}
 
 				if (staging.SortUsing != WritingSystemDefinitionV1.SortRulesType.OtherLanguage)


### PR DESCRIPTION
* standard collation isn't saved to .ldml so re-populate it on
  the load if there is no collations present
* handful of code cleanup changes
* Make number element for migrated ldml2 files match the
  ldml .dtd order

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/616)
<!-- Reviewable:end -->
