### PR TITLE
Fail build if we reference unsigned assemblies

### DIFF
--- a/AddSortKey/AddSortKey.csproj
+++ b/AddSortKey/AddSortKey.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ExtractCopyright.Tests/ExtractCopyright.Tests.csproj
+++ b/ExtractCopyright.Tests/ExtractCopyright.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/ExtractCopyright/ExtractCopyright.csproj
+++ b/ExtractCopyright/ExtractCopyright.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Archiving.Tests/SIL.Archiving.Tests.csproj
+++ b/SIL.Archiving.Tests/SIL.Archiving.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Archiving/SIL.Archiving.csproj
+++ b/SIL.Archiving/SIL.Archiving.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Core.Desktop.Tests/SIL.Core.Desktop.Tests.csproj
+++ b/SIL.Core.Desktop.Tests/SIL.Core.Desktop.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Core.Desktop/SIL.Core.Desktop.csproj
+++ b/SIL.Core.Desktop/SIL.Core.Desktop.csproj
@@ -18,6 +18,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Core.Tests/SIL.Core.Tests.csproj
+++ b/SIL.Core.Tests/SIL.Core.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -15,6 +15,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.DblBundle.Tests/SIL.DblBundle.Tests.csproj
+++ b/SIL.DblBundle.Tests/SIL.DblBundle.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/libpalaso</PackageProjectUrl>

--- a/SIL.DblBundle/SIL.DblBundle.csproj
+++ b/SIL.DblBundle/SIL.DblBundle.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.DictionaryServices.Tests/SIL.DictionaryServices.Tests.csproj
+++ b/SIL.DictionaryServices.Tests/SIL.DictionaryServices.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.DictionaryServices/SIL.DictionaryServices.csproj
+++ b/SIL.DictionaryServices/SIL.DictionaryServices.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Lexicon.Tests/SIL.Lexicon.Tests.csproj
+++ b/SIL.Lexicon.Tests/SIL.Lexicon.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Lexicon/SIL.Lexicon.csproj
+++ b/SIL.Lexicon/SIL.Lexicon.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Lift.Tests/SIL.Lift.Tests.csproj
+++ b/SIL.Lift.Tests/SIL.Lift.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Lift/SIL.Lift.csproj
+++ b/SIL.Lift/SIL.Lift.csproj
@@ -17,6 +17,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Linux.Logging.Tests/SIL.Linux.Logging.Tests.csproj
+++ b/SIL.Linux.Logging.Tests/SIL.Linux.Logging.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Linux.Logging/SIL.Linux.Logging.csproj
+++ b/SIL.Linux.Logging/SIL.Linux.Logging.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
+++ b/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/libpalaso</PackageProjectUrl>

--- a/SIL.Scripture/SIL.Scripture.csproj
+++ b/SIL.Scripture/SIL.Scripture.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.TestUtilities.Tests/SIL.TestUtilities.Tests.csproj
+++ b/SIL.TestUtilities.Tests/SIL.TestUtilities.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.TestUtilities/SIL.TestUtilities.csproj
+++ b/SIL.TestUtilities/SIL.TestUtilities.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
+++ b/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/SIL.Windows.Forms.GeckoBrowserAdapter.csproj
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/SIL.Windows.Forms.GeckoBrowserAdapter.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
+++ b/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -14,6 +14,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.Scripture.Tests/SIL.Windows.Forms.Scripture.Tests.csproj
+++ b/SIL.Windows.Forms.Scripture.Tests/SIL.Windows.Forms.Scripture.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Windows.Forms.Scripture/SIL.Windows.Forms.Scripture.csproj
+++ b/SIL.Windows.Forms.Scripture/SIL.Windows.Forms.Scripture.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests-Designer.csproj
+++ b/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests-Designer.csproj
@@ -37,6 +37,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <BaseIntermediateOutputPath>obj\Designer</BaseIntermediateOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests.csproj
+++ b/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms.WritingSystems.Tests/SIL.Windows.Forms.WritingSystems.Tests.csproj
+++ b/SIL.Windows.Forms.WritingSystems.Tests/SIL.Windows.Forms.WritingSystems.Tests.csproj
@@ -12,6 +12,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems.csproj
+++ b/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -16,6 +16,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <IncludeSymbols>true</IncludeSymbols>

--- a/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
+++ b/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
@@ -10,6 +10,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/sillsdev/libpalaso</PackageProjectUrl>

--- a/SIL.WritingSystems/SIL.WritingSystems.csproj
+++ b/SIL.WritingSystems/SIL.WritingSystems.csproj
@@ -14,6 +14,7 @@
     <OutputPath>../output/$(Configuration)</OutputPath>
     <PackageOutputPath>../output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/TestApps/FastSplitterTest/FastSplitterTest.csproj
+++ b/TestApps/FastSplitterTest/FastSplitterTest.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestApps/ReportingTest/Reporting.TestApp.csproj
+++ b/TestApps/ReportingTest/Reporting.TestApp.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestApps/SIL.Email.TestApp/SIL.Email.TestApp.csproj
+++ b/TestApps/SIL.Email.TestApp/SIL.Email.TestApp.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestApps/TestAppKeyboard/TestAppKeyboard.csproj
+++ b/TestApps/TestAppKeyboard/TestAppKeyboard.csproj
@@ -13,6 +13,7 @@
     <Copyright>Copyright © 2010-2020 SIL International</Copyright>
     <OutputPath>../../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
+    <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../palaso.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
When building (and running) a signed assembly, all the dependencies
have to be strong-named as well. This change fails the build if we
accidentally reference a non-signed assembly in a project that
produces a signed assembly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/931)
<!-- Reviewable:end -->
