### PR TITLE
Made LogBox enforce the MaximumLength value

### DIFF
--- a/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
+++ b/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
@@ -48,6 +48,7 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 				sb.Append('a', Int32.MaxValue - (hugestr.Length + 1) * 999 - 1);
 				progress.WriteVerbose(sb.ToString());
 				progress.WriteVerbose(".");
+				Assert.IsTrue(progress.ErrorEncountered);
 				Assert.IsFalse(progress.Rtf.Contains("."));
 				Assert.IsTrue(progress.Rtf.Contains("Maximum length exceeded!"));
 			}
@@ -68,6 +69,7 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 				progress.WriteVerbose(sb.ToString());
 				const string partThatWillFit = "Only this much.";
 				progress.WriteVerbose($"{partThatWillFit}~will fit!");
+				Assert.IsTrue(progress.ErrorEncountered);
 				Assert.AreEqual(progress.MaxLength + lengthOfBoxLabels, progress.Text.Length);
 				var iTruncatedMessage = progress.Rtf.IndexOf(partThatWillFit);
 				Assert.IsTrue(iTruncatedMessage > 83);
@@ -92,6 +94,7 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 				const string partThatWillFit = "Only this much.";
 				progress.WriteMessage($"{partThatWillFit}~will fit!");
 				// Turns out that the Text property returns the text twice, once labeled "Box:" and once labeled "Verbose:"
+				Assert.IsTrue(progress.ErrorEncountered);
 				Assert.AreEqual(progress.MaxLength * 2 + lengthOfBoxLabels, progress.Text.Length);
 				var iTruncatedMessage = progress.Rtf.IndexOf(partThatWillFit);
 				Assert.IsTrue(iTruncatedMessage > 83);

--- a/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
+++ b/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using NUnit.Framework;
 
 namespace SIL.Windows.Forms.Tests.Progress.LogBox
@@ -27,6 +28,75 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 				Console.WriteLine(progress.Text);
 				Console.WriteLine(progress.Rtf);
 				Console.WriteLine("Finished");
+			}
+		}
+
+		[Test]
+		[Category("Long Running")]
+		public void WriteVerbose_AtMaximumLength_RtfContainsMaximumLengthExceeded()
+		{
+			Console.WriteLine("Showing LogBox");
+			using (var e = new LogBoxFormForTest())
+			{
+				var sb = new StringBuilder();
+				sb.Append('a', Int32.MaxValue / 1000 - 1);
+				var hugestr = sb.ToString();
+				progress = e.progress;
+				for (int i = 0; i < 999; i++)
+					progress.WriteVerbose(hugestr);
+				sb.Clear();
+				sb.Append('a', Int32.MaxValue - (hugestr.Length + 1) * 999 - 1);
+				progress.WriteVerbose(sb.ToString());
+				progress.WriteVerbose(".");
+				Assert.IsFalse(progress.Rtf.Contains("."));
+				Assert.IsTrue(progress.Rtf.Contains("Maximum length exceeded!"));
+			}
+		}
+
+		[Test]
+		[Category("KnownMonoIssue")] // this test hangs on TeamCity for Linux
+		public void WriteVerbose_PartOfMessageExceedsMaximumLength_PartialMessageWrittenFollowedByMaximumLengthExceeded()
+		{
+			Console.WriteLine("Showing LogBox");
+			using (var e = new LogBoxFormForTest())
+			{
+				var sb = new StringBuilder();
+				progress = e.progress;
+				var lengthOfBoxLabels = progress.Text.Length;
+				sb.Append('a', 83 - progress.MaxLengthErrorMessage.Length);
+				progress.MaxLength = 100;
+				progress.WriteVerbose(sb.ToString());
+				const string partThatWillFit = "Only this much.";
+				progress.WriteVerbose($"{partThatWillFit}~will fit!");
+				Assert.AreEqual(progress.MaxLength + lengthOfBoxLabels, progress.Text.Length);
+				var iTruncatedMessage = progress.Rtf.IndexOf(partThatWillFit);
+				Assert.IsTrue(iTruncatedMessage > 83);
+				Assert.AreNotEqual("~", progress.Rtf[iTruncatedMessage + partThatWillFit.Length]);
+				Assert.IsTrue(iTruncatedMessage < progress.Rtf.IndexOf(progress.MaxLengthErrorMessage));
+			}
+		}
+
+		[Test]
+		[Category("KnownMonoIssue")] // this test hangs on TeamCity for Linux
+		public void WriteMessage_PartOfMessageExceedsMaximumLength_PartialMessageWrittenFollowedByMaximumLengthExceeded()
+		{
+			Console.WriteLine("Showing LogBox");
+			using (var e = new LogBoxFormForTest())
+			{
+				var sb = new StringBuilder();
+				progress = e.progress;
+				var lengthOfBoxLabels = progress.Text.Length;
+				sb.Append('a', 83 - progress.MaxLengthErrorMessage.Length);
+				progress.MaxLength = 100;
+				progress.WriteMessage(sb.ToString());
+				const string partThatWillFit = "Only this much.";
+				progress.WriteMessage($"{partThatWillFit}~will fit!");
+				// Turns out that the Text property returns the text twice, once labeled "Box:" and once labeled "Verbose:"
+				Assert.AreEqual(progress.MaxLength * 2 + lengthOfBoxLabels, progress.Text.Length);
+				var iTruncatedMessage = progress.Rtf.IndexOf(partThatWillFit);
+				Assert.IsTrue(iTruncatedMessage > 83);
+				Assert.AreNotEqual("~", progress.Rtf[iTruncatedMessage + partThatWillFit.Length]);
+				Assert.IsTrue(iTruncatedMessage < progress.Rtf.IndexOf(progress.MaxLengthErrorMessage));
 			}
 		}
 	}

