### PR TITLE
Fix and improve global writing system store

### DIFF
--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -9,5 +9,5 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyFileVersion("5.0.0.0")]
-[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("6.0.0.0")]
+[assembly: AssemblyVersion("6.0.0.0")]

--- a/GlobalAssemblyInfo.props
+++ b/GlobalAssemblyInfo.props
@@ -1,8 +1,8 @@
 <Project>
 	<PropertyGroup>
-		<Version>5.0.0</Version>
-		<AssemblyVersion>5.0.0.0</AssemblyVersion>
-		<FileVersion>5.0.0.0</FileVersion>
+		<Version>6.0.0</Version>
+		<AssemblyVersion>6.0.0.0</AssemblyVersion>
+		<FileVersion>6.0.0.0</FileVersion>
 		<Authors>SIL</Authors>
 		<Company>SIL</Company>
 		<Product>Palaso Library</Product>

--- a/SIL.WritingSystems.Tests/WritingSystemDefinitionPropertyTests.cs
+++ b/SIL.WritingSystems.Tests/WritingSystemDefinitionPropertyTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using SIL.Keyboarding;
+using SIL.ObjectModel;
 using SIL.TestUtilities;
 
 namespace SIL.WritingSystems.Tests
@@ -124,8 +125,8 @@ namespace SIL.WritingSystems.Tests
 		public void CloneCopiesQuotationMarks()
 		{
 			var original = new WritingSystemDefinition();
-			var qm1 = new QuotationMark("«", "»", null, 1, QuotationMarkingSystemType.Narrative);
-			var qm2 = new QuotationMark("‹", "›", null, 3, QuotationMarkingSystemType.Normal);
+			var qm1 = new QuotationMark("\u00AB", "\u00BB", null, 1, QuotationMarkingSystemType.Narrative); // Â«, Â»
+			var qm2 = new QuotationMark("\u2039", "\u203A", null, 3, QuotationMarkingSystemType.Normal); // â€¹â€¯â€º
 			original.QuotationMarks.Add(qm1);
 			original.QuotationMarks.Add(qm2);
 			WritingSystemDefinition copy = original.Clone();
@@ -302,8 +303,8 @@ namespace SIL.WritingSystems.Tests
 		public void ValueEqualsComparesQuotationMarks()
 		{
 			var first = new WritingSystemDefinition();
-			var qm1 = new QuotationMark("«", "»", null, 3, QuotationMarkingSystemType.Narrative);
-			var qm2 = new QuotationMark("‹", "›", null, 1, QuotationMarkingSystemType.Normal);
+			var qm1 = new QuotationMark("\u00AB", "\u00BB", null, 3, QuotationMarkingSystemType.Narrative); // Â«, Â»
+			var qm2 = new QuotationMark("\u2039", "\u203A", null, 1, QuotationMarkingSystemType.Normal); // â€¹â€¯â€º
 			first.QuotationMarks.Add(qm1);
 			first.QuotationMarks.Add(qm2);
 			var second = new WritingSystemDefinition();
@@ -1354,6 +1355,24 @@ namespace SIL.WritingSystems.Tests
 		{
 			var writingSystem = new WritingSystemDefinition(new WritingSystemDefinition("x-bogus"));
 			Assert.AreEqual("x-bogus", writingSystem.LanguageTag);
+		}
+
+		[Test]
+		public void CloneConstructor_DoesNotCopyIdByDefault()
+		{
+			var original = new WritingSystemDefinition();
+			original.Id = "foo";
+			var writingSystem = new WritingSystemDefinition(original);
+			Assert.That(writingSystem.Id, Is.Not.EqualTo(original.Id));
+		}
+
+		[Test]
+		public void CloneConstructor_CopyId()
+		{
+			var original = new WritingSystemDefinition();
+			original.Id = "foo";
+			var writingSystem = new WritingSystemDefinition(original, true);
+			Assert.That(writingSystem.Id, Is.EqualTo(original.Id));
 		}
 
 		[Test]

--- a/SIL.WritingSystems.Tests/WritingSystemDefinitionPropertyTests.cs
+++ b/SIL.WritingSystems.Tests/WritingSystemDefinitionPropertyTests.cs
@@ -27,7 +27,7 @@ namespace SIL.WritingSystems.Tests
 		public override string ExceptionList
 		{
 			// We do want to clone KnownKeyboards, but I don't think the automatic cloneable test for it can handle a list.
-			get { return "|MarkedForDeletion|Id|_knownKeyboards|_localKeyboard|_defaultFont|_fonts|_spellCheckDictionaries|IsChanged|_matchedPairs|_punctuationPatterns|_quotationMarks|_defaultCollation|_collations|_characterSets|_variants|_language|_script|_region|_ignoreVariantChanges|PropertyChanged|PropertyChanging|Template|"; }
+			get { return "|MarkedForDeletion|Id|_knownKeyboards|_localKeyboard|_defaultFont|_fonts|_spellCheckDictionaries|IsChanged|_matchedPairs|_punctuationPatterns|_quotationMarks|_defaultCollation|_collations|_characterSets|_language|_script|_region|_ignoreVariantChanges|PropertyChanged|PropertyChanging|Template|"; }
 		}
 
 		protected override List<ValuesToSet> DefaultValuesForTypes
@@ -35,14 +35,16 @@ namespace SIL.WritingSystems.Tests
 			get
 			{
 				return new List<ValuesToSet>
-							 {
-								 new ValuesToSet(3.14f, 2.72f),
-								 new ValuesToSet(true, false),
-								 new ValuesToSet("to be", "!(to be)"),
-								 new ValuesToSet(DateTime.Now, DateTime.MinValue),
-								 new ValuesToSet(QuotationParagraphContinueType.All, QuotationParagraphContinueType.None),
-								 new ValuesToSet(NumberingSystemDefinition.Default, NumberingSystemDefinition.CreateCustomSystem("9876543210"))
-							 };
+					{
+						new ValuesToSet(3.14f, 2.72f),
+						new ValuesToSet(true, false),
+						new ValuesToSet("to be", "!(to be)"),
+						new ValuesToSet(DateTime.Now, DateTime.MinValue),
+						new ValuesToSet(QuotationParagraphContinueType.All, QuotationParagraphContinueType.None),
+						new ValuesToSet(NumberingSystemDefinition.Default, NumberingSystemDefinition.CreateCustomSystem("9876543210")),
+						new ValuesToSet(new BulkObservableList<VariantSubtag>(new VariantSubtag[] {"1901", "biske"}),
+							new BulkObservableList<VariantSubtag>(new VariantSubtag[] {"foo", "bar"}))
+					};
 			}
 		}
 
@@ -1351,7 +1353,7 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
-		public void CloneContructor_VariantStartsWithxDash_VariantIsCopied()
+		public void CloneConstructor_VariantStartsWithxDash_VariantIsCopied()
 		{
 			var writingSystem = new WritingSystemDefinition(new WritingSystemDefinition("x-bogus"));
 			Assert.AreEqual("x-bogus", writingSystem.LanguageTag);
@@ -1384,7 +1386,7 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
-		public void Script_Set_LanguageTagchanged()
+		public void Script_Set_LanguageTagChanged()
 		{
 			var writingSystem = new WritingSystemDefinition("en", "Zxxx", "", "1901-x-bogus");
 			writingSystem.Script = "Armi";

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -67,6 +67,8 @@ namespace SIL.WritingSystems
 		private readonly GlobalMutex _mutex;
 		private readonly Dictionary<string, Tuple<DateTime, long>> _lastFileStats; 
 
+		private static string _defaultBasePath;
+
 		protected internal GlobalWritingSystemRepository(string basePath)
 		{
 			_lastFileStats = new Dictionary<string, Tuple<DateTime, long>>();
@@ -148,9 +150,16 @@ namespace SIL.WritingSystems
 		{
 			get
 			{
-				string basePath = Platform.IsLinux ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
-					: Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-				return Path.Combine(basePath, "SIL", "WritingSystemRepository");
+				// This allows unit tests to set the _defaultBasePath (through reflection)
+				if (string.IsNullOrEmpty(_defaultBasePath))
+				{
+					string basePath = Platform.IsLinux
+						? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+						: Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+					_defaultBasePath = Path.Combine(basePath, "SIL", "WritingSystemRepository");
+				}
+
+				return _defaultBasePath;
 			}
 		}
 

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -85,7 +85,7 @@ namespace SIL.WritingSystems
 		{
 			var ldmlDataMapper = new LdmlDataMapper(WritingSystemFactory);
 			var removedIds = new HashSet<string>(WritingSystems.Keys);
-			foreach (string file in Directory.GetFiles(_path, "*.ldml"))
+			foreach (string file in Directory.GetFiles(PathToWritingSystems, $"*{Extension}"))
 			{
 				var fi = new FileInfo(file);
 				string id = Path.GetFileNameWithoutExtension(file);
@@ -219,7 +219,7 @@ namespace SIL.WritingSystems
 				//Renaming the file here is a bit ugly as the content has not yet been updated. Thus there
 				//may be a mismatch between the filename and the contained rfc5646 tag. Doing it here however
 				//helps us avoid having to deal with situations where a writing system id is changed to be
-				//identical with the old id of another writing sytsem. This could otherwise lead to dataloss.
+				//identical with the old id of another writing system. This could otherwise lead to dataloss.
 				//The inconsistency is resolved on Save()
 				if (oldStoreId != ws.Id && File.Exists(GetFilePathFromLanguageTag(oldStoreId)))
 					File.Move(GetFilePathFromLanguageTag(oldStoreId), GetFilePathFromLanguageTag(ws.Id));
@@ -247,7 +247,7 @@ namespace SIL.WritingSystems
 		/// </summary>
 		public override void Replace(string languageTag, T newWs)
 		{
-			using (new WsStasher(Path.Combine(_path, languageTag + Extension)))
+			using (new WsStasher(Path.Combine(PathToWritingSystems, languageTag + Extension)))
 			{
 				base.Replace(languageTag, newWs);
 			}

--- a/SIL.WritingSystems/IWritingSystemFactory.cs
+++ b/SIL.WritingSystems/IWritingSystemFactory.cs
@@ -21,7 +21,7 @@
 		/// Creates a duplicate writing system.  Set will need to be called once identifying information
 		/// has been changed in order to save it in the store.
 		/// </summary>
-		WritingSystemDefinition Create(WritingSystemDefinition ws);
+		WritingSystemDefinition Create(WritingSystemDefinition ws, bool cloneId = false);
 	}
 
 	/// <summary>
@@ -31,6 +31,6 @@
 	{
 		new T Create();
 		bool Create(string ietfLanguageTag, out T ws);
-		T Create(T ws);
+		T Create(T ws, bool cloneId = false);
 	}
 }

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemFactory.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemFactory.cs
@@ -19,9 +19,9 @@ namespace SIL.WritingSystems
 			return new WritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override WritingSystemDefinition ConstructDefinition(WritingSystemDefinition ws)
+		protected override WritingSystemDefinition ConstructDefinition(WritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new WritingSystemDefinition(ws);
+			return new WritingSystemDefinition(ws, cloneId);
 		}
 	}
 

--- a/SIL.WritingSystems/LocalWritingSystemRepositoryBase.cs
+++ b/SIL.WritingSystems/LocalWritingSystemRepositoryBase.cs
@@ -47,7 +47,7 @@ namespace SIL.WritingSystems
 				{
 					if (ws.DateModified > globalWs.DateModified)
 					{
-						T newWs = WritingSystemFactory.Create(ws);
+						T newWs = WritingSystemFactory.Create(ws, cloneId: true);
 						try
 						{
 							_globalRepository.Replace(ws.LanguageTag, newWs);
@@ -61,7 +61,7 @@ namespace SIL.WritingSystems
 				}
 				else
 				{
-					_globalRepository.Set(WritingSystemFactory.Create(ws));
+					_globalRepository.Set(WritingSystemFactory.Create(ws, cloneId: true));
 				}
 			}
 		}

--- a/SIL.WritingSystems/SldrWritingSystemFactory.cs
+++ b/SIL.WritingSystems/SldrWritingSystemFactory.cs
@@ -14,9 +14,9 @@ namespace SIL.WritingSystems
 			return new WritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override WritingSystemDefinition ConstructDefinition(WritingSystemDefinition ws)
+		protected override WritingSystemDefinition ConstructDefinition(WritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new WritingSystemDefinition(ws);
+			return new WritingSystemDefinition(ws, cloneId);
 		}
 	}
 

--- a/SIL.WritingSystems/WritingSystemDefinition.cs
+++ b/SIL.WritingSystems/WritingSystemDefinition.cs
@@ -141,8 +141,11 @@ namespace SIL.WritingSystems
 		/// <summary>
 		/// Copy constructor.
 		/// </summary>
-		public WritingSystemDefinition(WritingSystemDefinition ws)
+		public WritingSystemDefinition(WritingSystemDefinition ws, bool cloneId = false)
 		{
+			if (cloneId)
+				Id = ws.Id;
+
 			_language = ws._language;
 			_script = ws._script;
 			_region = ws._region;

--- a/SIL.WritingSystems/WritingSystemFactory.cs
+++ b/SIL.WritingSystems/WritingSystemFactory.cs
@@ -14,9 +14,9 @@ namespace SIL.WritingSystems
 			return new WritingSystemDefinition(ietfLanguageTag);
 		}
 
-		protected override WritingSystemDefinition ConstructDefinition(WritingSystemDefinition ws)
+		protected override WritingSystemDefinition ConstructDefinition(WritingSystemDefinition ws, bool cloneId = false)
 		{
-			return new WritingSystemDefinition(ws);
+			return new WritingSystemDefinition(ws, cloneId);
 		}
 	}
 

--- a/SIL.WritingSystems/WritingSystemFactoryBase.cs
+++ b/SIL.WritingSystems/WritingSystemFactoryBase.cs
@@ -8,9 +8,9 @@
 			return false;
 		}
 
-		public virtual T Create(T ws)
+		public virtual T Create(T ws, bool cloneId = false)
 		{
-			return ConstructDefinition(ws);
+			return ConstructDefinition(ws, cloneId);
 		}
 
 		public virtual T Create()
@@ -34,7 +34,7 @@
 		/// Clones the specified writing system. This is implemented by subclasses to allow the
 		/// use subclasses of WritingSystemDefinition.
 		/// </summary>
-		protected abstract T ConstructDefinition(T ws);
+		protected abstract T ConstructDefinition(T ws, bool cloneId = false);
 
 		bool IWritingSystemFactory.Create(string ietfLanguageTag, out WritingSystemDefinition ws)
 		{
@@ -49,9 +49,9 @@
 			return Create();
 		}
 
-		WritingSystemDefinition IWritingSystemFactory.Create(WritingSystemDefinition ws)
+		WritingSystemDefinition IWritingSystemFactory.Create(WritingSystemDefinition ws, bool cloneId)
 		{
-			return Create((T) ws);
+			return Create((T) ws, cloneId);
 		}
 	}
 }

