### PR TITLE
Tweak title of Script and Variant dialog, fix for Linux

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
@@ -200,7 +200,7 @@ namespace SIL.Windows.Forms.WritingSystems
 			this._scriptsAndVariantsLink.Size = new System.Drawing.Size(101, 13);
 			this._scriptsAndVariantsLink.TabIndex = 17;
 			this._scriptsAndVariantsLink.TabStop = true;
-			this._scriptsAndVariantsLink.Text = "Scripts and Variants";
+			this._scriptsAndVariantsLink.Text = "Script and Variant";
 			this._scriptsAndVariantsLink.Visible = false;
 			this._scriptsAndVariantsLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this._scriptsAndVariants_LinkClicked);
 			// 

--- a/SIL.Windows.Forms.WritingSystems/ScriptsAndVariantsDialog.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/ScriptsAndVariantsDialog.Designer.cs
@@ -97,7 +97,7 @@ namespace SIL.Windows.Forms.WritingSystems
 			this.Name = "ScriptsAndVariantsDialog";
 			this.ShowIcon = false;
 			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-			this.Text = "Scripts and Variants";
+			this.Text = "Script and Variant";
 			this.TopMost = true;
 			((System.ComponentModel.ISupportInitialize)(this._L10NSharpExtender)).EndInit();
 			this.ResumeLayout(false);

--- a/SIL.Windows.Forms.WritingSystems/ScriptsAndVariantsDialog.cs
+++ b/SIL.Windows.Forms.WritingSystems/ScriptsAndVariantsDialog.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Drawing;
 using System.Windows.Forms;
+using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.WritingSystems
 {
@@ -28,6 +31,17 @@ namespace SIL.Windows.Forms.WritingSystems
 		private void _okButton_Click(object sender, System.EventArgs e)
 		{
 			_wsIdentifierView.MoveDataFromViewToModel(); // make sure the latest changes are saved
+		}
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			// On Linux, _wsIdentifierView, which is initially designed to cover the full width
+			// of this dialog, ends up narrower than expected, with some of its internal controls
+			// scrunched up.  Restoring the full width fixes the appearance.  See the comment and
+			// image near the bottom of https://silbloom.myjetbrains.com/youtrack/issue/BL-5736.
+			if (Platform.IsMono && _wsIdentifierView.Width < this.ClientSize.Width)
+				_wsIdentifierView.Size = new Size(this.ClientSize.Width, _wsIdentifierView.Height);
 		}
 	}
 }


### PR DESCRIPTION
The default Mono layout of the dialog left much to be desired.  See
https://silbloom.myjetbrains.com/youtrack/issue/BL-5736 for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/708)
<!-- Reviewable:end -->
