### PR TITLE
LT-19632: Share WS Data w/ SLDR by default

### DIFF
--- a/SIL.Lexicon/ProjectLexiconSettingsDataMapper.cs
+++ b/SIL.Lexicon/ProjectLexiconSettingsDataMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Xml.Linq;
 
 namespace SIL.Lexicon
@@ -5,10 +6,20 @@ namespace SIL.Lexicon
 	public class ProjectLexiconSettingsDataMapper
 	{
 		private readonly ISettingsStore _settingsStore;
+		private readonly bool _isRealUserNotTester;
 
 		public ProjectLexiconSettingsDataMapper(ISettingsStore settingsStore)
 		{
 			_settingsStore = settingsStore;
+			var feedbackEnvVar = Environment.GetEnvironmentVariable("FEEDBACK");
+			if (feedbackEnvVar != null)
+			{
+				_isRealUserNotTester = feedbackEnvVar.ToLower().Equals("true") || feedbackEnvVar.ToLower().Equals("yes");
+			}
+			else
+			{
+				_isRealUserNotTester = true;
+			}
 		}
 
 		public void Read(ProjectLexiconSettings settings)
@@ -21,10 +32,7 @@ namespace SIL.Lexicon
 				settings.ProjectSharing = (bool?)settingsElem.Attribute("projectSharing") ?? false;
 
 			XElement wssElem = settingsElem.Element("WritingSystems");
-			if (wssElem != null)
-			{
-				settings.AddWritingSystemsToSldr = (bool?) wssElem.Attribute("addToSldr") ?? false;
-			}
+			settings.AddWritingSystemsToSldr = (bool?) wssElem?.Attribute("addToSldr") ?? _isRealUserNotTester;
 
 			settings.AcceptChanges();
 		}


### PR DESCRIPTION
If the user has not set a preference for the project,
and has not set the FEEDBACK=off environment variable,
then enable sharing of Writing System data with SLDR
by default.
https://jira.sil.org/browse/LT-19632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/829)
<!-- Reviewable:end -->
