### PR TITLE
Adjust checkbox location in language lookup control

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
@@ -175,7 +175,7 @@
 			this._L10NSharpExtender.SetLocalizableToolTip(this._showRegionalDialectsCheckBox, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._showRegionalDialectsCheckBox, null);
 			this._L10NSharpExtender.SetLocalizingId(this._showRegionalDialectsCheckBox, "LanguageLookup.ShowRegionalDialectsLabel");
-			this._showRegionalDialectsCheckBox.Location = new System.Drawing.Point(235, 3);
+			this._showRegionalDialectsCheckBox.Location = new System.Drawing.Point(235, 5);
 			this._showRegionalDialectsCheckBox.Name = "_showRegionalDialectsCheckBox";
 			this._showRegionalDialectsCheckBox.Size = new System.Drawing.Size(132, 17);
 			this._showRegionalDialectsCheckBox.TabIndex = 16;


### PR DESCRIPTION
This recenters it vertically on the textbox control next to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/679)
<!-- Reviewable:end -->
