### PR TITLE
Stop creating invalid SystemCollations

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlContentForTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlContentForTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using SIL.WritingSystems.Migration.WritingSystemsLdmlV0To1Migration;
 
 namespace SIL.WritingSystems.Tests
@@ -104,7 +104,42 @@ namespace SIL.WritingSystems.Tests
 <collations>
 	<collation>
 		<base>
-			<alias source='de'/>
+			<alias source='en'/>
+		</base>
+		<special xmlns:palaso='urn://palaso.org/ldmlExtensions/v1'>
+			<palaso:sortRulesType value='OtherLanguage' />
+		</special>
+	</collation>
+</collations>
+<special xmlns:palaso='urn://palaso.org/ldmlExtensions/v1'>
+	<palaso:abbreviation value='la' />
+	<palaso:defaultFontFamily value='Arial' />
+	<palaso:defaultFontSize value='12' />
+	<palaso:defaultKeyboard value='bogusKeyboard' />
+	<palaso:isLegacyEncoded value='true' />
+	<palaso:languageName value='language' />
+	<palaso:spellCheckingId value='ol-GB-1996' />
+</special>
+</ldml>".Replace('\'', '"');
+		}
+
+		internal static string Version0WithBogusSystemCollationInfo()
+		{
+			return
+				@"<?xml version='1.0' encoding='utf-8'?>
+<ldml>
+<identity>
+	<version number='' />
+	<generation date='0001-01-01T00:00:00' />
+	<language type='mvp' />
+</identity>
+<layout>
+	<orientation characters='left-to-right'/>
+</layout>
+<collations>
+	<collation>
+		<base>
+			<alias source='mvp'/>
 		</base>
 		<special xmlns:palaso='urn://palaso.org/ldmlExtensions/v1'>
 			<palaso:sortRulesType value='OtherLanguage' />

--- a/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
@@ -1025,12 +1025,36 @@ namespace SIL.WritingSystems.Tests.Migration
 				migrator.ResetRemovedProperties(repo);
 
 				WritingSystemDefinition ws = repo.Get("de");
-				var scd = new SystemCollationDefinition {LanguageTag = "de"};
+				var scd = new SystemCollationDefinition {LanguageTag = "en"};
 				Assert.That(ws.DefaultCollation.ValueEquals(scd), Is.True);
 
 				var fromFile = new WritingSystemDefinition();
 				new LdmlDataMapper(new TestWritingSystemFactory()).Read(environment.MappedFilePath("test.ldml"), fromFile);
 				Assert.NotNull(fromFile.DefaultCollation);
+			}
+		}
+
+		[Test]
+		public void Migrate_OriginalFileContainsBogusSystemCollationInfo_DefaultCollationIsUsed()
+		{
+			using (var environment = new TestEnvironment())
+			{
+				environment.WriteLdmlFile(
+					"test.ldml",
+					LdmlContentForTests.Version0WithBogusSystemCollationInfo());
+				var wsV0 = new WritingSystemDefinitionV0();
+				new LdmlAdaptorV0().Read(environment.FilePath("test.ldml"), wsV0);
+
+				var migrator = new LdmlInFolderWritingSystemRepositoryMigrator(environment.LdmlPath, environment.OnMigrateCallback);
+				migrator.Migrate();
+				var repo = new TestLdmlInFolderWritingSystemRepository(environment.LdmlPath);
+				migrator.ResetRemovedProperties(repo);
+
+
+				var fromFile = new WritingSystemDefinition();
+				new LdmlDataMapper(new TestWritingSystemFactory()).Read(environment.MappedFilePath("test.ldml"), fromFile);
+				Assert.NotNull(fromFile.DefaultCollation);
+				Assert.That(fromFile.DefaultCollation.IsValid, Is.True);
 			}
 		}
 

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -336,7 +336,8 @@ namespace SIL.WritingSystems
 			else
 			{
 				ws.DefaultCollationType = "standard";
-				ws.DefaultCollation = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
+				var systemDefinition = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
+				ws.DefaultCollation = systemDefinition.IsValid ? systemDefinition : new SystemCollationDefinition();
 			}
 
 			foreach (XElement specialElem in element.NonAltElements("special"))
@@ -754,7 +755,8 @@ namespace SIL.WritingSystems
 			}
 			if (defaultCollationElem == null)
 			{
-				ws.DefaultCollation = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
+				var sysColDef = new SystemCollationDefinition { LanguageTag = ws.LanguageTag };
+				ws.DefaultCollation = sysColDef.IsValid ? sysColDef : new SystemCollationDefinition();
 			}
 		}
 


### PR DESCRIPTION
* Addresses bugs found by Flex users (LT-19466)
* On Migration create default SystemCollation if
  the default SystemCollation for the langage is invalid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/783)
<!-- Reviewable:end -->
