### PR TITLE
Fix private use scripts showing up as normal

### DIFF
--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -462,7 +462,6 @@ namespace SIL.WritingSystems.Tests
 			Assert.That(variantSubtags, Is.Empty);
 		}
 
-
 		[Test]
 		public void TryGetSubtags_XKalFake_ReturnsKalFake()
 		{
@@ -477,6 +476,40 @@ namespace SIL.WritingSystems.Tests
 			Assert.That(scriptSubtag, Is.EqualTo((ScriptSubtag) "Fake"));
 			Assert.That(regionSubtag, Is.Null);
 			Assert.That(variantSubtags, Is.Empty);
+		}
+
+		[Test]
+		public void TryGetSubtags_FullPUAConventionWithVariantAndPUAVariant_ReturnsAllParts()
+		{
+			LanguageSubtag languageSubtag;
+			ScriptSubtag scriptSubtag;
+			RegionSubtag regionSubtag;
+			IEnumerable<VariantSubtag> variantSubtags;
+			Assert.That(IetfLanguageTag.TryGetSubtags("qaa-Qaaa-QM-fonipa-x-kal-Fake-RG-extravar",
+				out languageSubtag, out scriptSubtag, out regionSubtag, out variantSubtags), Is.True);
+			// SUT
+			Assert.That(languageSubtag, Is.EqualTo((LanguageSubtag) "kal"));
+			Assert.That(scriptSubtag, Is.EqualTo((ScriptSubtag) "Fake"));
+			Assert.That(regionSubtag, Is.EqualTo((RegionSubtag) "RG"));
+			CollectionAssert.IsNotEmpty(variantSubtags);
+			CollectionAssert.AreEquivalent(new[] {"International Phonetic Alphabet", "extravar"},
+				variantSubtags.Select(x => x.ToString()));
+		}
+
+		[Test]
+		public void TryGetSubtags_InvalidConventionForScript_ReturnsPrivateUseScript()
+		{
+			LanguageSubtag languageSubtag;
+			ScriptSubtag scriptSubtag;
+			RegionSubtag regionSubtag;
+			IEnumerable<VariantSubtag> variantSubtags;
+			Assert.That(IetfLanguageTag.TryGetSubtags("en-Qaaa-x-toolong",
+				out languageSubtag, out scriptSubtag, out regionSubtag, out variantSubtags), Is.True);
+			Assert.That(languageSubtag, Is.EqualTo((LanguageSubtag) "en"));
+			Assert.IsNull(regionSubtag);
+			// SUT
+			Assert.That(scriptSubtag, Is.EqualTo((ScriptSubtag) "Qaaa"));
+			Assert.IsTrue(scriptSubtag.IsPrivateUse);
 		}
 
 		[Test]

--- a/SIL.WritingSystems.Tests/StandardSubtagsTests.cs
+++ b/SIL.WritingSystems.Tests/StandardSubtagsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NUnit.Framework;
 
 namespace SIL.WritingSystems.Tests
@@ -243,6 +243,18 @@ namespace SIL.WritingSystems.Tests
 			Assert.That(pinyinPrefixes, Has.Length.EqualTo(2));
 			Assert.That(pinyinPrefixes, Has.Member("zh-Latn"));
 			Assert.That(pinyinPrefixes, Has.Member("bo-Latn"));
+		}
+
+		[TestCase("Qaaa", true)]
+		[TestCase("Qabx", true)]
+		[TestCase("Qaby", false)] // Valid script code that will is unlikely to be registered
+		[TestCase("A1B2", false)] // Valid script code that will is unlikely to be registered
+		public void VerifyAddedPrivateUseScriptsMarkedProperly(string scriptCode, bool expectedValue)
+		{
+			StandardSubtags.RegisteredScripts.Remove(scriptCode);
+			StandardSubtags.AddScript(scriptCode, "description");
+			Assert.AreEqual(StandardSubtags.RegisteredScripts[scriptCode].IsPrivateUse, expectedValue);
+			StandardSubtags.RegisteredScripts.Remove(scriptCode);
 		}
 	}
 }

--- a/SIL.WritingSystems/LdmlInXmlWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInXmlWritingSystemRepository.cs
@@ -6,7 +6,7 @@ using System.Xml.XPath;
 namespace SIL.WritingSystems
 {
 	/// <summary>
-	/// A writing system repository where all LDML defintions are stored in a single XML file.
+	/// A writing system repository where all LDML definitions are stored in a single XML file.
 	/// </summary>
 	public class LdmlInXmlWritingSystemRepository : LdmlInXmlWritingSystemRepository<WritingSystemDefinition>
 	{

--- a/SIL.WritingSystems/StandardSubtags.cs
+++ b/SIL.WritingSystems/StandardSubtags.cs
@@ -38,7 +38,8 @@ namespace SIL.WritingSystems
 			var variants = new List<VariantSubtag>();
 			foreach (string ianaSubtagAsString in ianaSubtagsAsStrings)
 			{
-				string[] subTagComponents = ianaSubtagAsString.Replace("\r\n", "\n").Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+				string[] subTagComponents = ianaSubtagAsString.Replace("\r\n", "\n").Split(new[] { "\n" },
+					StringSplitOptions.RemoveEmptyEntries);
 
 				if (subTagComponents[0].Contains("File-Date"))
 				{
@@ -79,7 +80,8 @@ namespace SIL.WritingSystems
 							subtag = value;
 							break;
 						case "Description":
-							description = SubTagComponentDescription(component); ; // so that the description spread over 2 lines can be appended to
+							// so that the description spread over 2 lines can be appended to
+							description = SubTagComponentDescription(component);
 							descriptions.Add(description);
 							break;
 						case "Deprecated":
@@ -179,7 +181,7 @@ namespace SIL.WritingSystems
 
 		public static void AddScript(string script, string description)
 		{
-			var scriptTag = new ScriptSubtag(script, description, false, false);
+			var scriptTag = new ScriptSubtag(script, description, IsPrivateUseScriptCode(script), false);
 			RegisteredScripts.Add(scriptTag);
 		}
 


### PR DESCRIPTION
* Scripts added by SLDR from the languageTags.json
  were not retaining their private use identity
* Also cleaned up some comments and added some new
  comments relating to the private use convention

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/792)
<!-- Reviewable:end -->
