### PR TITLE
Fix Platform.IsLinux on .NET Standard

### DIFF
--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -28,7 +28,7 @@ namespace SIL.PlatformUtilities
 		public static bool IsDotNet => !IsMono;
 
 #if NETSTANDARD2_0
-		public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 		public static bool IsMac => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 		public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 


### PR DESCRIPTION
Fixes my stupid typo on Platform.IsLinux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/655)
<!-- Reviewable:end -->
