### PR TITLE
Improved the password notice in the settings protection dialog.

### DIFF
--- a/DistFiles/Palaso.es.tmx
+++ b/DistFiles/Palaso.es.tmx
@@ -571,12 +571,21 @@
 	  </tuv>
 	</tu>
 	<tu tuid="SettingsProtection.PasswordNotice">
-	  <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
+	  <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNoticeWithSupportUrl". Param 0: Factory password; Param 1: product name</note>
 	  <tuv xml:lang="en">
-		<seg>Factory password for these settings is "{0}".  If you forget it, you can always google for "{1}" and "{2}"</seg>
+		<seg>Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page."</seg>
 	  </tuv>
 	  <tuv xml:lang="es">
-		<seg>Contraseña de fábrica para estos ajustes es "{0}".  Si lo olvida, siempre puedes usar Google para buscar "{1}" y "{2}"</seg>
+		<seg>Contraseña de fábrica para estos ajustes es "{0}". Si lo olvida, siempre puedes encontrarlo en la página de apoyo de {1}.</seg>
+	  </tuv>
+	</tu>
+	<tu tuid="SettingsProtection.PasswordNoticeWithSupportUrl">
+	  <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNotice". Param 0: Factory password; Param 1: product name; Param 2: URL of support page</note>
+	  <tuv xml:lang="en">
+		<seg>Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page: {2}"</seg>
+	  </tuv>
+	  <tuv xml:lang="es">
+		<seg>Contraseña de fábrica para estos ajustes es "{0}". Si lo olvida, siempre puedes encontrarlo en la página de apoyo de {1}: {2}</seg>
 	  </tuv>
 	</tu>
 	<tu tuid="SettingsProtection.RequirePasswordCheckBox">

--- a/DistFiles/Palaso.fr.tmx
+++ b/DistFiles/Palaso.fr.tmx
@@ -523,15 +523,24 @@
         <seg>Afficher caractères</seg>
       </tuv>
     </tu>
-    <tu tuid="SettingsProtection.PasswordNotice">
-      <note>Don't forget to have the {0}, {1} and {2} in your translated string!</note>
-      <tuv xml:lang="en">
-        <seg>Factory password for these settings is "{0}".  If you forget it, you can always google for "{1}" and "{2}"</seg>
-      </tuv>
+	<tu tuid="SettingsProtection.PasswordNotice">
+	  <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNoticeWithSupportUrl". Param 0: Factory password; Param 1: product name</note>
+	  <tuv xml:lang="en">
+		<seg>Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page."</seg>
+	  </tuv>
       <tuv xml:lang="fr">
-        <seg>Le mot de passe d'usine pour cette configuration est "{0}". Pour le retrouver, vous pouvez toujours googler "{1}" et "{2}"</seg>
+        <seg>Le mot de passe par défaut pour ces paramètres est « {0} ». Si vous l'oubliez, vous pouvez visiter la page de support {1}.</seg>
       </tuv>
     </tu>
+	<tu tuid="SettingsProtection.PasswordNoticeWithSupportUrl">
+	  <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNotice". Param 0: Factory password; Param 1: product name; Param 2: URL of support page</note>
+	  <tuv xml:lang="en">
+		<seg>Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page: {2}"</seg>
+	  </tuv>
+	  <tuv xml:lang="fr">
+		<seg>Le mot de passe par défaut pour ces paramètres est « {0} ». Si vous l'oubliez, vous pouvez visiter la page de support {1}: {2}</seg>
+	  </tuv>
+	</tu>
     <tu tuid="SettingsProtection.RequirePasswordCheckBox">
       <tuv xml:lang="en">
         <seg>Require the factory password to get into settings.</seg>

--- a/DistFiles/Palaso.fr.tmx
+++ b/DistFiles/Palaso.fr.tmx
@@ -480,7 +480,7 @@
         <seg>Settings Protection...</seg>
       </tuv>
       <tuv xml:lang="fr">
-        <seg>Configuration...</seg>
+        <seg>Verrouillage des paramètres…</seg>
       </tuv>
     </tu>
     <tu tuid="SettingsProtection.NormallyHiddenCheckbox">
@@ -529,7 +529,7 @@
 		<seg>Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page."</seg>
 	  </tuv>
       <tuv xml:lang="fr">
