### PR TITLE
Fix missing irrKlang.NET4 exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] Merge missing `Keyman*Interop.dll` into the assembly (#865)
 - [SIL.Windows.Forms] Use signed version of `ibusdotnet.dll` (#865)
 - [SIL.Windows.Forms] Merge `Interop.WIA.dll`, `DialogAdapters.dll`, and `MarkdownDeep.dll` into the assembly
+- [SIL.Media] Fix missing `irrKlang.NET4.dll` exception by copying it to lib folder in output
 
 ## [7.0.0] - 2019-08-29
 

--- a/SIL.Media/SIL.Media.targets
+++ b/SIL.Media/SIL.Media.targets
@@ -1,7 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)**\*.dll"
-          Exclude="$(MSBuildThisFileDirectory)**\irrKlang.NET4.dll">
+    <None Include="$(MSBuildThisFileDirectory)**\*.dll">
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
The irrKlang.NET4.dll comes in different versions for 32- and 64-bit.
Copying it to the respective directory in the `lib` subdirectory of
the client's output directory allows the client application to pick
up the correct version at runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/876)
<!-- Reviewable:end -->
