### PR TITLE
Handle multiple unsupported keyboards

### DIFF
--- a/SIL.Core/Keyboarding/UnsupportedKeyboardDefinition.cs
+++ b/SIL.Core/Keyboarding/UnsupportedKeyboardDefinition.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SIL.Keyboarding
+{
+	/// <summary>
+	/// This class represents an unsupported or unrecognized keyboard definition.
+	/// It allows round tripping unrecognized keyboard formats to ldml
+	/// </summary>
+	public class UnsupportedKeyboardDefinition : DefaultKeyboardDefinition
+	{
+		public UnsupportedKeyboardDefinition(string id) : base(id, "(default)")
+		{
+			IsAvailable = false;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return Id == (obj as UnsupportedKeyboardDefinition)?.Id;
+		}
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -32,13 +32,7 @@ namespace SIL.Windows.Forms.Keyboarding
 		/// The null keyboard description
 		/// </summary>
 		public static readonly KeyboardDescription NullKeyboard = new NullKeyboardDescription();
-
-		private static KeyboardController _instance;
-
-		internal static KeyboardController Instance
-		{
-			get { return _instance; }
-		}
+		internal static KeyboardController Instance { get; private set; }
 
 		/// <summary>
 		/// Enables keyboarding. This should be called during application startup.
@@ -52,14 +46,14 @@ namespace SIL.Windows.Forms.Keyboarding
 			// global.
 			try
 			{
-				if (_instance != null)
+				if (Instance != null)
 					Shutdown();
-				_instance = new KeyboardController();
-				Keyboard.Controller = _instance;
+				Instance = new KeyboardController();
+				Keyboard.Controller = Instance;
 				if (adaptors.Length == 0)
-					_instance.SetDefaultKeyboardAdaptors();
+					Instance.SetDefaultKeyboardAdaptors();
 				else
-					_instance.SetKeyboardAdaptors(adaptors);
+					Instance.SetKeyboardAdaptors(adaptors);
 			}
 			catch (Exception e)
 			{
@@ -80,17 +74,17 @@ namespace SIL.Windows.Forms.Keyboarding
 		/// </summary>
 		public static void Shutdown()
 		{
-			if (_instance == null)
+			if (Instance == null)
 				return;
 
-			_instance.Dispose();
+			Instance.Dispose();
 			Keyboard.Controller = null;
 		}
 
 		/// <summary>
 		/// Returns <c>true</c> if KeyboardController.Initialize() got called before.
 		/// </summary>
-		public static bool IsInitialized { get { return _instance != null; } }
+		public static bool IsInitialized { get { return Instance != null; } }
 
 		/// <summary>
 		/// Register the control for keyboarding, optionally providing an event handler for
@@ -101,9 +95,9 @@ namespace SIL.Windows.Forms.Keyboarding
 		/// </summary>
 		public static void RegisterControl(Control control, object eventHandler = null)
 		{
-			_instance._eventHandlers[control] = eventHandler;
-			if (_instance.ControlAdded != null)
-				_instance.ControlAdded(_instance, new RegisterEventArgs(control, eventHandler));
+			Instance._eventHandlers[control] = eventHandler;
+			if (Instance.ControlAdded != null)
+				Instance.ControlAdded(Instance, new RegisterEventArgs(control, eventHandler));
 		}
 
 		/// <summary>
@@ -113,20 +107,20 @@ namespace SIL.Windows.Forms.Keyboarding
 		/// </summary>
 		public static void UnregisterControl(Control control)
 		{
-			if (_instance.ControlRemoving != null)
-				_instance.ControlRemoving(_instance, new ControlEventArgs(control));
-			_instance._eventHandlers.Remove(control);
+			if (Instance.ControlRemoving != null)
+				Instance.ControlRemoving(Instance, new ControlEventArgs(control));
+			Instance._eventHandlers.Remove(control);
 		}
 		/// <summary/>
 		/// <returns>An action that will bring up the keyboard setup application dialog</returns>
 		public static Action GetKeyboardSetupApplication()
 		{
 			Action program = null;
-			if (!HasSecondaryKeyboardSetupApplication && _instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm))
-				program = _instance.Adaptors[KeyboardAdaptorType.OtherIm].GetKeyboardSetupAction();
+			if (!HasSecondaryKeyboardSetupApplication && Instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm))
+				program = Instance.Adaptors[KeyboardAdaptorType.OtherIm].GetKeyboardSetupAction();
 
 			if (program == null)
-				program = _instance.Adaptors[KeyboardAdaptorType.System].GetKeyboardSetupAction();
+				program = Instance.Adaptors[KeyboardAdaptorType.System].GetKeyboardSetupAction();
 
 			return program;
 		}
@@ -134,8 +128,8 @@ namespace SIL.Windows.Forms.Keyboarding
 		public static Action GetSecondaryKeyboardSetupApplication()
 		{
 			Action program = null;
-			if (HasSecondaryKeyboardSetupApplication && _instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm))
-				program = _instance.Adaptors[KeyboardAdaptorType.OtherIm].GetKeyboardSetupAction();
+			if (HasSecondaryKeyboardSetupApplication && Instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm))
+				program = Instance.Adaptors[KeyboardAdaptorType.OtherIm].GetKeyboardSetupAction();
 
 			return program;
 		}
