### PR TITLE
Put Description elements in the right order in parent

### DIFF
--- a/SIL.Archiving/IMDI/Schema/IMDIDescription.cs
+++ b/SIL.Archiving/IMDI/Schema/IMDIDescription.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 using SIL.Archiving.Generic;
@@ -10,9 +10,19 @@ namespace SIL.Archiving.IMDI.Schema
 	{
 		private DescriptionTypeCollection _descriptionField;
 
-		/// <remarks/>
-		[XmlElement("Description")]
-		public DescriptionTypeCollection Description
+		/// <summary>
+		/// Every subclass of Description should have a Description property implemented as 
+		/// 		[XmlElement("Description")]
+		///	public DescriptionTypeCollection Description
+		///	{
+		///		get { return DescriptionInternal; }
+		///		set { DescriptionInternal = value; }
+		///	}
+		/// 
+		/// The reason it is not defined here is that order of serialization is important for IMDI.
+		/// Subclasses should use Order, or define properties in the right order, for correct serialization.
+		/// </summary>
+		internal DescriptionTypeCollection DescriptionInternal
 		{
 			get { return _descriptionField ?? (_descriptionField = new DescriptionTypeCollection()); }
 			set { _descriptionField = value; }
@@ -21,7 +31,7 @@ namespace SIL.Archiving.IMDI.Schema
 		/// <summary>Adds a description (in a particular language)</summary>
 		public void AddDescription(LanguageString description)
 		{
-			Description.Add(description.ToIMDIDescriptionType());
+			DescriptionInternal.Add(description.ToIMDIDescriptionType());
 		}
 	}
 

--- a/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
+++ b/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
@@ -617,11 +617,19 @@ namespace SIL.Archiving.IMDI.Schema
 	}
 
 	/// <remarks/>
+	/// I think this is the DocumentLanguages subelement of a Catalogue element
 	[SerializableAttribute]
 	[DebuggerStepThroughAttribute]
 	[XmlTypeAttribute(AnonymousType=true, Namespace="http://www.mpi.nl/IMDI/Schema/IMDI")]
 	public class CatalogueDocumentLanguages : IMDIDescription
 	{
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
+
 		/// <remarks/>
 		[XmlElement("Language")]
 		public List<SimpleLanguageType> Language { get; set; }
@@ -639,6 +647,13 @@ namespace SIL.Archiving.IMDI.Schema
 	[XmlTypeAttribute(AnonymousType=true, Namespace="http://www.mpi.nl/IMDI/Schema/IMDI")]
 	public class CatalogueSubjectLanguages : IMDIDescription
 	{
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
+
 		/// <remarks/>
 		[XmlElement("Language")]
 		public List<SubjectLanguageType> Language { get; set; }
@@ -874,6 +889,13 @@ namespace SIL.Archiving.IMDI.Schema
 
 		/// <remarks/>
 		public ContactType Contact { get; set; }
+
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
 	}
 
 	/// <remarks/>
@@ -1157,6 +1179,13 @@ namespace SIL.Archiving.IMDI.Schema
 	{
 		private List<LanguageType> _languageField;
 
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
+
 		/// <remarks/>
 		[XmlElementAttribute("Language")]
 		public List<LanguageType> Language {
@@ -1200,6 +1229,13 @@ namespace SIL.Archiving.IMDI.Schema
 		/// <remarks/>
 		public BooleanType TargetLanguage { get; set; }
 
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
+
 		/// <remarks/>
 		[XmlAttribute]
 		public string ResourceRef { get; set; }
@@ -1212,6 +1248,13 @@ namespace SIL.Archiving.IMDI.Schema
 	public class ActorsType : IMDIDescription
 	{
 		private List<ActorType> _actorField;
+
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
 
 		/// <remarks/>
 		[XmlElementAttribute("Actor")]
@@ -1514,6 +1557,13 @@ namespace SIL.Archiving.IMDI.Schema
 
 		/// <remarks/>
 		public AccessType Access { get; set; }
+
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
 
 		/// <remarks/>
 		public KeysType Keys { get; set; }
@@ -2153,6 +2203,12 @@ namespace SIL.Archiving.IMDI.Schema
 	[XmlTypeAttribute(AnonymousType=true, Namespace="http://www.mpi.nl/IMDI/Schema/IMDI")]
 	public class SessionReferences : IMDIDescription
 	{
+		[XmlElement("Description")]
+		public DescriptionTypeCollection Description
+		{
+			get { return DescriptionInternal; }
+			set { DescriptionInternal = value; }
+		}
 	}
 
 	/// <remarks/>


### PR DESCRIPTION
The IMDI xsd specifies the order of child elements in various xsd:sequence elements that include Description. This change puts them in the right order in our export.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/756)
<!-- Reviewable:end -->
