### PR TITLE
Fix: LT-19077 Crash while trying to use Archive with RAMP 3.0

### DIFF
--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -1820,6 +1820,15 @@ namespace SIL.Archiving
 			if (dir == null)
 				throw new DirectoryNotFoundException("The RAMP directory was not found.");
 
+
+			if (Platform.IsWindows)
+			{
+				//Ramp 3.0 Package doesn't have languages.yaml
+				if (!Directory.Exists(Path.Combine(dir, "data")))
+				{
+					return string.Empty;
+				}
+			}
 			// on Linux the exe and data directory are not in the same directory
 			if (!Directory.Exists(Path.Combine(dir, "data")))
 			{
@@ -1859,16 +1868,18 @@ namespace SIL.Archiving
 			{
 				_languageList = new Dictionary<string, string>();
 				var langFile = GetLanguageFileLocation();
-
-				foreach (var fileLine in File.ReadLines(langFile).Where(l => l.StartsWith("  code: \"")))
+				if (File.Exists(langFile))
 				{
-					const int start = 9;
-					var end = fileLine.IndexOf('"', start);
-					if (end > start)
+					foreach (var fileLine in File.ReadLines(langFile).Where(l => l.StartsWith("  code: \"")))
 					{
-						var parts = fileLine.Substring(start, end - start).Split(':');
-						if (parts.Length == 2)
-							_languageList[parts[0]] = parts[1];
+						const int start = 9;
+						var end = fileLine.IndexOf('"', start);
+						if (end > start)
+						{
+							var parts = fileLine.Substring(start, end - start).Split(':');
+							if (parts.Length == 2)
+								_languageList[parts[0]] = parts[1];
+						}
 					}
 				}
 			}

--- a/SIL.Core.Desktop/IO/FileLocator.cs
+++ b/SIL.Core.Desktop/IO/FileLocator.cs
@@ -243,8 +243,13 @@ namespace SIL.IO
 				return null;
 
 			key = Registry.ClassesRoot.OpenSubKey(string.Format("{0}\\shell\\open\\command", value));
-			if (key == null)
-				return null;
+
+			if (key == null && value.ToLower() == "ramp.package")
+			{
+				key = Registry.ClassesRoot.OpenSubKey(string.Format("{0}\\shell\\open\\command", "ramp"));
+				if (key == null)
+					return null;
+			}
 
 			value = key.GetValue(string.Empty) as string;
 			key.Close();


### PR DESCRIPTION
 * Handled the Ramp 3.0 Package doesn't have languages.yaml
 * Locate the ramp installer for 3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/711)
<!-- Reviewable:end -->