@@ -148,8 +142,8 @@ namespace SIL.Windows.Forms.Keyboarding
 		{
 			get
 			{
-				return _instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm) &&
-					_instance.Adaptors[KeyboardAdaptorType.OtherIm].IsSecondaryKeyboardSetupApplication;
+				return Instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm) &&
+					Instance.Adaptors[KeyboardAdaptorType.OtherIm].IsSecondaryKeyboardSetupApplication;
 			}
 		}
 
@@ -474,7 +468,7 @@ namespace SIL.Windows.Forms.Keyboarding
 				if (firstCompatibleAdapter == null)
 				{
 					Debug.Fail(string.Format("Could not load keyboard for {0}. Did not find {1} in {2} adapters", id, format, _adaptors.Count));
-					return NullKeyboard;
+					return new UnsupportedKeyboardDefinition(id);
 				}
 				keyboard = firstCompatibleAdapter.CreateKeyboardDefinition(id);
 				_keyboards.Add(keyboard);

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardUtils.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardUtils.cs
@@ -101,8 +101,8 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 		/// </summary>
 		internal static KeyboardDescription GetKeyboardDescription(IInputLanguage inputLanguage)
 		{
-			KeyboardDescription sameLayout = KeyboardController.NullKeyboard;
-			KeyboardDescription sameCulture = KeyboardController.NullKeyboard;
+			KeyboardDescription sameLayout = null;
+			KeyboardDescription sameCulture = null;
 			// TODO: write some tests
 			string requestedLayout = GetLayoutNameEx(inputLanguage.Handle).Name;
 			foreach (WinKeyboardDescription keyboardDescription in KeyboardController.Instance.AvailableKeyboards.OfType<WinKeyboardDescription>())
@@ -126,7 +126,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 					// http://www.ironspeed.com/Designer/3.2.4/WebHelp/Part_VI/Culture_ID__XXX__is_not_a_supported_culture.htm and others
 				}
 			}
-			return sameLayout ?? sameCulture;
+			return sameLayout ?? sameCulture ?? KeyboardController.NullKeyboard;
 		}
 
 		/// <summary>

--- a/SIL.WritingSystems.Tests/LdmlContentForTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlContentForTests.cs
@@ -658,6 +658,18 @@ namespace SIL.WritingSystems.Tests
 		</sil:external-resources>
 	</special>".Replace("'", "\"");
 
+		public static string TwoKeyboardElems = @"
+	<special xmlns:sil='urn://www.sil.org/ldml/0.1'>
+		<sil:external-resources>
+			<sil:kbd id='basic_kbdgr' type='kmp'>
+				<sil:url draft='generated'>https://keyman.com/go/keyboard/basic_kbdgr/download/kmp</sil:url>
+			</sil:kbd>
+			<sil:kbd id='sil_euro_latin' type='kmp'>
+				<sil:url draft='generated'>https://keyman.com/go/keyboard/sil_euro_latin/download/kmp</sil:url>
+			</sil:kbd>
+		</sil:external-resources>
+	</special>".Replace("'", "\"");
+
 		/// <summary>
 		/// Minimal LDML for version 3
 		/// </summary>

--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -200,7 +200,8 @@ namespace SIL.WritingSystems.Tests
 			{
 				var kbElem = LdmlContentForTests.KeyboardElem.Replace("kmx", "fakekeyboardtype");
 				var ldmlWithFakeKbType = LdmlContentForTests.CurrentVersion("so", "", "", "", kbElem);
-				StringAssert.Contains("type=\"fakekeyboardtype\"", ldmlWithFakeKbType, "The test data is not valid for this unit test anymore.");
+				Assert.That(ldmlWithFakeKbType, Is.StringContaining("type=\"fakekeyboardtype\""),
+					"The test data is not valid for this unit test anymore.");
 				var adaptor = new LdmlDataMapper(new TestWritingSystemFactory());
 				var sw = new StringWriter();
 				var ws = new WritingSystemDefinition("en");
@@ -212,8 +213,52 @@ namespace SIL.WritingSystems.Tests
 			}
 		}
 
-		#region Roundtrip
 		[Test]
