### PR TITLE
Guard against null values

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardSwitchingAdapter.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardSwitchingAdapter.cs
@@ -12,6 +12,10 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 	{
 		public bool ActivateKeyboard(KeyboardDescription keyboard)
 		{
+			if (keyboard?.InputLanguage?.Culture == null)
+			{
+				return false;
+			}
 #if !MONO
 			foreach (InputLanguage lang in InputLanguage.InstalledInputLanguages)
 			{


### PR DESCRIPTION
* Don't crash if a client tries to use a keyman
  keyboard that is not associated with a language

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/632)
<!-- Reviewable:end -->
