### PR TITLE
St382 reports blank Genre correctly by removing angle brackets

### DIFF
--- a/SIL.Archiving.Tests/IMDI30Tests.cs
+++ b/SIL.Archiving.Tests/IMDI30Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
@@ -305,6 +305,14 @@ namespace SIL.Archiving.Tests
 			Assert.IsNull(countries.FindByText("Unknown"));
 			Assert.IsNull(countries.FindByText("Unspecified"));
 			Assert.IsNull(countries.FindByText("Undefined"));
+		}
+
+		[Test]
+		public void SetSessionGenre_ContainsAngleBrackets_LatinOnly()
+		{
+			var session = new Session();
+			session.Genre = "<Unknown>";
+			Assert.AreEqual("Unknown", session.Genre);
 		}
 	}
 }

--- a/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
+++ b/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -1870,7 +1870,7 @@ namespace SIL.Archiving.IMDI.Schema
 			}
 			set
 			{
-				MDGroup.Content.Genre = value.ToVocabularyType(false, ListType.Link(ListType.ContentGenre));
+				MDGroup.Content.Genre = value.Replace("<","").Replace(">","").ToVocabularyType(false, ListType.Link(ListType.ContentGenre));
 			}
 		}
 


### PR DESCRIPTION
Angle brackets around <Unknown> were preventing the use of the item from the controlled vocabulary

Card: https://trello.com/c/9eUfILJG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/646)
<!-- Reviewable:end -->
