### PR TITLE
Report useful error from bad font content in ldml

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -1277,6 +1277,25 @@ namespace SIL.WritingSystems.Tests
 			}
 		}
 
+		[Test]
+		public void DuplicatedFontInLdml_ReportsBadData()
+		{
+			using (var roundTripOut = new TempFile())
+			using (var tempFile = new TempFile())
+			{
+
+				using (var writer = new StreamWriter(tempFile.Path, false, Encoding.UTF8))
+				{
+					writer.Write(LdmlContentForTests.Version3("qaa", "", "", "", LdmlContentForTests.FontElem + LdmlContentForTests.FontElem));
+				}
+				var ws = new WritingSystemDefinition();
+				var dataMapper = new LdmlDataMapper(new TestWritingSystemFactory());
+
+				var message = Assert.Throws<ArgumentException>(() => dataMapper.Read(tempFile.Path, ws)).Message;
+				StringAssert.IsMatch("The font .* is defined twice in .*\\.ldml", message);
+			}
+		}
+
 		private static void WriteVersion0Ldml(string language, string script, string territory, string variant, TempFile file)
 		{
 			//using a writing system V0 here because the real writing system can't cope with the way

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -464,7 +464,15 @@ namespace SIL.WritingSystems
 					foreach (XElement urlElem in fontElem.NonAltElements(Sil + "url"))
 						fd.Urls.Add(urlElem.Value);
 
-					ws.Fonts.Add(fd);
+					FontDefinition existingFont;
+					if (!ws.Fonts.TryGet(fontName, out existingFont))
+					{
+						ws.Fonts.Add(fd);
+					}
+					else
+					{
+						throw new ArgumentException($"The font {fontName} is defined twice in {ws.LanguageTag}.ldml");
+					}
 				}
 			}
 		}

--- a/SIL.WritingSystems/WritingSystemChangeLog.cs
+++ b/SIL.WritingSystems/WritingSystemChangeLog.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
 namespace SIL.WritingSystems
 {
 	/// <summary>
-	/// This class is used by tthe LdmlInFolderWritingsystemRepository to log any changes that an application makes to the repository.
+	/// This class is used by the LdmlInFolderWritingSystemRepository to log any changes that an application makes to the repository.
 	/// The idea is that consumers can query this class to learn of any changes made to contained writing systems by another program
 	/// and update its other files accordingly.
 	/// </summary>


### PR DESCRIPTION
At least one user was found to have a duplicated font in
their ldml data (we don't know how it was duplicated)

* Throw an exception with the actual font name and .ldml file
  when a duplicate is found during the parse.
* Add a unit test to verify this.
* Fix a typo that I noticed in a random file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/827)
<!-- Reviewable:end -->
