### PR TITLE
BL-8082/8097 Don't lose Script/Region/Variant info

### DIFF
--- a/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupControlTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/LanguageLookupControlTests.cs
@@ -95,25 +95,61 @@ namespace SIL.Windows.Forms.WritingSystems.Tests
 
 		[Test, Ignore("By Hand")]
 		[Category("SkipOnTeamCity")]
-		public void TestLanguageLookupDialog_manualTest()
+		public void TestLanguageLookupDialog_manualTest_Ojicree()
 		{
-			const string testLangCode = "sok-x-easy";
-			const string testLangThreeLetterCode = "sok";
-			const string testLangName = "Sokoro";
+			const string testLangCode = "ojs-Latn-CA";
+			const string testLangThreeLetterCode = "ojs";
+			const string testLangName = "Ojibwa, Severn";
 			using (var dlg = new LanguageLookupDialog())
 			{
 				dlg.IsDesiredLanguageNameFieldVisible = true;
 				dlg.IsShowRegionalDialectsCheckBoxVisible = true;
 				dlg.IsScriptAndVariantLinkVisible = true;
 
-				var language = new LanguageInfo() { LanguageTag = testLangCode };
-				language.DesiredName = testLangName;
+				var language = new LanguageInfo
+				{
+					LanguageTag = testLangCode,
+					ThreeLetterTag = testLangThreeLetterCode,
+					DesiredName = testLangName
+				};
 				dlg.SelectedLanguage = language;
 				dlg.SearchText = testLangThreeLetterCode;
 				dlg.UseSimplifiedChinese();
 
 				dlg.ShowDialog();
-				MessageBox.Show("Got LanguageTag='" + dlg.SelectedLanguage.LanguageTag + "'.");
+				// I want to be able to change DesiredName, but keep the original Script tag.
+				var msg =
+					$"Got LanguageTag='{dlg.SelectedLanguage.LanguageTag}' Desired Name is='{dlg.DesiredLanguageName}'.";
+				MessageBox.Show(msg);
+			}
+		}
+
+		[Test, Ignore("By Hand")]
+		[Category("SkipOnTeamCity")]
+		public void TestLanguageLookupDialog_manualTest_FLExCornerCase()
+		{
+			const string testLangCode = "es-AR";
+			using (var dlg = new LanguageLookupDialog())
+			{
+				dlg.IsDesiredLanguageNameFieldVisible = true;
+				dlg.IsShowRegionalDialectsCheckBoxVisible = true;
+				dlg.IsScriptAndVariantLinkVisible = false;
+
+				var language = new LanguageInfo
+				{
+					LanguageTag = testLangCode,
+					DesiredName = "Spanish"
+				};
+				dlg.SelectedLanguage = language;
+				dlg.SearchText = "es";
+				dlg.UseSimplifiedChinese();
+
+				dlg.ShowDialog();
+				// FLEx needs to be able to come into the dialog with Script/Region/Variant settings on the LanguageTag,
+				// and know that they will be preserved if the base language doesn't change.
+				var msg =
+					$"Got LanguageTag='{dlg.SelectedLanguage.LanguageTag}' Desired Name is='{dlg.DesiredLanguageName}'.";
+				MessageBox.Show(msg);
 			}
 		}
 	}

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
@@ -150,16 +150,15 @@ namespace SIL.Windows.Forms.WritingSystems
 			if(_listView.SelectedIndices != null && _listView.SelectedIndices.Count > 0)
 			{
 				ListViewItem item = _listView.Items[_listView.SelectedIndices[0]];
-				var oldLangInfo = SelectedLanguage;
 				var newLangInfo = (LanguageInfo) item.Tag;
-				// If the user has already set some Script/Region/Variant info, and the link to the
-				// Script/Region/Variant dialog isn't available, we don't want to undo that just because
-				// the listview is set to that main language in the search.
-				if (!_scriptsAndVariantsLink.Visible && _model.LanguageTagContainsScriptRegionVariantInfo &&
-				    newLangInfo.LanguageTag == _model.LanguageTagWithoutScriptRegionVariant)
+				// If the user has already set some Script/Region/Variant info, or a DesiredName for a language,
+				// we don't want to undo that just because the listview is set to that main language in the search
+				// (unless eventually the user specifically removes said info).
+				if (_model.OriginalLanguageTagContainsSubtags &&
+				    newLangInfo.LanguageTag == _model.OriginalLanguageTagWithoutSubtags)
 				{
-					newLangInfo.DesiredName = oldLangInfo.DesiredName;
-					newLangInfo.LanguageTag = oldLangInfo.LanguageTag;
+					// Set our SelectedLanguage to our stored clone of what the user had when they came into the dialog.
+					newLangInfo = _model.OriginalLanguageInfo;
 				}
 				SelectedLanguage = newLangInfo;
 			}

--- a/SIL.WritingSystems/LanguageInfo.cs
+++ b/SIL.WritingSystems/LanguageInfo.cs
@@ -74,5 +74,14 @@ namespace SIL.WritingSystems
 			}
 			set { _desiredName = value; }
 		}
+
+		/// <summary>
+		/// Create a shallow copy of a LanguageInfo object to avoid messing with any "official" version.
+		/// </summary>
+		/// <returns></returns>
+		public LanguageInfo ShallowCopy()
+		{
+			return this.MemberwiseClone() as LanguageInfo;
+		}
 	}
 }


### PR DESCRIPTION
* going into LanguageLookupDialog with SRV data doesn't
   lose said data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/896)
<!-- Reviewable:end -->
