### PR TITLE
Handle bad numbering system data more gracefully

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -391,6 +391,13 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
+		public void BadCustomDigitsReturnDefault()
+		{
+			Assert.AreSame(NumberingSystemDefinition.Default, NumberingSystemDefinition.CreateCustomSystem(string.Empty));
+			Assert.AreSame(NumberingSystemDefinition.Default, NumberingSystemDefinition.CreateCustomSystem("123"));
+		}
+
+		[Test]
 		public void Roundtrip_LdmlCustomNumbersWithSurrogatePairs()
 		{
 			using (var environment = new TestEnvironment())

--- a/SIL.WritingSystems/NumberingSystemDefinition.cs
+++ b/SIL.WritingSystems/NumberingSystemDefinition.cs
@@ -65,11 +65,13 @@ namespace SIL.WritingSystems
 		/// <summary>
 		/// Factory method to create a custom numbering system with specific digits
 		/// </summary>
+		/// <remarks>If the digits given are invalid it will return the Default instead.</remarks>
 		public static NumberingSystemDefinition CreateCustomSystem(string digits)
 		{
 			if (new StringInfo(digits).LengthInTextElements != 10)
 			{
-				throw new ArgumentException("numbering systems must contain exactly 10 digits");
+				Debug.WriteLine("Numbering systems must contain exactly 10 digits. Tried to create one with '{0}'");
+				return Default;
 			}
 			return new NumberingSystemDefinition {_digits = digits};
 		}


### PR DESCRIPTION
  Some old ldml files had defined empty custom
  numbers in the character section and crashed
  this fix will return the default latn instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/727)
<!-- Reviewable:end -->
