### PR TITLE
Improvements in ExceptionHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- [SIL.Core] and [SIL.Core.Desktop] Moved several classes back to SIL.Core from SIL.Core.Desktop to make them available to .NET Standard clients.
+- Add build number to AssemblyFileVersion
+- [SIL.Core] and [SIL.Core.Desktop] Move several classes back to SIL.Core from SIL.Core.Desktop to make
+  them available to .NET Standard clients.
   - IO/PathUtilities
   - IO/TempFileForSafeWriting
   - Reporting/AnalyticsEventSender
@@ -31,8 +33,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Reporting/Logger
   - Reporting/ReportingSettings
   - Reporting/UsageReporter
-- Add build number to AssemblyFileVersion
-- [SIL.Windows.Forms] Removed unnecessary dependency on NAudio
+- [SIL.Windows.Forms] Remove unnecessary dependency on NAudio
+- [SIL.Core] Deprecate `ExceptionHandler.Init()` method in favor of more explicit version
+  `ExceptionHandler.Init(ExceptionHandler)`, e.g. `ExceptionHandler.Init(new WinFormsExceptionHandler())`
+- [SIL.Core] Move `HandleUnhandledException()` method from derived classes to base class
 
 ### Fixed
 

--- a/SIL.Core.Tests/IO/PathUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/PathUtilitiesTests.cs
@@ -78,9 +78,9 @@ namespace SIL.Tests.IO
 					var lines = metaFileContent.Split('\n');
 					Assert.That(lines.Length, Is.GreaterThanOrEqualTo(3));
 					Assert.That(lines[0], Is.EqualTo("[Trash Info]"));
-					Assert.That(lines[1], Is.StringStarting("Path="));
-					Assert.That(lines[1], Is.StringEnding(file));
-					Assert.That(lines[2], Is.StringMatching(@"DeletionDate=\d\d\d\d\d\d\d\dT\d\d:\d\d:\d\d"));
+					Assert.That(lines[1], Does.StartWith("Path="));
+					Assert.That(lines[1], Does.EndWith(file));
+					Assert.That(lines[2], Does.Match(@"DeletionDate=\d\d\d\d\d\d\d\dT\d\d:\d\d:\d\d"));
 				}
 			}
 		}
@@ -145,7 +145,7 @@ namespace SIL.Tests.IO
 		[Test, Ignore("By Hand")]
 		public void OpenDirectoryInExplorer_PathIsADirectoryHasCombiningCharacters_StillOpens()
 		{
-			//as of May 27 2015, this is expected to fail on Windows. See enhancment note 
+			//as of May 27 2015, this is expected to fail on Windows. See enhancement note
 			//in the OpenDirectoryInExplorer() code.
 			var path = Path.Combine(Path.GetTempPath(), "ปู should select this directory");
 			if(!Directory.Exists(path))

--- a/SIL.Core.Tests/Reporting/ExceptionHandlerTests.cs
+++ b/SIL.Core.Tests/Reporting/ExceptionHandlerTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+using System;
+using NUnit.Framework;
+using SIL.Reporting;
+// ReSharper disable ConvertClosureToMethodGroup
+
+namespace SIL.Tests
+{
+	[TestFixture]
+	public class ExceptionHandlerTests
+	{
+		private class TestExceptionHandler : ExceptionHandler
+		{
+			public static Exception ReceivedException { get; set; }
+
+			protected override bool ShowUI => false;
+			protected override bool DisplayError(Exception exception)
+			{
+				ReceivedException = exception;
+				return true;
+			}
+		}
+
+		private class ExceptionHandlerHelper : ExceptionHandler
+		{
+			public static void ReportException(Exception exception)
+			{
+				HandleUnhandledExceptionOnSingleton(new UnhandledExceptionEventArgs(exception, false));
+			}
+
+			public static void Reset()
+			{
+				ResetSingleton();
+			}
+
+			protected override bool ShowUI => false;
+			protected override bool DisplayError(Exception exception)
+			{
+				return false;
+			}
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			ExceptionHandlerHelper.Reset();
+		}
+
+		[Test]
+		public void Init()
+		{
+			// Execute
+			ExceptionHandler.Init(new TestExceptionHandler());
+
+			// Verify
+			var exception = new ArgumentOutOfRangeException();
+			ExceptionHandlerHelper.ReportException(exception);
+			Assert.That(TestExceptionHandler.ReceivedException, Is.EqualTo(exception));
+		}
+
+		[Test]
+		public void Init_ThrowsIfAlreadyInitialized()
+		{
+			// Setup
+			ExceptionHandler.Init(new ConsoleExceptionHandler());
+
+			// Execute
+			Assert.That(() => ExceptionHandler.Init(new TestExceptionHandler()),
+				Throws.InvalidOperationException.With.Message.Contains(nameof(ConsoleExceptionHandler)));
+		}
+	}
+}

--- a/SIL.Core/Reporting/ConsoleExceptionHandler.cs
+++ b/SIL.Core/Reporting/ConsoleExceptionHandler.cs
@@ -17,23 +17,6 @@ namespace SIL.Reporting
 			AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
 		}
 
