### PR TITLE
Dispose RuleBasedCollators

### DIFF
--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -159,6 +159,8 @@ namespace SIL.WritingSystems
 			_sldrCacheMutex.Dispose();
 			_sldrCacheMutex = null;
 			_languageTags = null;
+
+			IcuRulesCollator.DisposeCollators();
 		}
 
 		private static void CheckInitialized()


### PR DESCRIPTION
This change implements a hack to dispose the RuleBasedCollators
we create when shutting down the SLDR. Disposing of the collators
is necessary to prevent a crash when running tests in LfMerge (and
potentially anywhere else we use collators).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/778)
<!-- Reviewable:end -->
