### PR TITLE
Fix keyboard switching on Ubuntu 18.04 (fixes #887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+
 - [SIL.DblBundle] `DblMetadata.Load` overload to allow deserialization from a `TextReader`.
 - [SIL.Scripture] `Versification.Table.Load` overload to allow deserialization from a `TextReader`.
 - [SIL.DblBundle] `TextBundle<TM, TL>.GetVersification` (to replace deprecated `CopyVersificationFile`)
@@ -25,14 +26,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Scripture] `ScrVers.Save` overload to allow serialization to a `TextWriter`.
 - [SIL.Core] `XmlSerializationHelper.Serialize<T>` to allow serialization to a `TextWriter`.
 - [SIL.Core] `XmlSerializationHelper.Deserialize<T>` to allow deserialization from a `TextReader`.
+- [SIL.Core] `Platform.IsGnomeShell` to detect if executing in a Gnome Shell
 
 ### Changed
 
 - Add build number to `AssemblyFileVersion`
 - Improve nuget symbol packages
 - Use NUnit 3 for unit tests
-- [SIL.Core, SIL.Core.Desktop] Move several classes back to `SIL.Core` from `SIL.Core.Desktop` to make
-  them available to .NET Standard clients.
+- [SIL.Core, SIL.Core.Desktop] Move several classes back to `SIL.Core` from `SIL.Core.Desktop` to
+  make them available to .NET Standard clients:
   - IO/PathUtilities
   - IO/TempFileForSafeWriting
   - Reporting/AnalyticsEventSender
@@ -53,8 +55,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms.Keyboarding] Use signed version of `Keyman*Interop.dll` (#865)
-- [SIL.Windows.Forms] Use signed versions of `ibusdotnet.dll`, `Interop.WIA.dll`, `DialogAdapters.dll`,
-  and `MarkdownDeep.dll` (#865)
+- [SIL.Windows.Forms.Keyboarding] Fixed keyboard switching for Ubuntu 18.04 (#887)
+- [SIL.Windows.Forms] Use signed versions of `ibusdotnet.dll`, `Interop.WIA.dll`,
+  `DialogAdapters.dll`, and `MarkdownDeep.dll` (#865)
 - [SIL.Media] Fix missing `irrKlang.NET4.dll` exception by copying it to `lib` folder in output
 
 ### Deprecated
@@ -62,8 +65,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Deprecate `ExceptionHandler.Init()` method in favor of more explicit version
   `ExceptionHandler.Init(ExceptionHandler)`, e.g. `ExceptionHandler.Init(new WinFormsExceptionHandler())`
 - [SIL.Core] Deprecate `HttpUtilityFromMono` class. Use `System.Web.HttpUtility` instead.
-- [SIL.DblBundle] Deprecate `TextBundle.CopyVersificationFile`, `CopyFontFiles` and `CopyLdmlFile` in favor
-  of `GetVersificationFile`, `GetFontFiles`, and `GetLdmlFile`.
+- [SIL.DblBundle] Deprecate `TextBundle.CopyVersificationFile`, `CopyFontFiles` and
+  `CopyLdmlFile` in favor of `GetVersificationFile`, `GetFontFiles`, and `GetLdmlFile`.
 
 ### Removed
 

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -325,5 +325,17 @@ namespace SIL.PlatformUtilities
 		public static string ProcessArchitecture => Environment.Is64BitProcess ? x64 : x86;
 
 		public static bool IsRunning64Bit => Environment.Is64BitProcess;
+
+		public static bool IsGnomeShell
+		{
+			get
+			{
+				if (!IsLinux)
+					return false;
+
+				var pids = RunTerminalCommand("pidof", "gnome-shell");
+				return !string.IsNullOrEmpty(pids);
+			}
+		}
 	}
 }

--- a/SIL.Core/Program/Process.cs
+++ b/SIL.Core/Program/Process.cs
@@ -15,7 +15,7 @@ namespace SIL.Program
 	/// </summary>
 	/// <remarks>
 	/// I suppose this could be fixed by a change to System.Diagnostics.Process.Start(), but I
-	/// would argue that the current behavior is probaby by design and a change would be rejected
+	/// would argue that the current behavior is probably by design and a change would be rejected
 	/// by the Mono project.
 	/// See https://silbloom.myjetbrains.com/youtrack/issue/BL-5993 for the bug report that
 	/// triggered this class and methods.

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -219,7 +219,8 @@ namespace SIL.Windows.Forms.Keyboarding
 					{
 						new XkbKeyboardRetrievingAdaptor(), new IbusKeyboardRetrievingAdaptor(),
 						new UnityXkbKeyboardRetrievingAdaptor(), new UnityIbusKeyboardRetrievingAdaptor(),
-						new CombinedIbusKeyboardRetrievingAdaptor()
+						new CombinedIbusKeyboardRetrievingAdaptor(),
+						new GnomeShellIbusKeyboardRetrievingAdaptor()
 					}
 			);
 		}

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -153,7 +153,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				}
 				var list = GetMyKeyboards(_settingsGeneral);
 				return list != null && list.Length > 0 && Platform.DesktopEnvironment != "unity"