--- a/build/Palaso.proj
+++ b/build/Palaso.proj
@@ -4,7 +4,7 @@
 		<RootDir Condition="'$(teamcity_build_checkoutDir)' != ''">$(teamcity_build_checkoutDir)</RootDir>
 		<BUILD_COUNTER Condition="'$(BUILD_COUNTER)'==''">1</BUILD_COUNTER>
 		<!-- Note, after some thought, we've decided this is the best place to keep the version number (not on TeamCity, not in the assemblies). -->
-		<Version>5.0.0</Version>
+		<Version>6.0.0</Version>
 	</PropertyGroup>
 
 	<UsingTask TaskName="StampAssemblies" AssemblyFile="$(RootDir)/packages/SIL.BuildTasks.1.0.0/tools/SIL.BuildTasks.dll" />
@@ -34,9 +34,9 @@
 		<CreateProperty Value="$(Version.Substring(0, $(Version.LastIndexOf('.')))).0.0">
 			<Output PropertyName="AssemblyVersion" TaskParameter="Value"/>
 		</CreateProperty>
-		
+
 		<Message Text="Assembly Version: $(AssemblyVersion)" Importance="high"/>
-	
+
 		<Message Text="BUILD_COUNTER: $(BUILD_COUNTER)" Importance="high"/>
 
 		<CreateProperty Value="$(Version).$(BUILD_COUNTER)">
