### PR TITLE
Added DblMetadata.Load overload to allow deserialization from a TextReader.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- DblMetadata.Load overload to allow deserialization from a TextReader.
+- [SIL.DblBundle] DblMetadata.Load overload to allow deserialization from a TextReader.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- DblMetadata.Load overload to allow deserialization from a TextReader.
+
 ### Changed
 
 - Add build number to AssemblyFileVersion

--- a/SIL.DblBundle.Tests/DBLMetadataTests.cs
+++ b/SIL.DblBundle.Tests/DBLMetadataTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -113,23 +113,46 @@ namespace SIL.DblBundle.Tests
 		}
 
 		[Test]
-		public void Load_Successful()
+		public void Load_FromValidFile_Successful()
 		{
 			using (var metadataFile = new TempFile())
 			{
 				File.WriteAllText(metadataFile.Path, Resources.metadata_xml);
-				Exception exception;
-				DblTextMetadata<DblMetadataLanguage>.Load<DblTextMetadata<DblMetadataLanguage>>(metadataFile.Path, out exception);
+				DblTextMetadata<DblMetadataLanguage>.Load<DblTextMetadata<DblMetadataLanguage>>(metadataFile.Path, out var exception);
 				Assert.Null(exception);
+			}
+		}
+
+		[Test]
+		public void Load_FromTextReader_Successful()
+		{
+			using (var textReader = new StringReader(Resources.metadata_xml))
+			{
+				var data = DblTextMetadata<DblMetadataLanguage>.Load<DblTextMetadata<DblMetadataLanguage>>(textReader, "Resources.metadata_xml", out var exception);
+				Assert.Null(exception);
+				Assert.IsNotNull(data);
 			}
 		}
 
 		[Test]
 		public void Load_FileDoesNotExist_HandlesException()
 		{
-			Exception exception;
-			DblTextMetadata<DblMetadataLanguage>.Load<DblTextMetadata<DblMetadataLanguage>>("", out exception);
+			var data = DblTextMetadata<DblMetadataLanguage>.Load<DblTextMetadata<DblMetadataLanguage>>("", out var exception);
 			Assert.NotNull(exception);
+			Assert.IsNotNull(data);
+		}
+
+		[Test]
+		public void Load_FromTextReaderNotPositionedAtStartOfMetadata_SetsException()
+		{
+			using (var textReader = new StringReader(Resources.metadata_xml))
+			{
+				textReader.ReadLine(); // Skip past XML header - not required by deserializer
+				textReader.ReadLine(); // Skip past next line - root element!
+				var data = DblTextMetadata<DblMetadataLanguage>.Load<DblTextMetadata<DblMetadataLanguage>>(textReader, "Resources.metadata_xml", out var exception);
+				Assert.True(exception is InvalidOperationException);
+				Assert.Null(data);
+			}
 		}
 
 		[Test]

--- a/SIL.DblBundle.Tests/Text/TextBundleTests.cs
+++ b/SIL.DblBundle.Tests/Text/TextBundleTests.cs
@@ -72,7 +72,7 @@ namespace SIL.DblBundle.Tests.Text
 			var bundle = legacy ? _legacyBundle : _bundle;
 			var stylesheet = bundle.Stylesheet;
 			IStyle style = stylesheet.GetStyle("mt1");
-			Assert.NotNull(style);
+			Assert.IsNotNull(style);
 			Assert.AreEqual("Cambria", stylesheet.FontFamily);
 			Assert.AreEqual(14, stylesheet.FontSizeInPoints);
 		}
