### PR TITLE
Do not crash if .ldml has bad collation data

### DIFF
--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -787,7 +787,15 @@ namespace SIL.WritingSystems
 
 				// Only add collation definition if it's been set
 				if (cd != null)
-					ws.Collations.Add(cd);
+				{
+					// If there are duplicate collations of a type in the ldml file drop all but the first
+					// Enhance: Log this somehow
+					CollationDefinition existing;
+					if (!ws.Collations.TryGet(cd.Type, out existing))
+					{
+						ws.Collations.Add(cd);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
* Past bugs have written out duplicate collation
  elements of the same type. We saw files in the
  wild with this data so we'll protect against crashes
  when loading it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/822)
<!-- Reviewable:end -->
