### PR TITLE
Improve LanguageLookup to work better with new langtags data

### DIFF
--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -206,24 +206,24 @@ namespace SIL.WritingSystems.Tests
 
 		#region Create
 		[Test]
-		[ExpectedException(typeof(ArgumentException), ExpectedMessage = "code [a] is invalid", MatchType = MessageMatch.Contains)]
 		public void Create_InvalidLanguageTag_Throws()
 		{
-			IetfLanguageTag.Create("a", "", "", string.Empty);
+			Assert.That(()=>IetfLanguageTag.Create("a", "", "", string.Empty),
+				Throws.ArgumentException.With.Message.Contains("code [a] is invalid"));
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException), ExpectedMessage = "code [scripty] is invalid", MatchType = MessageMatch.Contains)]
 		public void Create_InvalidScriptTag_Throws()
 		{
-			IetfLanguageTag.Create("aa", "scripty", "", string.Empty);
+			Assert.That(() => IetfLanguageTag.Create("aa", "scripty", "", string.Empty),
+				Throws.ArgumentException.With.Message.Contains("code [scripty] is invalid"));
 		}
 
 		[Test]
-		[ExpectedException(typeof(ArgumentException), ExpectedMessage = "code [region] is invalid", MatchType = MessageMatch.Contains)]
 		public void Create_InvalidRegionTag_Throws()
 		{
-			IetfLanguageTag.Create("aa", "latn", "region", string.Empty);
+			Assert.That(() => IetfLanguageTag.Create("aa", "latn", "region", string.Empty),
+				Throws.ArgumentException.With.Message.Contains("code [region] is invalid"));
 		}
 
 		[Test]
@@ -361,10 +361,9 @@ namespace SIL.WritingSystems.Tests
 		/// Tests the ToIcuLocale method with an invalid language tag.
 		/// </summary>
 		[Test]
-		[ExpectedException(typeof(ArgumentException))]
 		public void ToIcuLocale_InvalidLangTag_Throws()
 		{
-			IetfLanguageTag.ToIcuLocale("en_Latn_US_X_ETIC");
+			Assert.Throws<ArgumentException>(()=>IetfLanguageTag.ToIcuLocale("en_Latn_US_X_ETIC"));
 		}
 		#endregion
 

--- a/SIL.WritingSystems/LanguageInfo.cs
+++ b/SIL.WritingSystems/LanguageInfo.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace SIL.WritingSystems
@@ -17,6 +18,7 @@ namespace SIL.WritingSystems
 	/// LanguageLookup() needs to read and add the new field from LanguageDataIndex to the LanguageInfo
 	/// change the check for number of items in a record from LanguageDataIndex
 	/// </summary>
+	[DebuggerDisplay("{LanguageTag}")]
 	public class LanguageInfo
 	{
 		private readonly List<string> _names = new List<string>();

--- a/SIL.WritingSystems/SingleStringToListOfStringConverter.cs
+++ b/SIL.WritingSystems/SingleStringToListOfStringConverter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SIL.WritingSystems
+{
+	internal class SingleStringToListOfStringConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			writer.WriteValue(value);
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+			JsonSerializer serializer)
+		{
+			object retVal = new Object();
+			if (reader.TokenType == JsonToken.String)
+			{
+				var instance = (string)serializer.Deserialize(reader, typeof(string));
+				retVal = new List<string> { instance };
+			}
+			else if (reader.TokenType == JsonToken.StartArray)
+			{
+				retVal = serializer.Deserialize(reader, objectType);
+			}
+			return retVal;
+		}
+
+		public override bool CanConvert(Type objectType)
+		{
+			return objectType == typeof(string) || objectType == typeof(List<string>);
+		}
+	}
+}

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -58,6 +58,9 @@ namespace SIL.WritingSystems
 		public bool sldr { get; set; }
 		public string tag { get; set; }
 		public List<string> tags { get; set; }
+		[JsonConverter(typeof(SingleStringToListOfStringConverter))]
+		public List<string> iana { get; set; }
+		public string regionName { get; set; }
 	}
 
 	/// <summary>


### PR DESCRIPTION
* Add Country match into sort
* Add Match on any Name into sort
* Include iana names into data considered by the lookup
* Add class to handle loading a single json string into
  a string collection (to handle the iana data)
* Add debugging help to LanguageInfo
* Modernize Exception handling in IetfLanguageTagTests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/820)
<!-- Reviewable:end -->