@@ -86,7 +86,7 @@ namespace SIL.DblBundle.Tests.Text
 		{
 			var bundle = legacy ? _legacyBundle : _bundle;
 			var ws = bundle.WritingSystemDefinition;
-			Assert.NotNull(ws);
+			Assert.IsNotNull(ws);
 
 			Assert.AreEqual(WellKnownSubtags.UnlistedLanguage, ws.LanguageTag);
 
@@ -133,7 +133,7 @@ namespace SIL.DblBundle.Tests.Text
 		public void ContainsLdmlFile_FileDoesNotExist_ReturnsFalse(bool legacy)
 		{
 			var bundleWithoutLdml = legacy ? _legacyBundleWithoutLdml : _bundleWithoutLdml;
-			Assert.False(bundleWithoutLdml.ContainsLdmlFile());
+			Assert.IsFalse(bundleWithoutLdml.ContainsLdmlFile());
 		}
 
 		/// <summary>

--- a/SIL.DblBundle/DblMetadata.cs
+++ b/SIL.DblBundle/DblMetadata.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Xml.Serialization;
 using SIL.DblBundle.Text;
 using SIL.Xml;
@@ -34,17 +35,16 @@ namespace SIL.DblBundle
 		/// </summary>
 		[XmlAttribute("revision")]
 		public string Revision_Surrogate {
-			get { return Revision.ToString(); }
+			get => Revision.ToString();
 			set
 			{
-				int revision;
-				Int32.TryParse(value, out revision);
+				Int32.TryParse(value, out var revision);
 				Revision = revision;
 			}
 		}
 
 		/// <summary>Gets whether bundle is for text</summary>
-		public bool IsTextReleaseBundle { get { return Type == "text"; } }
+		public bool IsTextReleaseBundle => Type == "text";
 	}
 
 	/// <summary>
@@ -55,15 +55,29 @@ namespace SIL.DblBundle
 	public abstract class DblMetadataBase<TL> : DblMetadata, IProjectInfo where TL: DblMetadataLanguage, new()
 	{
 		/// <summary>
-		/// Loads information about a Digital Bible Library bundle from the specified projectFilePath.
+		/// Loads information about a Digital Bible Library bundle from the specified reader.
 		/// </summary>
-		public static T Load<T>(string projectFilePath, out Exception exception) where T : DblMetadataBase<TL>
+		/// <param name="metadataReader">A TextReader object assumed to be positioned at the start of the </param>
+		/// <param name="resourceIdentifier">Filename or other meaningful identifier that can be used in an error message if there is a
+		/// problem reading the data or creating the desired type of DblMetadata object from it.</param>
+		/// <param name="exception">Set if the metadata object could not be instantiated or initialized.</param>
+		public static T Load<T>(TextReader metadataReader, string resourceIdentifier,  out Exception exception) where T : DblMetadataBase<TL>
 		{
-			var metadata = XmlSerializationHelper.DeserializeFromFile<T>(projectFilePath, out exception);
+			string data;
+			try
+			{
+				data = metadataReader.ReadToEnd();
+			}
+			catch (Exception e)
+			{
+				exception = e;
+				return null;
+			}
+			var metadata = XmlSerializationHelper.DeserializeFromString<T>(data, out exception);
 			if (metadata == null)
 			{
 				if (exception == null)
-					exception = new ApplicationException(string.Format("Loading metadata ({0}) was unsuccessful.", projectFilePath));
+					exception = new ApplicationException($"Loading metadata ({resourceIdentifier}) was unsuccessful.");
 				return null;
 			}
 			try
@@ -75,6 +89,15 @@ namespace SIL.DblBundle
 				exception = e;
 			}
 			return metadata;
+		}
+
+		/// <summary>
+		/// Loads information about a Digital Bible Library bundle from the specified projectFilePath.
+		/// </summary>
+		public static T Load<T>(string projectFilePath, out Exception exception) where T : DblMetadataBase<TL>
+		{
+			using (var stream = new FileStream(projectFilePath, FileMode.Open))
+				return Load<T>(new StreamReader(stream), projectFilePath, out exception);
 		}
 
 		/// <summary>

--- a/SIL.DblBundle/DblMetadata.cs
+++ b/SIL.DblBundle/DblMetadata.cs
@@ -29,9 +29,10 @@ namespace SIL.DblBundle
 		public int Revision { get; set; }
 
 		/// <summary>
