### PR TITLE
More work preventing crashes from bad ldml (LT-20125)

### DIFF
--- a/SIL.WritingSystems/SldrWritingSystemFactory.cs
+++ b/SIL.WritingSystems/SldrWritingSystemFactory.cs
@@ -47,9 +47,16 @@ namespace SIL.WritingSystems
 			{
 				ws = ConstructDefinition();
 				var loader = new LdmlDataMapper(this);
-				loader.Read(templatePath, ws, e => { sldrStatus = SldrStatus.NotFound; });
-				ws.Template = templatePath;
-				return sldrStatus == SldrStatus.FromSldr;
+				var errorEncountered = false;
+				loader.Read(templatePath, ws, e => {
+					sldrStatus = SldrStatus.NotFound;
+					errorEncountered = true;
+				});
+				if (!errorEncountered)
+				{
+					ws.Template = templatePath;
+					return sldrStatus == SldrStatus.FromSldr;
+				}
 			}
 
 			return base.Create(ietfLanguageTag, out ws) && sldrStatus == SldrStatus.NotFound;


### PR DESCRIPTION
* If there is a ldml read error using the SLDR template
  then bail and return the base create
Unit test skipped to avoid the need to mock receiving bad ldml from the internet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/922)
<!-- Reviewable:end -->
