### PR TITLE
PTX-18778 Prevent errors when initializing keyboards

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -81,7 +81,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 
 			foreach (InputLanguage inputLanguage in InputLanguage.InstalledInputLanguages)
 			{
-				if (InvalidLanguageName(inputLanguage))
+				if (HasInvalidLanguageName(inputLanguage))
 					continue;
 
 				int langCode = (int)((ulong) inputLanguage.Handle & 0x000000000000ffffUL);
@@ -147,7 +147,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 			}
 		}
 
-		private bool InvalidLanguageName(InputLanguage inputLanguage)
+		private bool HasInvalidLanguageName(InputLanguage inputLanguage)
 		{
 			// We have had some input languages get errors when trying to get the layout name, so just want to skip those
 			try

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -81,6 +81,9 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 
 			foreach (InputLanguage inputLanguage in InputLanguage.InstalledInputLanguages)
 			{
+				if (InvalidLanguageName(inputLanguage))
+					continue;
+
 				int langCode = (int)((ulong) inputLanguage.Handle & 0x000000000000ffffUL);
 				if (!processedLanguages.Add(langCode))
 					continue;
@@ -141,6 +144,20 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 			foreach (var existingKeyboard in curKeyboards.Values)
 			{
 				existingKeyboard.SetIsAvailable(false);
+			}
+		}
+
+		private bool InvalidLanguageName(InputLanguage inputLanguage)
+		{
+			// We have had some input languages get errors when trying to get the layout name, so just want to skip those
+			try
+			{
+				string test = inputLanguage.LayoutName;
+				return false;
+			}
+			catch (Exception)
+			{
+				return true;
 			}
 		}
 


### PR DESCRIPTION
Prevent bad input language settings from creating errors when initializing keyboards

This may be related to InKey keyboards - some systems have problems when InKey is running and Paratext is started.

The actual error is occurring in .Net code, so just needed to try accessing the value causing the error and ignore input languages that fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/858)
<!-- Reviewable:end -->
