### PR TITLE
Report GDK warnings as warnings

### DIFF
--- a/SIL.BuildTasks/UnitTestTasks/TestTask.cs
+++ b/SIL.BuildTasks/UnitTestTasks/TestTask.cs
@@ -301,7 +301,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 					// If looks like an error but includes induce or simulator then log as warning instead of error
 					// Change this if it is still too broad.
 					string[] toerror = { "error", "crash", "fail" };
-					string[] noterror = { "induce", "simulator" };
+					string[] noterror = { "induce", "simulator", "Gdk-CRITICAL **:", "Gtk-CRITICAL **:" };
 
 					if (toerror.Any(err => logContents.IndexOf(err, StringComparison.OrdinalIgnoreCase) >= 0) &&
 						!noterror.Any(err => logContents.IndexOf(err, StringComparison.OrdinalIgnoreCase) >= 0))


### PR DESCRIPTION
Some GDK warnings contain the word 'failure' and therefore were
reported as errors previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/691)
<!-- Reviewable:end -->