-        <seg>Le mot de passe par défaut pour ces paramètres est « {0} ». Si vous l'oubliez, vous pouvez visiter la page de support {1}.</seg>
+        <seg>Le mot de passe d'usine pour ces paramètres est « {0} ». Si vous l'oubliez, vous pouvez visiter la page de support {1}.</seg>
       </tuv>
     </tu>
 	<tu tuid="SettingsProtection.PasswordNoticeWithSupportUrl">
@@ -538,7 +538,7 @@
 		<seg>Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page: {2}"</seg>
 	  </tuv>
 	  <tuv xml:lang="fr">
-		<seg>Le mot de passe par défaut pour ces paramètres est « {0} ». Si vous l'oubliez, vous pouvez visiter la page de support {1}: {2}</seg>
+		<seg>Le mot de passe d'usine pour ces paramètres est « {0} ». Si vous l'oubliez, vous pouvez visiter la page de support {1} : {2}</seg>
 	  </tuv>
 	</tu>
     <tu tuid="SettingsProtection.RequirePasswordCheckBox">

--- a/SIL.Windows.Forms/SettingProtection/SettingProtectionDialog.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingProtectionDialog.Designer.cs
@@ -100,7 +100,8 @@ namespace SIL.Windows.Forms.SettingProtection
 			this._passwordNotice.Font = new System.Drawing.Font("Segoe UI", 9F);
 			this._passwordNotice.ForeColor = System.Drawing.Color.DimGray;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this._passwordNotice, null);
-			this.l10NSharpExtender1.SetLocalizationComment(this._passwordNotice, "Param 0: Factory password; Param 1: product name; 2: English words \"factory password\"");
+			this.l10NSharpExtender1.SetLocalizationComment(this._passwordNotice, "The localization for this should be kept " +
+				"in sync with \"SettingsProtection.PasswordNoticeWithSupportUrl\". Param 0: Factory password; Param 1: product name");
 			this.l10NSharpExtender1.SetLocalizingId(this._passwordNotice, "SettingsProtection.PasswordNotice");
 			this._passwordNotice.Location = new System.Drawing.Point(59, 156);
 			this._passwordNotice.Multiline = true;
@@ -109,8 +110,8 @@ namespace SIL.Windows.Forms.SettingProtection
 			this._passwordNotice.Size = new System.Drawing.Size(407, 33);
 			this._passwordNotice.TabIndex = 5;
 			this._passwordNotice.TabStop = false;
-			this._passwordNotice.Text = "Factory password for these settings is \"{0}\".  If you forget it, you can always g" +
-    "oogle for \"{1}\" and \"{2}\"";
+			this._passwordNotice.Text = "Factory password for these settings is \"{0}\". If you forget it, you can always v" +
+    "isit the {1} support page.";
 			// 
 			// betterLabel1
 			//

