### PR TITLE
[feature/nuget - keyboarding] Don't crash if we encounter duplicate layouts

### DIFF
--- a/SIL.Windows.Forms.Keyboarding.Tests/GnomeKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/GnomeKeyboardRetrievingHelperTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.Windows.Forms.Keyboarding.Linux;
+
+namespace SIL.Windows.Forms.Keyboarding.Tests
+{
+	[TestFixture]
+	[Platform(Include="Linux", Reason="Linux specific tests")]
+	public class GnomeKeyboardRetrievingHelperTests
+	{
+		[Test]
+		public void InitKeyboards_XkbAndIbus()
+		{
+			IDictionary<string, uint> registeredKeyboards = null;
+			var installedKeyboards = new[] {
+				"xkb;;us",
+				"ibus;;km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx"
+			};
+			var sut = new GnomeKeyboardRetrievingHelper(() => installedKeyboards);
+			Assert.That(() => sut.InitKeyboards(s => true,
+					(keyboards, firstKeyboard) => registeredKeyboards = keyboards),
+				Throws.Nothing);
+			Assert.That(registeredKeyboards, Is.EquivalentTo(new Dictionary<string, int> {
+				{ "us", 0 },
+				{ "km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx", 1 }
+			}));
+		}
+
+		[Test]
+		public void InitKeyboards_DuplicateKeyboard()
+		{
+			IDictionary<string, uint> registeredKeyboards = null;
+			var installedKeyboards = new[] {
+				"ibus;;km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx",
+				"ibus;;km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx",
+				"xkb;;us"
+			};
+			var sut = new GnomeKeyboardRetrievingHelper(() => installedKeyboards);
+			Assert.That(() => sut.InitKeyboards(s => true,
+					(keyboards, firstKeyboard) => registeredKeyboards = keyboards),
+				Throws.Nothing); // LT-20410
+			Assert.That(registeredKeyboards, Is.EquivalentTo(new Dictionary<string, int> {
+				{ "km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx", 0 },
+				{ "us", 2 }
+			}));
+		}
+
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeKeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeKeyboardRetrievingHelper.cs
@@ -12,17 +12,27 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// </summary>
 	internal class GnomeKeyboardRetrievingHelper
 	{
+		private readonly Func<string[]> _GetKeyboards;
+
 		public GnomeKeyboardRetrievingHelper()
 		{
+			_GetKeyboards = GetMyKeyboards;
 			GlibHelper.InitGlib();
 		}
+
+		// Used in unit tests
+		internal GnomeKeyboardRetrievingHelper(Func<string[]> getKeyboards): this()
+		{
+			_GetKeyboards = getKeyboards;
+		}
+
 
 		#region Public methods and properties
 		public bool IsApplicable
 		{
 			get
 			{
-				var list = GetMyKeyboards();
+				var list = _GetKeyboards();
 				return list != null && list.Length > 0;
 			}
 		}
@@ -30,7 +40,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		public void InitKeyboards(Func<string, bool> keyboardTypeMatches,
 			Action<IDictionary<string, uint>, (string, string)> registerKeyboards)
 		{
-			var list = GetMyKeyboards();
+			var list = _GetKeyboards();
 			if (list == null || list.Length < 1)
 				return;
 
@@ -86,7 +96,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			IDictionary<string, uint> keyboards, Func<string, bool> keyboardTypeMatches)
 		{
 			var (type, layout) = SplitKeyboardEntry(source);
-			if (keyboardTypeMatches(type))
+			if (keyboardTypeMatches(type) && !keyboards.ContainsKey(layout))
 				keyboards.Add(layout, kbdIndex);
 			++kbdIndex;
 		}


### PR DESCRIPTION
Sometimes for whatever reason we get duplicate keyboard layouts. This shouldn't lead to a crash. This fixes LT-20410.

(more or less cherry-pick from master branch)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/977)
<!-- Reviewable:end -->
