### PR TITLE
[linux] Fix location detection for RAMP (LT-16894)

### DIFF
--- a/SIL.Archiving/ArchivingPrograms.cs
+++ b/SIL.Archiving/ArchivingPrograms.cs
@@ -26,7 +26,7 @@ namespace SIL.Archiving
 			const string rampFileExtension = ".ramp";
 
 			if (ArchivingDlgViewModel.IsMono)
-				exeFile = FileLocationUtilities.LocateInProgramFiles("RAMP", true);
+				exeFile = FileLocationUtilities.LocateInProgramFiles("ramp", true);
 			else
 				exeFile = FileLocator.GetFromRegistryProgramThatOpensFileType(rampFileExtension) ??
 					FileLocationUtilities.LocateInProgramFiles("ramp.exe", true, "ramp");

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -84,6 +84,78 @@ namespace SIL.Tests.IO
 			Assert.DoesNotThrow(() => FileLocationUtilities.LocateInProgramFiles(findFile, true, "!~@blah"));
 		}
 
+		[Test]
+		[Platform(Include = "Linux")]
+		public void LocateInProgramFiles_DeepSearch_FindsFileInSubdir()
+		{
+			// This simulates finding RAMP which is installed as /opt/RAMP/ramp. We can't put
+			// anything in /opt for testing, so we add our tmp directory to the path.
+
+			// Setup
+			var simulatedOptDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			var pathVariable = Environment.GetEnvironmentVariable("PATH");
+			try
+			{
+				Directory.CreateDirectory(simulatedOptDir);
+				Directory.CreateDirectory(Path.Combine(simulatedOptDir, "RAMP"));
+				var file = Path.Combine(simulatedOptDir, "RAMP", "ramp");
+				File.WriteAllText(file, "Simulated RAMP starter");
+				Environment.SetEnvironmentVariable("PATH", $"{simulatedOptDir}{Path.PathSeparator}{pathVariable}");
+
+				// Exercise/Verify
+				Assert.That(FileLocationUtilities.LocateInProgramFiles("ramp", true),
+					Is.EqualTo(file));
+			}
+			finally
+			{
+				try
+				{
+					Environment.SetEnvironmentVariable("PATH", pathVariable);
+					Directory.Delete(simulatedOptDir, true);
+				}
+				catch
+				{
+					// just ignore
+				}
+			}
+		}
+
+		[Test]
+		[Platform(Include = "Linux")]
+		public void LocateInProgramFiles_ShallowSearch_FindsNothing()
+		{
+			// This simulates finding RAMP which is installed as /opt/RAMP/ramp. We can't put
+			// anything in /opt for testing, so we add our tmp directory to the path.
+
+			// Setup
+			var simulatedOptDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			var pathVariable = Environment.GetEnvironmentVariable("PATH");
+			try
+			{
+				Directory.CreateDirectory(simulatedOptDir);
+				Directory.CreateDirectory(Path.Combine(simulatedOptDir, "RAMP"));
+				var file = Path.Combine(simulatedOptDir, "RAMP", "ramp");
+				File.WriteAllText(file, "Simulated RAMP starter");
+				Environment.SetEnvironmentVariable("PATH", $"{simulatedOptDir}{Path.PathSeparator}{pathVariable}");
+
+				// Exercise/Verify
+				Assert.That(FileLocationUtilities.LocateInProgramFiles("ramp", false),
+					Is.Null);
+			}
+			finally
+			{
+				try
+				{
+					Environment.SetEnvironmentVariable("PATH", pathVariable);
+					Directory.Delete(simulatedOptDir, true);
+				}
+				catch
+				{
+					// just ignore
+				}
+			}
+		}
+
 		//TODO: this could use lots more tests
 
 		[Test]

--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -224,11 +224,6 @@ namespace SIL.IO
 		///		- If fallBackToDeepSearch is false, then only the top-level program files
 		///		  folder is searched.
 		///
-		/// Note: For Mono the deep search and shallow search are the same because there
-		///		normally are no sub-directories in the program files directories.
-		///
-		/// Note: For Mono the subFoldersToSearch parameter is ignored.
-		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static string LocateInProgramFiles(string exeName, bool fallBackToDeepSearch,
@@ -240,16 +235,13 @@ namespace SIL.IO
 				if (tgtPath != null)
 					return tgtPath;
 
-				return (!fallBackToDeepSearch
+				return !fallBackToDeepSearch
 					? null
-					: LocateInProgramFilesUsingDeepSearch(exeName, subFoldersToSearch));
+					: LocateInProgramFilesUsingDeepSearch(exeName, subFoldersToSearch);
 			}
 
-			// For Mono, the deep search and shallow search are the same because there
-			// normally are no sub-directories in the program files directories.
-
-			// The subFoldersToSearch parameter is not valid on Linux.
-			return LocateInProgramFilesUsingShallowSearch(exeName);
+			return fallBackToDeepSearch ? LocateInProgramFilesUsingDeepSearch(exeName) :
+				LocateInProgramFilesUsingShallowSearch(exeName);
 		}
 
 		private static string LocateInProgramFilesUsingShallowSearch(string exeName,


### PR DESCRIPTION
RAMP installs in /opt/RAMP/ramp. LocateInProgramFiles() previously
didn't check subdirectories when running on Linux and so didn't find
RAMP even when installed. This change optionally checks in subdirectories.

This kind of changes API (or at least behavior) on Linux, but this
probably doesn't have noticeable effects for most projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/697)
<!-- Reviewable:end -->
