### PR TITLE
Dispose of GeckoWebBrowser objects properly (20190911)

### DIFF
--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoFxWebBrowserAdapter.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoFxWebBrowserAdapter.cs
@@ -403,6 +403,14 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			get { return AllowNavigation && GetBrowserProperty<bool>(_webBrowser, "CanGoForward"); }
 		}
 
+		public void Dispose()
+		{
+			CallBrowserMethod(_webBrowser, "Dispose", null);
+			// Call GC.SupressFinalize to take this object off the finalization queue
+			// and prevent finalization code for this object from executing a second time.
+			GC.SuppressFinalize(this);
+		}
+
 		public string DocumentText
 		{
 			set

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/WebThumbnailViewer.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/WebThumbnailViewer.cs
@@ -259,21 +259,27 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		{
 		}
 
+		private bool disposed = false;
 		/// <summary>
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (_htmlFile != null)
+			if (disposed)
+				return;
+			disposed = true;
+			if (disposing)
 			{
-				_htmlFile.Dispose();
-				_htmlFile = null;
-			}
-
-			if (disposing && (components != null))
-			{
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
+				if (_browser != null)
+					_browser.Dispose();
+				if (_htmlFile != null)
+				{
+					_htmlFile.Dispose();
+					_htmlFile = null;
+				}
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/HtmlBrowser/IWebBrowser.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/IWebBrowser.cs
@@ -6,7 +6,7 @@ using System.Windows.Forms;
 
 namespace SIL.Windows.Forms.HtmlBrowser
 {
-	public interface IWebBrowser
+	public interface IWebBrowser : IDisposable
 	{
 		bool AllowWebBrowserDrop { get; set; }
 		bool CanGoBack { get; }

--- a/SIL.Windows.Forms/HtmlBrowser/WinFormsBrowserAdapter.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/WinFormsBrowserAdapter.cs
@@ -46,6 +46,14 @@ namespace SIL.Windows.Forms.HtmlBrowser
 			get { return m_WebBrowser.CanGoForward; }
 		}
 
+		public void Dispose()
+		{
+			m_WebBrowser.Dispose();
+			// Call GC.SupressFinalize to take this object off the finalization queue
+			// and prevent finalization code for this object from executing a second time.
+			GC.SuppressFinalize(this);
+		}
+
 		public string DocumentText
 		{
 			get { return m_WebBrowser.DocumentText; }

--- a/SIL.Windows.Forms/HtmlBrowser/XWebBrowser.Designer.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/XWebBrowser.Designer.cs
@@ -10,15 +10,22 @@ namespace SIL.Windows.Forms.HtmlBrowser
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
+		private bool disposed = false;
 		/// <summary> 
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposed)
+				return;
+			disposed = true;
+			if (disposing)
 			{
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
+				if (m_WebBrowserAdapter != null)
+					m_WebBrowserAdapter.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.Designer.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.Designer.cs
@@ -7,15 +7,25 @@
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
+		private bool disposed = false;
 		/// <summary>
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposed)
+				return;
+			disposed = true;
+			if (disposing)
 			{
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
+				if (_thumbnailViewer != null)
+				{
+					_thumbnailViewer.Dispose();
+					_thumbnailViewer = null;
+				}
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ThumbnailViewer.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ThumbnailViewer.cs
@@ -79,6 +79,24 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 		}
 		public void Clear() { _thumbnailViewer.Clear();}
 		public void Closing() { _thumbnailViewer.Closing();}
+
+		private bool disposed = false;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposed)
+				return;
+			disposed = true;
+			if (disposing)
+			{
+				if (_thumbnailViewer != null)
+				{
+					_thumbnailViewer.Dispose();
+					_thumbnailViewer = null;
+				}
+			}
+			base.Dispose(disposing);
+		}
+
 		public void LoadItems(IEnumerable<string> pathList) { _thumbnailViewer.LoadItems(pathList);}
 		public bool HasSelection {
 			get { return _thumbnailViewer.HasSelection; }
@@ -102,7 +120,7 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 		public event EventHandler LoadComplete;
 	}
 
-	public interface IThumbnailViewer
+	public interface IThumbnailViewer : IDisposable
 	{
 		Control TheControl { get; }
 		Func<string, string> CaptionMethod { get; set; }

--- a/SIL.Windows.Forms/Miscellaneous/SILAboutBox.Designer.cs
+++ b/SIL.Windows.Forms/Miscellaneous/SILAboutBox.Designer.cs
@@ -10,14 +10,24 @@ namespace SIL.Windows.Forms.Miscellaneous
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
+		private bool disposed = false;
 		/// <summary>
 		/// Clean up any resources being used.
 		/// </summary>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposed)
+				return;
+			disposed = true;
+			if (disposing)
 			{
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
+				if (_browser != null)
+				{
+					_browser.Dispose();
+					_browser = null;
+				}
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/ReleaseNotes/ShowReleaseNotesDialog.Designer.cs
+++ b/SIL.Windows.Forms/ReleaseNotes/ShowReleaseNotesDialog.Designer.cs
@@ -11,12 +11,16 @@ namespace SIL.Windows.Forms.ReleaseNotes
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
+		private bool disposed = false;
 		/// <summary>
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
+			if (disposed)
+				return;
+			disposed = true;
 			if (disposing)
 			{
 				if (components != null)
@@ -32,8 +36,11 @@ namespace SIL.Windows.Forms.ReleaseNotes
 						Debug.Fail(error.Message);
 					}
 				}
+				if (_browser != null)
+					_browser.Dispose();
 			}
 			_temp = null;
+			_browser = null;
 			base.Dispose(disposing);
 		}
 

--- a/SIL.Windows.Forms/Widgets/HtmlLabel.Designer.cs
+++ b/SIL.Windows.Forms/Widgets/HtmlLabel.Designer.cs
@@ -7,15 +7,22 @@
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
+		bool disposed = false;
 		/// <summary> 
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposed)
+				return;
+			disposed = true;
+			if (disposing)
 			{
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
+				if (_browser != null)
+					_browser.Dispose();
 			}
 			base.Dispose(disposing);
 		}


### PR DESCRIPTION
Tom Hindle has pointed out that GeckoWebBrowser objects should be disposed.  These are used
by various dialogs and controls in libpalaso under SIL.Windows.Forms, albeit indirectly through
SIL.Windows.Forms.GeckoBrowserAdapter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/861)
<!-- Reviewable:end -->