--- a/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
+++ b/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
@@ -63,14 +63,13 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 			{
 				var sb = new StringBuilder();
 				progress = e.progress;
-				var lengthOfBoxLabels = progress.Text.Length;
 				sb.Append('a', 83 - progress.MaxLengthErrorMessage.Length);
 				progress.MaxLength = 100;
 				progress.WriteVerbose(sb.ToString());
 				const string partThatWillFit = "Only this much.";
 				progress.WriteVerbose($"{partThatWillFit}~will fit!");
 				Assert.IsTrue(progress.ErrorEncountered);
-				Assert.AreEqual(progress.MaxLength + lengthOfBoxLabels, progress.Text.Length);
+				Assert.AreEqual(progress.MaxLength, progress.Text.Length);
 				var iTruncatedMessage = progress.Rtf.IndexOf(partThatWillFit);
 				Assert.IsTrue(iTruncatedMessage > 83);
 				Assert.AreNotEqual("~", progress.Rtf[iTruncatedMessage + partThatWillFit.Length]);
@@ -87,7 +86,6 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 			{
 				var sb = new StringBuilder();
 				progress = e.progress;
-				var lengthOfBoxLabels = progress.Text.Length;
 				sb.Append('a', 83 - progress.MaxLengthErrorMessage.Length);
 				progress.MaxLength = 100;
 				progress.WriteMessage(sb.ToString());
@@ -95,7 +93,7 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 				progress.WriteMessage($"{partThatWillFit}~will fit!");
 				// Turns out that the Text property returns the text twice, once labeled "Box:" and once labeled "Verbose:"
 				Assert.IsTrue(progress.ErrorEncountered);
-				Assert.AreEqual(progress.MaxLength * 2 + lengthOfBoxLabels, progress.Text.Length);
+				Assert.AreEqual(progress.MaxLength, progress.Text.Length);
 				var iTruncatedMessage = progress.Rtf.IndexOf(partThatWillFit);
 				Assert.IsTrue(iTruncatedMessage > 83);
 				Assert.AreNotEqual("~", progress.Rtf[iTruncatedMessage + partThatWillFit.Length]);

--- a/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
+++ b/SIL.Windows.Forms.Tests/Progress/LogBox/LogBoxTests.cs
@@ -38,14 +38,14 @@ namespace SIL.Windows.Forms.Tests.Progress.LogBox
 			Console.WriteLine("Showing LogBox");
 			using (var e = new LogBoxFormForTest())
 			{
-				var sb = new StringBuilder();
-				sb.Append('a', Int32.MaxValue / 1000 - 1);
-				var hugestr = sb.ToString();
 				progress = e.progress;
+				var sb = new StringBuilder();
+				sb.Append('a', progress.MaxLength / 1000 - 1);
+				var hugestr = sb.ToString();
 				for (int i = 0; i < 999; i++)
 					progress.WriteVerbose(hugestr);
 				sb.Clear();
-				sb.Append('a', Int32.MaxValue - (hugestr.Length + 1) * 999 - 1);
+				sb.Append('a', progress.MaxLength - (hugestr.Length + 1) * 999 - 1);
 				progress.WriteVerbose(sb.ToString());
 				progress.WriteVerbose(".");
 				Assert.IsTrue(progress.ErrorEncountered);

--- a/SIL.Windows.Forms/Progress/LogBox.cs
+++ b/SIL.Windows.Forms/Progress/LogBox.cs
@@ -362,6 +362,12 @@ namespace SIL.Windows.Forms.Progress
 					append(message);
 				}
 
+				// The first time we attempt to write a message that would overflow the verbose stream,
+				// WriteErrorInternal gets called, and we notify the user in both message streams. The
+				// above logic will prevent subsequent writes to a box which is already full. The
+				// following check will keep us from re-reporting the problem (in either box). If we
+				// later fill up the terse box, it will display the warning message a second time for its
+				// own overlfow (so that will then be the last message in both boxes).
 				if (remainingCharactersThatWillFit >= 0)
 					WriteErrorInternal(_maxLengthError);
 			}

--- a/SIL.Windows.Forms/Progress/LogBox.cs
+++ b/SIL.Windows.Forms/Progress/LogBox.cs
@@ -306,7 +306,7 @@ namespace SIL.Windows.Forms.Progress
 					// inside this loop because it needs to be inside the same call to "SafeInvoke" to prevent
 					// the possibility of additional verbose messages getting added to the buffer before the
 					// normal message gets written out to the verbose log box itself.
-					if (rtfBox == _verboseBox)
+					if (rtfBoxForDelegate == _verboseBox)
 						FlushPendingVerboseMessageBuffer();
 
 					if (Platform.IsWindows)

--- a/SIL.Windows.Forms/Progress/LogBox.cs
+++ b/SIL.Windows.Forms/Progress/LogBox.cs
@@ -87,6 +87,11 @@ namespace SIL.Windows.Forms.Progress
 			_box.LinkClicked += _box_LinkClicked;
 			_verboseBox.LinkClicked += _box_LinkClicked;
 			_synchronizationContext = SynchronizationContext.Current;
+			// The default is defnitely too big. If client pushes enough messages, there will be memory problems.
+			// Based on testing, cutting it down to a third of that size seems to get us into a "safe" zone. Can't
+			// guarantee that this will be safe on all systems or in all circumstances. And it might still be safe
+			// to go a little bigger. (Just cutting it in half still caused the test to red-bar with an access violation.)
+			MaxLength /= 3;
 		}
 
 		public int MaxLength

