### PR TITLE
SP-1816: Archive directory set to empty string

### DIFF
--- a/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -438,6 +438,8 @@ namespace SIL.Archiving.Tests
 		{
 			IgnoreTestIfRampIsNotInstalled();
 
+			Assert.Ignore("This test is no longer valid because RAMP 3.0 does not have a languages file");
+
 			_helper.SetContentLanguages("eng", "fra");
 			var data = _helper.GetMetadata();
 			Assert.AreEqual("{\"dc.title\":\"Test Title\",\"" +
@@ -622,6 +624,8 @@ namespace SIL.Archiving.Tests
 		{
 			IgnoreTestIfRampIsNotInstalled();
 
+			Assert.Ignore("This test is no longer valid because RAMP 3.0 does not have a languages file");
+
 			var langName = _helper.GetLanguageName("eng");
 			Assert.AreEqual(langName, "English");
 		}
@@ -644,6 +648,8 @@ namespace SIL.Archiving.Tests
 		public void GetLanguageName_ArchivingLanguage_ReturnsCorrectName()
 		{
 			IgnoreTestIfRampIsNotInstalled();
+
+			Assert.Ignore("This test is no longer valid because RAMP 3.0 does not have a languages file");
 
 			// FieldWorks associates the name "Chinese" with the ISO3 Code "cmn"
 			ArchivingLanguage lang = new ArchivingLanguage("cmn", "Chinese");

--- a/SIL.Archiving/ArchivingDlg.cs
+++ b/SIL.Archiving/ArchivingDlg.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 using SIL.Windows.Forms;
@@ -15,7 +15,7 @@ namespace SIL.Archiving
 		protected readonly string _launchButtonTextFormat;
 
 		/// ------------------------------------------------------------------------------------
-		/// <summary>Caller can use this to retrieve and persist form settings (typicvally
+		/// <summary>Caller can use this to retrieve and persist form settings (typically
 		/// after form is closed).</summary>
 		/// ------------------------------------------------------------------------------------
 		public FormSettings FormSettings

--- a/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
+++ b/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -620,7 +620,7 @@ namespace SIL.Archiving.IMDI
 					Path.Combine(value, CorpusDirectoryName):
 					CorpusDirectoryName;
 				if (_imdiData != null)
-					_imdiData.PackagePath = "";
+					_imdiData.PackagePath = PackagePath;
 			}
 		}
 	}


### PR DESCRIPTION
Archive directory is being set to empty string instead of the selected directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/901)
<!-- Reviewable:end -->
