### PR TITLE
Handle Unicode 'apostrophe' in language lookup

### DIFF
--- a/SIL.WritingSystems.Tests/LanguageLookupTests.cs
+++ b/SIL.WritingSystems.Tests/LanguageLookupTests.cs
@@ -353,5 +353,15 @@ namespace SIL.WritingSystems.Tests
 			Assert.AreEqual("etr", lookup.GetLanguageFromCode("etr").LanguageTag);
 			Assert.AreEqual("English", lookup.GetLanguageFromCode("en").DesiredName);
 		}
+
+		[Test]
+		public void SuggestLanguages_HandlesApostrophe()
+		{
+			var lookup = new LanguageLookup();
+			var languages = lookup.SuggestLanguages("K\u2019i").ToArray();
+			Assert.True(languages.Any(l => l.DesiredName == "K\u2019iche\u2019"));
+			languages = lookup.SuggestLanguages("K'i").ToArray();
+			Assert.True(languages.Any(l => l.DesiredName == "K\u2019iche\u2019"));
+		}
 	}
 }

--- a/SIL.WritingSystems/LanguageLookup.cs
+++ b/SIL.WritingSystems/LanguageLookup.cs
@@ -151,6 +151,18 @@ namespace SIL.WritingSystems
 			{
 				IEnumerable<LanguageInfo> matchOnCode = from x in _codeToLanguageIndex where x.Key.StartsWith(searchString, StringComparison.InvariantCultureIgnoreCase) select x.Value;
 				List<LanguageInfo>[] matchOnName = (from x in _nameToLanguageIndex where x.Key.StartsWith(searchString, StringComparison.InvariantCultureIgnoreCase) select x.Value).ToArray();
+				// Apostrophes can cause trouble in lookup.  Unicode TR-29 inexplicably says to use
+				// u2019 (RIGHT SINGLE QUOTATION MARK) for the English apostrophe when it also defines
+				// u02BC (MODIFIER LETTER APOSTROPHE) as a Letter character.  Users are quite likely to
+				// type the ASCII apostrophe (u0027) which is defined as Punctuation.  The current
+				// data appears to use u2019 in several language names, which means that users might
+				// end up thinking the language isn't in our database.
+				// See https://silbloom.myjetbrains.com/youtrack/issue/BL-6339.
+				if (!matchOnName.Any() && searchString.Contains('\''))
+				{
+					searchString = searchString.Replace('\'','\u2019');
+					matchOnName = (from x in _nameToLanguageIndex where x.Key.StartsWith(searchString, StringComparison.InvariantCultureIgnoreCase) select x.Value).ToArray();
+				}
 				List<LanguageInfo>[] matchOnCountry = (from x in _countryToLanguageIndex where x.Key.StartsWith(searchString, StringComparison.InvariantCultureIgnoreCase) select x.Value).ToArray();
 
 				if (!matchOnName.Any())


### PR DESCRIPTION
It's really the Unicode RIGHT SINGLE QUOTATION MARK in the language
data.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-6339.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/741)
<!-- Reviewable:end -->
