### PR TITLE
Keep GTK file chooser on top of program window and calling dialog

### DIFF
--- a/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
@@ -45,43 +45,55 @@ namespace SIL.Windows.Forms.ImageToolbox
 				ImageChanged(sender, e);
 		}
 
+		private bool _forceModal;
+
 		private void OnGetFromFileSystemClick(object sender, EventArgs e)
 		{
-			SetMode(Modes.SingleImage);
-			// The primary thing that OpenFileDialogWithViews buys us is the ability to default to large icons.
-			// OpenFileDialogWithViews still doesn't let us read (and thus remember) the selected view.
-			using (var dlg = new OpenFileDialogWithViews(OpenFileDialogWithViews.DialogViewTypes.Large_Icons))
+			if (_forceModal)
+				return;		// The GTK file chooser on Linux isn't acting modal, so we simulate it.
+			_forceModal = true;
+			try
 			{
-				if (string.IsNullOrEmpty(ImageToolboxSettings.Default.LastImageFolder))
+				SetMode(Modes.SingleImage);
+				// The primary thing that OpenFileDialogWithViews buys us is the ability to default to large icons.
+				// OpenFileDialogWithViews still doesn't let us read (and thus remember) the selected view.
+				using (var dlg = new OpenFileDialogWithViews(OpenFileDialogWithViews.DialogViewTypes.Large_Icons))
 				{
-					dlg.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
-				}
-				else
-				{
-					dlg.InitialDirectory = ImageToolboxSettings.Default.LastImageFolder; ;
-				}
-
-				//NB: dissallowed gif because of a .net crash:  http://jira.palaso.org/issues/browse/BL-85
-				dlg.Filter = "picture files".Localize("ImageToolbox.PictureFiles", "Shown in the file-picking dialog to describe what kind of files the dialog is filtering for") + "(*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp)|*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp;";
-
-				if (DialogResult.OK == dlg.ShowDialog())
-				{
-					ImageToolboxSettings.Default.LastImageFolder = Path.GetDirectoryName(dlg.FileName);
-					ImageToolboxSettings.Default.Save();
-
-					try
+					if (string.IsNullOrEmpty(ImageToolboxSettings.Default.LastImageFolder))
 					{
-						_currentImage = PalasoImage.FromFile(dlg.FileName);
+						dlg.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
 					}
-					catch (Exception err) //for example, http://jira.palaso.org/issues/browse/BL-199
+					else
 					{
-						ErrorReport.NotifyUserOfProblem(err, "Sorry, there was a problem loading that image.".Localize("ImageToolbox.ProblemLoadingImage"));
-						return;
+						dlg.InitialDirectory = ImageToolboxSettings.Default.LastImageFolder; ;
 					}
-					_pictureBox.Image = _currentImage.Image;
-					if (ImageChanged != null)
-						ImageChanged.Invoke(this, null);
+
+					//NB: dissallowed gif because of a .net crash:  http://jira.palaso.org/issues/browse/BL-85
+					dlg.Filter = "picture files".Localize("ImageToolbox.PictureFiles", "Shown in the file-picking dialog to describe what kind of files the dialog is filtering for") + "(*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp)|*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp;";
+
+					if (DialogResult.OK == dlg.ShowDialog(this.ParentForm))
+					{
+						ImageToolboxSettings.Default.LastImageFolder = Path.GetDirectoryName(dlg.FileName);
+						ImageToolboxSettings.Default.Save();
+
+						try
+						{
+							_currentImage = PalasoImage.FromFile(dlg.FileName);
+						}
+						catch (Exception err) //for example, http://jira.palaso.org/issues/browse/BL-199
+						{
+							ErrorReport.NotifyUserOfProblem(err, "Sorry, there was a problem loading that image.".Localize("ImageToolbox.ProblemLoadingImage"));
+							return;
+						}
+						_pictureBox.Image = _currentImage.Image;
+						if (ImageChanged != null)
+							ImageChanged.Invoke(this, null);
+					}
 				}
+			}
+			finally
+			{
+				_forceModal = false;
 			}
 		}
 

--- a/SIL.Windows.Forms/ImageToolbox/OpenFileDialogWithViews.cs
+++ b/SIL.Windows.Forms/ImageToolbox/OpenFileDialogWithViews.cs
@@ -83,8 +83,14 @@ namespace SIL.Windows.Forms.ImageToolbox
 				if (m_OpenFileDialog == null)
 				{
 					m_OpenFileDialog = new DialogAdapters.OpenFileDialogAdapter();
+					if (DialogAdapters.CommonDialogAdapter.UseGtkDialogs)
+					{
+						DialogAdapters.CommonDialogAdapter.WindowType = Platform.IsCinnamon ?
+							DialogAdapters.CommonDialogAdapter.WindowTypeHintAdaptor.Dialog :
+							DialogAdapters.CommonDialogAdapter.WindowTypeHintAdaptor.Utility;
+						DialogAdapters.CommonDialogAdapter.ForceKeepAbove = true;
+					}
 				}
-
 				return m_OpenFileDialog;
 			}
 

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -388,7 +388,7 @@
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
     </Reference>
     <Reference Include="DialogAdapters">
-      <HintPath>..\packages\DialogAdapters.0.1.1.32530\lib\net45\DialogAdapters.dll</HintPath>
+      <HintPath>..\packages\DialogAdapters.0.1.2.18378\lib\net45\DialogAdapters.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" Condition="'$(OS)'=='Windows_NT'" />
     <Reference Include="System" />

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40" />
   <package id="NAudio" version="1.8.3" />
-  <package id="DialogAdapters" version="0.1.1.32530" targetFramework="net40" />
+  <package id="DialogAdapters" version="0.1.2.18378" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The code also prevents the user from accidentally (or maliciously) invoking multiple file
choosers at the same time.  The GTK dialog doesn't seem to want to behave as a true
modal dialog with respect to the Mono/C# program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/620)
<!-- Reviewable:end -->
