### PR TITLE
Update DialogAdapters package for mono5-sil compatibility

### DIFF
--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -384,7 +384,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="DialogAdapters">
-      <HintPath>..\packages\DialogAdapters.0.1.3.26068\lib\net45\DialogAdapters.dll</HintPath>
+      <HintPath>..\packages\DialogAdapters.0.1.4.30000\lib\net45\DialogAdapters.dll</HintPath>
     </Reference>
     <Reference Include="MarkdownDeep, Version=1.5.6607.21413, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\MarkdownDeep.NET.Patched.1.5.0.1\lib\net35\MarkdownDeep.dll</HintPath>

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DialogAdapters" version="0.1.3.26068" targetFramework="net40" />
+  <package id="DialogAdapters" version="0.1.4.30000" targetFramework="net45" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net40" />
   <package id="MarkdownDeep.NET.Patched" version="1.5.0.1" targetFramework="net461" />
   <package id="NAudio" version="1.8.4" targetFramework="net461" />


### PR DESCRIPTION
Note that this version of DialogAdapters limits Geckofx use to Geckofx45
and before.  (DialogAdapters 1.6.* limit Geckofx use to Geckofx60 and
later!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/919)
<!-- Reviewable:end -->
