### PR TITLE
[feature/nuget] Use DialogAdapters.Gtk2

### DIFF
--- a/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
@@ -141,7 +141,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 					// Call OpenFile asynchronously.
 					// Explorer instance from which file is dropped is not responding
 					// all the time when DragDrop handler is active, so we need to return
-					// immidiately (especially if OpenFile shows MessageBox).
+					// immediately (especially if OpenFile shows MessageBox).
 
 					BeginInvoke(new Action<string>(OpenFileFromDrag), s);
 
@@ -230,7 +230,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 			}
 			catch (WIA_Version2_MissingException)
 			{
-				_messageLabel.Text = "Windows XP does not come with a crucial DLL that lets you use a WIA scanner with this program. Get a technical person to downloand and follow the directions at http://vbnet.mvps.org/files/updates/wiaautsdk.zip";
+				_messageLabel.Text = "Windows XP does not come with a crucial DLL that lets you use a WIA scanner with this program. Get a technical person to download and follow the directions at http://vbnet.mvps.org/files/updates/wiaautsdk.zip";
 				_messageLabel.Visible = true;
 			}
 			catch (Exception error)

--- a/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
@@ -65,8 +65,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DialogAdapters, Version=0.1.6.21495, Culture=neutral, PublicKeyToken=7dc842182b0626dc">
-      <HintPath>..\packages\DialogAdapters.0.1.6.21495\lib\net45\DialogAdapters.dll</HintPath>
+    <Reference Include="DialogAdapters, Version=0.1.9.0, Culture=neutral, PublicKeyToken=7dc842182b0626dc">
+      <HintPath>..\packages\DialogAdapters.Gtk2.0.1.9\lib\net461\DialogAdapters.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Enchant.Net">

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -30,7 +30,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DialogAdapters" Version="0.1.4.30000" />
+    <PackageReference Include="DialogAdapters.Gtk2" Version="0.1.9" />
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
     <PackageReference Include="L10NSharp" Version="4.0.0" />
     <PackageReference Include="MarkdownDeep.NET.Patched" Version="1.5.0.2" />
@@ -58,9 +58,15 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)'!='Windows_NT'">
-    <Reference Include="gtk-sharp" />
-    <Reference Include="gdk-sharp" />
-    <Reference Include="glib-sharp" />
+    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <HintPath>\usr\lib\cli\gdk-sharp-2.0\gdk-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <HintPath>\usr\lib\cli\glib-sharp-2.0\glib-sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
+      <HintPath>\usr\lib\cli\gtk-sharp-2.0\gtk-sharp.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Posix" />
   </ItemGroup>
 
@@ -71,10 +77,5 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <Reference Include="System.Configuration" />
     <Reference Include="System.Security" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <!-- See https://github.com/dotnet/sdk/issues/987#issuecomment-286307697 why that is needed -->
-    <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
-  </PropertyGroup>
 
 </Project>

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DialogAdapters" version="0.1.4.30000" targetFramework="net45" />
+  <package id="DialogAdapters.Gtk2" version="0.1.9" targetFramework="net461" />
   <package id="Enchant.Net" version="1.4.2" requireReinstallation="true" />
   <package id="GdkSharp-signed" version="3.22.24.37" requireReinstallation="true" />
   <package id="GioSharp-signed" version="3.22.24.37" requireReinstallation="true" />

--- a/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
+++ b/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Geckofx45" Version="45.0.34" />
+    <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" />
+    <PackageReference Include="Geckofx45.64" Version="45.0.34" />
+    <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" />
     <PackageReference Include="GitVersionTask" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/TestApps/SIL.Windows.Forms.TestApp/environ
+++ b/TestApps/SIL.Windows.Forms.TestApp/environ
@@ -8,11 +8,6 @@ BASE="$(pwd)"
 [ -z "$BUILD" ] && BUILD=Debug
 [ -z "$MONO_PREFIX" ] && MONO_PREFIX=/opt/mono5-sil
 
-# Dependency locations
-# Search for xulrunner and geckofx, select the best, and add its location to LD_LIBRARY_PATH.
-# Also determine the location of the geckofx assemblies and shared object libraries.
-# Also define LD_PRELOAD to get geckofix.so to work properly
-
 # MonoDevelop seems to set PKG_CONFIG_LIBDIR to the empty string, which is bad
 # for us because that eliminates most packages, including geckofx29.
 # If PKG_CONFIG_LIBDIR is not set at all, then the default paths are searched.
@@ -22,11 +17,16 @@ if [ "${PKG_CONFIG_LIBDIR+set}" = set ]; then
 	unset PKG_CONFIG_LIBDIR
 fi
 
-XULRUNNER=/usr/lib/xulrunner-geckofx-29
-if [ ! -d ${XULRUNNER} ]; then XULRUNNER=/usr/lib/xulrunner-29; fi
+# Simplified setup - assuming the nuget packages got installed in ~/.nuget/packages
+if [ "$(uname -m)" == "x86_64" ]; then
+	ARCH=64
+else
+	ARCH=32
+fi
+XULRUNNER=$HOME/.nuget/packages/geckofx45.$ARCH.linux/45.0.37/content/Firefox-Linux${ARCH}
+
 LD_LIBRARY_PATH="${XULRUNNER}:${LD_LIBRARY_PATH}"
-GECKOFX="$(pkg-config --variable assemblies_dir Geckofx-Core-29)"
-export LD_PRELOAD=${GECKOFX}/geckofix.so
+export LD_PRELOAD=${XULRUNNER}/libgeckofix.so
 export XULRUNNER
 
 if [ "${OLD_PKG_CONFIG_LIBDIR+set}" = set ]; then


### PR DESCRIPTION
This change makes use of the new DialogAdapters.Gtk2 nuget package. This can be swapped out by the client against the Gtk3-based DialogAdapters.

This change will fix the builds of the `feature/nuget` branch.

This change depends on the availability of `DialogAdapters.Gtk2` on nuget.org (cf. https://bitbucket.org/hindlemail/dialogadapters/pull-requests/5).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/937)
<!-- Reviewable:end -->
