### PR TITLE
Check that we don't add duplicate layouts (LT-20288)

### DIFF
--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -17,9 +17,14 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IETF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IMDI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Keyman/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Klavier/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LDML/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=libxklavier/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Saami/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SLDR/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=versifications/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subitem/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=versifications/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=xklavier/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
@@ -310,7 +310,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 			var keyboards = Keyboard.Controller.AvailableKeyboards.OrderBy(kbd => kbd.Id).ToArray();
 			// It seems that Dutch (Belgium) got added recently, so some machines are missing
 			// this.
-			Assert.That(keyboards.Length == 3 || keyboards.Length == 2);
+			Assert.That(keyboards.Length, Is.EqualTo(3).Or.EqualTo(2));
 			var expectedKeyboardIds = new List<string>()
 				{ "de-BE_be", "fr-BE_be" };
 
@@ -375,7 +375,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 		/// layouts (smi_FIN and sme_FIN), but ICU returns a LCID only for one of them.
 		/// </summary>
 		[Test]
-		public void InstalledKeyboards_NorthernSami()
+		public void InstalledKeyboards_NorthernSaami()
 		{
 			XklEngineResponder.SetGroupNames = new[] { KeyboardFinlandNorthernSaami };
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/XklConfigRegistry.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XklConfigRegistry.cs
@@ -76,6 +76,35 @@ namespace X11.XKlavier
 						$"LayoutVariant={LayoutVariant}, Locale={LocaleId}, LanguageCode={LanguageCode}, Language={Language}, " +
 						$"CountryCode={CountryCode}, Country={Country}]";
 			}
+
+			public override bool Equals(object obj)
+			{
+				if (!(obj is LayoutDescription))
+					return false;
+
+				var other = (LayoutDescription)obj;
+				return Equals(other);
+			}
+
+			public bool Equals(LayoutDescription other)
+			{
+				return LayoutId == other.LayoutId && Description == other.Description &&
+						LayoutVariant == other.LayoutVariant &&
+						LanguageCode == other.LanguageCode && CountryCode == other.CountryCode;
+			}
+
+			public override int GetHashCode()
+			{
+				unchecked
+				{
+					var hashCode = (LayoutId != null ? LayoutId.GetHashCode() : 0);
+					hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
+					hashCode = (hashCode * 397) ^ (LayoutVariant != null ? LayoutVariant.GetHashCode() : 0);
+					hashCode = (hashCode * 397) ^ (LanguageCode != null ? LanguageCode.GetHashCode() : 0);
+					hashCode = (hashCode * 397) ^ (CountryCode != null ? CountryCode.GetHashCode() : 0);
+					return hashCode;
+				}
+			}
 		}
 		#endregion
 
@@ -150,6 +179,7 @@ namespace X11.XKlavier
 			var name = subitemIsNull ? item.Name : subitem.Name;
 			var variant = subitemIsNull ? string.Empty : subitem.Description;
 			var layouts = GetLayoutList(description);
+
 			var newLayout = new LayoutDescription {
 				LayoutId = name,
 				Description = description,
@@ -157,7 +187,9 @@ namespace X11.XKlavier
 				LanguageCode = Get2LetterLanguageCode(language.Name),
 				CountryCode = item.Name.ToUpper()
 			};
-			layouts.Add(newLayout);
+			// don't add same layout twice (LT-20288)
+			if (!layouts.Any(layout => layout.Equals(newLayout)))
+				layouts.Add(newLayout);
 		}
 
 		private void ProcessCountry(IntPtr configRegistry, ref XklConfigItem item, IntPtr unused)

--- a/SIL.Windows.Forms.Keyboarding/Linux/XklConfigRegistry.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XklConfigRegistry.cs
@@ -1,11 +1,13 @@
-﻿// Copyright (c) 2011-2015 SIL International
+﻿// Copyright (c) 2011-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Icu;
 using SIL.Windows.Forms.Keyboarding.Linux;
 
