### PR TITLE
[TestUtilities] Implement XmlEqualTo constraint for unit tests

### DIFF
--- a/SIL.Lexicon.Tests/ProjectLexiconSettingsDataMapperTests.cs
+++ b/SIL.Lexicon.Tests/ProjectLexiconSettingsDataMapperTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Xml.Linq;
 using NUnit.Framework;
+using Is = SIL.TestUtilities.NUnitExtensions.Is;
 
 namespace SIL.Lexicon.Tests
 {
@@ -49,10 +50,10 @@ namespace SIL.Lexicon.Tests
 			var settings = new ProjectLexiconSettings {AddWritingSystemsToSldr = true, ProjectSharing = true};
 			projectSettingsDataMapper.Write(settings);
 
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<ProjectLexiconSettings projectSharing=""true"">
   <WritingSystems addToSldr=""true"" />
-</ProjectLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</ProjectLexiconSettings>"));
 		}
 
 		[Test]
@@ -74,7 +75,7 @@ namespace SIL.Lexicon.Tests
 			var settings = new ProjectLexiconSettings {AddWritingSystemsToSldr = true, ProjectSharing = true };
 			projectSettingsDataMapper.Write(settings);
 
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<ProjectLexiconSettings projectSharing=""true"">
   <WritingSystems addToSldr=""true"">
     <WritingSystem id=""fr-FR"">
@@ -83,7 +84,7 @@ namespace SIL.Lexicon.Tests
       <Keyboard>Old Keyboard</Keyboard>
     </WritingSystem>
   </WritingSystems>
-</ProjectLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</ProjectLexiconSettings>"));
 		}
 
 		[Test]

--- a/SIL.Lexicon.Tests/ProjectLexiconSettingsWritingSystemDataMapperTests.cs
+++ b/SIL.Lexicon.Tests/ProjectLexiconSettingsWritingSystemDataMapperTests.cs
@@ -102,7 +102,7 @@ namespace SIL.Lexicon.Tests
 			ws1.Variants[1] = new VariantSubtag(ws1.Variants[1], "Custom 2");
 			projectSettingsDataMapper.Write(ws1);
 
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<ProjectLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""qaa-Qaaa-QM-x-kal-Fake-ZG-var1-var2"">
@@ -112,7 +112,7 @@ namespace SIL.Lexicon.Tests
       <RegionName>Zolrog</RegionName>
     </WritingSystem>
   </WritingSystems>
-</ProjectLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</ProjectLexiconSettings>"));
 		}
 
 		[Test]
@@ -141,7 +141,7 @@ namespace SIL.Lexicon.Tests
 			ws1.DefaultCollation = scd;
 			projectSettingsDataMapper.Write(ws1);
 
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<ProjectLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""qaa-Qaaa-QM-x-kal-Fake-ZG-var1-var2-var3"">
@@ -152,7 +152,7 @@ namespace SIL.Lexicon.Tests
       <SystemCollation>snarf</SystemCollation>
     </WritingSystem>
   </WritingSystems>
-</ProjectLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</ProjectLexiconSettings>"));
 		}
 
 		[Test]
@@ -182,7 +182,7 @@ namespace SIL.Lexicon.Tests
 			var settingsStore = new MemorySettingsStore {SettingsElement = XElement.Parse(projectSettingsXml)};
 			var projectSettingsDataMapper = new ProjectLexiconSettingsWritingSystemDataMapper(settingsStore);
 			projectSettingsDataMapper.Remove("fr-FR");
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<ProjectLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""qaa-Qaaa-QM-x-kal-Fake-ZG-var1-var2"">
@@ -196,10 +196,10 @@ namespace SIL.Lexicon.Tests
       </VariantNames>
     </WritingSystem>
   </WritingSystems>
-</ProjectLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</ProjectLexiconSettings>"));
 
 			projectSettingsDataMapper.Remove("qaa-Qaaa-QM-x-kal-Fake-ZG-var1-var2");
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse("<ProjectLexiconSettings />")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo("<ProjectLexiconSettings />"));
 		}
 
 		[Test]
