### PR TITLE
PTX-16877 make VerseRef a struct

### DIFF
--- a/SIL.Core/Xml/XmlSerializationHelper.cs
+++ b/SIL.Core/Xml/XmlSerializationHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -293,7 +293,7 @@ namespace SIL.Xml
 		/// Deserializes XML from the specified string to an object of the specified type.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromString<T>(string input) where T : class
+		public static T DeserializeFromString<T>(string input)
 		{
 			Exception e;
 			return (DeserializeFromString<T>(input, out e));
@@ -305,7 +305,6 @@ namespace SIL.Xml
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static T DeserializeFromString<T>(string input, bool fKeepWhitespaceInElements)
-			where T : class
 		{
 			Exception e;
 			return (DeserializeFromString<T>(input, fKeepWhitespaceInElements, out e));
@@ -316,7 +315,7 @@ namespace SIL.Xml
 		/// Deserializes XML from the specified string to an object of the specified type.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromString<T>(string input, out Exception e) where T : class
+		public static T DeserializeFromString<T>(string input, out Exception e)
 		{
 			return DeserializeFromString<T>(input, false, out e);
 		}
@@ -327,15 +326,15 @@ namespace SIL.Xml
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public static T DeserializeFromString<T>(string input, bool fKeepWhitespaceInElements,
-			out Exception e) where T : class
+			out Exception e)
 		{
-			T data = null;
+			T data = default(T);
 			e = null;
 
 			try
 			{
 				if (string.IsNullOrEmpty(input))
-					return null;
+					return data;
 
 				// Whitespace is not allowed before the XML declaration,
 				// so get rid of any that exists.
@@ -362,7 +361,7 @@ namespace SIL.Xml
 		/// <typeparam name="T">The object type</typeparam>
 		/// <param name="filename">The filename from which to load</param>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromFile<T>(string filename) where T : class
+		public static T DeserializeFromFile<T>(string filename)
 		{
 			Exception e;
 			return DeserializeFromFile<T>(filename, false, out e);
@@ -373,7 +372,7 @@ namespace SIL.Xml
 		/// Deserializes XML from the specified file to an object of the specified type.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromFile<T>(string filename, string rootElementName) where T : class
+		public static T DeserializeFromFile<T>(string filename, string rootElementName)
 		{
 			Exception e;
 			return DeserializeFromFile<T>(filename, rootElementName, false, out e);
@@ -390,7 +389,6 @@ namespace SIL.Xml
 		/// these elements will be ignored during a deserialization.</param>
 		/// ------------------------------------------------------------------------------------
 		public static T DeserializeFromFile<T>(string filename, bool fKeepWhitespaceInElements)
-			where T : class
 		{
 			Exception e;
 			return DeserializeFromFile<T>(filename, fKeepWhitespaceInElements, out e);
@@ -409,7 +407,7 @@ namespace SIL.Xml
 		/// these elements will be ignored during a deserialization.</param>
 		/// ------------------------------------------------------------------------------------
 		public static T DeserializeFromFile<T>(string filename, string rootElementName,
-			bool fKeepWhitespaceInElements) where T : class
+			bool fKeepWhitespaceInElements)
 		{
 			Exception e;
 			return DeserializeFromFile<T>(filename, rootElementName, fKeepWhitespaceInElements, out e);
@@ -423,7 +421,7 @@ namespace SIL.Xml
 		/// <param name="filename">The filename from which to load</param>
 		/// <param name="e">The exception generated during the deserialization.</param>
 		/// ------------------------------------------------------------------------------------
-		public static T DeserializeFromFile<T>(string filename, out Exception e) where T : class
+		public static T DeserializeFromFile<T>(string filename, out Exception e)
 		{
 			return DeserializeFromFile<T>(filename, false, out e);
 		}
@@ -440,7 +438,7 @@ namespace SIL.Xml
 		/// <returns></returns>
 		/// ------------------------------------------------------------------------------------
 		public static T DeserializeFromFile<T>(string filename, string rootElementName,
-			out Exception e) where T : class
+			out Exception e)
 		{
 			return DeserializeFromFile<T>(filename, rootElementName, false, out e);
 		}
@@ -457,7 +455,7 @@ namespace SIL.Xml
 		/// <param name="e">The exception generated during the deserialization.</param>
 		/// ------------------------------------------------------------------------------------
 		public static T DeserializeFromFile<T>(string filename, bool fKeepWhitespaceInElements,
-			out Exception e) where T : class
+			out Exception e)
 		{
 			return DeserializeFromFile<T>(filename, null, fKeepWhitespaceInElements, out e);
 		}
@@ -477,15 +475,15 @@ namespace SIL.Xml
 		/// <returns></returns>
 		/// --------------------------------------------------------------------------------
 		public static T DeserializeFromFile<T>(string filename, string rootElementName,
-			bool fKeepWhitespaceInElements, out Exception e) where T : class
+			bool fKeepWhitespaceInElements, out Exception e)
 		{
-			T data = null;
+			T data = default(T);
 			e = null;
 
 			try
 			{
 				if (!File.Exists(filename))
-					return null;
+					return data;
 
 				using (InternalXmlReader reader = new InternalXmlReader(
 					filename, fKeepWhitespaceInElements))

--- a/SIL.Scripture.Tests/ScrVersTests.cs
+++ b/SIL.Scripture.Tests/ScrVersTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using System.IO;
@@ -249,11 +249,11 @@ namespace SIL.Scripture.Tests
 
 			// Get mapping from "NUM 17:1 = NUM 17:16" in the versification
 			VerseRef vref = new VerseRef(4, 17, 1, versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef(4, 17, 16, ScrVers.Original), vref);
 
 			vref = new VerseRef(4, 17, 16, ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef(4, 17, 1, versification), vref);
 		}
 		
@@ -270,14 +270,14 @@ namespace SIL.Scripture.Tests
 			for (int i = 1; i <= 13; i++)
 			{
 				vref = new VerseRef(4, 17, i, versification);
-				ScrVers.Original.ChangeVersification(vref);
+				vref = ScrVers.Original.ChangeVersification(vref);
 				Assert.AreEqual(new VerseRef(4, 17, i + 15, ScrVers.Original), vref);
 			}
 
 			for (int i = 16; i <= 28; i++)
 			{
 				vref = new VerseRef(4, 17, i, ScrVers.Original);
-				versification.ChangeVersification(vref);
+				vref = versification.ChangeVersification(vref);
 				Assert.AreEqual(new VerseRef(4, 17, i - 15, versification), vref);
 			}
 		}
@@ -305,28 +305,28 @@ namespace SIL.Scripture.Tests
 			versification.ParseRangeToOneMappingLine("&ACT 19:39-41 = ACT 19:40");
 
 			VerseRef vref = new VerseRef("ACT 19:39", versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:40", ScrVers.Original), vref);
 
 			vref = new VerseRef("ACT 19:40", versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:40", ScrVers.Original), vref);
 
 			vref = new VerseRef("ACT 19:41", versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:40", ScrVers.Original), vref);
 
 
 			vref = new VerseRef("ACT 19:39", ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:39", versification), vref);
 
 			vref = new VerseRef("ACT 19:40", ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:39", versification), vref);
 
 			vref = new VerseRef("ACT 19:41", ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:41", versification), vref);
 		}
 
@@ -340,28 +340,28 @@ namespace SIL.Scripture.Tests
 		{
 			versification.ParseRangeToOneMappingLine("&ACT 19:39 = ACT 19:38-40");
 			VerseRef vref = new VerseRef("ACT 19:38", versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:38", ScrVers.Original), vref);
 
 			vref = new VerseRef("ACT 19:39", versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:38", ScrVers.Original), vref);
 
 			vref = new VerseRef("ACT 19:40", versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:40", ScrVers.Original), vref);
 
 
 			vref = new VerseRef("ACT 19:38", ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:39", versification), vref);
 
 			vref = new VerseRef("ACT 19:39", ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:39", versification), vref);
 
 			vref = new VerseRef("ACT 19:40", ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:39", versification), vref);
 		}
 
@@ -650,7 +650,7 @@ namespace SIL.Scripture.Tests
 			for (int i = 1; i <= 16; i++)
 			{
 				vref = new VerseRef(19, 119, i, versification);
-				ScrVers.Original.ChangeVersification(vref);
+				vref = ScrVers.Original.ChangeVersification(vref);
 				if (i == 1)
 				{
 					Assert.AreEqual(new VerseRef(19, 119, 1, ScrVers.Original), vref);
@@ -660,13 +660,13 @@ namespace SIL.Scripture.Tests
 			}
 
 			vref = new VerseRef(19, 119, 1, ScrVers.Original);
-			versification.ChangeVersification(vref);
+			vref = versification.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef(19, 119, 1, versification), vref);
 
 			for (int i = 20; i <= 34; i++)
 			{
 				vref = new VerseRef(19, 119, i, ScrVers.Original);
-				versification.ChangeVersification(vref);
+				vref = versification.ChangeVersification(vref);
 				Assert.AreEqual(new VerseRef(19, 119, i - 18, versification), vref);
 			}
 		}
@@ -688,20 +688,20 @@ namespace SIL.Scripture.Tests
 
 			// Get mapping from "PSA 78:20-34 = PSA 78:2-16" in the versification
 			VerseRef vref = new VerseRef(19, 78, 1, versification);
-			ScrVers.Original.ChangeVersification(vref);
+			vref = ScrVers.Original.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef(19, 78, 1, ScrVers.Original), vref);
 
 			for (int i = 20; i <= 34; i++)
 			{
 				vref = new VerseRef(19, 78, i, versification);
-				ScrVers.Original.ChangeVersification(vref);
+				vref = ScrVers.Original.ChangeVersification(vref);
 				Assert.AreEqual(new VerseRef(19, 78, i - 18, ScrVers.Original), vref);
 			}
 
 			for (int i = 1; i <= 16; i++)
 			{
 				vref = new VerseRef(19, 78, i, ScrVers.Original);
-				versification.ChangeVersification(vref);
+				vref = versification.ChangeVersification(vref);
 				if (i == 1)
 				{
 					Assert.AreEqual(new VerseRef(19, 78, 1, versification), vref);
@@ -777,11 +777,11 @@ namespace SIL.Scripture.Tests
 			// based on the same original versification.
 
 			VerseRef vref = new VerseRef("ACT 19:40", versification);
-			versification2.ChangeVersification(vref);
+			vref = versification2.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:40", versification2), vref);
 
 			vref = new VerseRef("ACT 19:41", versification);
-			versification2.ChangeVersification(vref);
+			vref = versification2.ChangeVersification(vref);
 			Assert.AreEqual(new VerseRef("ACT 19:41", versification2), vref);
 		}
 		#endregion
@@ -900,7 +900,7 @@ namespace SIL.Scripture.Tests
 		public void FirstIncludedVerse()
 		{
 			versification.ParseChapterVerseLine("GEN 51:0 52:0 53:10");
-			Assert.AreEqual(53, versification.FirstIncludedVerse(1, 51).ChapterNum);
+			Assert.AreEqual(53, ((VerseRef)versification.FirstIncludedVerse(1, 51)).ChapterNum);
 		}
 
 		[Test]

--- a/SIL.Scripture.Tests/TestScrVers.cs
+++ b/SIL.Scripture.Tests/TestScrVers.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2014, SIL International.
 // <copyright from='2013' to='2014' company='SIL International'>
 //		Copyright (c) 2014, SIL International.   
@@ -69,7 +69,7 @@ namespace SIL.Scripture.Tests
 			throw new System.NotImplementedException();
 		}
 
-		public VerseRef FirstIncludedVerse(int bookNum, int chapterNum)
+		public VerseRef? FirstIncludedVerse(int bookNum, int chapterNum)
 		{
 			throw new System.NotImplementedException();
 		}
@@ -79,12 +79,12 @@ namespace SIL.Scripture.Tests
 			throw new System.NotImplementedException();
 		}
 
-		public void ChangeVersification(VerseRef reference)
+		public VerseRef ChangeVersification(VerseRef reference)
 		{
 			throw new System.NotImplementedException();
 		}
 
-		public bool ChangeVersificationWithRanges(VerseRef reference)
+		public bool ChangeVersificationWithRanges(VerseRef reference, out VerseRef newReference)
 		{
 			throw new System.NotImplementedException();
 		}

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -63,14 +63,15 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(VerseRef.defaultVersification, vref.Versification);
 
 			vref = new VerseRef();
+			Assert.IsTrue(vref.IsDefault);
 			Assert.IsFalse(vref.Valid);
 			Assert.AreEqual(000000000, vref.BBBCCCVVV);
 			Assert.AreEqual("000000000", vref.BBBCCCVVVS);
 			Assert.AreEqual(0, vref.BookNum);
 			Assert.AreEqual(string.Empty, vref.Book);
-			Assert.AreEqual(-1, vref.ChapterNum);
+			Assert.AreEqual(0, vref.ChapterNum);
 			Assert.AreEqual(string.Empty, vref.Chapter);
-			Assert.AreEqual(-1, vref.VerseNum);
+			Assert.AreEqual(0, vref.VerseNum);
 			Assert.AreEqual(string.Empty, vref.Verse);
 			Assert.AreEqual(VerseRef.defaultVersification, vref.Versification);
 
@@ -192,8 +193,8 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(VerseRef.ValidStatusType.OutOfRange, vref.ValidStatus); // 0 not allowed for chapter
 			Assert.AreEqual(013000000, vref.BBBCCCVVV);
 			Assert.AreEqual(13, vref.BookNum);
-			Assert.AreEqual(-1, vref.ChapterNum);
-			Assert.AreEqual(-1, vref.VerseNum);
+			Assert.AreEqual(0, vref.ChapterNum);
+			Assert.AreEqual(0, vref.VerseNum);
 
 			vref.ChapterNum = 1;
 			vref.VerseNum = 0;
@@ -220,7 +221,7 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(000016000, vref.BBBCCCVVV);
 			Assert.AreEqual(0, vref.BookNum);
 			Assert.AreEqual(16, vref.ChapterNum);
-			Assert.AreEqual(-1, vref.VerseNum);
+			Assert.AreEqual(0, vref.VerseNum);
 
 			vref = new VerseRef();
 			vref.Versification = ScrVers.English;
@@ -229,7 +230,7 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(VerseRef.ValidStatusType.OutOfRange, vref.ValidStatus);
 			Assert.AreEqual(000000017, vref.BBBCCCVVV);
 			Assert.AreEqual(0, vref.BookNum);
-			Assert.AreEqual(-1, vref.ChapterNum);
+			Assert.AreEqual(0, vref.ChapterNum);
 			Assert.AreEqual(17, vref.VerseNum);
 		}
 
@@ -519,7 +520,7 @@ namespace SIL.Scripture.Tests
 		{
 			VerseRef vrefSource = new VerseRef("LUK", "3", "4b-6a", ScrVers.Vulgate);
 			VerseRef vrefDest = new VerseRef();
-			vrefSource.CopyTo(vrefDest);
+			vrefDest.CopyFrom(vrefSource);
 			// Now change the source to ensure that we didn't just make it referentially equal.
 			vrefSource.BookNum = 2;
 			vrefSource.ChapterNum = 6;
@@ -541,7 +542,7 @@ namespace SIL.Scripture.Tests
 		{
 			VerseRef vrefSource = new VerseRef("LUK", "3", "4b-6a", ScrVers.Vulgate);
 			VerseRef vrefDest = new VerseRef(1, 3, 5, ScrVers.RussianOrthodox);
-			vrefSource.CopyVerseTo(vrefDest);
+			vrefDest.CopyVerseFrom(vrefSource);
 			// Now change the source to ensure that we didn't just make it referentially equal.
 			vrefSource.BookNum = 2;
 			vrefSource.ChapterNum = 6;
@@ -555,7 +556,7 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(ScrVers.RussianOrthodox, vrefDest.Versification);
 
 			// Now test when the source just has a plain verse number (no bridges or segments)
-			vrefSource.CopyVerseTo(vrefDest);
+			vrefDest.CopyVerseFrom(vrefSource);
 			Assert.AreEqual("GEN", vrefDest.Book);
 			Assert.AreEqual(3, vrefDest.ChapterNum);
 			Assert.AreEqual("9", vrefDest.Verse);

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -73,7 +73,7 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(string.Empty, vref.Chapter);
 			Assert.AreEqual(0, vref.VerseNum);
 			Assert.AreEqual(string.Empty, vref.Verse);
-			Assert.AreEqual(VerseRef.defaultVersification, vref.Versification);
+			Assert.AreEqual(null, vref.Versification);
 
 			vref = new VerseRef("LUK", "3", "4b-5a", ScrVers.Vulgate);
 			Assert.IsTrue(vref.Valid);
@@ -1782,11 +1782,24 @@ namespace SIL.Scripture.Tests
 			Console.WriteLine();
 
 			VerseRef restored = XmlSerializationHelper.DeserializeFromString<VerseRef>(serialized);
-			Assert.IsNotNull(restored);
+			Assert.IsFalse(restored.IsDefault);
 			Assert.AreEqual("LEV", restored.Book);
 			Assert.AreEqual("12", restored.Chapter);
 			Assert.AreEqual("6-7a", restored.Verse);
 			Assert.AreEqual(ScrVers.Vulgate, restored.Versification);
+		}
+
+		[Test]
+		public void Deserialize_DefaultVerification()
+		{
+			string serialized = "<VerseRef>LEV 12:6-7a</VerseRef>";
+
+			VerseRef restored = XmlSerializationHelper.DeserializeFromString<VerseRef>(serialized);
+			Assert.IsFalse(restored.IsDefault);
+			Assert.AreEqual("LEV", restored.Book);
+			Assert.AreEqual("12", restored.Chapter);
+			Assert.AreEqual("6-7a", restored.Verse);
+			Assert.AreEqual(VerseRef.defaultVersification, restored.Versification);
 		}
 		#endregion
 

--- a/SIL.Scripture/IScrVers.cs
+++ b/SIL.Scripture/IScrVers.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2014, SIL International.
 // <copyright from='2008' to='2014' company='SIL International'>
 //		Copyright (c) 2014, SIL International.   
@@ -42,7 +42,7 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <returns>first verse in the specified book and chapter that is not excluded or
 		/// returns <c>null</c> if no included verse left in book</returns>
-		VerseRef FirstIncludedVerse(int bookNum, int chapterNum);
+		VerseRef? FirstIncludedVerse(int bookNum, int chapterNum);
 
 		/// <summary>
 		/// Gets a list of verse segments for the specified reference or null if the specified
@@ -53,7 +53,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Change the passed VerseRef to be this versification applying any necessary mappings.
 		/// </summary>
-		void ChangeVersification(VerseRef reference);
+		VerseRef ChangeVersification(VerseRef reference);
 
 		/// <summary>
 		/// Change the versification of an entry with Verse like 1-3 or 1,3a applying any necessary mappings to each part.
@@ -61,6 +61,6 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <returns>true if successful (i.e. all verses were in the same the same chapter in the new versification),
 		/// false if the changing resulted in the reference spanning chapters (which makes the results undefined)</returns>
-		bool ChangeVersificationWithRanges(VerseRef reference);
+		bool ChangeVersificationWithRanges(VerseRef reference, out VerseRef newReference);
 	}
 }

--- a/SIL.Scripture/ScrVers.cs
+++ b/SIL.Scripture/ScrVers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Xml.Serialization;
 using System.IO;
 using System.Text;
@@ -106,7 +106,7 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <returns>first verse in the specified book and chapter that is not excluded or
 		/// returns <c>null</c> if no included verse left in book</returns>
-		public VerseRef FirstIncludedVerse(int bookNum, int chapterNum)
+		public VerseRef? FirstIncludedVerse(int bookNum, int chapterNum)
 		{
 			do
 			{
@@ -147,9 +147,9 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <returns>true if successful (i.e. all verses were in the same the same chapter in the new versification),
 		/// false if the changing resulted in the reference spanning chapters (which makes the results undefined)</returns>
-		public bool ChangeVersificationWithRanges(VerseRef vref)
+		public bool ChangeVersificationWithRanges(VerseRef vref, out VerseRef newRef)
 		{
-			return VersInfo.ChangeVersificationWithRanges(vref);
+			return VersInfo.ChangeVersificationWithRanges(vref, out newRef);
 		}
 
 		public int ChangeVersification(int bbbcccvvv, IScrVers otherVersification)
@@ -162,9 +162,9 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Change the passed VerseRef to be this versification.
 		/// </summary>
-		public void ChangeVersification(VerseRef vref)
+		public VerseRef ChangeVersification(VerseRef vref)
 		{
-			VersInfo.ChangeVersification(vref);
+			return VersInfo.ChangeVersification(vref);
 		}
 
 		/// <summary>

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -270,6 +270,8 @@ namespace SIL.Scripture
 				chapterNum = -1;
 				verseNum = -1;
 				verse = null;
+				if (versification == null)
+					versification = defaultVersification;
 				try
 				{
 					Parse(value);

--- a/SIL.Windows.Forms.Scripture/VerseControl.cs
+++ b/SIL.Windows.Forms.Scripture/VerseControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -202,7 +202,7 @@ namespace SIL.Windows.Forms.Scripture
 					return;
 				}
 
-				value.CopyTo(curRef);
+				curRef.CopyFrom(value);
 				if (!allowVerseSegments)
 					curRef.Simplify();
 
@@ -665,7 +665,7 @@ namespace SIL.Windows.Forms.Scripture
 				return;
 			}
 			ScrVers versif = ScrVers.English;
-			if (curRef != null)
+			if (!curRef.IsDefault)
 				versif = curRef.Versification;
 
 			VerseRef = new VerseRef(((BookListItem)uiBook.SelectedItem).Abbreviation + " 1:1", versif);
@@ -780,7 +780,7 @@ namespace SIL.Windows.Forms.Scripture
 			AdvanceToLastSegment(vref);
 			uiChapter.Text = vref.Chapter;
 			uiVerse.Text = vref.Verse;
-			vref.CopyTo(curRef);
+			curRef.CopyFrom(vref);
 		}
 
 		private static void AdvanceToLastSegment(VerseRef vref)
@@ -797,7 +797,7 @@ namespace SIL.Windows.Forms.Scripture
 			vref.VerseNum = vref.LastVerse;
 			AdvanceToLastSegment(vref);
 			uiVerse.Text = vref.Verse;
-			vref.CopyTo(curRef);
+			curRef.CopyFrom(vref);
 		}
 
 		void Revert()


### PR DESCRIPTION
This is a breaking change, but class is not widely used.

We are changing VerseRef from a class to a struct to prevent problems with shared references to the same instance.

Minimal changes were done for this. The main changes involved using a new IsDefault property to check for a struct that hasn't been set since a null check can't be used.

The XmlSerializationHelper Deserialize methods were changed to support a struct. Needed to remove 'where class' restriction and use 'default(T)' rather than null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/742)
<!-- Reviewable:end -->