+// ReSharper disable once CheckNamespace
 namespace X11.XKlavier
 {
 	/// <summary>
@@ -77,17 +79,17 @@ namespace X11.XKlavier
 		}
 		#endregion
 
-		private Dictionary<string, List<LayoutDescription>> m_Layouts;
+		private Dictionary<string, List<LayoutDescription>> _layouts;
 
 		public static XklConfigRegistry Create(IXklEngine engine)
 		{
 			var configRegistry = xkl_config_registry_get_instance(engine.Engine);
 			if (!xkl_config_registry_load(configRegistry, true))
-				throw new ApplicationException("Got error trying to load config registry: " + engine.LastError);
+				throw new ApplicationException($"Got error trying to load config registry: {engine.LastError}");
 			return new XklConfigRegistry(configRegistry);
 		}
 
-		internal IntPtr ConfigRegistry { get; private set; }
+		private IntPtr ConfigRegistry { get; }
 
 		private XklConfigRegistry(IntPtr configRegistry)
 		{
@@ -102,9 +104,9 @@ namespace X11.XKlavier
 		{
 			get
 			{
-				if (m_Layouts == null)
+				if (_layouts == null)
 				{
-					m_Layouts = new Dictionary<string, List<LayoutDescription>>();
+					_layouts = new Dictionary<string, List<LayoutDescription>>();
 					// add layouts with standard language code (in /usr/share/locale)
 					xkl_config_registry_foreach_language(ConfigRegistry,
 						ProcessLanguage, IntPtr.Zero);
@@ -115,18 +117,18 @@ namespace X11.XKlavier
 					xkl_config_registry_foreach_layout(ConfigRegistry,
 						ProcessMainLayout, IntPtr.Zero);
 				}
-				return m_Layouts;
+				return _layouts;
 			}
 		}
 
-		private static string Get2LetterLanguageCode(string langCode3letter)
+		private static string Get2LetterLanguageCode(string langCode3Letter)
 		{
-			return new Locale(AlternateLanguageCodes.GetLanguageCode(langCode3letter)).Language;
+			return new Locale(AlternateLanguageCodes.GetLanguageCode(langCode3Letter)).Language;
 		}
 
 		private void ProcessLanguage(IntPtr configRegistry, ref XklConfigItem item, IntPtr unused)
 		{
-			IntPtr dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(item));
+			var dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(item));
 			try
 			{
 				Marshal.StructureToPtr(item, dataPtr, false);
@@ -143,13 +145,15 @@ namespace X11.XKlavier
 			ref XklConfigItem subitem, IntPtr data)
 		{
 			var subitemIsNull = subitem.Parent.RefCount == IntPtr.Zero;
-			XklConfigItem language = (XklConfigItem)Marshal.PtrToStructure(data, typeof(XklConfigItem));
+			var language = (XklConfigItem)Marshal.PtrToStructure(data, typeof(XklConfigItem));
 			var description = subitemIsNull ? item.Description : subitem.Description;
+			var name = subitemIsNull ? item.Name : subitem.Name;
+			var variant = subitemIsNull ? string.Empty : subitem.Description;
 			var layouts = GetLayoutList(description);
 			var newLayout = new LayoutDescription {
-				LayoutId = subitemIsNull ? item.Name : subitem.Name,
+				LayoutId = name,
 				Description = description,
-				LayoutVariant = subitemIsNull ? string.Empty : subitem.Description,
+				LayoutVariant = variant,
 				LanguageCode = Get2LetterLanguageCode(language.Name),
 				CountryCode = item.Name.ToUpper()
 			};
@@ -158,7 +162,7 @@ namespace X11.XKlavier
 
 		private void ProcessCountry(IntPtr configRegistry, ref XklConfigItem item, IntPtr unused)
 		{
-			IntPtr dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(item));
+			var dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(item));
 			try
 			{
 				Marshal.StructureToPtr(item, dataPtr, false);
@@ -175,16 +179,14 @@ namespace X11.XKlavier
 			ref XklConfigItem subitem, IntPtr data)
 		{
 			var subitemIsNull = subitem.Parent.RefCount == IntPtr.Zero;
-			XklConfigItem country = (XklConfigItem)Marshal.PtrToStructure(data, typeof(XklConfigItem));
+			var country = (XklConfigItem)Marshal.PtrToStructure(data, typeof(XklConfigItem));
 			var description = subitemIsNull ? item.Description : subitem.Description;
 			var name = subitemIsNull ? item.Name : subitem.Name;
 			var variant = subitemIsNull ? string.Empty : subitem.Description;
 			var layouts = GetLayoutList(description);
-			foreach (var desc in layouts)
-			{
-				if (desc.LayoutId == name && desc.Description == description && desc.LayoutVariant == variant)
-					return;
-			}
+			if (layouts.Any(desc => desc.LayoutId == name && desc.Description == description && desc.LayoutVariant == variant))
+				return;
+
 			var langCode = subitemIsNull ? item.Short_Description : subitem.Short_Description;
 			if (string.IsNullOrEmpty(langCode))
 				langCode = subitemIsNull ? item.Name : subitem.Name;
@@ -200,7 +202,7 @@ namespace X11.XKlavier
 
 		private void ProcessMainLayout(IntPtr configRegistry, ref XklConfigItem item, IntPtr data)
 		{
-			IntPtr dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(item));
+			var dataPtr = Marshal.AllocHGlobal(Marshal.SizeOf(item));
 			try
 			{
 				StoreLayoutInfo(item, data);
@@ -219,16 +221,14 @@ namespace X11.XKlavier
 			StoreLayoutInfo(item, data);
 		}
 
-		void StoreLayoutInfo(XklConfigItem item, IntPtr data)
+		private void StoreLayoutInfo(XklConfigItem item, IntPtr data)
 		{
 			var description = item.Description;
 			var variant = data != IntPtr.Zero ? description : string.Empty;
 			var layouts = GetLayoutList(description);
-			foreach (var desc in layouts)
-			{
-				if (desc.LayoutId == item.Name && desc.Description == description && desc.LayoutVariant == variant)
-					return;
-			}
+			if (layouts.Any(desc => desc.LayoutId == item.Name && desc.Description == description && desc.LayoutVariant == variant))
+				return;
+
 			var newLayout = new LayoutDescription {
 				LayoutId = item.Name,
 				Description = description,
@@ -236,7 +236,7 @@ namespace X11.XKlavier
 			};
 			if (data != IntPtr.Zero)
 			{
-				XklConfigItem parent = (XklConfigItem)Marshal.PtrToStructure(data, typeof(XklConfigItem));
+				var parent = (XklConfigItem)Marshal.PtrToStructure(data, typeof(XklConfigItem));
 				var langCode = string.IsNullOrEmpty(item.Short_Description) ? parent.Short_Description : item.Short_Description;
 				if (string.IsNullOrEmpty(langCode))
 					langCode = string.IsNullOrEmpty(item.Name) ? parent.Name : item.Name;
@@ -253,27 +253,30 @@ namespace X11.XKlavier
 			layouts.Add(newLayout);
 		}
 
-		List<LayoutDescription> GetLayoutList(string description)
+		private List<LayoutDescription> GetLayoutList(string description)
 		{
 			List<LayoutDescription> layouts;
-			if (m_Layouts.ContainsKey(description))
+			if (_layouts.ContainsKey(description))
 			{
-				layouts = m_Layouts[description];
+				layouts = _layouts[description];
 			}
 			else
 			{
 				layouts = new List<LayoutDescription>();
-				m_Layouts[description] = layouts;
+				_layouts[description] = layouts;
 			}
 			return layouts;
 		}
 
 		#region p/invoke related
+		// ReSharper disable FieldCanBeMadeReadOnly.Local
+		// ReSharper disable MemberCanBePrivate.Local
+		// ReSharper disable InconsistentNaming
 		[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
 		private struct XklConfigItem
 		{
 			private const int XKL_MAX_CI_NAME_LENGTH = 32;
-			private const int XKL_MAX_CI_SHORT_DESC_LENGTH = 10;
+			// private const int XKL_MAX_CI_SHORT_DESC_LENGTH = 10;
 			private const int XKL_MAX_CI_DESC_LENGTH = 192;
 
 			[StructLayout(LayoutKind.Sequential)]
@@ -294,6 +297,9 @@ namespace X11.XKlavier
 			[MarshalAs(UnmanagedType.ByValTStr, SizeConst=XKL_MAX_CI_DESC_LENGTH)]
 			public string Description;
 		}
+		// ReSharper restore FieldCanBeMadeReadOnly.Local
+		// ReSharper restore MemberCanBePrivate.Local
+		// ReSharper restore InconsistentNaming
 
 		private delegate void ConfigItemProcessFunc(IntPtr configRegistry, ref XklConfigItem item, IntPtr data);
 		private delegate void TwoConfigItemsProcessFunc(IntPtr configRegistry,
@@ -301,33 +307,33 @@ namespace X11.XKlavier
 
 
 		[DllImport("libxklavier")]
-		private extern static IntPtr xkl_config_registry_get_instance(IntPtr engine);
+		private static extern IntPtr xkl_config_registry_get_instance(IntPtr engine);
 
 		[DllImport("libxklavier")]
-		private extern static bool xkl_config_registry_load(IntPtr configRegistry, bool fExtrasNeeded);
+		private static extern bool xkl_config_registry_load(IntPtr configRegistry, bool fExtrasNeeded);
 
 		[DllImport("libxklavier")]
-		private extern static void xkl_config_registry_foreach_language(IntPtr configRegistry,
+		private static extern void xkl_config_registry_foreach_language(IntPtr configRegistry,
 			ConfigItemProcessFunc func, IntPtr data);
 
 		[DllImport("libxklavier")]
-		private extern static void xkl_config_registry_foreach_language_variant(IntPtr configRegistry,
+		private static extern void xkl_config_registry_foreach_language_variant(IntPtr configRegistry,
 			string languageCode, TwoConfigItemsProcessFunc func, IntPtr data);
 
 		[DllImport("libxklavier")]
-		private extern static void xkl_config_registry_foreach_country(IntPtr configRegistry,
+		private static extern void xkl_config_registry_foreach_country(IntPtr configRegistry,
 			ConfigItemProcessFunc func, IntPtr data);
 
 		[DllImport("libxklavier")]
-		private extern static void xkl_config_registry_foreach_country_variant(IntPtr configRegistry,
+		private static extern void xkl_config_registry_foreach_country_variant(IntPtr configRegistry,
 			string countryCode, TwoConfigItemsProcessFunc func, IntPtr data);
 
 		[DllImport("libxklavier")]
-		private extern static void xkl_config_registry_foreach_layout(IntPtr configRegistry,
+		private static extern void xkl_config_registry_foreach_layout(IntPtr configRegistry,
 			ConfigItemProcessFunc func, IntPtr data);
 
 		[DllImport("libxklavier")]
-		private extern static void xkl_config_registry_foreach_layout_variant(IntPtr configRegistry,
+		private static extern void xkl_config_registry_foreach_layout_variant(IntPtr configRegistry,
 			string layoutCode, ConfigItemProcessFunc func, IntPtr data);
 		#endregion
 	}


### PR DESCRIPTION
We already checked in most cases that we don't add the same
layout twice. However, in `ProcessLanguage` which adds the first
bunch of layouts we didn't check. It's not entirely clear why we
get the same layout twice (bug in Linux Mint?), but this change
deals with that case.

This PR is against the `feature/nuget` branch.