### PR TITLE
Don't reference NDesk.DBus from SIL.Core.Desktop

### DIFF
--- a/SIL.Core.Desktop/SIL.Core.Desktop.csproj
+++ b/SIL.Core.Desktop/SIL.Core.Desktop.csproj
@@ -276,7 +276,8 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NDesk.DBus, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f6716e4f9b2ed099, processorArchitecture=MSIL">
+    <Reference Include="NDesk.DBus, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f6716e4f9b2ed099, processorArchitecture=MSIL"
+      Condition="'$(OS)'!='Windows_NT'">
       <HintPath>..\packages\NDesk.DBus.0.15.0\lib\NDesk.DBus.dll</HintPath>
       <Private>True</Private>
     </Reference>


### PR DESCRIPTION
So when FW runs ILRepack on SIL.Core.Desktop it doesn't try to include
NDesk.DBus on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/744)
<!-- Reviewable:end -->
