### PR TITLE
Add Keyman configuration link on Linux (LT-20361)

### DIFF
--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -14,6 +14,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ibus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IETF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IMDI/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Keyman/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Klavier/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LDML/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libxklavier/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Windows.Forms.Keyboarding/IKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/IKeyboardRetrievingAdaptor.cs
@@ -86,6 +86,13 @@ namespace SIL.Windows.Forms.Keyboarding
 		Action GetKeyboardSetupAction();
 
 		/// <summary>
+		/// Gets an action that when executed will launch the secondary keyboard setup
+		/// application, or null if this adaptor doesn't support secondary keyboard setup
+		/// applications
+		/// </summary>
+		Action GetSecondaryKeyboardSetupAction();
+
+		/// <summary>
 		/// Returns <c>true</c> if this is the secondary keyboard application, e.g.
 		/// Keyman setup dialog on Windows.
 		/// </summary>

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -129,7 +129,7 @@ namespace SIL.Windows.Forms.Keyboarding
 		{
 			Action program = null;
 			if (HasSecondaryKeyboardSetupApplication && Instance.Adaptors.ContainsKey(KeyboardAdaptorType.OtherIm))
-				program = Instance.Adaptors[KeyboardAdaptorType.OtherIm].GetKeyboardSetupAction();
+				program = Instance.Adaptors[KeyboardAdaptorType.OtherIm].GetSecondaryKeyboardSetupAction();
 
 			return program;
 		}

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -57,9 +57,9 @@ namespace SIL.Windows.Forms.Keyboarding
 			}
 			catch (Exception e)
 			{
-				Console.WriteLine("Got exception {0} initalizing keyboard controller", e.GetType());
+				Console.WriteLine("Got exception {0} initializing keyboard controller", e.GetType());
 				Console.WriteLine(e.StackTrace);
-				Logger.WriteEvent("Got exception {0} initalizing keyboard controller", e.GetType());
+				Logger.WriteEvent("Got exception {0} initializing keyboard controller", e.GetType());
 				Logger.WriteEvent(e.StackTrace);
 
 				if (Keyboard.Controller != null)

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -17,7 +17,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// It also works for other desktop environments that use combined ibus keyboards, e.g.
 	/// XFCE.
 	/// </summary>
-	[CLSCompliant(false)]
 	public class CombinedIbusKeyboardRetrievingAdaptor : IbusKeyboardRetrievingAdaptor
 	{
 		private IntPtr _settingsGeneral;

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
@@ -17,7 +17,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// It also works for other desktop environments that use combined ibus keyboards, e.g.
 	/// XFCE.
 	/// </summary>
-	[CLSCompliant(false)]
 	public class CombinedIbusKeyboardSwitchingAdaptor : IbusKeyboardSwitchingAdaptor
 	{
 		// These should not change while the program is running, and they're expensive to obtain.

--- a/SIL.Windows.Forms.Keyboarding/Linux/IIbusCommunicator.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IIbusCommunicator.cs
@@ -93,7 +93,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// <summary>IBus raises this event so that the application can act on the key event,
 		/// e.g. it will pass Backspace as argument so that the application/control can delete
 		/// the character to the left of the IP before IBus commits a new character.</summary>
-		/// <seealso cref="SIL.Windows.Forms.Keyboarding.Interfaces.IIbusEventHandler.OnIbusKeyPress"/>
+		/// <seealso cref="SIL.Windows.Forms.Keyboarding.Linux.IIbusEventHandler.OnIbusKeyPress"/>
 		event Action<int, int, int> KeyEvent;
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
@@ -188,7 +188,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		/// <summary>
 		/// Finalizer, in case client doesn't dispose it.
-		/// Force Dispose(false) if not already called (i.e. m_isDisposed is true)
+		/// Force Dispose(false) if not already called (i.e. IsDisposed is true)
 		/// </summary>
 		/// <remarks>
 		/// In case some clients forget to dispose it directly.
@@ -207,7 +207,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		{
 			Dispose(true);
 			// This object will be cleaned up by the Dispose method.
-			// Therefore, you should call GC.SupressFinalize to
+			// Therefore, you should call GC.SuppressFinalize to
 			// take this object off the finalization queue
 			// and prevent finalization code for this object
 			// from executing a second time.

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardSwitchingAdaptor.cs
@@ -11,7 +11,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// <summary>
 	/// Class for handling ibus keyboards on Linux.
 	/// </summary>
-	[CLSCompliant(false)]
 	public class IbusKeyboardSwitchingAdaptor : IKeyboardSwitchingAdaptor
 	{
 		private readonly IIbusCommunicator _ibusComm;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -14,7 +14,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// a different dconf key (/org/gnome/desktop/input-sources/sources). This retriever reads
 	/// the list of keyboards and registers the ibus keyboards.
 	/// </summary>
-	[CLSCompliant(false)]
 	public class UnityIbusKeyboardRetrievingAdaptor : IbusKeyboardRetrievingAdaptor
 	{
 		protected readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
@@ -7,7 +7,7 @@ using SIL.Reporting;
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
 	/// <summary>
-	/// Class for dealing with ibus keyboards on Unity (as found in Trusty >= 13.10 < 18.04)
+	/// Class for dealing with ibus keyboards on Unity (as found in Trusty &gt;= 13.10 &lt; 18.04)
 	/// </summary>
 	public class UnityIbusKeyboardSwitchingAdaptor : IbusKeyboardSwitchingAdaptor, IUnityKeyboardSwitchingAdaptor
 	{

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
@@ -14,7 +14,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// a different dconf key (/org/gnome/desktop/input-sources/sources). This retriever reads
 	/// the list of keyboards and registers the xkb keyboards.
 	/// </summary>
-	[CLSCompliant(false)]
 	public class UnityXkbKeyboardRetrievingAdaptor : XkbKeyboardRetrievingAdaptor
 	{
 		private readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -246,10 +246,9 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			return null;
 		}
 
-		public bool IsSecondaryKeyboardSetupApplication
-		{
-			get { return false; }
-		}
+		public Action GetSecondaryKeyboardSetupAction() => null;
+
+		public bool IsSecondaryKeyboardSetupApplication => false;
 
 		#region IDisposable & Co. implementation
 		// Region last reviewed: never

--- a/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardAdaptor.cs
@@ -301,6 +301,8 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 			}
 		}
 
+		public Action GetSecondaryKeyboardSetupAction() => GetKeyboardSetupAction();
+
 		public bool IsSecondaryKeyboardSetupApplication => true;
 
 		public bool CanHandleFormat(KeyboardFormat format)

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -37,7 +37,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 			ProfileManager = ProcessorProfiles as ITfInputProcessorProfileMgr;
 			SwitchingAdaptor = new WindowsKeyboardSwitchingAdapter(this);
 		}
-		
+
 		private static string GetDisplayName(string layout, string locale)
 		{
 			return $"{layout} - {locale}";
@@ -272,6 +272,8 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 					"input.dll")) {}
 			};
 		}
+
+		public Action GetSecondaryKeyboardSetupAction() => null;
 
 		public bool IsSecondaryKeyboardSetupApplication => false;
 		#endregion

--- a/TestApps/SIL.Windows.Forms.TestApp/Program.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Program.cs
@@ -19,7 +19,7 @@ namespace SIL.Windows.Forms.TestApp
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 			Sldr.Initialize();
-			Icu.Wrapper.ConfineIcuVersions(54);
+			Icu.Wrapper.Init();
 			var localizationFolder = Path.GetDirectoryName(FileLocationUtilities.GetFileDistributedWithApplication("Palaso.en.tmx"));
 			LocalizationManager.Create(TranslationMemory.Tmx, "fr", "Palaso", "Palaso", "1.0.0", localizationFolder, "SIL/Palaso",
 				null, "");
@@ -36,9 +36,7 @@ namespace SIL.Windows.Forms.TestApp
 			Application.Run(new TestAppForm());
 
 			Sldr.Cleanup();
-	   }
-
-
+		}
 
 	}
 }


### PR DESCRIPTION
This change enables the Keyman configuration link on Linux if _Keyman for Linux_ is installed, and adds a new method
`GetSecondaryKeyboardSetupAction()` to the semi-public `IKeyboardRetrievingAdaptor` interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/969)
<!-- Reviewable:end -->
