### PR TITLE
Allow easier subclassing of metadata dialog

### DIFF
--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataEditorDialog.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataEditorDialog.cs
@@ -54,10 +54,21 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 			Close();
 		}
 
+		// allow subclass to access these methods/properties.
 
-		private void _minimallyCompleteCheckTimer_Tick(object sender, EventArgs e)
+		protected virtual void _minimallyCompleteCheckTimer_Tick(object sender, EventArgs e)
 		{
 			_okButton.Enabled = _metadataEditorControl.Metadata.IsMinimallyComplete;
+		}
+
+		protected MetadataEditorControl MetadataControl
+		{
+			get { return _metadataEditorControl; }
+		}
+
+		protected Button OkButton
+		{
+			get { return _okButton; }
 		}
 	}
 }


### PR DESCRIPTION
See https://issues.bloomlibrary.org/youtrack/issue/BL-7381 for the motivation behind this change.  I think subclassing the dialog is a bit cleaner than making the original dialog more complicated.  And what Bloom wants to add here may be too Bloom-specific to be of interest to other projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/859)
<!-- Reviewable:end -->
