### PR TITLE
Avoid getting the list of recording devices twice when updating.

### DIFF
--- a/SIL.Media/Naudio/UI/RecordingDeviceIndicator.cs
+++ b/SIL.Media/Naudio/UI/RecordingDeviceIndicator.cs
@@ -1,4 +1,4 @@
-﻿#if !MONO
+#if !MONO
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -87,7 +87,7 @@ namespace SIL.Media.Naudio.UI
 				{
 					_recorder.SelectedDeviceChanged += RecorderOnSelectedDeviceChanged;
 					_checkNewMicTimer.Start();
-					SetKnownRecordingDevices();
+					SetKnownRecordingDevices(RecordingDevice.Devices);
 				}
 				else
 				{
@@ -98,10 +98,9 @@ namespace SIL.Media.Naudio.UI
 			}
 		}
 
-		private void SetKnownRecordingDevices()
+		private void SetKnownRecordingDevices(IEnumerable<RecordingDevice> devices)
 		{
-			_knownRecordingDevices =
-				new HashSet<string>(from d in RecordingDevice.Devices select d.ProductName);
+			_knownRecordingDevices = new HashSet<string>(devices.Select(d => d.ProductName));
 		}
 
 		/// <summary>
@@ -166,7 +165,7 @@ namespace SIL.Media.Naudio.UI
 				}
 			}
 			// Update the list so one that was never active can be made active by unplugging and replugging
-			SetKnownRecordingDevices();
+			SetKnownRecordingDevices(devices);
 		}
 
 		protected override void OnHandleDestroyed(EventArgs e)


### PR DESCRIPTION
This is mainly for (massive) performance improvement, but it also avoids a race condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/832)
<!-- Reviewable:end -->
