### PR TITLE
Do not show Script/Region/Variant for Implicit Script

### DIFF
--- a/SIL.Windows.Forms.WritingSystems.Tests/WritingSystemSetupPMTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/WritingSystemSetupPMTests.cs
@@ -779,6 +779,15 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		}
 
 		[Test]
+		public void SelectionForSpecialCombo_HasImplicitScript_GivesNone()
+		{
+			_model.AddNew();
+			_model.CurrentIso = "en";
+			_model.CurrentScriptCode = "Latn";
+			Assert.AreEqual(WritingSystemSetupModel.SelectionsForSpecialCombo.None, _model.SelectionForSpecialCombo);
+		}
+
+		[Test]
 		public void VerboseDescriptionWhenNoSubtagsSet()
 		{
 			_model.CurrentDefinition = new WritingSystemDefinition();

--- a/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
@@ -990,7 +990,7 @@ namespace SIL.Windows.Forms.WritingSystems
 				{
 					return SelectionsForSpecialCombo.UnlistedLanguageDetails;
 				}
-				if (_currentWritingSystem.Script != null
+				if ((_currentWritingSystem.Script != null && !IetfLanguageTag.IsScriptImplied(_currentWritingSystem.LanguageTag))
 					|| _currentWritingSystem.Region != null
 					|| _currentWritingSystem.Variants.Count > 0
 				)


### PR DESCRIPTION
* If a language tag is using an implicit script it should
  not push the user into the Script/Region/Variant options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/795)
<!-- Reviewable:end -->
