### PR TITLE
Fix or ignore tests that fail on Linux

### DIFF
--- a/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
+++ b/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
@@ -49,57 +49,64 @@ namespace SIL.Tests.Extensions
 			Assert.AreEqual(whenSample, when.ToISO8601TimeFormatDateOnlyString());
 		}
 
-		[Test]
-		public void IsISO8601Date_ReturnsCorrectValue()
+		[TestCase("2014-01-01", ExpectedResult = true)]
+		[TestCase("2014-12-31", ExpectedResult = true)]
+		[TestCase("2014/12/31", ExpectedResult = false)]
+		[TestCase("12/12/2014", ExpectedResult = false)]
+		[TestCase("12 DEC 2014", ExpectedResult = false)]
+		[TestCase("2014-13-01", ExpectedResult = false)]
+		[TestCase("2014-12-32", ExpectedResult = false)]
+		public bool IsISO8601Date_ReturnsCorrectValue(string date)
 		{
-			Assert.True(DateTimeExtensions.IsISO8601Date("2014-01-01"));
-			Assert.True(DateTimeExtensions.IsISO8601Date("2014-12-31"));
-			Assert.False(DateTimeExtensions.IsISO8601Date("2014/12/31"));
-			Assert.False(DateTimeExtensions.IsISO8601Date("12/12/2014"));
-			Assert.False(DateTimeExtensions.IsISO8601Date("12 DEC 2014"));
-			Assert.False(DateTimeExtensions.IsISO8601Date("2014-13-01"));
-			Assert.False(DateTimeExtensions.IsISO8601Date("2014-12-32"));
+			return DateTimeExtensions.IsISO8601Date(date);
 		}
 
-		[Test]
-		public void IsISO8601DateTime_ReturnsCorrectValue()
+		// We used to test with a timezone offset of 20 hours instead of 12. This works with .NET
+		// Framework, but fails with .NET Core and with Mono 6. The exception we get on these
+		// platforms mentions that the time zone offset must be within plus or minus 14 hours -
+		// which makes sense.
+		[TestCase("2014-12-31T13:56:29+0000", ExpectedResult = true)]
+		[TestCase("2014-12-31T13:56:29+1200", ExpectedResult = true)]
+		[TestCase("2014-12-31T13:56:29-1200", ExpectedResult = true)]
+		[TestCase("2014-12-31T13:56:29Z", ExpectedResult = true)]
+		[TestCase("2014-12-31T13:56:29", ExpectedResult = true)]
+		[TestCase("2014-12-31T13:56:29-12:00", ExpectedResult = true)]
+		[TestCase("2014-12-31T13:56:29+12:00", ExpectedResult = true)]
+		[TestCase("2014/12/31T13:56:29-1200", ExpectedResult = false)]
+		[TestCase("2014-12-31 13:56:29-1200", ExpectedResult = false)]
+		[TestCase("2014-12-31T13:56:29 0000", ExpectedResult = false)]
+		[TestCase("2014-12-31T13:56:29ZZ", ExpectedResult = false)]
+		[TestCase("2014-12-31T13:56:29Z0000", ExpectedResult = false)]
+		[TestCase("2014-12-31T13:56:29 0000", ExpectedResult = false)]
+		[TestCase("2014-12-31 04:45:29", ExpectedResult = false)]
+		[TestCase("2014/12/32T04:45:29", ExpectedResult = false)]
+		[TestCase("2014-13-01T04:45:29", ExpectedResult = false)]
+		[TestCase("2014-12-32T04:45:29", ExpectedResult = false)]
+		public bool IsISO8601DateTime_ReturnsCorrectValue(string dateTime)
 		{
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29+0000"));
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29+2000"));
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29-2000"));
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29Z"));
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29"));
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29-20:00"));
-			Assert.True(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29+20:00"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014/12/31T13:56:29-2000"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-31 13:56:29-2000"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29 0000"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29ZZ"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29Z0000"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-31T13:56:29 0000"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-31 04:45:29"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014/12/32T04:45:29"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-13-01T04:45:29"));
-			Assert.False(DateTimeExtensions.IsISO8601DateTime("2014-12-32T04:45:29"));
-
+			return DateTimeExtensions.IsISO8601DateTime(dateTime);
 		}
 