-		/// Apparently it is possible to have revision set to "" in the XML. I'm not sure if this is new with version 2+ or if we just never saw it before.
-		/// Anyway, previously, Revision was simply an int as above, but I had to add this surrogate field to be able to handle the case when it is set to ""
-		/// while also not breaking the API.
+		/// Apparently it is possible to have revision set to "" in the XML. I'm not sure if this
+		/// is new with version 2+ or if we just never saw it before. Anyway, previously, Revision
+		/// was simply an int as above, but I had to add this surrogate field to be able to handle
+		/// the case when it is set to "" while also not breaking the API.
 		/// </summary>
 		[XmlAttribute("revision")]
 		public string Revision_Surrogate {
@@ -52,16 +53,22 @@ namespace SIL.DblBundle
 	/// itself cannot be abstract because in the event of a loading error, we need to deserialize it
 	/// to properly report the situation to the user.
 	/// </summary>
-	public abstract class DblMetadataBase<TL> : DblMetadata, IProjectInfo where TL: DblMetadataLanguage, new()
+	public abstract class DblMetadataBase<TL> : DblMetadata, IProjectInfo
+		where TL: DblMetadataLanguage, new()
 	{
 		/// <summary>
 		/// Loads information about a Digital Bible Library bundle from the specified reader.
 		/// </summary>
-		/// <param name="metadataReader">A TextReader object assumed to be positioned at the start of the </param>
-		/// <param name="resourceIdentifier">Filename or other meaningful identifier that can be used in an error message if there is a
-		/// problem reading the data or creating the desired type of DblMetadata object from it.</param>
-		/// <param name="exception">Set if the metadata object could not be instantiated or initialized.</param>
-		public static T Load<T>(TextReader metadataReader, string resourceIdentifier,  out Exception exception) where T : DblMetadataBase<TL>
+		/// <param name="metadataReader">A TextReader object assumed to be positioned at the
+		/// start of the metadata (leading XML element is permitted, but not required)</param>
+		/// <param name="resourceIdentifier">Filename or other meaningful identifier that can be
+		/// used in an error message if there is a
+		/// problem reading the data or creating the desired type of DblMetadata object from it.
+		/// </param>
+		/// <param name="exception">Set if the metadata object could not be instantiated or
+		/// initialized.</param>
+		public static T Load<T>(TextReader metadataReader, string resourceIdentifier,
+			out Exception exception) where T : DblMetadataBase<TL>
 		{
 			string data;
 			try
@@ -77,7 +84,11 @@ namespace SIL.DblBundle
 			if (metadata == null)
 			{
 				if (exception == null)
-					exception = new ApplicationException($"Loading metadata ({resourceIdentifier}) was unsuccessful.");
+				{
+					exception = new ApplicationException(
+						$"Loading metadata ({resourceIdentifier}) was unsuccessful.");
+				}
+
 				return null;
 			}
 			try
@@ -92,12 +103,21 @@ namespace SIL.DblBundle
 		}
 
 		/// <summary>
-		/// Loads information about a Digital Bible Library bundle from the specified projectFilePath.
+		/// Loads information about a Digital Bible Library bundle from the specified filePath.
 		/// </summary>
-		public static T Load<T>(string projectFilePath, out Exception exception) where T : DblMetadataBase<TL>
+		public static T Load<T>(string filePath, out Exception exception)
+			where T : DblMetadataBase<TL>
 		{
-			using (var stream = new FileStream(projectFilePath, FileMode.Open))
-				return Load<T>(new StreamReader(stream), projectFilePath, out exception);
+			try
+			{
+				using (var stream = new FileStream(filePath, FileMode.Open))
+					return Load<T>(new StreamReader(stream), filePath, out exception);
+			}
+			catch (Exception e)
+			{
+				exception = e;
+				return null;
+			}
 		}
 
 		/// <summary>

--- a/SIL.DblBundle/Text/DblTextMetadata.cs
+++ b/SIL.DblBundle/Text/DblTextMetadata.cs
@@ -12,7 +12,7 @@ using SIL.Xml;
 namespace SIL.DblBundle.Text
 {
 	/// <summary>
-	/// Information about a Digitial Bible Library bundle
+	/// Information about a Digital Bible Library bundle
 	/// </summary>
 	[XmlRoot("DBLMetadata")]
 	public class DblTextMetadata<TL> : DblMetadataBase<TL> where TL : DblMetadataLanguage, new()


### PR DESCRIPTION
This is needed to allow Vessel to use a non-file-based persistence layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/905)
<!-- Reviewable:end -->