@@ -44,11 +44,11 @@
 		</CreateProperty>
 
 		<Message Text="File Version: $(FileVersion)" Importance="high"/>
-		
+
 		<CreateProperty Value="$(Version)-$(BUILD_COUNTER)">
 			<Output PropertyName="PackageVersion" TaskParameter="Value"/>
 		</CreateProperty>
-		
+
 		<Message Text="Package Version: $(PackageVersion)" Importance="high"/>
 	</Target>
 
@@ -167,14 +167,14 @@
 			WorkingDirectory="$(OutputDir)"
 		/>
 	</Target>
-	
+
 	<ItemGroup>
 		<PackProjects Include="$(RootDir)/SIL.Core/SIL.Core.csproj" />
 		<PackProjects Include="$(RootDir)/SIL.DblBundle/SIL.DblBundle.csproj" />
 		<PackProjects Include="$(RootDir)/SIL.Scripture/SIL.Scripture.csproj" />
 		<PackProjects Include="$(RootDir)/SIL.WritingSystems/SIL.WritingSystems.csproj" />
 	</ItemGroup>
-	
+
 	<Target Name="Pack" DependsOnTargets="SetAssemblyVersion;RestorePackages">
 		<MSBuild
 			Projects="@(PackProjects)"


### PR DESCRIPTION
- Allow to set path for GlobalWritingSystemRepo in unit tests

  Get the default path to the GlobalWritingSystemRepo from a field. This allows unit tests to set the field through reflection so that they can have the global writing system repo in a defined state. This is necessary when testing S/R where changes in the global WS store might cause additional commits to appear.

- Don't update timestamp when copying to global store

  Updating DateModified causes extra commits when doing a S/R because the WS gets copied from the global to the local store, introducing a modified timestamp and thus a change. This change adds an optional flag to `IWritingSystem.Create()` whether to clone the Id of the writing system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/773)
<!-- Reviewable:end -->