--- a/SIL.Windows.Forms/Progress/LogBox.cs
+++ b/SIL.Windows.Forms/Progress/LogBox.cs
@@ -229,13 +229,13 @@ namespace SIL.Windows.Forms.Progress
 				// empty string in that case. This works around a crash
 				// in WeSay.
 				if (_box == null || _verboseBox == null) return String.Empty;
-				return _verboseBox.Text;
+				return _showDetailsMenu.Checked ? _verboseBox.Text : _box.Text;
 			}
 		}
 
 		public string Rtf
 		{
-			get { return _verboseBox.Rtf; }
+			get { return _showDetailsMenu.Checked ? _verboseBox.Rtf : _box.Rtf; }
 		}
 
 		public void ScrollToTop()
@@ -362,7 +362,8 @@ namespace SIL.Windows.Forms.Progress
 					append(message);
 				}
 
-				WriteErrorInternal(_maxLengthError);
+				if (remainingCharactersThatWillFit >= 0)
+					WriteErrorInternal(_maxLengthError);
 			}
 		}
 


### PR DESCRIPTION
MaximumLength is now exposed so the client can set it (mainly to support testing).
The logic is in place (with passing unit tests) to truncate any message that would exceed the limit and output a special error message.
WIP: Failing (and very slow) test for the more interesting case where the default maximum is used. In this case, an access violation occurs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/845)
<!-- Reviewable:end -->
