### PR TITLE
Provide access to LanguageLookupModel's LanguageLookup object

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupModel.cs
@@ -18,6 +18,11 @@ namespace SIL.Windows.Forms.WritingSystems
 
 		public Func<LanguageInfo, bool> MatchingLanguageFilter { get; set; }
 
+		public LanguageLookup LanguageLookup
+		{
+			get { return _languageLookup; }
+		}
+
 		public string SearchText
 		{
 			get { return _searchText; }


### PR DESCRIPTION
This is needed for Bloom to avoid instantiating a separate object or
using reflection to obtain a private object.