### PR TITLE
Use TextRenderer.DrawText instead of Graphics.DrawString

### DIFF
--- a/SIL.Archiving/Extensions.cs
+++ b/SIL.Archiving/Extensions.cs
@@ -31,7 +31,7 @@ namespace SIL.Archiving
 					{
 						var thisSegment = segment.Trim();
 
-						while (g.MeasureString(thisSegment, linkLabel.Font).Width > w)
+						while (MeasureText(linkLabel, g, thisSegment, linkLabel.Font).Width > w)
 						{
 							var line = string.Empty;
 							var lastSpace = 0;
@@ -40,7 +40,7 @@ namespace SIL.Archiving
 							{
 								if (char.IsWhiteSpace(thisSegment[i]))
 								{
-									if (g.MeasureString(line, linkLabel.Font).Width > w)
+									if (MeasureText(linkLabel, g, line, linkLabel.Font).Width > w)
 									{
 										newText.AppendLine(thisSegment.Substring(0, lastSpace));
 										thisSegment = thisSegment.Substring(lastSpace + 1);
@@ -61,9 +61,23 @@ namespace SIL.Archiving
 					linkLabel.Text = newText.ToString();
 				}
 
-				var size = g.MeasureString(linkLabel.Text, linkLabel.Font, w);
-				linkLabel.Height = (int)Math.Ceiling(size.Height);
+				var size = MeasureText(linkLabel, g, linkLabel.Text, linkLabel.Font, new System.Drawing.Size(w, Int32.MaxValue));
+				linkLabel.Height = size.Height;
 			}
+		}
+		private static System.Drawing.Size MeasureText(this LinkLabel linkLabel, System.Drawing.Graphics g, string text, System.Drawing.Font font)
+		{
+			if (linkLabel.UseCompatibleTextRendering)
+				return g.MeasureString(text, font).ToSize();
+			else
+				return TextRenderer.MeasureText(g, text, font);
+		}
+		private static System.Drawing.Size MeasureText(this LinkLabel linkLabel, System.Drawing.Graphics g, string text, System.Drawing.Font font, System.Drawing.Size proposedSize)
+		{
+			if (linkLabel.UseCompatibleTextRendering)
+				return g.MeasureString(text, font, proposedSize.Width).ToSize();
+			else
+				return TextRenderer.MeasureText(g, text, font, proposedSize, TextFormatFlags.WordBreak);
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataDisplayControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataDisplayControl.cs
@@ -94,7 +94,8 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 			using (var g = this.CreateGraphics())
 			{
 				var w = this.Width - 10;
-				var h = g.MeasureString(label, this.Font, w).Height;
+				// UserControl does not have UseCompatibleTextRendering.
+				var h = TextRenderer.MeasureText(g, label, this.Font, new System.Drawing.Size(w, Int32.MaxValue), TextFormatFlags.WordBreak).Height;
 				var linkLabel = new LinkLabel() {Text = label, Width = this.Width - 10, Height = (int) (h + 5)};
 
 				linkLabel.Click += new EventHandler((x, y) => SIL.Program.Process.SafeStart(url));

--- a/SIL.Windows.Forms/Extensions/ToolStripExtensions.cs
+++ b/SIL.Windows.Forms/Extensions/ToolStripExtensions.cs
@@ -6,7 +6,8 @@ namespace SIL.Windows.Forms.Extensions
 	{
 		public static void SizeTextRectangleToText(this ToolStripItemTextRenderEventArgs args)
 		{
-			var textSize = args.Graphics.MeasureString(args.Text, args.TextFont);
+			// ToolStrip does not have UseCompatibleTextRendering.
+			var textSize = TextRenderer.MeasureText(args.Graphics, args.Text, args.TextFont, args.TextRectangle.Size, TextFormatFlags.WordBreak);
 			const int padding = 2;
 
 			var rc = args.TextRectangle;
@@ -15,7 +16,7 @@ namespace SIL.Windows.Forms.Extensions
 			// adjust the rectangle to fit the calculated text size
 			if (rc.Width < textSize.Width + padding)
 			{
-				var diffX = (int)System.Math.Ceiling(textSize.Width + padding - rc.Width);
+				var diffX = textSize.Width + padding - rc.Width;
 				rc.X -= diffX / 2;
 				rc.Width += diffX;
 				changed = true;
@@ -23,7 +24,7 @@ namespace SIL.Windows.Forms.Extensions
 
 			if (rc.Height < textSize.Height + padding)
 			{
-				var diffY = (int)System.Math.Ceiling(textSize.Height + padding - rc.Height);
+				var diffY = textSize.Height + padding - rc.Height;
 				rc.Y -= diffY / 2;
 				rc.Height += diffY;
 				changed = true;

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -318,7 +318,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 			catch (Exception error)
 			{
 				Debug.Fail(error.Message);
-				e.Graphics.DrawString("Error in OnPaint()", SystemFonts.DefaultFont, Brushes.Red, 20, 20);
+				// UserControl does not have UseCompatibleTextRendering.
+				TextRenderer.DrawText(e.Graphics, "Error in OnPaint()", SystemFonts.DefaultFont, new Point(20,20), Color.Red);
 				//swallow in release build
 			}
 		}


### PR DESCRIPTION
Also use TextRenderer.MeasureText instead of Graphics.MeasureString.  This
change is motivated by a recent crash in Bloom caused by trying to measure
and draw a non-Roman script string.  TextRenderer successfully draws that
string.  See https://silbloom.myjetbrains.com/youtrack/issue/BL-6370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/753)
<!-- Reviewable:end -->
