### PR TITLE
Remove dependency on System.Runtime.InteropServices.RuntimeInformation

### DIFF
--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -16,9 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0-beta4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -335,8 +335,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="icu.net, Version=2.3.0.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
-      <HintPath>..\packages\icu.net.2.3.0\lib\net451\icu.net.dll</HintPath>
+    <Reference Include="icu.net, Version=2.3.2.0, Culture=neutral, PublicKeyToken=416fdd914afa6b66, processorArchitecture=MSIL">
+      <HintPath>..\packages\icu.net.2.3.2\lib\net451\icu.net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.0.4.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.DotNet.PlatformAbstractions.2.0.4\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
@@ -350,10 +350,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="NDesk.DBus">
       <HintPath>..\packages\NDesk.DBus.0.15.0\lib\NDesk.DBus.dll</HintPath>

--- a/SIL.Windows.Forms.Keyboarding/packages.config
+++ b/SIL.Windows.Forms.Keyboarding/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ibusdotnet" version="2.0.0.20771" targetFramework="net40" />
-  <package id="icu.net" version="2.3.0" targetFramework="net461" />
+  <package id="icu.net" version="2.3.2" targetFramework="net461" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.0.4" targetFramework="net461" />
   <package id="Microsoft.Extensions.DependencyModel" version="2.0.4" targetFramework="net461" />
   <package id="NDesk.DBus" version="0.15.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
-  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -577,7 +577,9 @@
     </Compile>
     <Compile Include="ImageToolbox\ImageAcquisitionService.cs" />
     <Compile Include="Miscellaneous\PortableClipboard.cs" />
-    <Compile Include="Miscellaneous\FormForUsingPortableClipboard.cs" />
+    <Compile Include="Miscellaneous\FormForUsingPortableClipboard.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Miscellaneous\IUserInterfaceMemory.cs" />
     <Compile Include="Miscellaneous\SILAboutBox.cs">
       <SubType>Form</SubType>

--- a/SIL.WritingSystems/SIL.WritingSystems.csproj
+++ b/SIL.WritingSystems/SIL.WritingSystems.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="icu.net" Version="2.3.0" />
+    <PackageReference Include="icu.net" Version="2.3.2" />
     <PackageReference Include="Spart" Version="1.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
   </ItemGroup>


### PR DESCRIPTION
This fixes an issue with the Platform class not working properly because it was using the "RuntimeInformation" API. When targeting .NET Framework, "RuntimeInformation" is hardcoded to always return Windows for the current platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/650)
<!-- Reviewable:end -->