@@ -247,7 +247,7 @@ namespace SIL.Lexicon.Tests
 			var settingsStore = new MemorySettingsStore {SettingsElement = XElement.Parse(projectSettingsXml)};
 			var projectSettingsDataMapper = new ProjectLexiconSettingsWritingSystemDataMapper(settingsStore);
 			projectSettingsDataMapper.Remove("fr-FR");
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<ProjectLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""qaa-Qaaa-QM-x-kal-Fake-ZG-var1-var2"">
@@ -261,7 +261,7 @@ namespace SIL.Lexicon.Tests
       </VariantNames>
     </WritingSystem>
   </WritingSystems>
-</ProjectLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</ProjectLexiconSettings>"));
 		}
 	}
 }

--- a/SIL.Lexicon.Tests/UserLexiconSettingsWritingSystemDataMapperTests.cs
+++ b/SIL.Lexicon.Tests/UserLexiconSettingsWritingSystemDataMapperTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using NUnit.Framework;
+using Is = SIL.TestUtilities.NUnitExtensions.Is;
 using SIL.Keyboarding;
 using SIL.WritingSystems;
 
@@ -83,7 +83,7 @@ namespace SIL.Lexicon.Tests
 			ws1.DefaultFont = new FontDefinition("Times New Roman");
 			userSettingsDataMapper.Write(ws1);
 
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<UserLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""en-US"">
@@ -94,7 +94,7 @@ namespace SIL.Lexicon.Tests
       <DefaultFontName>Times New Roman</DefaultFontName>
     </WritingSystem>
   </WritingSystems>
-</UserLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</UserLexiconSettings>"));
 		}
 
 		[Test]
@@ -122,7 +122,7 @@ namespace SIL.Lexicon.Tests
 			ws1.IsGraphiteEnabled = false;
 			userSettingsDataMapper.Write(ws1);
 
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<UserLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""en-US"">
@@ -134,7 +134,7 @@ namespace SIL.Lexicon.Tests
       <IsGraphiteEnabled>false</IsGraphiteEnabled>
     </WritingSystem>
   </WritingSystems>
-</UserLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</UserLexiconSettings>"));
 		}
 
 		[Test]
@@ -157,7 +157,7 @@ namespace SIL.Lexicon.Tests
 			var settingsStore = new MemorySettingsStore {SettingsElement = XElement.Parse(userSettingsXml)};
 			var userSettingsDataMapper = new UserLexiconSettingsWritingSystemDataMapper(settingsStore);
 			userSettingsDataMapper.Remove("fr-FR");
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<UserLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""en-US"">
@@ -165,10 +165,10 @@ namespace SIL.Lexicon.Tests
       <DefaultFontName>Times New Roman</DefaultFontName>
     </WritingSystem>
   </WritingSystems>
-</UserLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</UserLexiconSettings>"));
 
 			userSettingsDataMapper.Remove("en-US");
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse("<UserLexiconSettings />")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo("<UserLexiconSettings />"));
 		}
 
 		[Test]
@@ -187,7 +187,7 @@ namespace SIL.Lexicon.Tests
 			var settingsStore = new MemorySettingsStore {SettingsElement = XElement.Parse(userSettingsXml)};
 			var userSettingsDataMapper = new UserLexiconSettingsWritingSystemDataMapper(settingsStore);
 			userSettingsDataMapper.Remove("fr-FR");
