### PR TITLE
Merge unsigned assemblies (Fixes #865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Add build number to AssemblyFileVersion
+- [SIL.Windows.Forms] Removed unnecessary dependency on NAudio
+
+### Fixed
+
+- [SIL.Windows.Forms.Keyboarding] Merge missing `Keyman*Interop.dll` into the assembly (#865). On Linux there's
+  still a similar issue outstanding with `ibusdotnet.dll`.
+- [SIL.Windows.Forms] Merge `Interop.WIA.dll`, `DialogAdapters.dll`, and `MarkdownDeep.dll` into the assembly
 
 ## [7.0.0] - 2019-08-29
 

--- a/SIL.Windows.Forms.Keyboarding/ILRepack.targets
+++ b/SIL.Windows.Forms.Keyboarding/ILRepack.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+
+    <ItemGroup>
+      <InputAssemblies Include="$(OutputPath)$(TargetName)$(TargetExt)"/>
+      <InputAssemblies Include="$(OutputPath)Keyman10Interop.dll"/>
+      <InputAssemblies Include="$(OutputPath)Keyman7Interop.dll"/>
+      <InputAssemblies Include="$(OutputPath)KeymanLink.dll"/>
+    </ItemGroup>
+
+    <ILRepack
+      Verbose="true"
+      Parallel="true"
+      KeyFile="../palaso.snk"
+      Internalize="true"
+      DebugInfo="true"
+      InputAssemblies="@(InputAssemblies)"
+      LibraryPath="$(OutputPath);$(FrameworkPathOverride)"
+      AttributeFile="$(OutputPath)$(TargetName)$(TargetExt)"
+      TargetKind="SameAsPrimaryAssembly"
+      OutputFile="$(OutputPath)$(AssemblyName)$(TargetExt)"
+    />
+
+  </Target>
+</Project>

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <RootNamespace>SIL.Windows.Forms.Keyboarding</RootNamespace>
-    <AssemblyTitle>SIL.Windows.Forms.Keyboarding</AssemblyTitle>
     <Configurations>Debug;Release</Configurations>
     <Description>The SIL.Windows.Forms.Keyboarding library provides cross-platform functionality for keyboard selection and switching in Windows Forms applications. Currently, this library supports system and Keyman keyboards on Windows, and X keyboard extension (XKB) and Intelligent Input Bus (IBus) keyboards on Linux.</Description>
     <Company>SIL International</Company>
@@ -38,6 +36,9 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="StrongNamer" Version="0.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.18">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -55,8 +56,14 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <Reference Include="KeymanLink, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\lib\common\KeymanLink.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Mono.Posix" Condition="'$(OS)' != 'Windows_NT'" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- See https://github.com/dotnet/sdk/issues/987#issuecomment-286307697 why that is needed -->
+    <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+  </PropertyGroup>
 
 </Project>

--- a/SIL.Windows.Forms/ILRepack.targets
+++ b/SIL.Windows.Forms/ILRepack.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="ILRepacker" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+
+    <ItemGroup>
+      <InputAssemblies Include="$(OutputPath)$(TargetName)$(TargetExt)"/>
+      <InputAssemblies Include="$(OutputPath)Interop.WIA.dll"/>
+      <InputAssemblies Include="$(OutputPath)DialogAdapters.dll" />
+      <InputAssemblies Include="$(OutputPath)MarkdownDeep.dll" />
+    </ItemGroup>
+
+    <ILRepack
+      Verbose="true"
+      Parallel="true"
+      KeyFile="../palaso.snk"
+      Internalize="true"
+      DebugInfo="true"
+      InputAssemblies="@(InputAssemblies)"
+      LibraryPath="$(OutputPath);$(FrameworkPathOverride)"
+      AttributeFile="$(OutputPath)$(TargetName)$(TargetExt)"
+      TargetKind="SameAsPrimaryAssembly"
+      OutputFile="$(OutputPath)$(AssemblyName)$(TargetExt)"
+    />
+
+  </Target>
+</Project>

--- a/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
@@ -72,9 +72,6 @@
       <HintPath>..\packages\L10NSharp.4.0.0\lib\net461\L10NSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NAudio">
-      <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
-    </Reference>
     <!-- this is the Microsoft WIndows Image Acquisition COM library, for scanner and camera control-->
     <Reference Include="Interop.WIA, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -28,12 +28,12 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
   <ItemGroup>
     <PackageReference Include="DialogAdapters" Version="0.1.3.26068" />
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
+    <PackageReference Include="L10NSharp" Version="4.0.0" />
+    <PackageReference Include="MarkdownDeep.NET.Patched" Version="1.5.0.1" />
+    <PackageReference Include="TagLibSharp" Version="2.2.0" />
     <PackageReference Include="GitVersionTask" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="L10NSharp" Version="4.0.0" />
-    <PackageReference Include="MarkdownDeep.NET.Patched" Version="1.5.0.1" />
-    <PackageReference Include="NAudio" Version="1.8.4" />
     <PackageReference Include="SIL.BuildTasks" Version="[2.2.0,)">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -43,7 +43,9 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="StrongNamer" Version="0.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="TagLibSharp" Version="2.2.0" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.18">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -9,7 +9,6 @@
   <package id="L10NSharp" version="4.0.0" targetFramework="net461" />
   <package id="MarkdownDeep.NET.Patched" version="1.5.0.1" targetFramework="net461" />
   <package id="Mono.Posix" version="5.4.0.201" requireReinstallation="true" />
-  <package id="NAudio" version="1.8.4" targetFramework="net461" />
   <package id="SIL.BuildTasks" version="1.0.0" targetFramework="net461" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
We have some unsigned dependencies that we sign on-the-fly during
the build. However, this makes it difficult for clients to use
the library. This change uses ILRepack to merge these dependent
assemblies.

NOTE: there is still a similar problem with `ibusdotnet.dll`. We can't
merge that because it appears in the API. The solution here will be
to create a nuget package version with signed `ibusdotnet.dll`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/869)
<!-- Reviewable:end -->
