### PR TITLE
 Add classes to increase compatibility with NUnit 3 

### DIFF
--- a/SIL.Core.Tests/Acknowledgements/AcknowledgementsProviderTests.cs
+++ b/SIL.Core.Tests/Acknowledgements/AcknowledgementsProviderTests.cs
@@ -31,8 +31,8 @@ namespace SIL.Tests.Acknowledgements
 			_ackDict.Add(ack1.Key, ack1);
 			_ackDict.Add(ack2.Key, ack2);
 			var html = AcknowledgementsProvider.SortByNameAndConcatenateHtml(_ackDict);
-			Assert.That(html, Is.StringStarting("<li>Bob\'s project"));
-			Assert.That(html, Is.StringContaining("my Name"));
+			Assert.That(html, Does.StartWith("<li>Bob\'s project"));
+			Assert.That(html, Does.Contain("my Name"));
 		}
 
 		[Test]

--- a/SIL.Core.Tests/Email/LinuxEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/LinuxEmailProviderTests.cs
@@ -29,28 +29,28 @@ namespace SIL.Tests.Email
 		}
 
 		// Does not change most things.
-		[TestCase(@"hello1234 hello", Result = @"hello1234 hello")]
-		[TestCase("hello\"hello", Result = "hello\"hello")]
-		[TestCase(@"hello`~!@#$%^&*)(][}{/?=+-_|", Result = @"hello`~!@#$%^&*)(][}{/?=+-_|")]
+		[TestCase(@"hello1234 hello", ExpectedResult = @"hello1234 hello")]
+		[TestCase("hello\"hello", ExpectedResult = "hello\"hello")]
+		[TestCase(@"hello`~!@#$%^&*)(][}{/?=+-_|", ExpectedResult = @"hello`~!@#$%^&*)(][}{/?=+-_|")]
 		// Escapes quote and backslash characters.
