### PR TITLE
Change WritingSystemRepository interaction with the Id field

### DIFF
--- a/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
@@ -322,7 +322,7 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
-		public void AllWritingSystems_LdmlCheckingSetEmptyandGetWSId()
+		public void AllWritingSystems_LdmlCheckingSetEmptyCanNotSave()
 		{
 			using (var tf = new TemporaryFolder("GlobalWritingSystemRepositoryTests"))
 			{
@@ -337,12 +337,12 @@ namespace SIL.WritingSystems.Tests
 				Thread.Sleep(1000);
 				ws = repo2.Get("en-US");
 				ws.WindowsLcid = "test";
-				// Make an arbitrary change to force a save of the ldml file.
+				// a ws with an empty Id is assumed to be new, we can't save it if the LanguageTag is already found
+				// in the repo.
 				ws.Id = string.Empty;
+				Assert.That(repo2.CanSet(ws), Is.False, "A ws with an empty ID will not save if the LanguageTag matches an existing ws");
 				repo2.Save();
-				Assert.That(repo1.Get("en-US").WindowsLcid, Is.EqualTo("test"));
-				Assert.That(ws.IsChanged, Is.False);
-				Assert.AreEqual(ws.Id, "en-US");
+				Assert.That(repo1.Get("en-US").WindowsLcid, Is.Not.EqualTo("test"), "Changes should not have been saved.");
 			}
 		}
 	}

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -743,5 +743,14 @@ namespace SIL.WritingSystems.Tests
 			Assert.That(ws.LanguageTag, Is.EqualTo("en-Zxxx-x-dupl0-audio-dupl1"));
 		}
 		#endregion
+
+		[TestCase("en", true)]
+		[TestCase("en-Latn", true)]
+		[TestCase("en-Arab", false)]
+		[TestCase("en-Latn-US", true)]
+		public void IsScriptImplied_ReturnsExpectedResults(string tag, bool expectedResult)
+		{
+			Assert.That(IetfLanguageTag.IsScriptImplied(tag), Is.EqualTo(expectedResult));
+		}
 	}
 }

--- a/SIL.WritingSystems.Tests/Migration/IetfLanguageTagCleanerTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/IetfLanguageTagCleanerTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using SIL.WritingSystems.Migration;
 
 namespace SIL.WritingSystems.Tests.Migration
@@ -312,6 +312,22 @@ namespace SIL.WritingSystems.Tests.Migration
 			var cleaner = new IetfLanguageTagCleaner("zh-Phnx-CN-fonipa-x-emic");
 			cleaner.Clean();
 			VerifyRfcCleaner(cleaner, "zh", "Phnx", "CN", "fonipa", "zh-Phnx-CN-fonipa-x-emic");
+		}
+
+		[Test]
+		public void GetFullCode_CaseCleaning_Lang_Script_Region_Works()
+		{
+			var cleaner = new IetfLanguageTagCleaner("EN-latn-us-x-NotCHang");
+			cleaner.Clean();
+			VerifyRfcCleaner(cleaner, "en", "Latn", "US", "", "en-Latn-US-x-NotCHang");
+		}
+
+		[Test]
+		public void GetFullCode_CaseCleaning_AudioWs_PrivateUseIsChanged()
+		{
+			var cleaner = new IetfLanguageTagCleaner("EN-Zxxx-x-AudIO");
+			cleaner.Clean();
+			VerifyRfcCleaner(cleaner, "en", "Zxxx", "", "", "en-Zxxx-x-audio");
 		}
 
 		void VerifyRfcCleaner(IetfLanguageTagCleaner cleaner, string language, string script, string region, string variant, string completeTag)

--- a/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
@@ -239,7 +239,6 @@ namespace SIL.WritingSystems.Tests.Migration
 				AssertLdmlHasXpath(environment.MappedFilePath("bogus.ldml"), "/ldml/identity/language[@type='en']");
 				AssertLdmlHasXpath(environment.MappedFilePath("bogus1.ldml"), "/ldml/identity/language[@type='en']");
 				AssertLdmlHasNoXpath(environment.MappedFilePath("bogus1.ldml"), "/ldml/identity/script");
-				AssertLdmlHasXpath(environment.MappedFilePath("bogus1.ldml"), "/ldml/identity/variant[@type='x-dupl0']");
 			}
 
 		}
