### PR TITLE
Add missing validation to TryGetVariantSubtags

### DIFF
--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -443,6 +443,16 @@ namespace SIL.WritingSystems.Tests
 			}
 		}
 
+		[TestCase("x-a#b")] // non alpha numeric
+		[TestCase("x-thisiswaytoolong")] // > 15 characters (should be 8 but langtags.json has up to 15)
+		public void TryGetVariantSubtags_PrivateUseRulesHonored(string privateUseVariantTag)
+		{
+			IEnumerable<VariantSubtag> variantSubtags;
+			// Test both with and without custom name
+			Assert.That(IetfLanguageTag.TryGetVariantSubtags(privateUseVariantTag, out variantSubtags, "Bad Variant"), Is.False);
+			Assert.That(IetfLanguageTag.TryGetVariantSubtags(privateUseVariantTag, out variantSubtags), Is.False);
+		}
+
 		[Test]
 		public void TryGetSubtags_FonipaXEtic_ReturnsFonipaEtic()
 		{

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -426,7 +426,7 @@ namespace SIL.WritingSystems.Tests
 			IEnumerable<VariantSubtag> variantSubtags;
 			IetfLanguageTag.TryGetVariantSubtags("x-code1-code2", out variantSubtags, "x-name1,name2");
 			Assert.AreEqual(2, variantSubtags.Count());
-			int index = 0;
+			var index = 0;
 			foreach (VariantSubtag variantSubtag in variantSubtags)
 			{
 				if (index == 0) //For first VariantSubTag

--- a/SIL.WritingSystems/IetfLanguageTag.cs
+++ b/SIL.WritingSystems/IetfLanguageTag.cs
@@ -107,13 +107,20 @@ namespace SIL.WritingSystems
 				VariantSubtag variantSubtag;
 				if (!StandardSubtags.CommonPrivateUseVariants.TryGet(privateUseCode, out variantSubtag))
 				{
+					if (!PrivateUsePattern.IsMatch(privateUseCode))
+					{
+						variantSubtags = null;
+						return false;
+					}
 					if (!string.IsNullOrEmpty(variantNames) && index < variantName.Length)
 					{
 						variantSubtag = new VariantSubtag(privateUseCode, variantName[index]);
 						index++;
 					}
 					else
+					{
 						variantSubtag = new VariantSubtag(privateUseCode);
+					}
 				}
 				variantSubtagsList.Add(variantSubtag);
 			}


### PR DESCRIPTION
* Invalid private use codes should cause a false return

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/915)
<!-- Reviewable:end -->
