### PR TITLE
Prevent BetterLabel.OnSizeChanged recursion

### DIFF
--- a/SIL.Windows.Forms/Widgets/BetterLabel.cs
+++ b/SIL.Windows.Forms/Widgets/BetterLabel.cs
@@ -14,6 +14,7 @@ namespace SIL.Windows.Forms.Widgets
 	{
 		private Brush _backgroundBrush;
 		private bool _isTextSelectable;
+		private bool _inOnSizeChanged;
 
 		public BetterLabel()
 		{
@@ -163,8 +164,21 @@ namespace SIL.Windows.Forms.Widgets
 
 		protected override void OnSizeChanged(EventArgs e)
 		{
-			DetermineHeight();
-			base.OnSizeChanged(e);
+			if (_inOnSizeChanged)
+			{
+				// Don't end up getting called recursively.
+				return;
+			}
+			try
+			{
+				_inOnSizeChanged = true;
+				DetermineHeight();
+				base.OnSizeChanged(e);
+			}
+			finally
+			{
+				_inOnSizeChanged = false;
+			}
 		}
 
 		protected override void OnVisibleChanged(EventArgs e)


### PR DESCRIPTION
* Fixes LT-20131.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/929)
<!-- Reviewable:end -->
