### PR TITLE
Fix exception when there is a problem migrating writing systems

### DIFF
--- a/SIL.Core/Migration/FolderMigrator.cs
+++ b/SIL.Core/Migration/FolderMigrator.cs
@@ -166,7 +166,7 @@ namespace SIL.Migration
 						{
 							// Put the unmigrated file where the migrated files will end up
 							string unmigratedFile = Path.Combine(SourcePath, Path.GetFileName(sourceFilePath) + ".bad");
-							File.Copy(sourceFilePath, unmigratedFile);
+							File.Copy(sourceFilePath, unmigratedFile, true);
 							problems.Add(new FolderMigratorProblem { Exception = e, FilePath = sourceFilePath });
 						}
 					}


### PR DESCRIPTION
Getting "The file 'C:\ProgramData\SIL\WritingSystemStore\bn.ldml.bad' already exists" exception if there is a problem migrating a writing system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/825)
<!-- Reviewable:end -->