-			Assert.That(settingsStore.SettingsElement, Is.EqualTo(XElement.Parse(
+			Assert.That(settingsStore.SettingsElement, Is.XmlEqualTo(
 @"<UserLexiconSettings>
   <WritingSystems>
     <WritingSystem id=""en-US"">
@@ -195,7 +195,7 @@ namespace SIL.Lexicon.Tests
       <DefaultFontName>Times New Roman</DefaultFontName>
     </WritingSystem>
   </WritingSystems>
-</UserLexiconSettings>")).Using((IEqualityComparer<XNode>) new XNodeEqualityComparer()));
+</UserLexiconSettings>"));
 		}
 	}
 }

--- a/SIL.TestUtilities.Tests/NUnitExtensions/IsTests.cs
+++ b/SIL.TestUtilities.Tests/NUnitExtensions/IsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System.Xml.Linq;
 using NUnit.Framework;
 using SIL.TestUtilities.NUnitExtensions;
 using Is = SIL.TestUtilities.NUnitExtensions.Is;
@@ -20,6 +21,20 @@ namespace SIL.TestUtilities.Tests.NUnitExtensions
 		public void ValueEqualTo_NotEqual()
 		{
 			Assert.That(new SomeClass("foo"), Is.Not.ValueEqualTo(new SomeClass("bar")));
+		}
+
+		[Test]
+		public void XmlEqualTo_Equal()
+		{
+			var xmlString = @"<root><foo id='abc'/></root>";
+			Assert.That(XElement.Parse(xmlString), Is.XmlEqualTo(xmlString));
+		}
+
+		[Test]
+		public void XmlEqualTo_NotEqual()
+		{
+			Assert.That(XElement.Parse(@"<root><foo id='abc'/></root>"),
+				Is.Not.XmlEqualTo(@"<root><somethingother/></root>"));
 		}
 	}
 

--- a/SIL.TestUtilities.Tests/NUnitExtensions/XmlEquatableConstraintTests.cs
+++ b/SIL.TestUtilities.Tests/NUnitExtensions/XmlEquatableConstraintTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Xml;
+using System.Xml.Linq;
+using NUnit.Framework;
+using SIL.TestUtilities.NUnitExtensions;
+using Is = NUnit.Framework.Is;
+
+namespace SIL.TestUtilities.Tests.NUnitExtensions
+{
+	[TestFixture]
+	public class XmlEquatableConstraintTests
+	{
+		[Test]
+		public void XmlEquatableConstraint_TrueIfBothMatch()
+		{
+			var xmlString = @"<root><foo id='abc'/></root>";
+			Assert.That(new XmlEquatableConstraint(xmlString)
+				.Matches(XElement.Parse(xmlString)), Is.True);
+		}
+
+		[TestCase(null)]
+		[TestCase("")]
+		public void XmlEquatableConstraint_NullValue(string expectedXml)
+		{
+			Assert.That(new XmlEquatableConstraint(expectedXml).Matches(null), Is.True);
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_FailsIfDifferent()
+		{
+			Assert.That(new XmlEquatableConstraint(@"<root><foo id='abc'/></root>")
+				.Matches(XElement.Parse(@"<root><somethingOther/></root>")), Is.False);
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_FailsIfActualNull()
+		{
+			Assert.That(new XmlEquatableConstraint(@"<root><foo id='abc'/></root>")
+				.Matches(null), Is.False);
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_WorksWithXmlDocument()
+		{
+			var xmlString = @"<root><foo id='abc'/></root>";
+			var doc = new XmlDocument();
+			doc.LoadXml(xmlString);
+			Assert.That(new XmlEquatableConstraint(xmlString).Matches(doc), Is.True);
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_WorksWithXmlString()
+		{
+			var xmlString = @"<root><foo id='abc'/></root>";
+			Assert.That(new XmlEquatableConstraint(xmlString).Matches(xmlString), Is.True);
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_FailsWithRandomString()
+		{
+			Assert.That(() => new XmlEquatableConstraint(@"<root><foo id='abc'/></root>")
+				.Matches("some text"), Throws.Exception.TypeOf<XmlException>());
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_FailsWithNonXmlObject()
+		{
+			Assert.That(() => new XmlEquatableConstraint(@"<root><foo id='abc'/></root>")
+				.Matches(new object()), Throws.ArgumentException);
+		}
+
+		[Test]
+		public void XmlEquatableConstraint_WorksWithXElement()
+		{
+			var xmlString = @"<root><foo id='abc'/></root>";
+			var xmlElement = XElement.Parse(xmlString);
+			Assert.That(new XmlEquatableConstraint(xmlString).Matches(xmlElement), Is.True);
+		}
+	}
+}

--- a/SIL.TestUtilities.Tests/SIL.TestUtilities.Tests.csproj
+++ b/SIL.TestUtilities.Tests/SIL.TestUtilities.Tests.csproj
@@ -254,6 +254,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">
@@ -263,6 +264,7 @@
     <Compile Include="FluentAssertXmlTests.cs" />
     <Compile Include="NUnitExtensions\IsTests.cs" />
     <Compile Include="NUnitExtensions\ValueEquatableConstraintTests.cs" />
+    <Compile Include="NUnitExtensions\XmlEquatableConstraintTests.cs" />
     <Compile Include="TemporaryFolderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SIL.TestUtilities/NUnitExtensions/Is.cs
+++ b/SIL.TestUtilities/NUnitExtensions/Is.cs
@@ -19,6 +19,16 @@ namespace SIL.TestUtilities.NUnitExtensions
 		{
 			return new ValueEquatableConstraint<T>(expected);
 		}
+
+		/// <summary>
+		/// Checks if the actual XML node is equal to the expected
+		/// XML string.
+		/// </summary>
+		/// <example>Assert.That(actual, Is.XmlEqualTo("<root/>"));</example>
+		public static XmlEquatableConstraint XmlEqualTo(string expected)
+		{
+			return new XmlEquatableConstraint(expected);
+		}
 	}
 
 }

--- a/SIL.TestUtilities/NUnitExtensions/XmlEquatableConstraint.cs
+++ b/SIL.TestUtilities/NUnitExtensions/XmlEquatableConstraint.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Xml;
+using System.Xml.Linq;
+using NUnit.Framework.Constraints;
+
+namespace SIL.TestUtilities.NUnitExtensions
+{
+	/// <summary>
+	/// Checks if the actual XML node is equal to the expected
+	/// XML string with the help of System.Xml.Linq.XNodeEqualityComparer.
+	/// </summary>
+	public class XmlEquatableConstraint: Constraint
+	{
+		private string _expectedXml;
+
+		public XmlEquatableConstraint(string expectedXml)
+		{
+			_expectedXml = expectedXml;
+		}
+
+		public override bool Matches(object actualParam)
+		{
+			this.actual = actualParam;
+			var actualXml = actualParam as XNode;
+			if (actualXml == null)
+			{
+				var actualXmlNode = actualParam as XmlNode;
+				if (actualXmlNode != null)
+				{
+					actualXml = XElement.Parse(actualXmlNode.OuterXml);
+				}
+				else if (actualParam is string)
+				{
+					actualXml = XElement.Parse((string)actualParam);
+				}
+				else if (actualParam == null)
+				{
+					return string.IsNullOrEmpty(_expectedXml);
+				}
+				else
+				{
+					throw new ArgumentException("Don't know how to convert value to XML",
+						nameof(actualParam));
+				}
+			}
+
+			var equalityComparer = new XNodeEqualityComparer();
+			return equalityComparer.Equals(XElement.Parse(_expectedXml), actualXml);
+		}
+
+		public override void WriteDescriptionTo(MessageWriter writer)
+		{
+			writer.WriteExpectedValue(_expectedXml);
+		}
+	}
+
+	public static class XmlEquatableConstraintExtensionMethods
+	{
+		public static XmlEquatableConstraint XmlEqualTo(
+			this ConstraintExpression expression, string expected)
+		{
+			var constraint = new XmlEquatableConstraint(expected);
+			expression.Append(constraint);
+			return constraint;
+		}
+	}
+
+}

--- a/SIL.TestUtilities/SIL.TestUtilities.csproj
+++ b/SIL.TestUtilities/SIL.TestUtilities.csproj
@@ -312,6 +312,7 @@
     <Compile Include="LiftContentForTests.cs" />
     <Compile Include="NUnitExtensions\Is.cs" />
     <Compile Include="NUnitExtensions\ValueEquatableConstraint.cs" />
+    <Compile Include="NUnitExtensions\XmlEquatableConstraint.cs" />
     <Compile Include="OfflineSldr.cs" />
     <Compile Include="OfflineSldrAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
- implement `XmlEquatableConstraint` class
- implement `Is.XmlEqualTo` method
- refactor `SIL.Lexicon.Tests` to use `XmlEqualTo`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/831)
<!-- Reviewable:end -->
