### PR TITLE
+semver:major: Changed TextBundle<TM, TL>.GetFonts to return Streams …

### DIFF
--- a/SIL.DblBundle.Tests/Text/TextBundleTests.cs
+++ b/SIL.DblBundle.Tests/Text/TextBundleTests.cs
@@ -133,7 +133,7 @@ namespace SIL.DblBundle.Tests.Text
 				{
 					var fontInfo = bundle.GetFonts().Single();
 					Assert.AreEqual("AppSILI.ttf", fontInfo.Item1);
-					Assert.IsTrue(fontInfo.Item2.ReadToEnd().Length > 0);
+					Assert.IsTrue(fontInfo.Item2.ReadByte() >= 0);
 			}
 		}
 

--- a/SIL.DblBundle/Text/TextBundle.cs
+++ b/SIL.DblBundle/Text/TextBundle.cs
@@ -251,13 +251,13 @@ namespace SIL.DblBundle.Text
 		/// they represent that can be used to access the contents of the font files in the
 		/// text bundle.
 		/// </summary>
-		public IEnumerable<Tuple<string, TextReader>> GetFonts()
+		public IEnumerable<Tuple<string, Stream>> GetFonts()
 		{
 			foreach (var ttfFile in Directory.GetFiles(PathToUnzippedBundleInnards, "*.ttf"))
 			{
 				var fileName = Path.GetFileName(ttfFile);
-				yield return new Tuple<string, TextReader>(fileName,
-					new StreamReader(new FileStream(ttfFile, FileMode.Open)));
+				yield return new Tuple<string, Stream>(fileName,
+					new FileStream(ttfFile, FileMode.Open));
 			}
 		}
 


### PR DESCRIPTION
…instead of TextReaders because font files have binary contents, not text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/913)
<!-- Reviewable:end -->