-		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// Catches and displays otherwise unhandled exception, especially those that happen
-		/// during startup of the application before we show our main window.
-		/// </summary>
-		/// ------------------------------------------------------------------------------------
-		protected void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)
-		{
-			if (!GetShouldHandleException(sender, e.ExceptionObject as Exception))
-				return;
-
-			if (e.ExceptionObject is Exception)
-				DisplayError(e.ExceptionObject as Exception);
-			else
-				DisplayError(new ApplicationException("Got unknown exception"));
-		}
-
 		protected override bool ShowUI
 		{
 			get { return false; }

--- a/SIL.Core/Reporting/ConsoleExceptionHandler.cs
+++ b/SIL.Core/Reporting/ConsoleExceptionHandler.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace SIL.Reporting
 {
@@ -17,87 +19,44 @@ namespace SIL.Reporting
 			AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
 		}
 
-		protected override bool ShowUI
-		{
-			get { return false; }
-		}
+		protected override bool ShowUI => false;
 
 		protected override bool DisplayError(Exception exception)
 		{
-
+			try
 			{
-				//try
-				//{
-				//    if (exception.InnerException != null)
-				//    {
-				//        Debug.WriteLine(string.Format("Exception: {0} {1}", exception.Message, exception.InnerException.Message));
-				//        Logger.WriteEvent("Exception: {0} {1}", exception.Message, exception.InnerException.Message);
-				//    }
-				//    else
-				//    {
-				//        Debug.WriteLine(String.Format("Exception: {0}", exception.Message));
-				//        Logger.WriteEvent("Exception: {0}", exception.Message);
-				//    }
+				if (exception.InnerException != null)
+				{
+					Debug.WriteLine(
+						$"Exception: {exception.Message} {exception.InnerException.Message}");
+					Logger.WriteError(exception.Message, exception.InnerException);
+				}
+				else
+				{
+					Debug.WriteLine($"Exception: {exception.Message}");
+					Logger.WriteError(exception.Message, exception);
+				}
 
-				//    if (exception is ExternalException
-				//        && (uint)(((ExternalException)exception).ErrorCode) == 0x8007000E) // E_OUTOFMEMORY
-				//    {
-				//        if (showUI)
-				//            ExceptionReportingDialog.ReportException(exception);//, parent);
-				//        else
-				//        {
-				//            Trace.Fail("Out of memory");
-				//            //                        Trace.Assert(false, FwApp.GetResourceString("kstidMiscError"),
-				//            //                            FwApp.GetResourceString("kstidOutOfMemory"));
-				//        }
-				//    }
-				//    else
-				//    {
-				//        Debug.Assert(exception.Message != string.Empty || exception is COMException,
-				//            "Oops - we got an empty exception description. Change the code to handle that!");
-
-				//        if (showUI)
-				//        {
-				//            // bool fIsLethal = !(exception is Reporting.ConfigurationException);
-				//            //ErrorReporter.ReportException(exception, parent, fIsLethal);
-				//            ExceptionReportingDialog.ReportException(exception);
-				//            return false;
-				//        }
-				//        else
-				//        {
-				//            //todo: the reporting component should do all this, too
-				//            /*                       Exception innerE = ExceptionHelper.GetInnerMostException(exception);
-				//                                   string strMessage = "Error: "; // FwApp.GetResourceString("kstidProgError") + FwApp.GetResourceString("kstidFatalError");
-				//                                   string strVersion;
-				//                                   Assembly assembly = Assembly.GetEntryAssembly();
-				//                                   object[] attributes = null;
-				//                                   if (assembly != null)
-				//                                       attributes = assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false);
-				//                                   if (attributes != null && attributes.Length > 0)
-				//                                       strVersion = ((AssemblyFileVersionAttribute)attributes[0]).Version;
-				//                                   else
-				//                                       strVersion = Application.ProductVersion;
-				//                                   string strReport = string.Format(
-				//                                       "Got Exception", //"FwApp.GetResourceString("kstidGotException"),
-				//                                       "errors@wesay.org", //"FwApp.GetResourceString("kstidSupportEmail"),
-
-				//                                       exception.Source, strVersion,
-				//                                       ExceptionHelper.GetAllExceptionMessages(exception), innerE.Source,
-				//                                       innerE.TargetSite.Name, ExceptionHelper.GetAllStackTraces(exception));
-				//                                   Trace.Assert(false, strMessage, strReport);
-				//            */
-
-				//            Debug.Fail(exception.Message);
-				//        }
-				//    }
-
-				//}
-				//catch (Exception)
-				//{
-				//    Debug.Fail("This error could not be reported normally: ", exception.Message);
-				//}
-				return true;
+				if (exception is ExternalException externalException
+					&& (uint) (externalException.ErrorCode) == 0x8007000E) // E_OUTOFMEMORY
+				{
+					Debug.WriteLine("Out of memory");
+					Logger.WriteEvent("Out of memory");
+				}
+				else
+				{
+					Debug.Assert(
+						exception.Message != string.Empty || exception is COMException,
+						"Oops - we got an empty exception description. Change the code to handle that!");
+				}
 			}
+			catch (Exception)
+			{
+				Logger.WriteEvent($"This error could not be reported normally: ${exception.Message}");
+				Debug.Fail("This error could not be reported normally: ", exception.Message);
+			}
+
+			return true;
 		}
 	}
 }

