### PR TITLE
Ignore oleaut32.dll in Acknowledgements

### DIFF
--- a/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
+++ b/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
@@ -16,7 +16,7 @@ namespace SIL.Acknowledgements
 		private static readonly string[] Exclusions =
 		{
 			"Interop.WIA.dll", "vshost.exe", "CommandLine.dll",
-			"nunit.framework.dll", ".Tests.dll", ".Tests.exe", "TestApp.dll", "TestApp.exe"
+			"nunit.framework.dll", ".Tests.dll", ".Tests.exe", "TestApp.dll", "TestApp.exe", "oleaut32.dll"
 
 			// Use this version to see the TestApp dependencies in SIL.Windows.Forms.TestApp.AssemblyInfo.cs
 			//"Interop.WIA.dll", "vshost.exe", "CommandLine.dll",


### PR DESCRIPTION
* FW links oleaut32.dll to libViews.so (as discussed in FWNX-823).
* AcknowledgementsProvider crashes when Assembly.LoadFile opens
oleaut32.dll, saying System.BadImageFormatException: Invalid Image.
* This results in FW not showing any acknowledgements, as reported in
LT-20121.

--- 

Unfortunately I could not test or confirm this locally since I haven't managed to build libpalaso today. But hopefully it will work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/921)
<!-- Reviewable:end -->
