### PR TITLE
Fix keyboard switching on Ubuntu 18.04 (fixes #887)

### DIFF
--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -319,5 +319,17 @@ namespace SIL.PlatformUtilities
 			return output.Trim();
 		}
 
+
+		public static bool IsGnomeShell
+		{
+			get
+			{
+				if (!IsLinux)
+					return false;
+
+				var pids = RunTerminalCommand("pidof", "gnome-shell");
+				return !string.IsNullOrEmpty(pids);
+			}
+		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -229,7 +229,8 @@ namespace SIL.Windows.Forms.Keyboarding
 					{
 						new XkbKeyboardRetrievingAdaptor(), new IbusKeyboardRetrievingAdaptor(),
 						new UnityXkbKeyboardRetrievingAdaptor(), new UnityIbusKeyboardRetrievingAdaptor(),
-						new CombinedIbusKeyboardRetrievingAdaptor()
+						new CombinedIbusKeyboardRetrievingAdaptor(),
+						new GnomeShellIbusKeyboardRetrievingAdaptor()
 					}
 			);
 		}

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -154,7 +154,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				}
 				var list = GetMyKeyboards(_settingsGeneral);
 				return list != null && list.Length > 0 && Platform.DesktopEnvironment != "unity"
-					&& Platform.DesktopEnvironment != "gnome";
+					&& !Platform.DesktopEnvironment.Contains("gnome");
 			}
 		}
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using SIL.PlatformUtilities;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	/// <summary>
+	/// This class handles initializing the list of keyboards on Ubuntu versions >= 18.04.
+	/// The keyboard retrieving part is identical to previous versions but switching keyboards
+	/// changed with 18.04.
+	/// </summary>
+	public class GnomeShellIbusKeyboardRetrievingAdaptor: UnityIbusKeyboardRetrievingAdaptor
+	{
+		protected override IKeyboardSwitchingAdaptor CreateSwitchingAdaptor()
+		{
+			return new GnomeShellIbusKeyboardSwitchingAdaptor(IbusCommunicator);
+		}
+
+		public override bool IsApplicable => _helper.IsApplicable && Platform.IsGnomeShell;
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Diagnostics;
+using SIL.Reporting;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	/// <summary>
+	/// Class for dealing with ibus keyboards on Gnome Shell (as found in Ubuntu Bionic >= 18.04)
+	/// </summary>
+	public class GnomeShellIbusKeyboardSwitchingAdaptor: UnityIbusKeyboardSwitchingAdaptor, IUnityKeyboardSwitchingAdaptor
+	{
+		public GnomeShellIbusKeyboardSwitchingAdaptor(IIbusCommunicator ibusCommunicator)
+			: base(ibusCommunicator)
+		{
+		}
+
+		void IUnityKeyboardSwitchingAdaptor.SelectKeyboard(uint index)
+		{
+			var okay = false;
+			// https://askubuntu.com/a/1039964
+			try
+			{
+				using (var proc = new Process {
+					EnableRaisingEvents = false,
+					StartInfo = {
+						FileName = "/usr/bin/gdbus",
+						Arguments = "call --session --dest org.gnome.Shell --object-path /org/gnome/Shell " +
+							"--method org.gnome.Shell.Eval " +
+							$"\"imports.ui.status.keyboard.getInputSourceManager().inputSources[{index}].activate()\"",
+						UseShellExecute = false
+					}
+				})
+				{
+					proc.Start();
+					proc.WaitForExit();
+					okay = proc.ExitCode == 0;
+				}
+			}
+			finally
+			{
+				if (!okay)
+				{
+					var msg = $"GnomeShellIbusKeyboardSwitchingAdaptor.SelectKeyboard({index}) failed";
+					Console.WriteLine(msg);
+					Logger.WriteEvent(msg);
+				}
+			}
+		}
+
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/IUnityKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IUnityKeyboardSwitchingAdaptor.cs
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	internal interface IUnityKeyboardSwitchingAdaptor
+	{
+		void SelectKeyboard(uint index);
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
@@ -16,17 +17,22 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	[CLSCompliant(false)]
 	public class UnityIbusKeyboardRetrievingAdaptor : IbusKeyboardRetrievingAdaptor
 	{
-		private readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();
+		protected readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();
 
 		#region Specific implementations of IKeyboardRetriever
 
-		public override bool IsApplicable => _helper.IsApplicable;
+		public override bool IsApplicable => _helper.IsApplicable && !Platform.IsGnomeShell;
 
 		public override void Initialize()
 		{
-			SwitchingAdaptor = new UnityIbusKeyboardSwitchingAdaptor(IbusCommunicator);
+			SwitchingAdaptor = CreateSwitchingAdaptor();
 			KeyboardRetrievingHelper.AddIbusVersionAsErrorReportProperty();
 			InitKeyboards();
+		}
+
+		protected virtual IKeyboardSwitchingAdaptor CreateSwitchingAdaptor()
+		{
+			return new UnityIbusKeyboardSwitchingAdaptor(IbusCommunicator);
 		}
 
 		protected override string GetKeyboardSetupApplication(out string arguments)

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
@@ -1,22 +1,22 @@
 ﻿// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
+using SIL.PlatformUtilities;
 using SIL.Reporting;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
 	/// <summary>
-	/// Class for dealing with ibus keyboards on Unity (as found in Trusty >= 13.10)
+	/// Class for dealing with ibus keyboards on Unity (as found in Trusty >= 13.10 < 18.04)
 	/// </summary>
-	[CLSCompliant(false)]
-	public class UnityIbusKeyboardSwitchingAdaptor : IbusKeyboardSwitchingAdaptor
+	public class UnityIbusKeyboardSwitchingAdaptor : IbusKeyboardSwitchingAdaptor, IUnityKeyboardSwitchingAdaptor
 	{
 		public UnityIbusKeyboardSwitchingAdaptor(IIbusCommunicator ibusCommunicator) :
 			base(ibusCommunicator)
 		{
 		}
 
-		internal static void SelectKeyboard(uint index)
+		void IUnityKeyboardSwitchingAdaptor.SelectKeyboard(uint index)
 		{
 			const string schema = "org.gnome.desktop.input-sources";
 			bool okay = true;
@@ -46,8 +46,8 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		protected override void SelectKeyboard(KeyboardDescription keyboard)
 		{
 			var ibusKeyboard = (IbusKeyboardDescription) keyboard;
-			uint systemIndex = ibusKeyboard.SystemIndex;
-			SelectKeyboard(systemIndex);
+			var systemIndex = ibusKeyboard.SystemIndex;
+			((IUnityKeyboardSwitchingAdaptor)this).SelectKeyboard(systemIndex);
 		}
 
 	}

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardSwitchingAdaptor.cs
@@ -16,11 +16,13 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		protected override void SelectKeyboard(KeyboardDescription keyboard)
 		{
 			var xkbKeyboard = keyboard as XkbKeyboardDescription;
-			if (xkbKeyboard != null)
-			{
-				if (xkbKeyboard.GroupIndex >= 0)
-					UnityIbusKeyboardSwitchingAdaptor.SelectKeyboard((uint)xkbKeyboard.GroupIndex);
-			}
+			if (xkbKeyboard == null || xkbKeyboard.GroupIndex < 0)
+				return;
+
+			var switchingAdaptor = KeyboardController.Instance
+				.Adaptors[KeyboardAdaptorType.OtherIm]
+				.SwitchingAdaptor as IUnityKeyboardSwitchingAdaptor;
+			switchingAdaptor.SelectKeyboard((uint) xkbKeyboard.GroupIndex);
 		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -376,7 +376,10 @@
     <Compile Include="Linux\AlternateLanguageCodes.cs" />
     <Compile Include="Linux\CombinedIbusKeyboardRetrievingAdaptor.cs" />
     <Compile Include="Linux\CombinedIbusKeyboardSwitchingAdaptor.cs" />
+    <Compile Include="Linux\GnomeShellIbusKeyboardRetrievingAdaptor.cs" />
+    <Compile Include="Linux\GnomeShellIbusKeyboardSwitchingAdaptor.cs" />
     <Compile Include="Linux\IbusKeyboardSwitchingAdaptor.cs" />
+    <Compile Include="Linux\IUnityKeyboardSwitchingAdaptor.cs" />
     <Compile Include="Linux\KeyboardRetrievingHelper.cs" />
     <Compile Include="Linux\UnityIbusKeyboardRetrievingAdaptor.cs" />
     <Compile Include="Linux\UnityIbusKeyboardSwitchingAdaptor.cs" />


### PR DESCRIPTION
Ubuntu 18.04 changed the way how to switch keyboards. The previous
method of setting a dconf value is deprecated and no longer works.
Instead this is done by a DBus method call.

This change also adds a property to detect if the program runs in
a Gnome Shell, and fixes a bug where the wrong keyboard adaptor was
used in Ubuntu 18.04.

(cherry picked from commit 296705f3061f39363e7747722232f4d097bfcacd)