### PR TITLE
SP-2133: Crash when editing participant

### DIFF
--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
@@ -232,7 +232,9 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 					var rc = _grid.GetCellDisplayRectangle(col, e.RowIndex, true);
 					var pt = new Point(rc.X + (rc.Width / 2), rc.Y + 4);
 					_msgWindow.Show(kvp.Value, _grid.PointToScreen(pt));
-					_grid.CurrentCell = _grid[col, e.RowIndex];
+
+					// Invoking here because of "reentrant call to the SetCurrentCellAddressCore" exception.
+					BeginInvoke((Action)(() =>_grid.CurrentCell = _grid[col, e.RowIndex]));
 				}
 			}
 		}

--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design;
@@ -234,6 +234,7 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 					_msgWindow.Show(kvp.Value, _grid.PointToScreen(pt));
 
 					// Invoking here because of "reentrant call to the SetCurrentCellAddressCore" exception.
+					// Setting the CurrentCell can trigger validation again.
 					BeginInvoke((Action)(() =>_grid.CurrentCell = _grid[col, e.RowIndex]));
 				}
 			}


### PR DESCRIPTION
If a role is not selected for the participant, a "reentrant call" exception may be thrown when setting focus on the role cell.

This solution was found on S.O. - https://stackoverflow.com/questions/5114668/why-is-my-bound-datagridview-throwing-an-operation-not-valid-because-it-results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/898)
<!-- Reviewable:end -->
