### PR TITLE
[linux] Fix location detection for RAMP (LT-16894)

### DIFF
--- a/Palaso.Tests/IO/FileLocatorTests.cs
+++ b/Palaso.Tests/IO/FileLocatorTests.cs
@@ -114,6 +114,77 @@ namespace Palaso.Tests.IO
 			Assert.DoesNotThrow(() => FileLocator.LocateInProgramFiles(findFile, true, "!~@blah"));
 		}
 
+		[Test]
+		[Platform(Include = "Linux")]
+		public void LocateInProgramFiles_DeepSearch_FindsFileInSubdir()
+		{
+			// This simulates finding RAMP which is installed as /opt/RAMP/ramp. We can't put
+			// anything in /opt for testing, so we add our tmp directory to the path.
+
+			// Setup
+			var simulatedOptDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			var pathVariable = Environment.GetEnvironmentVariable("PATH");
+			try
+			{
+				Directory.CreateDirectory(simulatedOptDir);
+				Directory.CreateDirectory(Path.Combine(simulatedOptDir, "RAMP"));
+				var file = Path.Combine(simulatedOptDir, "RAMP", "ramp");
+				File.WriteAllText(file, "Simulated RAMP starter");
+				Environment.SetEnvironmentVariable("PATH", simulatedOptDir + Path.PathSeparator + pathVariable);
+
+				// Exercise/Verify
+				Assert.That(FileLocator.LocateInProgramFiles("ramp", true),
+					Is.EqualTo(file));
+			}
+			finally
+			{
+				try
+				{
+					Environment.SetEnvironmentVariable("PATH", pathVariable);
+					Directory.Delete(simulatedOptDir, true);
+				}
+				catch
+				{
+					// just ignore
+				}
+			}
+		}
+
+		[Test]
+		[Platform(Include = "Linux")]
+		public void LocateInProgramFiles_ShallowSearch_FindsNothing()
+		{
+			// This simulates finding RAMP which is installed as /opt/RAMP/ramp. We can't put
+			// anything in /opt for testing, so we add our tmp directory to the path.
+
+			// Setup
+			var simulatedOptDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+			var pathVariable = Environment.GetEnvironmentVariable("PATH");
+			try
+			{
+				Directory.CreateDirectory(simulatedOptDir);
+				Directory.CreateDirectory(Path.Combine(simulatedOptDir, "RAMP"));
+				var file = Path.Combine(simulatedOptDir, "RAMP", "ramp");
+				File.WriteAllText(file, "Simulated RAMP starter");
+				Environment.SetEnvironmentVariable("PATH", simulatedOptDir + Path.PathSeparator + pathVariable);
+
+				// Exercise/Verify
+				Assert.That(FileLocator.LocateInProgramFiles("ramp", false),
+					Is.Null);
+			}
+			finally
+			{
+				try
+				{
+					Environment.SetEnvironmentVariable("PATH", pathVariable);
+					Directory.Delete(simulatedOptDir, true);
+				}
+				catch
+				{
+					// just ignore
+				}
+			}
+		}
 		//TODO: this could use lots more tests
 
 		[Test]

--- a/Palaso/IO/FileLocator.cs
+++ b/Palaso/IO/FileLocator.cs
@@ -368,11 +368,6 @@ namespace Palaso.IO
 		///		- If fallBackToDeepSearch is false, then only the top-level program files
 		///		  folder is searched.
 		///
-		/// Note: For Mono the deep search and shallow search are the same because there
-		///		normally are no sub-directories in the program files directories.
-		///
-		/// Note: For Mono the subFoldersToSearch parameter is ignored.
-		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static string LocateInProgramFiles(string exeName, bool fallBackToDeepSearch,
@@ -386,11 +381,8 @@ namespace Palaso.IO
 			return (!fallBackToDeepSearch ? null :
 				LocateInProgramFilesUsingDeepSearch(exeName, subFoldersToSearch));
 #else
-			// For Mono, the deep search and shallow search are the same because there
-			// normally are no sub-directories in the program files directories.
-
-			// The subFoldersToSearch parameter is not valid on Linux.
-			return LocateInProgramFilesUsingShallowSearch(exeName);
+			return fallBackToDeepSearch ? LocateInProgramFilesUsingDeepSearch(exeName) :
+				LocateInProgramFilesUsingShallowSearch(exeName);
 #endif
 		}
 

--- a/SIL.Archiving/ArchivingPrograms.cs
+++ b/SIL.Archiving/ArchivingPrograms.cs
@@ -26,7 +26,7 @@ namespace SIL.Archiving
 			const string rampFileExtension = ".ramp";
 
 			if (ArchivingDlgViewModel.IsMono)
-				exeFile = FileLocator.LocateInProgramFiles("RAMP", true);
+				exeFile = FileLocator.LocateInProgramFiles("ramp", true);
 			else
 				exeFile = FileLocator.GetFromRegistryProgramThatOpensFileType(rampFileExtension) ??
 					FileLocator.LocateInProgramFiles("ramp.exe", true, "ramp");


### PR DESCRIPTION
RAMP installs in /opt/RAMP/ramp. LocateInProgramFiles() previously
didn't check subdirectories when running on Linux and so didn't find
RAMP even when installed. This change optionally checks in subdirectories.

This kind of changes API (or at least behavior) on Linux, but this
probably doesn't have noticeable effects for most projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/698)
<!-- Reviewable:end -->
