### PR TITLE
LT-19930: Report correct .NET version (for 4)

### DIFF
--- a/ExtractCopyright/Program.cs
+++ b/ExtractCopyright/Program.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) 2017 SIL International
+// Copyright (c) 2017-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;
-using System.Diagnostics;
 
 namespace SIL.ExtractCopyright
 {
@@ -27,7 +26,6 @@ namespace SIL.ExtractCopyright
 				case "-h":
 				case "--help":
 					return ShowUsage(CopyrightFile.ExitValue.Okay);
-					break;
 				case "-p":
 				case "--prefix":
 					if (++i < args.Length)

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -1,11 +1,17 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BCV/@EntryIndexedValue">BCV</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GUI/@EntryIndexedValue">GUI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GUID/@EntryIndexedValue">GUID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IMDI/@EntryIndexedValue">IMDI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LIFT/@EntryIndexedValue">LIFT</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue">/opt/mono5-sil/lib/mono/msbuild/15.0/bin/MSBuild.dll</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MonoExePath/@EntryValue">/opt/mono5-sil/bin/mono-sil.sh</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=acknowledgements/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=analytics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BBCCCVVV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ethnologue/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenames/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ibus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IETF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IMDI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LDML/@EntryIndexedValue">True</s:Boolean>

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IMDI/@EntryIndexedValue">IMDI</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue">/opt/mono5-sil/lib/mono/msbuild/15.0/bin/MSBuild.dll</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MonoExePath/@EntryValue">/opt/mono5-sil/bin/mono-sil.sh</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=analytics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BBCCCVVV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ethnologue/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IETF/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.DblBundle.Tests/SIL.DblBundle.Tests.csproj
+++ b/SIL.DblBundle.Tests/SIL.DblBundle.Tests.csproj
@@ -22,7 +22,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>..\output\Debug\SIL.DblBundle.Tests.XML</DocumentationFile>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/SIL.Lift/Validation/Validator.cs
+++ b/SIL.Lift/Validation/Validator.cs
@@ -7,6 +7,7 @@ using SIL.Progress;
 
 namespace SIL.Lift.Validation
 {
+	[Flags]
 	public enum ValidationOptions
 	{
 		CheckLIFT = 1,
@@ -87,15 +88,15 @@ namespace SIL.Lift.Validation
 		/// Parse the given LIFT file and return a string containing all the validation errors
 		/// (if any).  Progress reporting is supported.
 		///</summary>
-		static public string GetAnyValidationErrors(string path, IValidationProgress progress, ValidationOptions validationOptions)
+		public static string GetAnyValidationErrors(string path, IValidationProgress progress, ValidationOptions validationOptions)
 		{
 			string errors = "";
-			if ((validationOptions & ValidationOptions.CheckLIFT) != null)
+			if ((validationOptions & ValidationOptions.CheckLIFT) != 0)
 			{
 				errors += GetSchemaValidationErrors(path, progress);
 			}
 
-			if ((validationOptions & ValidationOptions.CheckGUIDs)!=null)
+			if ((validationOptions & ValidationOptions.CheckGUIDs) != 0)
 			{
 				errors += GetDuplicateGuidErrors(path, progress);
 			}

--- a/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
+++ b/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
@@ -50,7 +50,6 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>..\output\Debug\SIL.Scripture.Tests.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
+++ b/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
@@ -26,6 +26,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\output\Debug\SIL.Windows.Forms.DblBundle.XML</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusCommunicator.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusCommunicator.cs
@@ -352,10 +352,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		private void OnCommitText(object text)
 		{
-			if (CommitText != null)
-			{
-				CommitText(IBusText.FromObject(text));
-			}
+			CommitText?.Invoke(IBusText.FromObject(text));
 		}
 
 		private void OnUpdatePreeditText(object text, uint cursor_pos, bool visible)
@@ -368,20 +365,17 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		private void OnDeleteSurroundingText(int offset, uint nChars)
 		{
-			if (DeleteSurroundingText != null)
-				DeleteSurroundingText(offset, (int)nChars);
+			DeleteSurroundingText?.Invoke(offset, (int)nChars);
 		}
 
 		private void OnHidePreeditText()
 		{
-			if (HidePreeditText != null)
-				HidePreeditText();
+			HidePreeditText?.Invoke();
 		}
 
 		private void OnKeyEvent(uint keyval, uint keycode, uint modifiers)
 		{
-			if (KeyEvent != null)
-				KeyEvent((int)keyval, (int)keycode, (int)modifiers);
+			KeyEvent?.Invoke((int)keyval, (int)keycode, (int)modifiers);
 		}
 
 		#endregion

--- a/SIL.Windows.Forms.Keyboarding/Linux/XklEngine.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XklEngine.cs
@@ -17,8 +17,10 @@ namespace X11.XKlavier
 	{
 		private struct XklState
 		{
+#pragma warning disable 649 // the struct is initialized by marshaling pointers
 			public int Group;
 			public int Indicators;
+#pragma warning restore 649
 		}
 
 		private string[] m_GroupNames;

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -168,7 +168,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 			{
 				profilesEnumerator = ProfileManager.EnumProfiles((short)inputLanguage.Culture.KeyboardLayoutId);
 			}
-			catch (Exception e)
+			catch
 			{
 				Debug.WriteLine($"Error looking up keyboards for language {inputLanguage.Culture.Name} - {(short)inputLanguage.Culture.KeyboardLayoutId}");
 				yield break;

--- a/SIL.Windows.Forms.Keyboarding/Windows/WindowsKeyboardSwitchingAdapter.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WindowsKeyboardSwitchingAdapter.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using SIL.Keyboarding;
+using SIL.PlatformUtilities;
 using Timer = System.Windows.Forms.Timer;
 
 namespace SIL.Windows.Forms.Keyboarding.Windows
@@ -66,15 +67,12 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 				}
 
 				_expectedKeyboard = keyboard;
-#if !MONO
-				return SwitchByProfile(keyboard);
-#endif
+				return Platform.IsMono || SwitchByProfile(keyboard);
 			}
 			finally
 			{
 				IsSwitchingKeyboards = false;
 			}
-			return true;
 		}
 
 		private bool SwitchByProfile(WinKeyboardDescription keyboard)

--- a/SIL.Windows.Forms.WritingSystems/WSKeyboardControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/WSKeyboardControl.cs
@@ -317,7 +317,6 @@ namespace SIL.Windows.Forms.WritingSystems
 
 		private void _windowsKeyboardSettingsLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		{
-			string arguments;
 			var program = KeyboardController.GetKeyboardSetupApplication();
 			if (program == null)
 			{

--- a/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
+++ b/SIL.Windows.Forms/ClearShare/CreativeCommonsLicense.cs
@@ -85,9 +85,7 @@ namespace SIL.Windows.Forms.ClearShare
 		/// Other values are not guaranteed to work, though at present they will.
 		/// Enhance: Possibly we should try to verify that the token is a valid CCL one?
 		/// </summary>
-		/// <param name="token"></param>
-		/// <returns></returns>
-		public static LicenseInfo FromToken(string token)
+		public new static LicenseInfo FromToken(string token)
 		{
 			var result = new CreativeCommonsLicense();
 			// Note (JH): Since version was set to default, as I add the qualifier, I'm going to let it be default as well.

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -93,6 +93,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 		{
 			return;
 			// REVIEW: Is this code intentionally disabled?
+			// REVIEW (Hasso) 2020.04: looks like hatton started work on this in 2010-12 and gave up in 2012-04
 			Grip hStart, vStart, hEnd, vEnd;
 
 			Point mouse = PointToClient(MousePosition);

--- a/SIL.Windows.Forms/Reporting/ProblemNotificationDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ProblemNotificationDialog.cs
@@ -32,7 +32,7 @@ namespace SIL.Windows.Forms.Reporting
 			set { _reoccurenceMessage.Text = value;}
 		}
 
-		public Image Icon
+		public new Image Icon
 		{
 			get { return _icon.Image; }
 			set { _icon.Image = value; }

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -305,7 +305,7 @@ namespace SIL.WritingSystems
 						}
 						redirected = false;
 					}
-					catch (XmlException xe)
+					catch (XmlException)
 					{
 						// Download failed so check SLDR cache
 						sldrCacheFilePath = GetSldrCacheFilePath(uid, sldrLanguageTag);


### PR DESCRIPTION
Environment.Version is supposed to return the version of the
common language runtime, not .NET. Also, for .NET Framework 4.5
and later, Microsoft does not recommend using Environment.Version
to determine the version, but instead recommends
"community-maintained" command-line tools that query the registry.
The registry query is tied to v4, so this will need to be rewritten for
.NET 5.0 at the latest (perhaps Microsoft will hide it again sooner).

* Label Environment.Version "CLR Version (deprecated)"
* Query the registry for the .NET (v4) Version
* Fix some warnings

This partially addresses https://jira.sil.org/browse/LT-19930

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/923)
<!-- Reviewable:end -->
