### PR TITLE
[API] Encode ' ' as %20 in URL's

### DIFF
--- a/SIL.Core/Network/HttpEncoderFromMono.cs
+++ b/SIL.Core/Network/HttpEncoderFromMono.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Authors:
 //   Patrik Torstensson (Patrik.Torstensson@labs2.com)
 //   Wictor Wilén (decode/encode functions) (wictor@ibizkit.se)
@@ -605,11 +605,8 @@ namespace SIL.Network
 				result.WriteByte((byte)c);
 				return;
 			}
-			if (c == ' ')
-			{
-				result.WriteByte((byte)'+');
-				return;
-			}
+			// `c < '0'` includes ' '. We are choosing to encode ' ' as %20 rather than + because LanguageDepot users may wish to have spaces in
+			// their passwords, and we need to be able to distinguish between these two characters when the password is included in the URL.
 			if ((c < '0') ||
 				(c < 'A' && c > '9') ||
 				(c > 'Z' && c < 'a') ||

--- a/SIL.Core/Network/HttpUtilityFromMono.cs
+++ b/SIL.Core/Network/HttpUtilityFromMono.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // System.Web.HttpUtility
 //
 // Authors:
@@ -353,13 +353,13 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 			return UrlEncode(str, Encoding.UTF8);
 		}
 
-		public static string UrlEncode (string s, Encoding Enc)
+		public static string UrlEncode (string s, Encoding enc)
 		{
 			if (s == null)
 				return null;
 
-			if (s == String.Empty)
-				return String.Empty;
+			if (s == string.Empty)
+				return string.Empty;
 
 			bool needEncode = false;
 			int len = s.Length;
@@ -378,8 +378,8 @@ Actually when we go to net 4, I (hatton) think we can get rid of this. .net 4 cl
 				return s;
 
 			// avoided GetByteCount call
-			byte [] bytes = new byte[Enc.GetMaxByteCount(s.Length)];
-			int realLen = Enc.GetBytes (s, 0, s.Length, bytes, 0);
+			byte [] bytes = new byte[enc.GetMaxByteCount(s.Length)];
+			int realLen = enc.GetBytes (s, 0, s.Length, bytes, 0);
 			return Encoding.ASCII.GetString (UrlEncodeToBytes (bytes, 0, realLen));
 		}
 


### PR DESCRIPTION
* Differentiates between spaces and plusses
* Allows spaces to be used in passwords
* Required for https://jira.sil.org/browse/LT-20157

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/934)
<!-- Reviewable:end -->
