### PR TITLE
Add Linux build and download-dependencies scripts

### DIFF
--- a/build/build
+++ b/build/build
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Usage: ./build [targets [configuration]]
+#   Where targets is a semicolon delimited list of build targets.
+#   Examples:
+#     ./build 'Clean;Compile' ReleaseMonoStrongName
+#     AssertUiEnabled=false ./build Test
+
+set -e -o pipefail
+script_dir="$(dirname "$0")"
+
+mono --version
+which msbuild
+
+cd "${script_dir}/.."
+msbuild "/target:${1-Build}" /property:Configuration="${2-DebugMonoStrongName}" build/Palaso.proj

--- a/build/download-dependencies
+++ b/build/download-dependencies
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -o pipefail
+script_dir="$(dirname "$0")"
+
+"${script_dir}"/buildupdate.mono.sh
+
+msbuild /t:RestorePackages build/Palaso.proj


### PR DESCRIPTION
* To make it easier to successfully figure out how to build the
  project.
* Using some commands copied from CI.
* Not re-using TestBuild.sh. It has trouble presently from setting
  RootDir. Other scripts may rely on TestBuild.sh being there,
  receiving arguments in configuration,target order, and defaulting to
  targets `Clean;Compile`.
* environ is not needed if mono 6 is installed to /usr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/925)
<!-- Reviewable:end -->
