### PR TITLE
Hopefully fix symbol package for some projects

### DIFF
--- a/SIL.Archiving/SIL.Archiving-Designer.csproj
+++ b/SIL.Archiving/SIL.Archiving-Designer.csproj
@@ -31,7 +31,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Media.Tests/SIL.Media.Tests-Designer.csproj
+++ b/SIL.Media.Tests/SIL.Media.Tests-Designer.csproj
@@ -38,7 +38,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Media/SIL.Media-Designer.csproj
+++ b/SIL.Media/SIL.Media-Designer.csproj
@@ -53,7 +53,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle-Designer.csproj
+++ b/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle-Designer.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/SIL.Windows.Forms.GeckoBrowserAdapter-Designer.csproj
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/SIL.Windows.Forms.GeckoBrowserAdapter-Designer.csproj
@@ -30,7 +30,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>

--- a/SIL.Windows.Forms.Scripture/SIL.Windows.Forms.Scripture-Designer.csproj
+++ b/SIL.Windows.Forms.Scripture/SIL.Windows.Forms.Scripture-Designer.csproj
@@ -52,7 +52,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests-Designer.csproj
+++ b/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests-Designer.csproj
@@ -50,7 +50,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems-Designer.csproj
+++ b/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems-Designer.csproj
@@ -33,7 +33,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
@@ -55,7 +55,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/TestApps/FastSplitterTest/FastSplitterTest-Designer.csproj
+++ b/TestApps/FastSplitterTest/FastSplitterTest-Designer.csproj
@@ -41,7 +41,7 @@
     <OutputPath>bin-Designer\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisLogFile>bin\Release\FastSplitterTest.exe.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>

--- a/TestApps/ReportingTest/Reporting.TestApp-Designer.csproj
+++ b/TestApps/ReportingTest/Reporting.TestApp-Designer.csproj
@@ -54,7 +54,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\$(Configuration)</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/TestApps/SIL.Email.TestApp/SIL.Email.TestApp-Designer.csproj
+++ b/TestApps/SIL.Email.TestApp/SIL.Email.TestApp-Designer.csproj
@@ -36,7 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp-Designer.csproj
+++ b/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp-Designer.csproj
@@ -36,7 +36,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\Release\</OutputPath>
     <DefineConstants>TRACE;TESTING_WS</DefineConstants>

--- a/TestApps/TestAppKeyboard/TestAppKeyboard-Designer.csproj
+++ b/TestApps/TestAppKeyboard/TestAppKeyboard-Designer.csproj
@@ -51,7 +51,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin-Designer\$(Configuration)</OutputPath>
     <DefineConstants>TRACE</DefineConstants>


### PR DESCRIPTION
The nuget symbol packages for some projects fail validation after
uploading to nuget.org with the message: "The uploaded symbols
package contains one or more pdbs that are not portable." The
.csproj files specifies to use portable pdbs, but the Designer.csproj
files did not. Hopefully changing those as well will allow all
symbol packages to upload successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/893)
<!-- Reviewable:end -->