+		public void ExistingLdml_UnhandledKeyboards_Write_PreservesData()
+		{
+			using (var environment = new TestEnvironment())
+			{
+				var ldmlWith2Keyboards = LdmlContentForTests.CurrentVersion("so", "", "", "",
+					LdmlContentForTests.TwoKeyboardElems);
+				Assert.That(ldmlWith2Keyboards, Is.StringContaining("id=\"basic_kbdgr\""),
+					"The test data is not valid for this unit test anymore.");
+				Assert.That(ldmlWith2Keyboards, Is.StringContaining("id=\"sil_euro_latin\""),
+					"The test data is not valid for this unit test anymore.");
+				var adaptor = new LdmlDataMapper(new TestWritingSystemFactory());
+				var sw = new StringWriter();
+				var ws = new WritingSystemDefinition("en");
+				// Adding UnsupportedKeyboardDefinition files simulates keyboards that can't be handled by any KeyboardAdapter
+				ws.KnownKeyboards.Add(new UnsupportedKeyboardDefinition("basic_kbdgr"));
+				ws.KnownKeyboards.Add(new UnsupportedKeyboardDefinition("sil_euro_latin"));
+				var writer = XmlWriter.Create(sw, CanonicalXmlSettings.CreateXmlWriterSettings());
+				adaptor.Write(writer, ws, XmlReader.Create(new StringReader(ldmlWith2Keyboards)));
+				writer.Close();
+				AssertThatXmlIn.String(sw.ToString()).HasSpecifiedNumberOfMatchesForXpath(
+					"/ldml/special/sil:external-resources/sil:kbd",
+					2, true, environment.NamespaceManager);
+			}
+		}
+
+		[Test]
+		public void ExistingLdml_UnsupportedKeyboardType_Write_PreservesData()
+		{
+			using (var environment = new TestEnvironment())
+			{
+				var kbElem = LdmlContentForTests.KeyboardElem;
+				var ldmlWithFakeKbType = LdmlContentForTests.CurrentVersion("so", "", "", "", kbElem).Replace("kmx", "unknown");
+				var adaptor = new LdmlDataMapper(new TestWritingSystemFactory());
+				var sw = new StringWriter();
+				var ws = new WritingSystemDefinition("en");
+				var writer = XmlWriter.Create(sw, CanonicalXmlSettings.CreateXmlWriterSettings());
+				adaptor.Write(writer, ws, XmlReader.Create(new StringReader(ldmlWithFakeKbType)));
+				writer.Close();
+				AssertThatXmlIn.String(sw.ToString()).HasSpecifiedNumberOfMatchesForXpath("/ldml/special/sil:external-resources/sil:kbd",
+					1, environment.NamespaceManager);
+			}
+		}
+
+	  #region Roundtrip
+	  [Test]
 		public void RoundtripSimpleCustomSortRules_WS33715()
 		{
 			var ldmlAdaptor = new LdmlDataMapper(new TestWritingSystemFactory());

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -509,7 +509,10 @@ namespace SIL.WritingSystems
 						format = KeyboardFormat.Unknown;
 					}
 					IKeyboardDefinition keyboard = Keyboard.Controller.CreateKeyboard(id, format, kbdElem.NonAltElements(Sil + "url").Select(u => (string) u));
-					ws.KnownKeyboards.Add(keyboard);
+					if (!ws.KnownKeyboards.Contains(keyboard))
+					{
+						ws.KnownKeyboards.Add(keyboard);
+					}
 				}
 			}
 		}
@@ -1480,12 +1483,15 @@ namespace SIL.WritingSystems
 		{
 			Debug.Assert(externalResourcesElem != null);
 			Debug.Assert(ws != null);
-			
+
+			var unsupportedKeyboards =
+				ws.KnownKeyboards.Where(kb => kb is UnsupportedKeyboardDefinition).Select(k => k.Id).ToArray();
 			// Remove sil:kbd elements to repopulate later if they are 'known' keyboard types
 			externalResourcesElem.NonAltElements(Sil + "kbd")
-				.Where(elem => !elem.HasAttributes
+				.Where(elem => (!elem.HasAttributes
 					|| elem.Attribute("type") == null
-					|| KeyboardToKeyboardFormat.ContainsKey(elem.Attribute("type").Value)).Remove();
+					|| KeyboardToKeyboardFormat.ContainsKey(elem.Attribute("type").Value))
+					&& !unsupportedKeyboards.Contains(elem.Attribute("id")?.Value)).Remove();
 
 			// Don't include unknown system keyboard definitions
 			foreach (IKeyboardDefinition keyboard in ws.KnownKeyboards.Where(kbd=>kbd.Format != KeyboardFormat.Unknown))


### PR DESCRIPTION
* Don't crash if two unsupported keyboards are
  found in an ldml file
* Support round tripping unsupported keyboards to ldml
* Refactor NullKeyboard functionality to allow detecting an
  unsupported keyboard and round tripping

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/886)
<!-- Reviewable:end -->
