### PR TITLE
Abbreviate Creative Commons as "CC " instead of "CC-"

### DIFF
--- a/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
@@ -477,7 +477,7 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 			};
 
 			string idOfLanguageUsedForLicense;
-			Assert.AreEqual("My Collection, © 2014 SIL. CC-BY-SA IGO 3.0", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
+			Assert.AreEqual("My Collection, © 2014 SIL. CC BY-SA IGO 3.0", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
 		}
 
 		[Test]
@@ -494,7 +494,7 @@ namespace SIL.Windows.Forms.Tests.ClearShare
 			};
 
 			string idOfLanguageUsedForLicense;
-			Assert.AreEqual("© 2014 SIL. CC-BY-SA IGO 3.0. Only people named Fred can use this.", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
+			Assert.AreEqual("© 2014 SIL. CC BY-SA IGO 3.0. Only people named Fred can use this.", m.MinimalCredits(new[] { "en" }, out idOfLanguageUsedForLicense));
 		}
 	}
 }

--- a/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
+++ b/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
@@ -233,13 +233,13 @@ namespace SIL.Windows.Forms.ClearShare
 
 		/// <summary>
 		/// A compact form of of this license that doesn't introduce any new text (though the license may itself have text)
-		/// E.g. CC-BY-NC
+		/// E.g. CC BY-NC
 		/// </summary>
 		public override string GetMinimalFormForCredits(IEnumerable<string> languagePriorityIds, out string idOfLanguageUsed)
 		{
 			idOfLanguageUsed = "*";
 
-			var form = "CC-";
+			var form = "CC ";
 			if (AttributionRequired)
 				form += "BY-";
 			if (!CommercialUseAllowed)
@@ -257,7 +257,7 @@ namespace SIL.Windows.Forms.ClearShare
 				default:
 					throw new ArgumentOutOfRangeException("derivativeRule");
 			}
-			form = form.TrimEnd(new char[] { '-' });
+			form = form.TrimEnd(new char[] { '-', ' ' });
 
 			var additionalRights = (RightsStatement != null ? ". " + RightsStatement : "");
 			return (form + " " + (IntergovernmentalOriganizationQualifier ? "IGO " : "") + Version + additionalRights).Trim();

--- a/SIL.Windows.Forms/ClearShare/LicenseInfo.cs
+++ b/SIL.Windows.Forms/ClearShare/LicenseInfo.cs
@@ -25,7 +25,7 @@ namespace SIL.Windows.Forms.ClearShare
 
 		/// <summary>
 		/// A compact form of of this license that doesn't introduce any new text (though the license may itself have text)
-		/// E.g. CC-BY-NC
+		/// E.g. "CC BY-NC"
 		/// </summary>
 		public abstract string GetMinimalFormForCredits(IEnumerable<string> languagePriorityIds, out string idOfLanguageUsed);
 

--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -690,7 +690,7 @@ namespace SIL.Windows.Forms.ClearShare
 
 		/// <summary>
 		/// Deletes the stored exemplar (if it exists).  This can be useful if a program
-		/// wants to establish CC-BY as the default license for a new product.
+		/// wants to establish "CC BY" as the default license for a new product.
 		/// </summary>
 		static public void DeleteStoredExemplar(FileCategory category)
 		{
@@ -830,8 +830,8 @@ namespace SIL.Windows.Forms.ClearShare
 
 		/// <summary>
 		/// A super compact form of credits that doesn't introduce any English.
-		/// Jane Doe, © 2008 SIL International, CC-BY-NC 3.0
-		/// "International Illustrations: Art Of Reading", © 2009 SIL International, CC-ND
+		/// Jane Doe, © 2008 SIL International, CC BY-NC 3.0
+		/// "International Illustrations: Art Of Reading", © 2009 SIL International, CC ND
 		/// </summary>
 		public string MinimalCredits(IEnumerable<string> languagePriorityIds, out string idOfLanguageUsedForLicense)
 		{


### PR DESCRIPTION
This requirement was brought to our attention by a Bloom user (BL-6880 or
https://community.software.sil.org/t/changing-cc-version-in-license-notice/1726)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/793)
<!-- Reviewable:end -->
