### PR TITLE
Fix crashes updating global store with Id/LangTag mismatch

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlInFolderWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlInFolderWritingSystemRepositoryTests.cs
@@ -1093,6 +1093,47 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
+		public void Save_UpdatesGlobalStore_IdAndLangTagMismatchDoesNotCrash()
+		{
+			// If the global store has a writing system with the id that doesn't match
+			// the language tag we should not crash and we should match and update the
+			// global store
+			using (var environment = new TestEnvironment())
+			{
+				// Setup
+				// Create and save a new WS in the local store - this will copy the WS into the
+				// global store since it doesn't exist yet
+				var enLatnUsId = "en-Latn-US";
+				var enUsTag = "en-US";
+				var ws = new WritingSystemDefinition(enUsTag);
+				ws.Id = enLatnUsId;
+				var expectedDateTime = new DateTime(2018, 12, 01, 8, 7, 6, DateTimeKind.Utc);
+				ws.DateModified = expectedDateTime;
+				environment.LocalRepository.Set(ws);
+				ws.RightToLeftScript = true;
+				ws.DefaultCollation = new SystemCollationDefinition { LanguageTag = enUsTag };
+				ws.AcceptChanges();
+				Assert.That(ws.Id, Is.Not.EqualTo(ws.LanguageTag));
+				environment.LocalRepository.Save();
+				var lastModifiedInWs = environment.GlobalRepository.Get(enLatnUsId).DateModified;
+
+				// SUT
+				ws.RightToLeftScript = false;
+				environment.LocalRepository.Save();
+
+				// Verify
+				Assert.That(environment.GlobalRepository.Get(enLatnUsId).DateModified,
+					Is.GreaterThan(lastModifiedInWs), "WS in memory didn't get updated");
+				Assert.That(
+					environment.GlobalRepository.Get(enLatnUsId).DateModified
+						.ToISO8601TimeFormatWithUTCString(),
+					Is.EqualTo(environment.GetWsFromFileInGlobalWS(enLatnUsId).DateModified
+						.ToISO8601TimeFormatWithUTCString()),
+					"WS in memory and in global store are different");
+			}
+		}
+
+		[Test]
 		public void Save_UpdatesGlobalStore_ModificationsUpdateTimestamp()
 		{
 			using (var environment = new TestEnvironment())

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -433,8 +433,14 @@ namespace SIL.WritingSystems
 			// and not be allowed in a foreach loop
 			foreach (T ws in AllWritingSystems.Where(CanSet).ToArray())
 			{
-				SaveDefinition(ws);
-				OnChangeNotifySharedStore(ws);
+				// Changes made while calling Set on a writing system during the save
+				// could affect the ability to call Set on another writing system in the list.
+				// So test again even though we've done a first pass filter in the foreach
+				if (CanSet(ws))
+				{
+					SaveDefinition(ws);
+					OnChangeNotifySharedStore(ws);
+				}
 			}
 
 			LoadChangedIdsFromExistingWritingSystems();


### PR DESCRIPTION
* Fix Flex bug LT-20334
* Use the Id to index the global store
* Add some guards against extreme edge cases to avoid crashes
  - This could result in failed updates of the global store
    but that is more acceptable then crashing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/965)
<!-- Reviewable:end -->
