### PR TITLE
Support retrieving xkb keyboards on Cinnamon (#970)

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -137,6 +137,8 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			{
 				try
 				{
+					if (!base.IsApplicable)
+						return false;
 					if (!KeyboardRetrievingHelper.SchemaIsInstalled(GSettingsSchema))
 						return false;
 					_settingsGeneral = Unmanaged.g_settings_new(GSettingsSchema);

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -231,6 +231,12 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 						: "keyboard"); // Wasta 14;
 				return "/usr/bin/python";
 			}
+			// Cinnamon in Wasta 20.04
+			if (File.Exists("/usr/bin/cinnamon-settings"))
+			{
+				arguments = "keyboard -t layouts";
+				return "/usr/bin/cinnamon-settings";
+			}
 			// GNOME
 			if (File.Exists("/usr/bin/gnome-control-center"))
 			{

--- a/TestApps/TestAppKeyboard/KeyboardForm.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.cs
@@ -28,14 +28,21 @@ namespace TestAppKeyboard
 			LoadKeyboards(currentKeyboard);
 		}
 
-		public void LoadKeyboards(ComboBox comboBox)
+		private static void LoadKeyboards(ComboBox comboBox)
 		{
 			IEnumerable<IKeyboardDefinition> keyboards = Keyboard.Controller.AvailableKeyboards;
-			foreach (IKeyboardDefinition keyboard in keyboards)
+			foreach (var keyboard in keyboards)
 			{
 				comboBox.Items.Add(new WSKeyboardControl.KeyboardDefinitionAdapter(keyboard));
-				Console.WriteLine("added keyboard id: {0}, name: {1}", keyboard.Id, keyboard.Name);
+				Console.WriteLine($"added keyboard id: {keyboard.Id}, name: {keyboard.Name}");
 			}
+
+			if (comboBox.Items.Count <= 0)
+			{
+				Console.WriteLine("WARNING: No available keyboards found!");
+				return;
+			}
+
 			comboBox.SelectedIndex = 0;
 		}
 


### PR DESCRIPTION
This change fixes the retrieving of xkb keyboards on Cinnamon desktop if ibus is not installed. It also fixes the issue that in this case the keyboard setup link opened the wrong application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/971)
<!-- Reviewable:end -->
