### PR TITLE
Allow private language tags and related improvements

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.Designer.cs
@@ -197,7 +197,7 @@ namespace SIL.Windows.Forms.WritingSystems
 			this._L10NSharpExtender.SetLocalizingId(this._scriptsAndVariantsLink, "LanguageLookup._scriptsAndVariantsLink");
 			this._scriptsAndVariantsLink.Location = new System.Drawing.Point(3, 0);
 			this._scriptsAndVariantsLink.Name = "_scriptsAndVariantsLink";
-			this._scriptsAndVariantsLink.Size = new System.Drawing.Size(101, 13);
+			this._scriptsAndVariantsLink.Size = new System.Drawing.Size(91, 13);
 			this._scriptsAndVariantsLink.TabIndex = 17;
 			this._scriptsAndVariantsLink.TabStop = true;
 			this._scriptsAndVariantsLink.Text = "Script and Variant";
@@ -210,7 +210,7 @@ namespace SIL.Windows.Forms.WritingSystems
 			this._L10NSharpExtender.SetLocalizableToolTip(this._scriptsAndVariantsLabel, null);
 			this._L10NSharpExtender.SetLocalizationComment(this._scriptsAndVariantsLabel, null);
 			this._L10NSharpExtender.SetLocalizingId(this._scriptsAndVariantsLabel, "LanguageLookup._scriptsAndVariantsLabel");
-			this._scriptsAndVariantsLabel.Location = new System.Drawing.Point(110, 0);
+			this._scriptsAndVariantsLabel.Location = new System.Drawing.Point(100, 0);
 			this._scriptsAndVariantsLabel.Name = "_scriptsAndVariantsLabel";
 			this._scriptsAndVariantsLabel.Size = new System.Drawing.Size(108, 13);
 			this._scriptsAndVariantsLabel.TabIndex = 18;
@@ -224,7 +224,7 @@ namespace SIL.Windows.Forms.WritingSystems
 			this.flowLayoutPanel1.Controls.Add(this._scriptsAndVariantsLabel);
 			this.flowLayoutPanel1.Location = new System.Drawing.Point(-5, 336);
 			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-			this.flowLayoutPanel1.Size = new System.Drawing.Size(247, 19);
+			this.flowLayoutPanel1.Size = new System.Drawing.Size(372, 19);
 			this.flowLayoutPanel1.TabIndex = 18;
 			// 
 			// LanguageLookupControl

--- a/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
+++ b/SIL.Windows.Forms.WritingSystems/LanguageLookupControl.cs
@@ -335,7 +335,9 @@ namespace SIL.Windows.Forms.WritingSystems
 			}
 			else
 			{
-				if (_model.LanguageTagContainsScriptRegionVariantInfo)
+				// Usually it's not interesting to see this unless some script, region, or variant data is present.
+				// But when the user has entered a custom unknown language code, this is the only way to confirm it.
+				if (_model.LanguageTagContainsScriptRegionVariantInfo || LanguageSubtag.IsUnlistedCode(_model.SelectedLanguage.LanguageTag))
 				{
 					_scriptsAndVariantsLabel.Text = "(" + _model.LanguageTag + ")";
 					_scriptsAndVariantsLabel.Visible = true;

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -367,6 +367,28 @@ namespace SIL.WritingSystems.Tests
 		}
 		#endregion
 
+		#region TryGetParts
+
+		[TestCase("en", true, "en", null, null, null)]
+		[TestCase("tpi-AR", true, "tpi", null, "AR", null)]
+		[TestCase("tpi-Lepc-BR-fonipa-x-blah", true, "tpi", "Lepc", "BR", "fonipa-x-blah")]
+		[TestCase("a", false, null, null, null, null)]
+		[TestCase("qaa", true, "qaa", null, null, null)]
+		[TestCase("qed", true, "qed", null, null, null)]
+		[TestCase("qed-Lepc-x-rubbish", true, "qed", "Lepc", null, "x-rubbish")]
+		public void TryGetParts_ReturnsExpectedResults(string tag, bool valid, string expectedLanguage, string expectedScript, string expectedRegion, string expectedVariant)
+		{
+			string language, script, region, variant;
+			var result = IetfLanguageTag.TryGetParts(tag, out language, out script, out region, out variant);
+			Assert.That(result, Is.EqualTo(valid));
+			Assert.That(language, Is.EqualTo(expectedLanguage), "parsing " + tag + " produced unexpected language " + language + " instead of " + expectedLanguage);
+			Assert.That(script, Is.EqualTo(expectedScript), "parsing " + tag + " produced unexpected script " + script + " instead of " + expectedScript);
+			Assert.That(region, Is.EqualTo(expectedRegion), "parsing " + tag + " produced unexpected region " + region + " instead of " + expectedRegion);
+			Assert.That(variant, Is.EqualTo(expectedVariant), "parsing " + tag + " produced unexpected variant " + variant + " instead of " + expectedVariant);
+		}
+
+		#endregion
+
 		#region TryGetSubtags
 
 		/// <summary>
@@ -607,6 +629,38 @@ namespace SIL.WritingSystems.Tests
 					out regionSubtag, out variantSubtags), Is.True);
 			Assert.That(languageSubtag, Is.EqualTo((LanguageSubtag)"zh"));
 			Assert.That(scriptSubtag, Is.EqualTo((ScriptSubtag)"Hans"));
