### PR TITLE
LT-20124 Fix crash in reading LDML exemplars

### DIFF
--- a/SIL.Core/Xml/XElementExtensions.cs
+++ b/SIL.Core/Xml/XElementExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -38,6 +38,18 @@ namespace SIL.Xml
 		public static IEnumerable<XElement> NonAltElements(this XElement element)
 		{
 			return element.Elements().Where(e => e.Attribute("alt") == null);
+		}
+
+		/// <summary>
+		/// Returns a collection of the child elements of this element.  Only elements that have a matching XName
+		/// and don't have an "alt" attribute or a "draft" attribute are included in the collection
+		/// </summary>
+		/// <param name="element">The element.</param>
+		/// <param name="name">The name.</param>
+		/// <returns></returns>
+		public static IEnumerable<XElement> NonAltNonDraftElements(this XElement element, XName name)
+		{
+			return element.Elements(name).Where(e => e.Attribute("alt") == null && e.Attribute("draft") == null);
 		}
 
 		/// <summary>

--- a/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
@@ -37,7 +37,7 @@ namespace SIL.WritingSystems.Tests
 				File.WriteAllBytes(badFile, new byte[100]); // 100 nulls
 				var repo = GlobalWritingSystemRepository.InitializeWithBasePath(e.Path, null);
 				// main part of test is that we don't get any exception.
-				Assert.That(repo.Count, Is.EqualTo(0));
+				Assert.That(repo.Count, Is.EqualTo(1));
 				// original .ldml file should have been renamed
 				Assert.That(File.Exists(badFile), Is.False);
 				Assert.That(File.Exists(badFile + ".bad"), Is.True);
@@ -66,7 +66,7 @@ namespace SIL.WritingSystems.Tests
 				File.WriteAllText(badFile, ldmlData);
 				var repo = GlobalWritingSystemRepository.InitializeWithBasePath(e.Path, null);
 				// main part of test is that we don't get any exception.
-				Assert.That(repo.Count, Is.EqualTo(0));
+				Assert.That(repo.Count, Is.EqualTo(1));
 				// original .ldml file should have been renamed
 				Assert.That(File.Exists(badFile), Is.False);
 				Assert.That(File.Exists(badFile + ".bad"), Is.True);

