### PR TITLE
Fix Art Of Reading Search to handle country subdirectories.

### DIFF
--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageCollectionManager.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageCollectionManager.cs
@@ -172,7 +172,14 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 					result.AddRange(collection.GetApproximateMatchingImages(searchTermArray));
 				}
 			}
-			return limitToThoseActuallyAvailable ? result.Where(File.Exists) : result;
+			var finalResult = limitToThoseActuallyAvailable ? result.Where(File.Exists) : result;
+#if DEBUG
+			if (limitToThoseActuallyAvailable)
+			{
+				System.Diagnostics.Debug.Assert(result.Count == finalResult.Count(), "All of the images in the index should exist");
+			}
+#endif
+			return finalResult;
 		}
 
 


### PR DESCRIPTION
The information for handling this perhaps should be in the index file, but
even that would require code changes.  It is probably best not to force
users around the world into another 300MB download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/619)
<!-- Reviewable:end -->
