### PR TITLE
BL-7224 Give language lookup click priority

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
@@ -146,9 +146,10 @@ namespace SIL.Windows.Forms.WritingSystems
 				ListViewItem item = _listView.Items[_listView.SelectedIndices[0]];
 				var oldLangInfo = SelectedLanguage;
 				var newLangInfo = (LanguageInfo) item.Tag;
-				// If the user has already set some Script/Region/Variant info, we don't want
-				// to undo that just because the listview is set to that main language in the search.
-				if (_model.LanguageTagContainsScriptRegionVariantInfo &&
+				// If the user has already set some Script/Region/Variant info, and the link to the
+				// Script/Region/Variant dialog isn't available, we don't want to undo that just because
+				// the listview is set to that main language in the search.
+				if (!_scriptsAndVariantsLink.Visible && _model.LanguageTagContainsScriptRegionVariantInfo &&
 				    newLangInfo.LanguageTag == _model.LanguageTagWithoutScriptRegionVariant)
 				{
 					newLangInfo.DesiredName = oldLangInfo.DesiredName;


### PR DESCRIPTION
* 2 UI desires are conflicting here:
   1) update the Script and Variant label (to the right of the Script and Variant link)
       with the language clicked on in the list view
   2) keep script/region/variant info from the Script and Variant dialog when
       returning to the main list view.
* At this point, we are making the first a priority. If the user selects their
   language, then goes and adds more detail in the Script and Variant dialog,
   they can click 'OK' in the outer dialog and keep all that info. But clicking on a
   different language will reset that information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/841)
<!-- Reviewable:end -->