--- a/SIL.Windows.Forms/SettingProtection/SettingProtectionDialog.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingProtectionDialog.cs
@@ -1,12 +1,12 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
+using L10NSharp;
 
 namespace SIL.Windows.Forms.SettingProtection
 {
 	public partial class SettingProtectionDialog : Form
 	{
 		private bool _didHavePasswordSet;
-		private const string FactoryPassword = "factory password";
 
 		public SettingProtectionDialog()
 		{
@@ -16,8 +16,20 @@ namespace SIL.Windows.Forms.SettingProtection
 
 			_didHavePasswordSet = SettingsProtectionSingleton.Settings.RequirePassword;
 
-			_passwordNotice.Text = string.Format(_passwordNotice.Text, SettingsProtectionSingleton.FactoryPassword,
-												 SettingsProtectionSingleton.CoreProductName, FactoryPassword);
+			if (SettingsProtectionSingleton.ProductSupportUrl == null)
+			{
+				_passwordNotice.Text = string.Format(_passwordNotice.Text, SettingsProtectionSingleton.FactoryPassword,
+					SettingsProtectionSingleton.CoreProductName);
+			}
+			else
+			{
+				// The wording here should be kept essentially in sync with "SettingsProtection.PasswordNotice" in the Designer file.
+				_passwordNotice.Text = string.Format(LocalizationManager.GetString("SettingsProtection.PasswordNoticeWithSupportUrl",
+					"Factory password for these settings is \"{0}\". If you forget it, you can always visit the {1} support page: {2}",
+					"The localization for this should be kept in sync with \"SettingsProtection.PasswordNotice\". Param 0: Factory password; " +
+					"Param 1: product name; Param 2: URL of support page"),
+					SettingsProtectionSingleton.FactoryPassword, SettingsProtectionSingleton.CoreProductName, SettingsProtectionSingleton.ProductSupportUrl);
+			}
 		}
 
 		private void OnNormallHidden_CheckedChanged(object sender, EventArgs e)

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtection.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtection.cs
@@ -7,6 +7,7 @@ namespace SIL.Windows.Forms.SettingProtection
 	public class SettingsProtectionSingleton
 	{
 		private SettingsProtectionSettings config;
+		private string productSupportUrl;
 		private static SettingsProtectionSingleton _singleton;
 
 		private SettingsProtectionSingleton()
@@ -90,15 +91,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			}
 		}
 
-		public static string FactoryPassword
-		{
-			get
-			{
-				var overridePassword = ConfigurationManager.AppSettings["SettingsPassword"];
-				return string.IsNullOrEmpty(overridePassword) ? CoreProductName.Insert(1, "7").ToLower() :
-					overridePassword;
-			}
-		}
+		public static string FactoryPassword => CoreProductName.Insert(1, "7").ToLower();
 
 		/// <summary>
 		/// Use the CoreProductName value from the AppSettings in the application config file, if present
@@ -112,15 +105,19 @@ namespace SIL.Windows.Forms.SettingProtection
 			}
 		}
 
-		/// <summary>
-		/// Use the ProductSupportSite value from the AppSettings in the application config file, if present. Otherwise null.
-		/// </summary>
-		internal static string ProductSupportUrl
+		public static string ProductSupportUrl
 		{
-			get
+			get { return _singleton?.productSupportUrl; }
+			set
 			{
-				var productSupportUrl = ConfigurationManager.AppSettings["ProductSupportUrl"];
-				return string.IsNullOrWhiteSpace(productSupportUrl) ? null : productSupportUrl;
+				if (!string.IsNullOrEmpty(value))
+				{
+					if (_singleton == null)
+					{
+						_singleton = new SettingsProtectionSingleton();
+					}
+					_singleton.productSupportUrl = value;
+				}
 			}
 		}
 	}

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtection.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtection.cs
@@ -1,4 +1,4 @@
-﻿using System.Configuration;
+using System.Configuration;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -94,10 +94,10 @@ namespace SIL.Windows.Forms.SettingProtection
 		{
 			get
 			{
-				var productName = CoreProductName;
-				return productName.Insert(1, "7").ToLower();
+				var overridePassword = ConfigurationManager.AppSettings["SettingsPassword"];
+				return string.IsNullOrEmpty(overridePassword) ? CoreProductName.Insert(1, "7").ToLower() :
+					overridePassword;
 			}
-
 		}
 
 		/// <summary>
@@ -108,10 +108,19 @@ namespace SIL.Windows.Forms.SettingProtection
 			get
 			{
 				var productName = ConfigurationManager.AppSettings["CoreProductName"];
-				if (string.IsNullOrEmpty(productName))
-					productName = Application.ProductName;
+				return string.IsNullOrEmpty(productName) ? Application.ProductName : productName;
+			}
+		}
 
-				return productName;
+		/// <summary>
+		/// Use the ProductSupportSite value from the AppSettings in the application config file, if present. Otherwise null.
+		/// </summary>
+		internal static string ProductSupportUrl
+		{
+			get
+			{
+				var productSupportUrl = ConfigurationManager.AppSettings["ProductSupportUrl"];
+				return string.IsNullOrWhiteSpace(productSupportUrl) ? null : productSupportUrl;
 			}
 		}
 	}


### PR DESCRIPTION
Apps can now override the default password if needed and also specify the support page URL.
This should be 100% compatible with existing apps and not break anything. However, apps that ship their own localized versions of Palaso TMX file will want to fix any existing translations for SettingsProtection.PasswordNotice. (I rewrote the wording such that googling the new param 2 should still work -- even better than before -- but it might sound/look weird if the wording is not adjusted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/789)
<!-- Reviewable:end -->
