### PR TITLE
[keyboarding] Don't crash if no xkb keyboards installed

### DIFF
--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBase.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBase.cs
@@ -150,9 +150,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		}
 		public void AssignKeyboardFromWritingSystem()
 		{
-			if (_writingSystem == null)
-				return;
-			_writingSystem.LocalKeyboard.Activate();
+			_writingSystem?.LocalKeyboard?.Activate();
 		}
 
 		public void ClearKeyboard()

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -445,7 +445,7 @@ namespace SIL.Windows.Forms.Keyboarding
 		/// </summary>
 		public void ActivateDefaultKeyboard()
 		{
-			DefaultKeyboard.Activate();
+			DefaultKeyboard?.Activate();
 		}
 
 		/// <summary>

--- a/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
@@ -678,11 +678,7 @@ namespace SIL.Windows.Forms.WritingSystems
 		{
 			get
 			{
-				if (CurrentDefinition == null)
-					return null;
-				if (CurrentDefinition.LocalKeyboard != null)
-					return CurrentDefinition.LocalKeyboard;
-				return null;
+				return CurrentDefinition?.LocalKeyboard;
 			}
 			set
 			{
@@ -1504,8 +1500,7 @@ namespace SIL.Windows.Forms.WritingSystems
 		/// </summary>
 		public void ActivateCurrentKeyboard()
 		{
-			if (CurrentDefinition != null && CurrentDefinition.LocalKeyboard != null)
-				CurrentDefinition.LocalKeyboard.Activate();
+			CurrentDefinition?.LocalKeyboard?.Activate();
 		}
 
 		/// <summary>

--- a/SIL.Windows.Forms/Widgets/StdTextInputBox.cs
+++ b/SIL.Windows.Forms/Widgets/StdTextInputBox.cs
@@ -313,8 +313,7 @@ namespace SIL.Windows.Forms.Widgets
 
 		public void AssignKeyboardFromWritingSystem()
 		{
-			if (_writingSystem != null)
-				_writingSystem.LocalKeyboard.Activate();
+			_writingSystem?.LocalKeyboard?.Activate();
 		}
 
 		protected override void OnLeave(EventArgs e)


### PR DESCRIPTION
If the user removes all keyboards on Linux except ibus/keyman ones we still don't want to crash...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/975)
<!-- Reviewable:end -->
