### PR TITLE
Do not restrict custom language name to private use

### DIFF
--- a/SIL.Lexicon/ProjectLexiconSettingsWritingSystemDataMapper.cs
+++ b/SIL.Lexicon/ProjectLexiconSettingsWritingSystemDataMapper.cs
@@ -37,7 +37,7 @@ namespace SIL.Lexicon
 				ws.Abbreviation = abbreviation;
 
 			var languageName = (string) wsElem.Element("LanguageName");
-			if (!string.IsNullOrEmpty(languageName) && ws.Language != null && ws.Language.IsPrivateUse)
+			if (!string.IsNullOrEmpty(languageName) && ws.Language != null)
 				ws.Language = new LanguageSubtag(ws.Language, languageName);
 
 			var scriptName = (string) wsElem.Element("ScriptName");
@@ -89,7 +89,7 @@ namespace SIL.Lexicon
 
 			if (!string.IsNullOrEmpty(ws.Abbreviation))
 				wsElem.Add(new XElement("Abbreviation", ws.Abbreviation));
-			if (ws.Language != null && ws.Language.IsPrivateUse && !string.IsNullOrEmpty(ws.Language.Name))
+			if (ws.Language != null && !string.IsNullOrEmpty(ws.Language.Name))
 				wsElem.Add(new XElement("LanguageName", ws.Language.Name));
 			if (ws.Script != null && ws.Script.IsPrivateUse && !string.IsNullOrEmpty(ws.Script.Name))
 				wsElem.Add(new XElement("ScriptName", ws.Script.Name));


### PR DESCRIPTION
* Languages are referred to by different names in
  different areas regardless of their private use designation
* Change code to store the users preferred language name and
  verify that this happens during migration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/811)
<!-- Reviewable:end -->