-		[Test]
-		public void ParseISO8601DateTime()
+		[TestCase("0001-01-01T00:00:00+00:00")]
+		[TestCase("0001-01-01T00:00:00+0000")]
+		[TestCase("0001-01-01T00:00:00Z")]
+		[TestCase("0001-01-01T00:00:00")]
+		[TestCase("0001-01-01")]
+		public void ParseISO8601DateTime_DefaultTime(string dateTime)
 		{
 			var defaultTime = new DateTime();
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("0001-01-01T00:00:00+00:00"), Is.EqualTo(defaultTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("0001-01-01T00:00:00+0000"), Is.EqualTo(defaultTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("0001-01-01T00:00:00Z"), Is.EqualTo(defaultTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("0001-01-01T00:00:00"), Is.EqualTo(defaultTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("0001-01-01"), Is.EqualTo(defaultTime));
-
-			var expectedTime = new DateTime(2012, 02, 29, 12, 30, 45);
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("2012-02-29T12:30:45+0000"), Is.EqualTo(expectedTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("2012-02-29T12:30:45+00:00"), Is.EqualTo(expectedTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("2012-02-29T00:30:45-1200"), Is.EqualTo(expectedTime));
-			Assert.That(DateTimeExtensions.ParseISO8601DateTime("2012-02-29T00:30:45-12:00"), Is.EqualTo(expectedTime));
+			Assert.That(DateTimeExtensions.ParseISO8601DateTime(dateTime),
+				Is.EqualTo(defaultTime));
 		}
 
+		[TestCase("2012-02-29T12:30:45+0000")]
+		[TestCase("2012-02-29T12:30:45+00:00")]
+		[TestCase("2012-02-29T00:30:45-1200")]
+		[TestCase("2012-02-29T00:30:45-12:00")]
+		public void ParseISO8601DateTime_ExpectedTime(string dateTime)
+		{
+			Assert.That(DateTimeExtensions.ParseISO8601DateTime(dateTime),
+				Is.EqualTo(new DateTime(2012, 02, 29, 12, 30, 45)));
+		}
 	}
 }

--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using SIL.Extensions;
 using SIL.PlatformUtilities;
 using SIL.Reflection;
 
@@ -300,7 +301,8 @@ namespace SIL.IO
 		{
 			try
 			{
-				return Directory.GetFiles(subDir, exeName, srcOption).FirstOrDefault();
+				return Directory.GetFiles(subDir, exeName, srcOption)
+					.OrderBy(filename => filename).FirstOrDefault();
 			}
 			catch (Exception e)
 			{

--- a/SIL.Core/Migration/FolderMigrator.cs
+++ b/SIL.Core/Migration/FolderMigrator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using SIL.Extensions;
 using SIL.IO;
 
 namespace SIL.Migration
@@ -149,7 +150,8 @@ namespace SIL.Migration
 				);
 				Directory.CreateDirectory(destinationPath);
 				// Migrate all the files of the current version
-				foreach (var filePath in Directory.GetFiles(currentPath, SearchPattern))
+				foreach (var filePath in Directory.GetFiles(currentPath, SearchPattern)
+					.OrderBy(filename => filename))
 				{
 					string fileName = Path.GetFileName(filePath);
 					if (fileName == null)
@@ -232,7 +234,7 @@ namespace SIL.Migration
 			}
 
 			_versionCache.Clear();
-			foreach (var fileName in Directory.GetFiles(path, SearchPattern))
+			foreach (var fileName in Directory.GetFiles(path, SearchPattern).OrderBy(filename => filename))
 			{
 				int fileVersion = GetFileVersion(fileName);
 				_versionCache.Add(new FileVersionInfo(fileName, fileVersion));

--- a/SIL.DblBundle/Text/TextBundle.cs
+++ b/SIL.DblBundle/Text/TextBundle.cs
@@ -99,7 +99,8 @@ namespace SIL.DblBundle.Text
 				if (_ldmlFilePath != null)
 					return _ldmlFilePath;
 
-				_ldmlFilePath = Directory.GetFiles(PathToUnzippedBundleInnards, "*.ldml").FirstOrDefault();
+				_ldmlFilePath = Directory.GetFiles(PathToUnzippedBundleInnards, "*.ldml")
+					.OrderBy(filename => filename).FirstOrDefault();
 
 				if (_ldmlFilePath == null)
 					_ldmlFilePath = Path.Combine(PathToUnzippedBundleInnards, DblBundleFileUtils.kLegacyLdmlFileName);

--- a/SIL.Lift.Tests/Merging/SynchronicMergerTests.cs
+++ b/SIL.Lift.Tests/Merging/SynchronicMergerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Xml;
@@ -60,7 +61,8 @@ namespace SIL.Lift.Tests.Merging
 		private FileInfo GetBaseFileInfo()
 		{
 			DirectoryInfo di = new DirectoryInfo(_directory);
-			return di.GetFiles(_baseLiftFileName, SearchOption.TopDirectoryOnly)[0];
+			return di.GetFiles(_baseLiftFileName, SearchOption.TopDirectoryOnly)
+				.OrderBy(filename => filename).FirstOrDefault();
 		}
 
 		//private FileInfo[] GetFileInfos()
@@ -479,6 +481,7 @@ namespace SIL.Lift.Tests.Merging
 		}
 
 		[Test]
+		[Platform(Exclude = "Linux", Reason = "Locked files can still be moved on Linux")]
 		public void LockedBackupFile_StillMakesBackup()
 		{
 			string backupFilePath = Path.Combine(this._directory, _baseLiftFileName + ".bak");

--- a/SIL.Lift/LiftSorter.cs
+++ b/SIL.Lift/LiftSorter.cs
@@ -114,7 +114,7 @@ namespace SIL.Lift
 			Guard.Against(Path.GetExtension(liftRangesPathname).ToLowerInvariant() != ".lift-ranges", "Unexpected file extension");
 			var projectDir = Path.GetDirectoryName(liftRangesPathname);
 
-			foreach (var liftRangesFile in Directory.GetFiles(projectDir, @"*.lift-ranges"))
+			foreach (var liftRangesFile in Directory.GetFiles(projectDir, @"*.lift-ranges").OrderBy(filename => filename))
 			{
 				using (var tempFile = new TempFile(File.ReadAllText(liftRangesFile), Utf8))
 				{

--- a/SIL.Windows.Forms.DblBundle/ProjectsListBase.cs
+++ b/SIL.Windows.Forms.DblBundle/ProjectsListBase.cs
@@ -146,14 +146,15 @@ namespace SIL.Windows.Forms.DblBundle
 		protected abstract IEnumerable<string> AllProjectFolders { get; }
 
 		protected abstract string ProjectFileExtension { get; }
-	
+
 		protected virtual IEnumerable<Tuple<string, IProjectInfo>> Projects
 		{
 			get
 			{
 				foreach (var recordingProjectFolder in AllProjectFolders)
 				{
-					var path = Directory.GetFiles(recordingProjectFolder, "*" + ProjectFileExtension).FirstOrDefault();
+					var path = Directory.GetFiles(recordingProjectFolder, "*" + ProjectFileExtension)
+						.OrderBy(filename => filename).FirstOrDefault();
 					if (path != null)
 					{
 						var projectInfo = GetProjectInfo(path);

--- a/SIL.WritingSystems.Tests/LdmlInFolderWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlInFolderWritingSystemRepositoryTests.cs
@@ -286,12 +286,14 @@ namespace SIL.WritingSystems.Tests
 			using (var environment = new TestEnvironment())
 			{
 				environment.WritingSystem.Language = "en";
-				Assert.AreNotEqual(0, Directory.GetFiles(environment.LocalRepositoryPath, "*.ldml"));
+				Assert.That(Directory.GetFiles(environment.LocalRepositoryPath,
+					"*.ldml"), Is.Empty);
 				environment.LocalRepository.SaveDefinition(environment.WritingSystem);
 				environment.ResetRepositories();
 				WritingSystemDefinition ws2 = environment.LocalRepository.Get("en");
-				Assert.AreEqual(
-					Path.GetFileNameWithoutExtension(Directory.GetFiles(environment.LocalRepositoryPath, "*.ldml")[0]), ws2.Id);
+				Assert.That(Path.GetFileNameWithoutExtension(
+					Directory.GetFiles(environment.LocalRepositoryPath, "*.ldml")
+						.OrderBy(filename => filename).FirstOrDefault()), Is.EqualTo(ws2.Id));
 			}
 		}
 

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -85,7 +85,7 @@ namespace SIL.WritingSystems
 		{
 			var ldmlDataMapper = new LdmlDataMapper(WritingSystemFactory);
 			var removedIds = new HashSet<string>(WritingSystems.Keys);
-			foreach (string file in Directory.GetFiles(PathToWritingSystems, $"*{Extension}"))
+			foreach (var file in Directory.GetFiles(PathToWritingSystems, $"*{Extension}").OrderBy(filename => filename))
 			{
 				var fi = new FileInfo(file);
 				string id = Path.GetFileNameWithoutExtension(file);

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using SIL.Extensions;
 using SIL.WritingSystems.Migration;
 
 namespace SIL.WritingSystems
@@ -166,7 +167,7 @@ namespace SIL.WritingSystems
 			_loadProblems.Clear();
 			ChangedIds.Clear();
 			Clear();
-			foreach (string filePath in Directory.GetFiles(_path, "*.ldml"))
+			foreach (var filePath in Directory.GetFiles(_path, "*.ldml").OrderBy(filename => filename))
 				LoadDefinition(filePath);
 
 			LoadChangedIdsFromExistingWritingSystems();


### PR DESCRIPTION
With Mono 6 we get a new set of failing tests. This change fixes or ignores those tests.

- `SynchronicMergerTests`: this test should be ignored on Linux since it is possible to move locked files 
  on Linux.
- `DateTimeExtensionTests`: it seems that Mono 6 shares the implementation with .NET Core which 
  checks that the timezone offset is within plus or minus 14. Adjusted the tests.
- `LdmlInFolderWritingSystemRepositoryTests`: The tests were dependent on the order of files that 
  `Directory.GetFiles` returned. Since this can result in hard-to-reproduce error reports we now sort
  the list of LDML files before we process them.
- `LdmlInFolderWritingSystemRepositoryMigratorTests`: failing tests caused by another case of 
  differing sort order. Add sorting to all relevant instances of `Directory.GetFiles`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/840)
<!-- Reviewable:end -->
