### PR TITLE
Save DefaultCollationType from PM to WritingSystem

### DIFF
--- a/SIL.Windows.Forms.WritingSystems.Tests/WritingSystemSetupPMTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/WritingSystemSetupPMTests.cs
@@ -886,6 +886,23 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 		}
 
 		[Test]
+		public void SetAllPossibleAndRemoveOthers_DefaultCollationType_SetsToRepo()
+		{
+			Assert.That(_writingSystemRepository.Count, Is.EqualTo(0));
+			// initialize the model with english as the single defined language
+			_writingSystemRepository.Set(new WritingSystemDefinition("en"));
+			_model = new WritingSystemSetupModel(_writingSystemRepository);
+			// set english as the current definition
+			_model.SetCurrentDefinition(_writingSystemRepository.Get("en"));
+			// SUT
+			_model.CurrentCollationRulesType = "CustomSimple";
+			_model.SetAllPossibleAndRemoveOthers();
+			Assert.That(_writingSystemRepository.Contains("en"));
+			var enWs = _writingSystemRepository.Get("en");
+			Assert.That(enWs.DefaultCollationType == "CustomSimple");
+		}
+
+		[Test]
 		public void SetAllPossibleAndRemoveOthers_DuplicateIsCreatedFromWsAlreadyInRepo_OriginalWsIsUpdated()
 		{
 			Assert.That(_writingSystemRepository.Count, Is.EqualTo(0));

--- a/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
@@ -895,6 +895,8 @@ namespace SIL.Windows.Forms.WritingSystems
 								CurrentDefinition.DefaultCollation = new SystemCollationDefinition();
 								break;
 						}
+
+						CurrentDefinition.DefaultCollationType = value;
 						_currentCollationRulesType = type;
 						OnCurrentItemUpdated();
 					}


### PR DESCRIPTION
* Fix bug where the DefaultCollationType wasn't being
  saved into the actual writing system when it was set in
  the WritingSystemSetupModel
* Add unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/813)
<!-- Reviewable:end -->
