### PR TITLE
Exclude ole32.dll from Acknowledgements

### DIFF
--- a/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
+++ b/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
@@ -16,7 +16,8 @@ namespace SIL.Acknowledgements
 		private static readonly string[] Exclusions =
 		{
 			"Interop.WIA.dll", "vshost.exe", "CommandLine.dll",
-			"nunit.framework.dll", ".Tests.dll", ".Tests.exe", "TestApp.dll", "TestApp.exe", "oleaut32.dll"
+			"nunit.framework.dll", ".Tests.dll", ".Tests.exe", "TestApp.dll", "TestApp.exe",
+			"oleaut32.dll", "ole32.dll"
 
 			// Use this version to see the TestApp dependencies in SIL.Windows.Forms.TestApp.AssemblyInfo.cs
 			//"Interop.WIA.dll", "vshost.exe", "CommandLine.dll",


### PR DESCRIPTION
* On Linux, this is a symlink to libcom.so. An exception is thrown,
  contributing to LT-20121.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/939)
<!-- Reviewable:end -->