-		[TestCase(@"\", Result = @"\\\\\\\\")]
-		[TestCase(@"hello\hello", Result = @"hello\\\\\\\\hello")]
-		[TestCase(@"hello\t\n\a\r\0end", Result = @"hello\\\\\\\\t\\\\\\\\n\\\\\\\\a\\\\\\\\r\\\\\\\\0end")]
-		[TestCase(@"hello'hello", Result = @"hello\'hello")]
-		[TestCase(@"hello'hello'", Result = @"hello\'hello\'")]
-		[TestCase("hello'\"hello", Result = "hello\\'\"hello")]
-		[TestCase(@"C:\'Data\0end", Result = @"C:\\\\\\\\\'Data\\\\\\\\0end")]
+		[TestCase(@"\", ExpectedResult = @"\\\\\\\\")]
+		[TestCase(@"hello\hello", ExpectedResult = @"hello\\\\\\\\hello")]
+		[TestCase(@"hello\t\n\a\r\0end", ExpectedResult = @"hello\\\\\\\\t\\\\\\\\n\\\\\\\\a\\\\\\\\r\\\\\\\\0end")]
+		[TestCase(@"hello'hello", ExpectedResult = @"hello\'hello")]
+		[TestCase(@"hello'hello'", ExpectedResult = @"hello\'hello\'")]
+		[TestCase("hello'\"hello", ExpectedResult = "hello\\'\"hello")]
+		[TestCase(@"C:\'Data\0end", ExpectedResult = @"C:\\\\\\\\\'Data\\\\\\\\0end")]
 		public string EscapeString(string input)
 		{
 			return LinuxEmailProvider.EscapeString(input);
 		}
 
 		[TestCase("foo@example.com",
-			Result = "--subject 'Testing' --body 'Hi there!' 'foo@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' 'foo@example.com'")]
 		[TestCase("Foo <foo@example.com>",
-			Result = "--subject 'Testing' --body 'Hi there!' 'Foo <foo@example.com>'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' 'Foo <foo@example.com>'")]
 		[TestCase("foo@example.com;someone@example.com",
-			Result = "--subject 'Testing' --body 'Hi there!' 'foo@example.com' 'someone@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' 'foo@example.com' 'someone@example.com'")]
 		public string SendMessage_ToOnly(string to)
 		{
 			// Setup
@@ -68,15 +68,15 @@ namespace SIL.Tests.Email
 		}
 
 		[TestCase("foo@example.com", null,
-			Result = "--subject 'Testing' --body 'Hi there!' --cc 'foo@example.com' 'bar@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' --cc 'foo@example.com' 'bar@example.com'")]
 		[TestCase("foo@example.com;someone@example.com", null,
-			Result = "--subject 'Testing' --body 'Hi there!' --cc 'foo@example.com' --cc 'someone@example.com' 'bar@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' --cc 'foo@example.com' --cc 'someone@example.com' 'bar@example.com'")]
 		[TestCase(null, "foo@example.com",
-			Result = "--subject 'Testing' --body 'Hi there!' --bcc 'foo@example.com' 'bar@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' --bcc 'foo@example.com' 'bar@example.com'")]
 		[TestCase(null, "foo@example.com;someone@example.com",
-			Result = "--subject 'Testing' --body 'Hi there!' --bcc 'foo@example.com' --bcc 'someone@example.com' 'bar@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' --bcc 'foo@example.com' --bcc 'someone@example.com' 'bar@example.com'")]
 		[TestCase("a@example.com", "foo@example.com;someone@example.com",
-			Result = "--subject 'Testing' --body 'Hi there!' --cc 'a@example.com' --bcc 'foo@example.com' --bcc 'someone@example.com' 'bar@example.com'")]
+			ExpectedResult = "--subject 'Testing' --body 'Hi there!' --cc 'a@example.com' --bcc 'foo@example.com' --bcc 'someone@example.com' 'bar@example.com'")]
 		public string SendMessage_CcAndBcc(string cc, string bcc)
 		{
 			// Setup

--- a/SIL.Core.Tests/Email/MailToEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/MailToEmailProviderTests.cs
@@ -29,11 +29,11 @@ namespace SIL.Tests.Email
 		}
 
 		[TestCase("foo@example.com",
-			Result = "mailto:foo@example.com?subject=Testing&body=Hi%20there")]
+			ExpectedResult = "mailto:foo@example.com?subject=Testing&body=Hi%20there")]
 		[TestCase("Foo <foo@example.com>",
-			Result = "mailto:Foo <foo@example.com>?subject=Testing&body=Hi%20there")]
+			ExpectedResult = "mailto:Foo <foo@example.com>?subject=Testing&body=Hi%20there")]
 		[TestCase("foo@example.com;someone@example.com",
-			Result = "mailto:foo@example.com,someone@example.com?subject=Testing&body=Hi%20there")]
+			ExpectedResult = "mailto:foo@example.com,someone@example.com?subject=Testing&body=Hi%20there")]
 		public string SendMessage_ToOnly(string to)
 		{
 			// Setup
@@ -51,15 +51,15 @@ namespace SIL.Tests.Email
 		}
 
 		[TestCase("foo@example.com", null,
-			Result = "mailto:bar@example.com?subject=Testing&cc=foo@example.com&body=Hi%20there")]
+			ExpectedResult = "mailto:bar@example.com?subject=Testing&cc=foo@example.com&body=Hi%20there")]
 		[TestCase("foo@example.com;someone@example.com", null,
-			Result = "mailto:bar@example.com?subject=Testing&cc=foo@example.com,someone@example.com&body=Hi%20there")]
+			ExpectedResult = "mailto:bar@example.com?subject=Testing&cc=foo@example.com,someone@example.com&body=Hi%20there")]
 		[TestCase(null, "foo@example.com",
-			Result = "mailto:bar@example.com?subject=Testing&bcc=foo@example.com&body=Hi%20there")]
+			ExpectedResult = "mailto:bar@example.com?subject=Testing&bcc=foo@example.com&body=Hi%20there")]
 		[TestCase(null, "foo@example.com;someone@example.com",
-			Result = "mailto:bar@example.com?subject=Testing&bcc=foo@example.com,someone@example.com&body=Hi%20there")]
+			ExpectedResult = "mailto:bar@example.com?subject=Testing&bcc=foo@example.com,someone@example.com&body=Hi%20there")]
 		[TestCase("a@example.com", "foo@example.com;someone@example.com",
-			Result = "mailto:bar@example.com?subject=Testing&cc=a@example.com&bcc=foo@example.com,someone@example.com&body=Hi%20there")]
+			ExpectedResult = "mailto:bar@example.com?subject=Testing&cc=a@example.com&bcc=foo@example.com,someone@example.com&body=Hi%20there")]
 		public string SendMessage_CcAndBcc(string cc, string bcc)
 		{
 			// Setup

--- a/SIL.Core.Tests/Email/ThunderbirdEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/ThunderbirdEmailProviderTests.cs
@@ -30,11 +30,11 @@ namespace SIL.Tests.Email
 		}
 
 		[TestCase("foo@example.com",
-			Result = "-compose \"to='foo@example.com',subject='Testing',body='Hi there!'\"")]
+			ExpectedResult = "-compose \"to='foo@example.com',subject='Testing',body='Hi there!'\"")]
 		[TestCase("Foo <foo@example.com>",
-			Result = "-compose \"to='Foo <foo@example.com>',subject='Testing',body='Hi there!'\"")]
+			ExpectedResult = "-compose \"to='Foo <foo@example.com>',subject='Testing',body='Hi there!'\"")]
 		[TestCase("foo@example.com;someone@example.com",
-			Result = "-compose \"to='foo@example.com,someone@example.com',subject='Testing',body='Hi there!'\"")]
+			ExpectedResult = "-compose \"to='foo@example.com,someone@example.com',subject='Testing',body='Hi there!'\"")]
 		public string SendMessage_ToOnly(string to)
 		{
 			// Setup
@@ -52,15 +52,15 @@ namespace SIL.Tests.Email
 		}
 
 		[TestCase("foo@example.com", null,
-			Result = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',cc='foo@example.com'\"")]
+			ExpectedResult = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',cc='foo@example.com'\"")]
 		[TestCase("foo@example.com;someone@example.com", null,
-			Result = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',cc='foo@example.com,someone@example.com'\"")]
+			ExpectedResult = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',cc='foo@example.com,someone@example.com'\"")]
 		[TestCase(null, "foo@example.com",
-			Result = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',bcc='foo@example.com'\"")]
+			ExpectedResult = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',bcc='foo@example.com'\"")]
 		[TestCase(null, "foo@example.com;someone@example.com",
-			Result = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',bcc='foo@example.com,someone@example.com'\"")]
+			ExpectedResult = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',bcc='foo@example.com,someone@example.com'\"")]
 		[TestCase("a@example.com", "foo@example.com;someone@example.com",
-			Result = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',cc='a@example.com',bcc='foo@example.com,someone@example.com'\"")]
+			ExpectedResult = "-compose \"to='bar@example.com',subject='Testing',body='Hi there!',cc='a@example.com',bcc='foo@example.com,someone@example.com'\"")]
 		public string SendMessage_CcAndBcc(string cc, string bcc)
 		{
 			// Setup

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -31,10 +31,10 @@ namespace SIL.Tests.IO
 			}
 			catch (ArgumentException ex)
 			{
-				Assert.That(ex.Message, Is.StringContaining(Path.Combine("LookHere", "ThisWillNotExist")));
-				Assert.That(ex.Message, Is.StringContaining(FileLocationUtilities.DirectoryOfApplicationOrSolution));
-				Assert.That(ex.Message, Is.StringContaining("DistFiles"));
-				Assert.That(ex.Message, Is.StringContaining("src"));
+				Assert.That(ex.Message, Does.Contain(Path.Combine("LookHere", "ThisWillNotExist")));
+				Assert.That(ex.Message, Does.Contain(FileLocationUtilities.DirectoryOfApplicationOrSolution));
+				Assert.That(ex.Message, Does.Contain("DistFiles"));
+				Assert.That(ex.Message, Does.Contain("src"));
 			}
 		}
 
@@ -162,7 +162,7 @@ namespace SIL.Tests.IO
 		public void LocateExecutable_DistFiles()
 		{
 			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "SampleExecutable.exe"),
-				Is.StringEnding(string.Format("DistFiles{0}DirectoryForTests{0}SampleExecutable.exe",
+				Does.EndWith(string.Format("DistFiles{0}DirectoryForTests{0}SampleExecutable.exe",
 					Path.DirectorySeparatorChar)));
 		}
 
@@ -171,7 +171,7 @@ namespace SIL.Tests.IO
 		public void LocateExecutable_PlatformSpecificInDistFiles_Windows()
 		{
 			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "dummy.exe"),
-				Is.StringEnding(string.Format("DistFiles{0}Windows{0}DirectoryForTests{0}dummy.exe",
+				Does.EndWith(string.Format("DistFiles{0}Windows{0}DirectoryForTests{0}dummy.exe",
 				Path.DirectorySeparatorChar)));
 		}
 
@@ -180,7 +180,7 @@ namespace SIL.Tests.IO
 		public void LocateExecutable_PlatformSpecificInDistFiles_LinuxWithoutExtension()
 		{
 			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "dummy.exe"),
-				Is.StringEnding(string.Format("DistFiles{0}Linux{0}DirectoryForTests{0}dummy",
+				Does.EndWith(string.Format("DistFiles{0}Linux{0}DirectoryForTests{0}dummy",
 				Path.DirectorySeparatorChar)));
 		}
 
@@ -189,7 +189,7 @@ namespace SIL.Tests.IO
 		public void LocateExecutable_PlatformSpecificInDistFiles_Linux()
 		{
 			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "dummy2.exe"),
-				Is.StringEnding(string.Format("DistFiles{0}Linux{0}DirectoryForTests{0}dummy2.exe",
+				Does.EndWith(string.Format("DistFiles{0}Linux{0}DirectoryForTests{0}dummy2.exe",
 				Path.DirectorySeparatorChar)));
 		}
 

--- a/SIL.Core.Tests/IO/PathHelperTests.cs
+++ b/SIL.Core.Tests/IO/PathHelperTests.cs
@@ -17,7 +17,7 @@ namespace SIL.Tests.IO
 	{
 		private bool TmpAndRootOnDifferentPartitions;
 
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void FixtureSetUp()
 		{
 			if (Platform.IsUnix)
@@ -182,12 +182,12 @@ namespace SIL.Tests.IO
 			}
 		}
 
-		[TestCase(null, Result = false)]
-		[TestCase("", Result = false)]
-		[TestCase("rect", Result = false)]
-		[TestCase("none", Result = false)]
-		[TestCase("directory", Result = true)]
-		[TestCase("subdir", Result = true)]
+		[TestCase(null, ExpectedResult = false)]
+		[TestCase("", ExpectedResult = false)]
+		[TestCase("rect", ExpectedResult = false)]
+		[TestCase("none", ExpectedResult = false)]
+		[TestCase("directory", ExpectedResult = true)]
+		[TestCase("subdir", ExpectedResult = true)]
 		public bool ContainsDirectory(string directory)
 		{
 			var path = Path.Combine(Path.GetTempPath(), "some", "directory", "and", "other", "subdir");

--- a/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
+++ b/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
@@ -135,23 +135,23 @@ namespace SIL.Tests.PlatformUtilities
 		}
 
 		[Platform(Include = "Linux", Reason = "Linux specific test")]
-		[TestCase("Unity", null, "ubuntu", Result = "unity", TestName = "Unity")]
+		[TestCase("Unity", null, "ubuntu", ExpectedResult = "unity", TestName = "Unity")]
 		[TestCase("Unity", "/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/",
-			"ubuntu", Result = "unity", TestName = "Unity with dataDir")]
-		[TestCase("GNOME", null, "gnome-shell", Result = "gnome",
+			"ubuntu", ExpectedResult = "unity", TestName = "Unity with dataDir")]
+		[TestCase("GNOME", null, "gnome-shell", ExpectedResult = "gnome",
 			TestName = "Gnome shell")]
-		[TestCase("GNOME", null, "cinnamon", Result = "cinnamon",
+		[TestCase("GNOME", null, "cinnamon", ExpectedResult = "cinnamon",
 			TestName = "Wasta 12")]
-		[TestCase("x-cinnamon", null, "cinnamon", Result = "x-cinnamon",
+		[TestCase("x-cinnamon", null, "cinnamon", ExpectedResult = "x-cinnamon",
 			TestName = "Wasta 14")]
 		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
-			"kde-plasma", Result = "kde", TestName = "KDE on Ubuntu 12_04")]
-		[TestCase("XFCE", null, "xubuntu", Result = "xfce", TestName = "XFCE")]
-		[TestCase("foo", null, null, Result = "foo", TestName = "Only XDG_CURRENT_DESKTOP set")]
+			"kde-plasma", ExpectedResult = "kde", TestName = "KDE on Ubuntu 12_04")]
+		[TestCase("XFCE", null, "xubuntu", ExpectedResult = "xfce", TestName = "XFCE")]
+		[TestCase("foo", null, null, ExpectedResult = "foo", TestName = "Only XDG_CURRENT_DESKTOP set")]
 		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/", null,
-			Result = "kde", TestName = "Only XDG_DATA_DIRS set")]
-		[TestCase(null, null, "something", Result = "something", TestName = "Only GDMSESSION set")]
-		[TestCase(null, null, null, Result = "", TestName = "Nothing set")]
+			ExpectedResult = "kde", TestName = "Only XDG_DATA_DIRS set")]
+		[TestCase(null, null, "something", ExpectedResult = "something", TestName = "Only GDMSESSION set")]
+		[TestCase(null, null, null, ExpectedResult = "", TestName = "Nothing set")]
 		public string DesktopEnvironment_SimulateDesktops(string currDesktop,
 			string dataDirs, string gdmSession)
 		{
@@ -175,20 +175,20 @@ namespace SIL.Tests.PlatformUtilities
 		}
 
 		[Platform(Include = "Linux", Reason = "Linux specific test")]
-		[TestCase("Unity", null, "ubuntu", null, Result = "unity (ubuntu)", TestName = "Unity")]
+		[TestCase("Unity", null, "ubuntu", null, ExpectedResult = "unity (ubuntu)", TestName = "Unity")]
 		[TestCase("Unity", "/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/",
-			"ubuntu", null, Result = "unity (ubuntu)", TestName = "Unity with dataDir")]
+			"ubuntu", null, ExpectedResult = "unity (ubuntu)", TestName = "Unity with dataDir")]
 		[TestCase("Unity", null, "ubuntu", "session-1",
-			Result = "unity (ubuntu [display server: Mir])", TestName = "Unity with Mir")]
-		[TestCase("GNOME", null, "gnome-shell", null, Result = "gnome (gnome-shell)",
+			ExpectedResult = "unity (ubuntu [display server: Mir])", TestName = "Unity with Mir")]
+		[TestCase("GNOME", null, "gnome-shell", null, ExpectedResult = "gnome (gnome-shell)",
 			TestName = "Gnome shell")]
-		[TestCase("GNOME", null, "cinnamon", null, Result = "cinnamon (cinnamon)",
+		[TestCase("GNOME", null, "cinnamon", null, ExpectedResult = "cinnamon (cinnamon)",
 			TestName = "Wasta 12")]
-		[TestCase("x-cinnamon", null, "cinnamon", null, Result = "x-cinnamon (cinnamon)",
+		[TestCase("x-cinnamon", null, "cinnamon", null, ExpectedResult = "x-cinnamon (cinnamon)",
 			TestName = "Wasta 14")]
 		[TestCase(null, "/usr/share/ubuntu:/usr/share/kde:/usr/local/share/:/usr/share/",
-			"kde-plasma", null, Result = "kde (kde-plasma)", TestName = "KDE on Ubuntu 12_04")]
-		[TestCase(null, null, null, null, Result = " (not set)", TestName = "Nothing set")]
+			"kde-plasma", null, ExpectedResult = "kde (kde-plasma)", TestName = "KDE on Ubuntu 12_04")]
+		[TestCase(null, null, null, null, ExpectedResult = " (not set)", TestName = "Nothing set")]
 		public string DesktopEnvironmentInfoString_SimulateDesktopEnvironments(string currDesktop,
 			string dataDirs, string gdmSession, string mirServerName)
 		{

--- a/SIL.TestUtilities/NUnitExtensions/Does.cs
+++ b/SIL.TestUtilities/NUnitExtensions/Does.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using NUnit.Framework.Constraints;
+
+namespace NUnit.Framework
+{
+	// TODO: Remove this class when we start using NUnit 3
+
+	public static class Does
+	{
+		#region Not
+
+		/// <summary>
+		/// Returns a ConstraintExpression that negates any
+		/// following constraint.
+		/// </summary>
+		public static ConstraintExpression Not => new ConstraintExpression().Not;
+
+		#endregion
+
+		#region Contain
+
+		/// <summary>
+		/// Returns a new <see cref="SomeItemsConstraint"/> checking for the
+		/// presence of a particular object in the collection.
+		/// </summary>
+		public static SomeItemsConstraint Contain(object expected) =>
+			new SomeItemsConstraint(new EqualConstraint(expected));
+
+		/// <summary>
+		/// Returns a new <see cref="ContainsConstraint"/>. This constraint
+		/// will, in turn, make use of the appropriate second-level
+		/// constraint, depending on the type of the actual argument.
+		/// This overload is only used if the item sought is a string,
+		/// since any other type implies that we are looking for a
+		/// collection member.
+		/// </summary>
+		public static ContainsConstraint Contain(string expected) =>
+			new ContainsConstraint(expected);
+
+		#endregion
+
+		#region StartWith
+
+		/// <summary>
+		/// Returns a constraint that succeeds if the actual
+		/// value starts with the substring supplied as an argument.
+		/// </summary>
+		public static StartsWithConstraint StartWith(string expected)
+		{
+			return new StartsWithConstraint(expected);
+		}
+
+		#endregion
+
+		#region EndWith
+
+		/// <summary>
+		/// Returns a constraint that succeeds if the actual
+		/// value ends with the substring supplied as an argument.
+		/// </summary>
+		public static EndsWithConstraint EndWith(string expected)
+		{
+			return new EndsWithConstraint(expected);
+		}
+
+		#endregion
+
+		#region Match
+
+		/// <summary>
+		/// Returns a constraint that succeeds if the actual
+		/// value matches the regular expression supplied as an argument.
+		/// </summary>
+		public static RegexConstraint Match(string pattern)
+		{
+			return new RegexConstraint(pattern);
+		}
+
+		#endregion
+	}
+}

--- a/SIL.TestUtilities/NUnitExtensions/OneTimeSetUpAttribute.cs
+++ b/SIL.TestUtilities/NUnitExtensions/OneTimeSetUpAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+
+namespace NUnit.Framework
+{
+	// TODO: Remove this class when we start using NUnit 3
+
+	/// <summary>
+	/// This attribute allows to use the NUnit 3 name while we still use NUnit 2.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+	public class OneTimeSetUpAttribute: TestFixtureSetUpAttribute
+	{
+
+	}
+}


### PR DESCRIPTION
These classes allow to use NUnit 3 syntax while still using NUnit 2. This will then allow to switch to NUnit 3 without requiring code changes.

Also adjust SIL.Core.Tests for NUnit 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/836)
<!-- Reviewable:end -->