--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -596,6 +596,43 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
+		public void BadLdmlCharacters_GeneratesLog()
+		{
+			// Because we don't write elements with extra attributes (e.g. 'draft' at time of test creation),
+			// this test starts by writing a set content.
+			// The idea is to throw at the highest level of reading a downloaded LDML file,
+			// so that we can catch it in SldrWritingSystemFactory and save the file to {name}.bad
+			// and log the error.
+			using (var environment = new TestEnvironment())
+			{
+				var content =
+					@"<?xml version='1.0' encoding='utf-8'?>
+<ldml>
+	<identity>
+		<version number='VERSION' />
+		<language type='en' />
+		<script type='Latn' />
+	</identity>
+	<characters>
+		<exemplarCharacters>[a-z{az}]</exemplarCharacters>
+		<exemplarCharacters unknownAttribute='unknownAttributeData'>[A-Z{AZ}]</exemplarCharacters>
+	</characters>
+</ldml>".Replace("VERSION", LdmlDataMapper.CurrentLdmlLibraryVersion.ToString()).Replace("\'", "\"");
+
+				var filePath = environment.FilePath("test.ldml");
+				File.WriteAllText(filePath, content);
+
+				var ldmlAdaptor = new LdmlDataMapper(new TestWritingSystemFactory());
+				var wsFromLdml = new WritingSystemDefinition();
+				// SUT
+				ldmlAdaptor.Read(filePath, wsFromLdml);
+				var logFilePath = Path.Combine(Path.GetDirectoryName(filePath), "badldml.log");
+				Assert.That(File.Exists(logFilePath));
+				File.Delete(logFilePath); // don't want it to possibly mess up other tests in this fixture
+			}
+		}
+
+		[Test]
 		public void Roundtrip_LdmlDelimiters()
 		{
 			using (var environment = new TestEnvironment())
@@ -1267,18 +1304,18 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
-		public void Read_V0Ldml_ThrowFriendlyException()
+		public void Read_V0Ldml_ReportsBadVersion()
 		{
 			using (var file = new TempFile())
 			{
 				WriteVersion0Ldml("en", "", "", "", file);
 				var ws = new WritingSystemDefinition();
 				var dataMapper = new LdmlDataMapper(new TestWritingSystemFactory());
-				Assert.That(() => dataMapper.Read(file.Path, ws),
-								Throws.Exception.TypeOf<ApplicationException>()
-										.With.Property("Message")
-										.EqualTo(String.Format("The LDML tag 'en' is version 0.  Version {0} was expected.",
-										LdmlDataMapper.CurrentLdmlLibraryVersion)));
+				// SUT
+				dataMapper.Read(file.Path, ws);
+				var logFilePath = Path.Combine(Path.GetDirectoryName(file.Path), "badldml.log");
+				Assert.That(File.Exists(logFilePath));
+				File.Delete(logFilePath); // don't want it to possibly mess up other tests in this fixture
 			}
 		}
 
@@ -1291,11 +1328,11 @@ namespace SIL.WritingSystems.Tests
 				WriteVersion1Ldml("en", "", "", "", file);
 				var ws = new WritingSystemDefinition();
 				var dataMapper = new LdmlDataMapper(new TestWritingSystemFactory());
-				Assert.That(() => dataMapper.Read(file.Path, ws),
-								Throws.Exception.TypeOf<ApplicationException>()
-										.With.Property("Message")
-										.EqualTo(String.Format("The LDML tag 'en' is version 2.  Version {0} was expected.",
-										LdmlDataMapper.CurrentLdmlLibraryVersion)));
+				// SUT
+				dataMapper.Read(file.Path, ws);
+				var logFilePath = Path.Combine(Path.GetDirectoryName(file.Path), "badldml.log");
+				Assert.That(File.Exists(logFilePath));
+				File.Delete(logFilePath); // don't want it to possibly mess up other tests in this fixture
 			}
 		}
 
@@ -1371,8 +1408,11 @@ namespace SIL.WritingSystems.Tests
 				var ws = new WritingSystemDefinition();
 				var dataMapper = new LdmlDataMapper(new TestWritingSystemFactory());
 
-				var message = Assert.Throws<ArgumentException>(() => dataMapper.Read(tempFile.Path, ws)).Message;
-				StringAssert.IsMatch("The font .* is defined twice in .*\\.ldml", message);
+				// SUT
+				dataMapper.Read(tempFile.Path, ws);
+				var logFilePath = Path.Combine(Path.GetDirectoryName(tempFile.Path), "badldml.log");
+				Assert.That(File.Exists(logFilePath));
+				File.Delete(logFilePath); // don't want it to possibly mess up other tests in this fixture
 			}
 		}
 

--- a/SIL.WritingSystems/CharacterSetDefinition.cs
+++ b/SIL.WritingSystems/CharacterSetDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Specialized;
 using System.Linq;
 using SIL.Extensions;

--- a/SIL.WritingSystems/SldrWritingSystemFactory.cs
+++ b/SIL.WritingSystems/SldrWritingSystemFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System;
+using System.IO;
 
 namespace SIL.WritingSystems
 {
@@ -46,7 +47,7 @@ namespace SIL.WritingSystems
 			{
 				ws = ConstructDefinition();
 				var loader = new LdmlDataMapper(this);
-				loader.Read(templatePath, ws);
+				loader.Read(templatePath, ws, e => { sldrStatus = SldrStatus.NotFound; });
 				ws.Template = templatePath;
 				return sldrStatus == SldrStatus.FromSldr;
 			}

--- a/SIL.WritingSystems/WritingSystemFactory.cs
+++ b/SIL.WritingSystems/WritingSystemFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System;
+using System.IO;
 
 namespace SIL.WritingSystems
 {


### PR DESCRIPTION
* ignores lists of exemplars with "extra" attributes like "draft" or "alt"
* if 2 lists of the same "type" happen to slip into the global SLDR,
   it still won't crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/920)
<!-- Reviewable:end -->
