### PR TITLE
Use "Bahasa Indonesia" for the language name, not "Indonesia"

### DIFF
--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.Designer.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.Designer.cs
@@ -92,7 +92,7 @@
 			this.toolStrip1.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.Flow;
 			this.toolStrip1.Location = new System.Drawing.Point(228, 35);
 			this.toolStrip1.Name = "toolStrip1";
-			this.toolStrip1.Size = new System.Drawing.Size(145, 28);
+			this.toolStrip1.Size = new System.Drawing.Size(200, 28);
 			this.toolStrip1.TabIndex = 15;
 			this.toolStrip1.Text = "toolStrip1";
 			// 

--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.cs
@@ -331,14 +331,22 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 
 			public string Id { get { return _info.Name == "zh-Hans" ? "zh" : _info.Name; } }
 
-			public string NativeName { get { return _info.NativeName; } }
+			public string NativeName
+			{
+				get
+				{
+					if (_info.Name == "id" && _info.NativeName == "Indonesia")
+						return "Bahasa Indonesia";	// This is a known problem in Windows/.Net.
+					return _info.NativeName;
+				}
+			}
 
 			public override string ToString()
 			{
 				if (_info.NativeName == _info.EnglishName)
-					return _info.NativeName;	// English (English) looks rather silly...
+					return NativeName;	// English (English) looks rather silly...
 				if (idsOfRecognizableLanguages.Contains(Id))
-					return _info.NativeName;
+					return NativeName;
 				return String.Format("{0} ({1})", _info.NativeName, _info.EnglishName);
 			}
 		}


### PR DESCRIPTION
This occurs in the Art of Reading image chooser control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/684)
<!-- Reviewable:end -->
