### PR TITLE
Tweak using PortableClipboard for dialog textboxes

### DIFF
--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataEditorDialog.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataEditorDialog.cs
@@ -4,7 +4,7 @@ using L10NSharp;
 
 namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 {
-	public partial class MetadataEditorDialog : Form
+	public partial class MetadataEditorDialog : SIL.Windows.Forms.Miscellaneous.FormUsingPortableClipboard
 	{
 		private readonly Metadata _originalMetaData;
 		private Metadata _returnMetaData;
@@ -58,34 +58,6 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 		private void _minimallyCompleteCheckTimer_Tick(object sender, EventArgs e)
 		{
 			_okButton.Enabled = _metadataEditorControl.Metadata.IsMinimallyComplete;
-		}
-
-		private bool _usePortableClipboard;
-		/// <summary>
-		/// Clipboard operations (copy/cut/paste) in text boxes may not work properly on Linux
-		/// in some known situations, freezing or crashing the program.
-		/// See https://issues.bloomlibrary.org/youtrack/issue/BL-5681 for one example.
-		/// </summary>
-		public bool UsePortableClipboard
-		{
-			get { return _usePortableClipboard; }
-			set
-			{
-				_usePortableClipboard = value;
-				// Note that TextBox.ShortcutsEnabled does nothing in the Mono runtime.
-				if (value)
-					SIL.Windows.Forms.Miscellaneous.PortableClipboard.RemoveTextboxMenus(this);
-			}
-		}
-
-		protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
-		{
-			if (UsePortableClipboard &&
-				SIL.Windows.Forms.Miscellaneous.PortableClipboard.ProcessClipboardCmdKeysForDialog(this, msg, keyData))
-			{
-				return true;
-			}
-			return base.ProcessCmdKey(ref msg, keyData);
 		}
 	}
 }

--- a/SIL.Windows.Forms/Miscellaneous/FormUsingPortableClipboard.cs
+++ b/SIL.Windows.Forms/Miscellaneous/FormUsingPortableClipboard.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2018 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Windows.Forms;
+
+namespace SIL.Windows.Forms.Miscellaneous
+{
+	/// <summary>
+	/// This class helps dialogs (or program main windows) with textboxes to use the PortableClipboard
+	/// instead of the regular clipboard if needed.  Standard clipboard operations (copy/cut/paste) in
+	/// text boxes may not work properly on Linux in some situations, freezing or crashing the program.
+	/// </summary>
+	/// <remarks>
+	/// See https://issues.bloomlibrary.org/youtrack/issue/BL-5681 for one example of where this is needed.
+	/// </remarks>
+	public class FormUsingPortableClipboard : Form
+	{
+		private bool _usePortableClipboard;
+		public bool UsePortableClipboard
+		{
+			get { return _usePortableClipboard; }
+			set
+			{
+				_usePortableClipboard = value;
+				// Note that TextBox.ShortcutsEnabled does nothing in the Mono runtime.  Needing to
+				// remove (or fix) the context menu means that this must be done after the dialog
+				// has been initialized.
+				if (value)
+					PortableClipboard.RemoveTextboxMenus(this);
+			}
+		}
+
+		protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+		{
+			if (UsePortableClipboard &&
+				PortableClipboard.ProcessClipboardCmdKeysForDialog(this, msg, keyData))
+			{
+				return true;
+			}
+			return base.ProcessCmdKey(ref msg, keyData);
+		}
+	}
+}

--- a/SIL.Windows.Forms/Miscellaneous/PortableClipboard.cs
+++ b/SIL.Windows.Forms/Miscellaneous/PortableClipboard.cs
@@ -288,7 +288,7 @@ namespace SIL.Windows.Forms.Miscellaneous
 		// The following methods were added to allow dialogs to use the PortableClipboard in TextBox and RichTextBox
 		// controls.  It's possible that these methods might only be used on Linux, but they compile (and would work)
 		// fine for Windows.  I prefer not using #if MONO more than absolutely necessary.
-		// See SIL.Windows.Forms.ClearShare.WinFormsUI.MetadataEditorDialog for an example of using these methods.
+		// These methods are used by FormUsingPortableClipboard.
 
 		/// <summary>
 		/// Recursively remove all TextBox menus found owned by the control.
@@ -364,7 +364,12 @@ namespace SIL.Windows.Forms.Miscellaneous
 				var length = box.SelectionLength;
 				var text = box.Text;
 				if (length > 0)
-					text = text.Remove(start, length);
+				{
+					if (start + length > text.Length)	// shouldn't happen, but sometimes paranoia pays
+						text = text.Remove(start);
+					else
+						text = text.Remove(start, length);
+				}
 				var clipText = SIL.Windows.Forms.Miscellaneous.PortableClipboard.GetText();
 				box.Text = text.Insert(start, clipText);
 				box.SelectionStart = start + clipText.Length;
@@ -385,6 +390,10 @@ namespace SIL.Windows.Forms.Miscellaneous
 			if (length > 0)
 			{
 				var start = box.SelectionStart;
+				if (start + length > box.Text.Length)
+					length = box.Text.Length - start;	// shouldn't happen, but paranoia sometimes pays.
+				if (length <= 0)
+					return true;
 				var text = box.Text.Substring(start, length);
 				SIL.Windows.Forms.Miscellaneous.PortableClipboard.SetText(text);
 				if (cut)

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -577,6 +577,7 @@
     </Compile>
     <Compile Include="ImageToolbox\ImageAcquisitionService.cs" />
     <Compile Include="Miscellaneous\PortableClipboard.cs" />
+    <Compile Include="Miscellaneous\FormUsingPortableClipboard.cs" />
     <Compile Include="Miscellaneous\IUserInterfaceMemory.cs" />
     <Compile Include="Miscellaneous\SILAboutBox.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
Subclassing Form reduces the duplication of boilerplate code.
I encountered some strange problems which may reflect bugs in Mono, with box.SelectionStart + box.SelectionLength pointing past the end of the text, resulting in an exception being thrown.  So I also added code to check that situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/630)
<!-- Reviewable:end -->