@@ -1648,6 +1647,29 @@ namespace SIL.WritingSystems.Tests.Migration
 
 				Assert.AreEqual(1, Directory.GetFiles(environment.LdmlPath).Length);
 				Assert.AreEqual(0, Directory.GetDirectories(environment.LdmlPath).Length);
+			}
+		}
+
+		/// <summary>
+		/// Test that a writing system file with a valid but non-canonical identifier does not move after migration.
+		/// </summary>
+		[Test]
+		public void Migrate_ValidNonCanonicalLdmlFile_FileNameDoesNotChange()
+		{
+			string ldmlFileContent = LdmlContentForTests.Version2("en", "Latn", "US", "");
+
+			using (var environment = new TestEnvironment())
+			{
+				// Setup
+				environment.WriteLdmlFile("en-Latn-US.ldml", ldmlFileContent);
+				var migrator = new LdmlInFolderWritingSystemRepositoryMigrator(environment.LdmlPath, environment.OnMigrateCallback);
+				migrator.Migrate();
+
+				// Execute
+				var migratedEnglishFile = environment.FilePath("en-Latn-US.ldml");
+				Assert.True(File.Exists(migratedEnglishFile));
+				AssertLdmlHasXpath(migratedEnglishFile, "/ldml/identity/language[@type='en']");
+				AssertLdmlHasNoXpath(migratedEnglishFile, "/ldml/identity/script");
 			}
 		}
 

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -344,7 +344,7 @@ namespace SIL.WritingSystems
 
 		protected override void RemoveDefinition(T ws)
 		{
-			string file = GetFilePathFromLanguageTag(ws.LanguageTag);
+			string file = GetFilePathFromLanguageTag(ws.Id);
 			if (File.Exists(file))
 				File.Delete(file);
 			base.RemoveDefinition(ws);
@@ -356,7 +356,7 @@ namespace SIL.WritingSystems
 		{
 			base.Set(ws);
 
-			string writingSystemFilePath = GetFilePathFromLanguageTag(ws.LanguageTag);
+			string writingSystemFilePath = GetFilePathFromLanguageTag(ws.Id);
 			if (!File.Exists(writingSystemFilePath) && !string.IsNullOrEmpty(ws.Template))
 			{
 				// this is a new writing system that was generated from a template, so copy the template over before saving

--- a/SIL.WritingSystems/IetfLanguageTag.cs
+++ b/SIL.WritingSystems/IetfLanguageTag.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Icu;
+using SIL.Code;
 using SIL.Extensions;
 
 namespace SIL.WritingSystems
@@ -999,7 +1000,7 @@ namespace SIL.WritingSystems
 			if (!TryParse(langTag, out language, out script, out region, out variant))
 				throw new ArgumentException("The IETF language tag is invalid.", "langTag");
 
-			return string.IsNullOrEmpty(script) && !string.IsNullOrEmpty(GetImplicitScriptCode(language, region));
+			return string.IsNullOrEmpty(script) || script.Equals(GetImplicitScriptCode(language, region));
 		}
 
 		private static string GetImplicitScriptCode(LanguageSubtag languageSubtag, RegionSubtag regionSubtag)
@@ -1187,6 +1188,18 @@ namespace SIL.WritingSystems
 				ietfLanguageTag = Create(languageSubtag, scriptSubtag, regionSubtag, variants);
 			}
 			return ietfLanguageTag;
+		}
+
+		public static bool AreTagsEquivalent(string firstTag, string secondTag)
+		{
+			Guard.AgainstNullOrEmptyString(firstTag, "firstTag");
+			Guard.AgainstNullOrEmptyString(secondTag, "secondTag");
+			if (IsValid(firstTag) && IsValid(secondTag))
+			{
+				return Canonicalize(firstTag).Equals(Canonicalize(secondTag));
+			}
+			// If the tags aren't valid the only way they can be equivalent is if they are equal
+			return firstTag.Equals(secondTag, StringComparison.InvariantCultureIgnoreCase);
 		}
 	}
 }

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemFactory.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 
 namespace SIL.WritingSystems
 {
@@ -41,7 +41,7 @@ namespace SIL.WritingSystems
 			if (_writingSystemRepository.TryGet(ietfLanguageTag, out existingWS))
 			{
 				ws = ConstructDefinition(existingWS);
-				string templatePath = _writingSystemRepository.GetFilePathFromLanguageTag(existingWS.LanguageTag);
+				string templatePath = _writingSystemRepository.GetFilePathFromLanguageTag(existingWS.Id);
 				if (File.Exists(templatePath))
 					ws.Template = templatePath;
 				return true;

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -145,9 +145,9 @@ namespace SIL.WritingSystems
 		///<summary>
 		/// Returns the full path to the underlying store for this writing system.
 		///</summary>
-		public string GetFilePathFromLanguageTag(string langTag)
+		public string GetFilePathFromLanguageTag(string wsId)
 		{
-			return Path.Combine(PathToWritingSystems, GetFileNameFromLanguageTag(langTag));
+			return Path.Combine(PathToWritingSystems, GetFileNameFromLanguageTag(wsId));
 		}
 
 		/// <summary>
@@ -280,7 +280,7 @@ namespace SIL.WritingSystems
 		{
 			Set(ws);
 
-			string writingSystemFilePath = GetFilePathFromLanguageTag(ws.LanguageTag);
+			string writingSystemFilePath = GetFilePathFromLanguageTag(ws.Id);
 			if (!File.Exists(writingSystemFilePath) && !string.IsNullOrEmpty(ws.Template) && File.Exists(ws.Template))
 			{
 				// this is a new writing system that was generated from a template, so copy the template over before saving
@@ -466,7 +466,7 @@ namespace SIL.WritingSystems
 			//helps us avoid having to deal with situations where a writing system id is changed to be
 			//identical with the old id of another writing sytsem. This could otherwise lead to dataloss.
 			//The inconsistency is resolved on Save()
-			if (oldStoreId != ws.Id && File.Exists(GetFilePathFromLanguageTag(oldStoreId)))
+			if (oldStoreId != ws.Id && File.Exists(GetFilePathFromLanguageTag(oldStoreId)) && !IetfLanguageTag.AreTagsEquivalent(oldStoreId, ws.Id))
 				File.Move(GetFilePathFromLanguageTag(oldStoreId), GetFilePathFromLanguageTag(ws.Id));
 		}
 

--- a/SIL.WritingSystems/Migration/IetfLanguageTagCleaner.cs
+++ b/SIL.WritingSystems/Migration/IetfLanguageTagCleaner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SIL.Extensions;
@@ -46,7 +46,7 @@ namespace SIL.WritingSystems.Migration
 		/// </summary>
 		public string Language
 		{
-			get { return _languageSubTag.CompleteTag; }
+			get { return _languageSubTag.CompleteTag.ToLower(); }
 			private set { _languageSubTag = new SubTag(value); }
 		}
 
@@ -55,7 +55,7 @@ namespace SIL.WritingSystems.Migration
 		/// </summary>
 		public string Script
 		{
-			get { return _scriptSubTag.CompleteTag; }
+			get { return _scriptSubTag.CompleteTag.ToUpperFirstLetter(); }
 			private set { _scriptSubTag = new SubTag(value); }
 		}
 
@@ -64,7 +64,7 @@ namespace SIL.WritingSystems.Migration
 		/// </summary>
 		public string Region
 		{
-			get { return _regionSubTag.CompleteTag; }
+			get { return _regionSubTag.CompleteTag.ToUpper(); }
 			private set { _regionSubTag = new SubTag(value); }
 		}
 
@@ -134,13 +134,19 @@ namespace SIL.WritingSystems.Migration
 						return String.Empty;
 					}
 					string subtagAsString = "";
-					foreach (string part in _subTagParts)
+					for(var i = 0; i < _subTagParts.Count; ++i)
 					{
-						if (!String.IsNullOrEmpty(subtagAsString))
+						var cleanedPart = _subTagParts[i];
+						// force audio case to lower for audio writing systems.
+						if (i == 0 && cleanedPart.Equals(WellKnownSubtags.AudioPrivateUse, StringComparison.InvariantCultureIgnoreCase))
+						{
+							cleanedPart = WellKnownSubtags.AudioPrivateUse;
+						}
+						if (!string.IsNullOrEmpty(subtagAsString))
 						{
 							subtagAsString = subtagAsString + "-";
 						}
-						subtagAsString = subtagAsString + part;
+						subtagAsString = subtagAsString + cleanedPart;
 					}
 					return subtagAsString;
 				}

--- a/SIL.WritingSystems/Migration/LdmlMigrationInfo.cs
+++ b/SIL.WritingSystems/Migration/LdmlMigrationInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace SIL.WritingSystems.Migration
 {
@@ -19,8 +19,14 @@ namespace SIL.WritingSystems.Migration
 			get { return _fileName; }
 		}
 
+		/// <summary>
+		/// Should really be FilenameBeforeMigration
+		/// </summary>
 		public string LanguageTagBeforeMigration { get; set; }
 
+		/// <summary>
+		/// Should really be FilenameAfterMigration
+		/// </summary>
 		public string LanguageTagAfterMigration { get; set; }
 
 		internal Action<WritingSystemDefinition> RemovedPropertiesSetter { get; set; } 

--- a/SIL.WritingSystems/Migration/WritingSystemsLdmlV2To3Migration/LdmlVersion2MigrationStrategy.cs
+++ b/SIL.WritingSystems/Migration/WritingSystemsLdmlV2To3Migration/LdmlVersion2MigrationStrategy.cs
@@ -58,7 +58,8 @@ namespace SIL.WritingSystems.Migration.WritingSystemsLdmlV2To3Migration
 			var langTagCleaner = new IetfLanguageTagCleaner(writingSystemDefinitionV1.Language, writingSystemDefinitionV1.Script, writingSystemDefinitionV1.Region,
 				variant, privateUse);
 			langTagCleaner.Clean();
-			string langTag = IetfLanguageTag.Canonicalize(langTagCleaner.GetCompleteTag());
+			// just cleaning and not canonicalizing - This is used only for the filename which becomes the WritingSystemDefinition.Id
+			string writingSystemId = langTagCleaner.GetCompleteTag();
 			List<string> knownKeyboards = writingSystemDefinitionV1.KnownKeyboards.Select(k => string.IsNullOrEmpty(k.Locale) ? k.Layout : string.Format("{0}_{1}", k.Locale, k.Layout)).ToList();
 			bool isGraphiteEnabled = false;
 			string legacyMapping = string.Empty;
@@ -108,7 +109,7 @@ namespace SIL.WritingSystems.Migration.WritingSystemsLdmlV2To3Migration
 			var migrationInfo = new LdmlMigrationInfo(sourceFileName)
 				{
 					LanguageTagBeforeMigration = writingSystemDefinitionV1.Bcp47Tag,
-					LanguageTagAfterMigration = langTag,
+					LanguageTagAfterMigration = writingSystemId,
 					RemovedPropertiesSetter = ws =>
 					{
 						if (!string.IsNullOrEmpty(abbreviation))
@@ -417,7 +418,7 @@ namespace SIL.WritingSystems.Migration.WritingSystemsLdmlV2To3Migration
 
 				// Write out the elements.
 				XElement identityElem = ldmlElem.Element("identity");
-				WriteIdentityElement(identityElem, staging, migrationInfo.LanguageTagAfterMigration);
+				WriteIdentityElement(identityElem, staging, IetfLanguageTag.Canonicalize(migrationInfo.LanguageTagAfterMigration));
 
 				var layoutElement = ldmlElem.Element("layout");
 				WriteLayoutElement(layoutElement);

--- a/SIL.WritingSystems/WritingSystemDefinition.cs
+++ b/SIL.WritingSystems/WritingSystemDefinition.cs
@@ -120,7 +120,9 @@ namespace SIL.WritingSystems
 			if (!IetfLanguageTag.IsValid(languageTag))
 				throw new ArgumentException("The language tag is invalid.", languageTag);
 			_numberingSystem = NumberingSystemDefinition.Default;
-			_languageTag = IetfLanguageTag.Canonicalize(languageTag);
+			// The language tag may change when we canonicalize it but we want to construct with the original
+			// to help us keep track of changes
+			_languageTag = languageTag;
 			IEnumerable<VariantSubtag> variantSubtags;
 			IetfLanguageTag.TryGetSubtags(_languageTag, out _language, out _script, out _region, out variantSubtags);
 			_variants = new BulkObservableList<VariantSubtag>(variantSubtags);


### PR DESCRIPTION
* Stop treating the Canonicalized LanguageTag as a stable identifier
* Allow for multiple writing systems in the repository to have the same
  Canonicalized LanguageTag data
* Update the tag cleaner to handle some of the clean-up that
  Canonicalize did.
* Don't rename .ldml files if a writing system id has changed
  but is still equivalent
* Don't canonicalize language tags on WritingSystemDefinition creation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/817)
<!-- Reviewable:end -->
