### PR TITLE
Use SLDR template when making new WS (LT-20022)

### DIFF
--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -399,18 +399,12 @@ namespace SIL.WritingSystems
 			if (ws.IsChanged)
 				ws.DateModified = DateTime.UtcNow;
 
-			MemoryStream oldData = null;
+			MemoryStream oldData = GetDataToMergeWithInSave(writingSystemFilePath);
 			if (File.Exists(writingSystemFilePath))
 			{
-				// load old data to preserve stuff in LDML that we don't use, but don't throw up an error if it fails
-				try
-				{
-					oldData = new MemoryStream(File.ReadAllBytes(writingSystemFilePath), false);
-				}
-				catch {}
-				// What to do?  Assume that the UI has already checked for existing, asked, and allowed the overwrite.
-				File.Delete(writingSystemFilePath); //!!! Should this be move to trash?
+				File.Delete(writingSystemFilePath);
 			}
+
 			var ldmlDataMapper = new LdmlDataMapper(WritingSystemFactory);
 			try
 			{

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -298,17 +298,10 @@ namespace SIL.WritingSystems
 					return;
 			}
 
-			MemoryStream oldData = null;
+			var oldData = GetDataToMergeWithInSave(writingSystemFilePath);
 			if (File.Exists(writingSystemFilePath))
 			{
-				// load old data to preserve stuff in LDML that we don't use, but don't throw up an error if it fails
-				try
-				{
-					oldData = new MemoryStream(File.ReadAllBytes(writingSystemFilePath), false);
-				}
-				catch {}
-				// What to do?  Assume that the UI has already checked for existing, asked, and allowed the overwrite.
-				File.Delete(writingSystemFilePath); //!!! Should this be move to trash?
+				File.Delete(writingSystemFilePath);
 			}
 			var ldmlDataMapper = new LdmlDataMapper(WritingSystemFactory);
 			ldmlDataMapper.Write(writingSystemFilePath, ws, oldData);

--- a/SIL.WritingSystems/WritingSystemRepositoryBase.cs
+++ b/SIL.WritingSystems/WritingSystemRepositoryBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace SIL.WritingSystems
@@ -324,6 +325,38 @@ namespace SIL.WritingSystems
 		IWritingSystemFactory IWritingSystemRepository.WritingSystemFactory
 		{
 			get { return WritingSystemFactory; }
+		}
+
+		/// <summary>
+		/// Used whenever writing a WS definition to disk. Reads contents of any existing data in the folder,
+		/// falling back to any data in the SLDR Cache.
+		/// </summary>
+		/// <remarks>Does not attempt to pull the writing system into the SLDR Cache.</remarks>
+		protected static MemoryStream GetDataToMergeWithInSave(string writingSystemFilePath)
+		{
+			MemoryStream oldData = null;
+			if (File.Exists(writingSystemFilePath))
+			{
+				// load old data to preserve stuff in LDML that we don't use, but don't throw up an error if it fails
+				try
+				{
+					oldData = new MemoryStream(File.ReadAllBytes(writingSystemFilePath), false);
+				}
+				catch
+				{
+				}
+			}
+			else
+			{
+				var source = Path.Combine(Sldr.SldrCachePath,
+					Path.GetFileName(writingSystemFilePath));
+				if (File.Exists(source))
+				{
+					oldData = new MemoryStream(File.ReadAllBytes(source), false);
+				}
+			}
+
+			return oldData;
 		}
 	}
 }


### PR DESCRIPTION
When we save a writing system, we are supposed to preserve any data we don't care about, typically from the SLDR. If the WS has already been saved in the destination folder, we merge changes into the previously saved version. New writing systems that are based on an SLDR template are supposed to have a Template field set, which is used to copy the SLDR version before we look for an existing Save. But this only works for the first place we save a new writing system, since we clear it after using it. I'm not sure why we clear it, so hesitated to change that. A more robust fix, anyway, seems to be that if we are writing a new WS and don't already know of a template to copy and there is a corresponding template in the SLDR, just use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/918)
<!-- Reviewable:end -->
