### PR TITLE
Use GTK file dialogs for image chooser dialog on Linux

### DIFF
--- a/DistFiles/Palaso.en.tmx
+++ b/DistFiles/Palaso.en.tmx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <tmx version="1.4">
    <header srclang="en"
            adminlang="en"
@@ -192,6 +192,12 @@
       <tu tuid="ImageToolbox.FileButton">
          <tuv xml:lang="en">
             <seg>File</seg>
+         </tuv>
+      </tu>
+      <tu tuid="ImageToolbox.FileChooserTitle">
+         <note>Title shown for a file chooser dialog brought up by the ImageToolbox</note>
+         <tuv xml:lang="en">
+            <seg>Choose Picture File</seg>
          </tuv>
       </tu>
        <tu tuid="ImageToolbox.Galleries">

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -387,6 +387,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
     </Reference>
+    <Reference Include="DialogAdapters">
+      <HintPath>..\packages\DialogAdapters.0.1.3.26068\lib\net45\DialogAdapters.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualBasic" Condition="'$(OS)'=='Windows_NT'" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -1,5 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40" />
   <package id="NAudio" version="1.8.4" targetFramework="net461" />
+  <package id="DialogAdapters" version="0.1.3.26068" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This is targeted initially at libpalaso-4.0.  It will need to be merged to master after we're all happy with it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/660)
<!-- Reviewable:end -->