+			Assert.That(regionSubtag, Is.EqualTo((RegionSubtag)"CN"));
+			Assert.That(variantSubtags, Is.EqualTo(new VariantSubtag[] { "fonipa", "etic" }));
+		}
+
+		[Test]
+		public void TryGetSubtags_SimplePrivateUseLanguage_ReturnsValidResults()
+		{
+			LanguageSubtag languageSubtag;
+			ScriptSubtag scriptSubtag;
+			RegionSubtag regionSubtag;
+			IEnumerable<VariantSubtag> variantSubtags;
+			Assert.That(
+				IetfLanguageTag.TryGetSubtags("qtz", out languageSubtag, out scriptSubtag,
+					out regionSubtag, out variantSubtags), Is.True);
+			Assert.That(languageSubtag, Is.EqualTo((LanguageSubtag)"qtz"));
+			Assert.That(scriptSubtag, Is.Null);
+			Assert.That(regionSubtag, Is.Null);
+			Assert.That(variantSubtags, Is.EqualTo(new VariantSubtag[0]));
+		}
+
+		[Test]
+		public void TryGetSubtags_ComplexPrivateLanguageCode_ReturnsValidResults()
+		{
+			LanguageSubtag languageSubtag;
+			ScriptSubtag scriptSubtag;
+			RegionSubtag regionSubtag;
+			IEnumerable<VariantSubtag> variantSubtags;
+			Assert.That(
+				IetfLanguageTag.TryGetSubtags("qed-Lepc-cN-fonipa-x-etic", out languageSubtag, out scriptSubtag,
+					out regionSubtag, out variantSubtags), Is.True);
+			Assert.That(languageSubtag, Is.EqualTo((LanguageSubtag)"qed"));
+			Assert.That(scriptSubtag, Is.EqualTo((ScriptSubtag)"Lepc"));
 			Assert.That(regionSubtag, Is.EqualTo((RegionSubtag)"CN"));
 			Assert.That(variantSubtags, Is.EqualTo(new VariantSubtag[] { "fonipa", "etic" }));
 		}

--- a/SIL.WritingSystems/IetfLanguageTag.cs
+++ b/SIL.WritingSystems/IetfLanguageTag.cs
@@ -785,7 +785,8 @@ namespace SIL.WritingSystems
 				Group languageGroup = match.Groups["language"];
 				if (languageGroup.Success)
 				{
-					if (!StandardSubtags.IsValidIso639LanguageCode(languageGroup.Value))
+					// In addition to known valid codes, all the private use language codes are reasonable values.
+					if (!StandardSubtags.IsValidIso639LanguageCode(languageGroup.Value) && !LanguageSubtag.IsUnlistedCode(languageGroup.Value))
 						return false;
 					language = languageGroup.Value;
 				}
@@ -916,7 +917,8 @@ namespace SIL.WritingSystems
 				}
 				else
 				{
-					if (!StandardSubtags.IsValidIso639LanguageCode(languageCode))
+					// In addition to known valid codes, all the private use language codes are reasonable values.
+					if (!StandardSubtags.IsValidIso639LanguageCode(languageCode) && !LanguageSubtag.IsUnlistedCode(languageCode))
 						return false;
 
 					languageSubtag = languageCode;

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013-2014 SIL International
+// Copyright (c) 2013-2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -77,6 +77,8 @@ namespace SIL.Windows.Forms.TestApp
 			{
 				dialog.SetLanguageAlias("zh-Hans", "Simplified Chinese (简体中文)");
 				dialog.MatchingLanguageFilter = info => info.LanguageTag != "cmn";
+
+				dialog.IsScriptAndVariantLinkVisible = true;
 				dialog.ShowDialog();
 			}
 		}


### PR DESCRIPTION
This is a partial fix for BL-9004, a crash that was happening if you open the scripts and variants control again after entering a private use language code other than qaa.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/973)
<!-- Reviewable:end -->
