### PR TITLE
St383 - Add topic and keyword to content

### DIFF
--- a/SIL.Archiving.Tests/IMDI30Tests.cs
+++ b/SIL.Archiving.Tests/IMDI30Tests.cs
@@ -314,5 +314,15 @@ namespace SIL.Archiving.Tests
 			session.Genre = "<Unknown>";
 			Assert.AreEqual("Unknown", session.Genre);
 		}
+
+		[Test]
+		public void SessionAddKeyValuePair_TwoKeywords_numberUp2()
+		{
+			var session = new Session();
+			var number = session.MDGroup.Content.Keys.Key.Count;
+			session.AddKeyValuePair("keyword", "holiday");
+			session.AddKeyValuePair("keyword", "emotion");
+			Assert.AreEqual(number + 2, session.MDGroup.Content.Keys.Key.Count);
+		}
 	}
 }

--- a/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
+++ b/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
@@ -1826,7 +1826,7 @@ namespace SIL.Archiving.IMDI.Schema
 		/// <remarks/>
 		public void AddKeyValuePair(string key, string value)
 		{
-			MDGroup.Keys.Key.Add(new KeyType { Name = key, Value = value });
+			MDGroup.Content.Keys.Key.Add(new KeyType { Name = key, Value = value });
 		}
 
 		/// <remarks/>


### PR DESCRIPTION
Our code put this into the MDGroup element whereas the sample
from SOAS put these fields into the Content child element.

Card: https://trello.com/c/l1YrFRfB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/651)
<!-- Reviewable:end -->