--- a/SIL.Core/Reporting/ExceptionHandler.cs
+++ b/SIL.Core/Reporting/ExceptionHandler.cs
@@ -24,33 +24,33 @@ namespace SIL.Reporting
 		//ExceptionHandler from there through Reflection. Otherwise we will simply use a console
 		//exception handler
 		/// <summary>
-		/// Initialize the ExceptionHandler. By default, the exceptionhandler will be initialized with a ConsoleExceptionHandler
-		/// unless he entry assembly uses a dependency on SIL.Windows.Forms.dll. In that case we default to the WinFormsExceptionHandler
+		/// Initialize the ExceptionHandler. By default, the exception handler will be initialized with a ConsoleExceptionHandler
+		/// unless the entry assembly uses a dependency on SIL.Windows.Forms.dll. In that case we default to the WinFormsExceptionHandler
 		/// </summary>
+		[Obsolete("Use Init(ExceptionHandler) instead, e.g. Init(new ConsoleExceptionHandler()) or Init(new WinFormsExceptionHandler())")]
 		public static void Init()
 		{
-			if (_singleton == null)
-			{
-				//If we can't find the WinFormsExceptionHandler we'll use the Console
-				_singleton = GetObjectFromSilWindowsForms<ExceptionHandler>() ?? new ConsoleExceptionHandler();
-			}
-			else { throw new InvalidOperationException("An ExceptionHandler has already been set."); }
+			if (_singleton != null)
+				throw new InvalidOperationException($"An ExceptionHandler (of type ${_singleton.GetType()}) has already been set.");
+
+			//If we can't find the WinFormsExceptionHandler we'll use the Console
+			_singleton = GetObjectFromSilWindowsForms<ExceptionHandler>() ?? new ConsoleExceptionHandler();
 		}
 
 		/// <summary>
-		/// Use this method if you want to use an exeption handler besides the default.
-		/// This method should be called only once
+		/// Initialize the ExceptionHandler. This method should be called only once.
 		/// </summary>
-		/// <param name="handler"></param>
+		/// <param name="handler">The ExceptionHandler object. Predefined exception handlers are
+		/// ConsoleExceptionHandler and WinFormsExceptionHandler.</param>
 		public static void Init(ExceptionHandler handler)
 		{
-			if (_singleton == null)
-			{
-				_singleton = handler;
-			}
-			else{throw new InvalidOperationException("An ExceptionHandler has already been set.");}
+			if (_singleton != null)
+				throw new InvalidOperationException($"An ExceptionHandler (of type ${_singleton.GetType()}) has already been set.");
+
+			_singleton = handler;
 		}
 
+		// ReSharper disable once MemberCanBePrivate.Global
 		/// <summary>
 		/// Get all the types we can load from the assembly.
 		/// In case we can't load a particular type (e.g., TextBoxSpellChecker, because the
@@ -120,6 +120,7 @@ namespace SIL.Reporting
 			return null;
 		}
 
+		// ReSharper disable once MemberCanBePrivate.Global
 		/// ------------------------------------------------------------------------------------
 		public static bool Suspend { set; get; }
 
@@ -136,6 +137,7 @@ namespace SIL.Reporting
 			return (_singleton != null && _singleton._errorHandlerDelegates.Remove(errorHandlerDelegate));
 		}
 
+		// ReSharper disable once MemberCanBePrivate.Global
 		/// ------------------------------------------------------------------------------------
 		protected bool GetShouldHandleException(object sender, Exception error)
 		{
@@ -153,19 +155,20 @@ namespace SIL.Reporting
 			return true;
 		}
 
