### PR TITLE
[master - keyboarding] Don't crash if we encounter duplicate layouts

### DIFF
--- a/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
+++ b/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
@@ -291,6 +291,7 @@
     <Compile Include="KeyboardControllerTests.cs" />
     <Compile Include="LinuxKeyboardControllerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnityKeyboardRetrievingHelperTests.cs" />
     <Compile Include="WindowsKeyboardControllerTests.cs" />
     <Compile Include="XkbKeyboardAdapterTests.cs" />
     <Compile Include="XklEngineTests.cs" />

--- a/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.Windows.Forms.Keyboarding.Linux;
+
+namespace SIL.Windows.Forms.Keyboarding.Tests
+{
+	[TestFixture]
+	[Platform(Include = "Linux", Reason = "Linux specific tests")]
+	public class UnityKeyboardRetrievingHelperTests
+	{
+		[Test]
+		public void InitKeyboards_XkbAndIbus()
+		{
+			IDictionary<string, uint> registeredKeyboards = null;
+			var installedKeyboards = new[] {
+				"xkb;;us",
+				"ibus;;km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx"
+			};
+			var sut = new UnityKeyboardRetrievingHelper(() => installedKeyboards);
+			Assert.That(() => sut.InitKeyboards(s => true,
+				keyboards => registeredKeyboards = keyboards),
+				Throws.Nothing);
+			Assert.That(registeredKeyboards, Is.EquivalentTo(new Dictionary<string, int> {
+				{ "us", 0 },
+				{ "km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx", 1 }
+			}));
+		}
+
+		[Test]
+		public void InitKeyboards_DuplicateKeyboard()
+		{
+			IDictionary<string, uint> registeredKeyboards = null;
+			var installedKeyboards = new[] {
+				"ibus;;km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx",
+				"ibus;;km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx",
+				"xkb;;us"
+			};
+			var sut = new UnityKeyboardRetrievingHelper(() => installedKeyboards);
+			Assert.That(() => sut.InitKeyboards(s => true,
+				keyboards => registeredKeyboards = keyboards),
+				Throws.Nothing); // LT-20410
+			Assert.That(registeredKeyboards, Is.EquivalentTo(new Dictionary<string, int> {
+				{ "km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx", 0 },
+				{ "us", 2 } // 2 is the 0-based index of the 'us' layout in `installedKeyboards`
+			}));
+		}
+
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -16,7 +16,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// </summary>
 	public class UnityIbusKeyboardRetrievingAdaptor : IbusKeyboardRetrievingAdaptor
 	{
-		protected readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();
+		internal readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();
 
 		#region Specific implementations of IKeyboardRetriever
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
@@ -20,10 +20,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		#region Specific implementations of IKeyboardRetriever
 
-		public override bool IsApplicable
-		{
-			get { return _helper.IsApplicable; }
-		}
+		public override bool IsApplicable => _helper.IsApplicable;
 
 		public override void Initialize()
 		{


### PR DESCRIPTION
Sometimes for whatever reason we get duplicate keyboard layouts. This shouldn't lead to a crash. This fixes [LT-20410](https://jira.sil.org/browse/LT-20410).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/976)
<!-- Reviewable:end -->
