### PR TITLE
Replace remaining references to L10NSharp.tmx

### DIFF
--- a/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle-Designer.csproj
+++ b/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle-Designer.csproj
@@ -44,11 +44,13 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="L10NSharp">
-      <HintPath>..\packages\L10NSharp.tmx.3.1.0-nuget0010\lib\net461\L10NSharp.dll</HintPath>
+    <Reference Include="L10NSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28">
+      <HintPath>..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -80,6 +82,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SIL.Windows.Forms.DblBundle/packages.config
+++ b/SIL.Windows.Forms.DblBundle/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="L10NSharp" version="4.0.0" targetFramework="net462" />
+</packages>

--- a/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems-Designer.csproj
+++ b/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems-Designer.csproj
@@ -43,6 +43,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Enchant.Net, Version=1.4.0.0, Culture=neutral, PublicKeyToken=ae135aeb3d479ab9">
+      <HintPath>..\packages\Enchant.Net.1.4.2\lib\net461\Enchant.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="L10NSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28">
+      <HintPath>..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="sysglobl" />
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -50,14 +58,9 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="Enchant.Net">
-      <HintPath>..\packages\Enchant.Net.1.4.2\lib\net461\Enchant.Net.dll</HintPath>
-    </Reference>
-    <Reference Include="L10NSharp">
-      <HintPath>..\packages\L10NSharp.tmx.3.1.0-nuget0010\lib\net461\L10NSharp.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CannotFindMyLanguageDialog.cs">
@@ -309,6 +312,9 @@
     <EmbeddedResource Include="WSTree\WritingSystemTreeView.resx">
       <DependentUpon>WritingSystemTreeView.cs</DependentUpon>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/SIL.Windows.Forms.WritingSystems/packages.config
+++ b/SIL.Windows.Forms.WritingSystems/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Enchant.Net" version="1.4.2" targetFramework="net461" />
+  <package id="L10NSharp" version="4.0.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
The designer projects still had references to L10NSharp.tmx instead
of L10NSharp. Also `packages.config` file was missing for two
designer projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/856)
<!-- Reviewable:end -->