-		//// ------------------------------------------------------------------------------------
-		///// <summary>
-		///// Shows the error message of the exception to the user.
-		///// </summary>
-		///// <returns><c>true</c> to exit application, <c>false</c> to continue</returns>
-		///// ------------------------------------------------------------------------------------
-		////        protected bool DisplayError(Exception exception)
-		////        {
-		////  //review
-		////            //          Form form = (m_rgMainWindows.Count > 0 ? m_rgMainWindows[0] as Form : null);
-		////    //        return DisplayError(exception, form);
-		////            return DisplayError(exception, Application.m);
-		////        }
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Catches and displays otherwise unhandled exception, especially those that happen
+		/// during startup of the application before we show our main window.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		protected void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)
+		{
+			var exception = e.ExceptionObject as Exception;
+			if (!GetShouldHandleException(sender, exception))
+				return;
+
+			DisplayError(exception ?? new ApplicationException("Got unknown exception"));
+		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -188,11 +191,22 @@ namespace SIL.Reporting
 		/// <returns></returns>
 		/// ------------------------------------------------------------------------------------
 		protected abstract bool DisplayError(Exception exception);
+
+		protected static void HandleUnhandledExceptionOnSingleton(UnhandledExceptionEventArgs e)
+		{
+			_singleton.HandleUnhandledException(null, e);
+		}
+
+		protected static void ResetSingleton()
+		{
+			_singleton = null;
+		}
 	}
 
 	/// ----------------------------------------------------------------------------------------
 	public class CancelExceptionHandlingEventArgs : CancelEventArgs
 	{
+		// ReSharper disable once MemberCanBePrivate.Global
 		/// ------------------------------------------------------------------------------------
 		public Exception Exception { get; private set; }
 

--- a/SIL.Linux.Logging/SyslogExceptionHandler.cs
+++ b/SIL.Linux.Logging/SyslogExceptionHandler.cs
@@ -24,21 +24,7 @@ namespace SIL.Linux.Logging
 			AppDomain.CurrentDomain.UnhandledException += HandleUnhandledException;
 		}
 
-		protected void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)
-		{
-			if (!GetShouldHandleException(sender, e.ExceptionObject as Exception))
-				return;
-
-			if (e.ExceptionObject is Exception)
-				DisplayError(e.ExceptionObject as Exception);
-			else
-				DisplayError(new ApplicationException("Got unknown exception"));
-		}
-
-		protected override bool ShowUI
-		{
-			get { return false; }
-		}
+		protected override bool ShowUI => false;
 
 		protected override bool DisplayError(Exception exception)
 		{
@@ -52,7 +38,7 @@ namespace SIL.Linux.Logging
 			/* Commented out: Adding platform properties is unnecessary since ErrorReport's OSVersion property will tell us more anyway
 			errors.Add("Platform properties for above exception:");
 			foreach (PropertyInfo property in typeof(Platform).GetProperties())
-			{ 
+			{
 				errors.Add(String.Format("{0}: {1}", property.Name, property.GetValue(typeof(Platform), null)));
 			}
 			*/

--- a/SIL.Windows.Forms/Reporting/WinFormsExceptionHandler.cs
+++ b/SIL.Windows.Forms/Reporting/WinFormsExceptionHandler.cs
@@ -67,24 +67,6 @@ namespace SIL.Windows.Forms.Reporting
 			}
 		}
 
-		/// ------------------------------------------------------------------------------------
-		/// <summary>
-		/// Catches and displays otherwise unhandled exception, especially those that happen
-		/// during startup of the application before we show our main window.
-		/// </summary>
-		/// ------------------------------------------------------------------------------------
-		protected void HandleUnhandledException(object sender, UnhandledExceptionEventArgs e)
-		{
-			var exception = e.ExceptionObject as Exception;
-			if (!GetShouldHandleException(sender, exception))
-				return;
-
-			if (exception != null)
-				DisplayError(exception);
-			else
-				DisplayError(new ApplicationException("Got unknown exception"));
-		}
-
 		protected override bool ShowUI
 		{
 			get


### PR DESCRIPTION
##  [SIL.Core] Deprecate ExceptionHandler.Init()

- Deprecate `ExceptionHandler.Init()`. Clients should use `ExceptionHandler.Init(ExceptionHandler)` 
  instead.
- Move `HandleUnhandledException()` to base class
- Add some unit tests

### Why deprecate `ExceptionHandler.Init()`?

In `ExeceptionHandler.Init()` so far we used reflection to load `WinFormsExceptionHandler` from `SIL.Windows.Forms.dll`. If we couldn't load that assembly we used `ConsoleExceptionHandler` instead. While this is convenient for the client it can hide problems when the client partially updates to use a newer version of the libpalaso assemblies. In particular the client app seems to work unless it gets an exception, in which case it still works but doesn't show the expected green screen for error reporting. Using `ExceptionHandler.Init(new WinFormsExceptionHandler())` instead will allow to catch the incompatibilities at compile time.

## [SIL.Core] Improve NUnit 3 compatibility

## [SIL.Core] Improve ConsoleExceptionHandler.DisplayError

Output at least some information in DisplayError.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/878)
<!-- Reviewable:end -->