-					&& Platform.DesktopEnvironment != "gnome";
+					&& !Platform.DesktopEnvironment.Contains("gnome");
 			}
 		}
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
@@ -46,9 +46,9 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			startInfo.FileName = "/usr/bin/setxkbmap";
 			var bldr = new StringBuilder();
 			bldr.AppendFormat ("-layout {0}", layout);
-			if (!String.IsNullOrEmpty(variant))
+			if (!string.IsNullOrEmpty(variant))
 				bldr.AppendFormat (" -variant {0}", variant);
-			if (!String.IsNullOrEmpty(option))
+			if (!string.IsNullOrEmpty(option))
 				bldr.AppendFormat (" -option {0}", option);
 			//Console.WriteLine("DEBUG SetXkbLayout({0},{1},{2}): about to call \"{3} {4}\"", layout, variant, option, startInfo.FileName, bldr.ToString());
 			startInfo.Arguments = bldr.ToString();
@@ -75,10 +75,10 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// </remarks>
 		private static void SetXModMap()
 		{
-			string homedir = Environment.GetEnvironmentVariable("HOME");
-			foreach (string file in knownXModMapFiles)
+			var homedir = Environment.GetEnvironmentVariable("HOME");
+			foreach (var file in knownXModMapFiles)
 			{
-				string filepath = System.IO.Path.Combine(homedir, file);
+				var filepath = System.IO.Path.Combine(homedir, file);
 				if (!System.IO.File.Exists(filepath))
 					continue;
 				var startInfo = new ProcessStartInfo();
@@ -112,57 +112,56 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			var option = ibusKeyboard.IBusKeyboardEngine.LayoutOption;
 			Debug.Assert(parentLayout != null);
 
-			bool need_us_layout = false;
-			foreach (string latinLayout in LatinLayouts)
+			var need_us_layout = false;
+			foreach (var latinLayout in LatinLayouts)
 			{
 				if (parentLayout == latinLayout && variant != "eng")
 				{
 					need_us_layout = true;
 					break;
 				}
-				if (!String.IsNullOrEmpty(variant) && String.Format("{0}({1})", parentLayout, variant) == latinLayout)
+				if (!string.IsNullOrEmpty(variant) && $"{parentLayout}({variant})" == latinLayout)
 				{
 					need_us_layout = true;
 					break;
 				}
 			}
 
-			if (String.IsNullOrEmpty(parentLayout) || parentLayout == "default")
+			if (string.IsNullOrEmpty(parentLayout) || parentLayout == "default")
 			{
 				parentLayout = DefaultLayout;
 				variant = DefaultVariant;
 			}
-			if (String.IsNullOrEmpty(variant) || variant == "default")
+			if (string.IsNullOrEmpty(variant) || variant == "default")
 				variant = null;
-			if (String.IsNullOrEmpty(option) || option == "default")
+			if (string.IsNullOrEmpty(option) || option == "default")
 			{
 				option = DefaultOption;
 			}
 			else if (!string.IsNullOrEmpty(DefaultOption))
 			{
-				if (DefaultOption.Split(',').Contains(option, StringComparison.InvariantCulture))
-					option = DefaultOption;
-				else
-					option = String.Format("{0},{1}", DefaultOption, option);
+				option = DefaultOption.Split(',').Contains(option, StringComparison.InvariantCulture)
+					? DefaultOption
+					: $"{DefaultOption},{option}";
 			}
 
 			if (need_us_layout)
 			{
-				parentLayout = parentLayout + ",us";
+				parentLayout += ",us";
 				// If we have a variant, we need to indicate an empty variant to
 				// match the "us" layout.
-				if (!String.IsNullOrEmpty(variant))
-					variant = variant + ",";
+				if (!string.IsNullOrEmpty(variant))
+					variant += ",";
 			}
 
 			SetXkbLayout(parentLayout, variant, option);
 
-			if (!ibusKeyboard.Name.StartsWith("xkb:", StringComparison.InvariantCulture))
-			{
-				// Set the IBus keyboard
-				var context = GlobalCachedInputContext.InputContext;
-				context.SetEngine(ibusKeyboard.IBusKeyboardEngine.LongName);
-			}
+			if (ibusKeyboard.Name.StartsWith("xkb:", StringComparison.InvariantCulture))
+				return;
+
+			// Set the IBus keyboard
+			var context = GlobalCachedInputContext.InputContext;
+			context.SetEngine(ibusKeyboard.IBusKeyboardEngine.LongName);
 		}
 
 		/// <summary>
@@ -177,14 +176,14 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			{
 				if (_defaultKeyboard == null)
 				{
-					var desired = String.Format("xkb:{0}:", DefaultLayout);
-					if (!String.IsNullOrEmpty (DefaultVariant))
-						desired = String.Format ("xkb:{0}:{1}:", DefaultLayout, DefaultVariant);
-					var pattern = String.Format("[^A-Za-z]{0}[^A-Za-z]|^{0}[^A-Za-z]|.*[^A-Za-z]{0}$",
+					var desired = $"xkb:{DefaultLayout}:";
+					if (!string.IsNullOrEmpty (DefaultVariant))
+						desired = $"xkb:{DefaultLayout}:{DefaultVariant}:";
+					var pattern = string.Format("[^A-Za-z]{0}[^A-Za-z]|^{0}[^A-Za-z]|.*[^A-Za-z]{0}$",
 						DefaultLayout);
 					var regex = new System.Text.RegularExpressions.Regex(pattern);
 					KeyboardDescription first = null;
-					foreach (KeyboardDescription kbd in KeyboardController.Instance.AvailableKeyboards.OfType<KeyboardDescription>())
+					foreach (var kbd in KeyboardController.Instance.AvailableKeyboards.OfType<KeyboardDescription>())
 					{
 						if (first == null)
 							first = kbd;	// last-ditch value if all else fails

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using SIL.PlatformUtilities;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	/// <summary>
+	/// This class handles initializing the list of keyboards on Ubuntu versions >= 18.04.
+	/// The keyboard retrieving part is identical to previous versions but switching keyboards
+	/// changed with 18.04.
+	/// </summary>
+	public class GnomeShellIbusKeyboardRetrievingAdaptor: UnityIbusKeyboardRetrievingAdaptor
+	{
+		protected override IKeyboardSwitchingAdaptor CreateSwitchingAdaptor()
+		{
+			return new GnomeShellIbusKeyboardSwitchingAdaptor(IbusCommunicator);
+		}
+
+		public override bool IsApplicable => _helper.IsApplicable && Platform.IsGnomeShell;
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Diagnostics;
+using SIL.Reporting;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	/// <summary>
+	/// Class for dealing with ibus keyboards on Gnome Shell (as found in Ubuntu Bionic >= 18.04)
+	/// </summary>
+	public class GnomeShellIbusKeyboardSwitchingAdaptor: UnityIbusKeyboardSwitchingAdaptor, IUnityKeyboardSwitchingAdaptor
+	{
+		public GnomeShellIbusKeyboardSwitchingAdaptor(IIbusCommunicator ibusCommunicator)
+			: base(ibusCommunicator)
+		{
+		}
+
+		void IUnityKeyboardSwitchingAdaptor.SelectKeyboard(uint index)
+		{
+			var okay = false;
+			// https://askubuntu.com/a/1039964
+			try
+			{
+				using (var proc = new Process {
+					EnableRaisingEvents = false,
+					StartInfo = {
+						FileName = "/usr/bin/gdbus",
+						Arguments = "call --session --dest org.gnome.Shell --object-path /org/gnome/Shell " +
+							"--method org.gnome.Shell.Eval " +
+							$"\"imports.ui.status.keyboard.getInputSourceManager().inputSources[{index}].activate()\"",
+						UseShellExecute = false
+					}
+				})
+				{
+					proc.Start();
+					proc.WaitForExit();
+					okay = proc.ExitCode == 0;
+				}
+			}
+			finally
+			{
+				if (!okay)
+				{
+					var msg = $"GnomeShellIbusKeyboardSwitchingAdaptor.SelectKeyboard({index}) failed";
+					Console.WriteLine(msg);
+					Logger.WriteEvent(msg);
+				}
+			}
+		}
+
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/IUnityKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IUnityKeyboardSwitchingAdaptor.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	internal interface IUnityKeyboardSwitchingAdaptor
+	{
+		void SelectKeyboard(uint index);
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
@@ -28,22 +28,19 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// </summary>
 		private static string FormatKeyboardIdentifier(string layout, string locale)
 		{
-			string languageCode = AlternateLanguageCodes.GetLanguageCode(locale);
-			string languageName = string.IsNullOrEmpty(languageCode) ? OtherLanguage :
+			var languageCode = AlternateLanguageCodes.GetLanguageCode(locale);
+			var languageName = string.IsNullOrEmpty(languageCode) ? OtherLanguage :
 				new Locale(languageCode).GetDisplayName(new Locale(Application.CurrentCulture.TwoLetterISOLanguageName));
 			if (languageCode != null && languageCode.ToLowerInvariant() == languageName.ToLowerInvariant())
 				languageName = OtherLanguage;
-			return string.Format("{0} - {1}", languageName, layout);
+			return $"{languageName} - {layout}";
 		}
 
-		public string ParentLayout
-		{
-			get { return IBusKeyboardEngine.Layout; }
-		}
+		public string ParentLayout => IBusKeyboardEngine.Layout;
 
 		public IBusEngineDesc IBusKeyboardEngine
 		{
-			get { return _ibusKeyboard; }
+			get => _ibusKeyboard;
 			set
 			{
 				_ibusKeyboard = value;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
@@ -19,13 +20,18 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		#region Specific implementations of IKeyboardRetriever
 
-		public override bool IsApplicable => _helper.IsApplicable;
+		public override bool IsApplicable => _helper.IsApplicable && !Platform.IsGnomeShell;
 
 		public override void Initialize()
 		{
-			SwitchingAdaptor = new UnityIbusKeyboardSwitchingAdaptor(IbusCommunicator);
+			SwitchingAdaptor = CreateSwitchingAdaptor();
 			KeyboardRetrievingHelper.AddIbusVersionAsErrorReportProperty();
 			InitKeyboards();
+		}
+
+		protected virtual IKeyboardSwitchingAdaptor CreateSwitchingAdaptor()
+		{
+			return new UnityIbusKeyboardSwitchingAdaptor(IbusCommunicator);
 		}
 
 		protected override string GetKeyboardSetupApplication(out string arguments)

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
@@ -1,21 +1,22 @@
 ﻿// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
+using SIL.PlatformUtilities;
 using SIL.Reporting;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
 	/// <summary>
-	/// Class for dealing with ibus keyboards on Unity (as found in Trusty >= 13.10)
+	/// Class for dealing with ibus keyboards on Unity (as found in Trusty >= 13.10 < 18.04)
 	/// </summary>
-	public class UnityIbusKeyboardSwitchingAdaptor : IbusKeyboardSwitchingAdaptor
+	public class UnityIbusKeyboardSwitchingAdaptor : IbusKeyboardSwitchingAdaptor, IUnityKeyboardSwitchingAdaptor
 	{
 		public UnityIbusKeyboardSwitchingAdaptor(IIbusCommunicator ibusCommunicator) :
 			base(ibusCommunicator)
 		{
 		}
 
-		internal static void SelectKeyboard(uint index)
+		void IUnityKeyboardSwitchingAdaptor.SelectKeyboard(uint index)
 		{
 			const string schema = "org.gnome.desktop.input-sources";
 			bool okay = true;
@@ -45,8 +46,8 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		protected override void SelectKeyboard(KeyboardDescription keyboard)
 		{
 			var ibusKeyboard = (IbusKeyboardDescription) keyboard;
-			uint systemIndex = ibusKeyboard.SystemIndex;
-			SelectKeyboard(systemIndex);
+			var systemIndex = ibusKeyboard.SystemIndex;
+			((IUnityKeyboardSwitchingAdaptor)this).SelectKeyboard(systemIndex);
 		}
 
 	}

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
@@ -20,10 +20,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		#region Specific implementations of IKeyboardRetriever
 
-		public override bool IsApplicable
-		{
-			get { return _helper.IsApplicable; }
-		}
+		public override bool IsApplicable => _helper.IsApplicable;
 
 		public override void Initialize()
 		{
@@ -50,27 +47,22 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 			var configRegistry = XklConfigRegistry.Create(XklEngine);
 			var layouts = configRegistry.Layouts;
-			Dictionary<string, XkbKeyboardDescription> curKeyboards = KeyboardController.Instance.Keyboards.OfType<XkbKeyboardDescription>().ToDictionary(kd => kd.Id);
+			var curKeyboards = KeyboardController.Instance.Keyboards.OfType<XkbKeyboardDescription>().ToDictionary(kd => kd.Id);
 			foreach (var kvp in layouts)
 			{
 				foreach (var layout in kvp.Value)
 				{
-					uint index;
 					// Custom keyboards may omit defining a country code.  Try to survive such cases.
-					string codeToMatch;
-					if (layout.CountryCode == null)
-						codeToMatch = layout.LanguageCode.ToLowerInvariant();
-					else
-						codeToMatch = layout.CountryCode.ToLowerInvariant();
-					if ((keyboards.TryGetValue(layout.LayoutId, out index) && (layout.LayoutId == codeToMatch)) ||
-						keyboards.TryGetValue(string.Format("{0}+{1}", codeToMatch, layout.LayoutId), out index))
+					var codeToMatch = layout.CountryCode == null ? layout.LanguageCode.ToLowerInvariant() : layout.CountryCode.ToLowerInvariant();
+					if ((keyboards.TryGetValue(layout.LayoutId, out var index) && (layout.LayoutId == codeToMatch)) ||
+						keyboards.TryGetValue($"{codeToMatch}+{layout.LayoutId}", out index))
 					{
 						AddKeyboardForLayout(curKeyboards, layout, index, SwitchingAdaptor);
 					}
 				}
 			}
 
-			foreach (XkbKeyboardDescription existingKeyboard in curKeyboards.Values)
+			foreach (var existingKeyboard in curKeyboards.Values)
 				existingKeyboard.SetIsAvailable(false);
 		}
 	}

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardSwitchingAdaptor.cs
@@ -16,11 +16,13 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		protected override void SelectKeyboard(KeyboardDescription keyboard)
 		{
 			var xkbKeyboard = keyboard as XkbKeyboardDescription;
-			if (xkbKeyboard != null)
-			{
-				if (xkbKeyboard.GroupIndex >= 0)
-					UnityIbusKeyboardSwitchingAdaptor.SelectKeyboard((uint)xkbKeyboard.GroupIndex);
-			}
+			if (xkbKeyboard == null || xkbKeyboard.GroupIndex < 0)
+				return;
+
+			var switchingAdaptor = KeyboardController.Instance
+				.Adaptors[KeyboardAdaptorType.OtherIm]
+				.SwitchingAdaptor as IUnityKeyboardSwitchingAdaptor;
+			switchingAdaptor.SelectKeyboard((uint) xkbKeyboard.GroupIndex);
 		}
 	}
 }


### PR DESCRIPTION
Ubuntu 18.04 changed the way how to switch keyboards. The previous
method of setting a dconf value is deprecated and no longer works.
Instead this is done by a DBus method call.

This change also adds a property to detect if the program runs in
a Gnome Shell, and fixes a bug where the wrong keyboard adaptor was
used in Ubuntu 18.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/949)
<!-- Reviewable:end -->
