### PR TITLE
Improve error handling when loading images (for BL-8996)

### DIFF
--- a/SIL.Windows.Forms/ClearShare/MetaData.cs
+++ b/SIL.Windows.Forms/ClearShare/MetaData.cs
@@ -67,6 +67,38 @@ namespace SIL.Windows.Forms.ClearShare
 		/// </summary>
 		TagLib.Image.File _originalTaglibMetadata;
 
+		// This is called when we got an out of memory exception reading the image itself.
+		// Often this means the image file is actually corrupt.
+		// This is then called to try to decide whether to report out of memory (if we return true)
+		// or corrupt file (if we return false).
+		// If it returns true, it will add an "imageSize" item to ex.Data, where the value is a
+		// Tuple<int,int> giving the width and height of the image in pixels. This may be useful
+		// in reporting the problem.
+		public bool IsOutOfMemoryPlausible(OutOfMemoryException ex)
+		{
+			if (_originalTaglibMetadata.PossiblyCorrupt)
+				return false; // Taglib already figured it as suspicious
+			if (_originalTaglibMetadata.Properties == null)
+				return false; // valid JPG, PNG, and TIF usually have this
+			// Setting limit here at 10 mega-pixels. Pretty arbitrary, even phones can produce bigger images
+			// these days. It's a bit more than an A4 full page at Bloom's min recommended 300dpi, a bit
+			// more than we need at max recommended 600dpi for a half page in A5. There could be smaller
+			// images that really run us out of memory, or larger ones that only fail because they are
+			// corrupt. But Image.FromFile's bad design forces us to guess somehow. It seems unhelpful
+			// to issue the sorts of advice we give about big files if the image is not unusually large.
+			if ((long) _originalTaglibMetadata.Properties.PhotoHeight *
+				(long) _originalTaglibMetadata.Properties.PhotoWidth > 10000000L)
+			{
+				// It's a pretty big picture, maybe we really are out of memory
+				ex.Data["imageSize"] =
+					Tuple.Create(_originalTaglibMetadata.Properties.PhotoWidth,
+						_originalTaglibMetadata.Properties.PhotoHeight);
+				return true;
+			}
+
+			return false;
+		}
+
 		/// <summary>
 		/// NB: this is used in 2 places; one is loading from the image we are linked to, the other from a sample image we are copying metadata from
 		/// </summary>

--- a/SIL.Windows.Forms/ImageToolbox/ImageToolboxControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageToolboxControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
@@ -9,6 +9,7 @@ using SIL.Reporting;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Windows.Forms.ClearShare.WinFormsUI;
 using SIL.Windows.Forms.ImageToolbox.Cropping;
+using SIL.Windows.Forms.Miscellaneous;
 
 namespace SIL.Windows.Forms.ImageToolbox
 {
@@ -169,6 +170,20 @@ namespace SIL.Windows.Forms.ImageToolbox
 		/// </summary>
 		public string InitialSearchString { get; set; }
 
+		/// <summary>
+		/// Used to report problems loading images. See more detail on AcquireImageControl
+		/// </summary>
+		public Action<string, Exception, string> ImageLoadingExceptionReporter
+		{
+			get { return _imageLoadingExceptionReporter; }
+			set
+			{
+				_imageLoadingExceptionReporter = value;
+				if (_acquireImageControl != null)
+					_acquireImageControl.ImageLoadingExceptionReporter = value;
+			}
+		}
+
 		private void SetupMetaDataControls(Metadata metaData)
 		{
 			Guard.AgainstNull(_imageInfo, "_imageInfo");
@@ -234,6 +249,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 		// Changed this to remember the selected index because something is causing the SelectedIndexChanged
 		// event to fire twice each time an icon is clicked.
 		int _previousSelectedIndex = -1;
+		private Action<string, Exception, string> _imageLoadingExceptionReporter;
 
 		private void listView1_SelectedIndexChanged(object sender, EventArgs e)
 		{
@@ -367,6 +383,8 @@ namespace SIL.Windows.Forms.ImageToolbox
 			AddControl("Get Picture".Localize("ImageToolbox.GetPicture"), ImageToolboxButtons.browse, "browse", (x) =>
 			{
 				_acquireImageControl = new AcquireImageControl();
+				_acquireImageControl.ImageLoadingExceptionReporter =
+					ImageLoadingExceptionReporter;
 				_acquireImageControl.SetIntialSearchString(InitialSearchString);
 				_acquireImageControl.SearchLanguage = _incomingSearchLanguage;
 				return _acquireImageControl;

--- a/SIL.Windows.Forms/ImageToolbox/ImageToolboxDialog.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageToolboxDialog.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 using SIL.Reporting;
 
@@ -19,6 +19,17 @@ namespace SIL.Windows.Forms.ImageToolbox
 			SearchLanguage = "en";	// unless the caller specifies otherwise explicitly
 		}
 		public PalasoImage ImageInfo { get { return _imageToolboxControl.ImageInfo; } }
+		/// <summary>
+		/// Used to report problems loading images. See more detail on AcquireImageControl
+		/// </summary>
+		public Action<string, Exception, string> ImageLoadingExceptionReporter
+		{
+			get { return _imageToolboxControl.ImageLoadingExceptionReporter; }
+			set
+			{
+				_imageToolboxControl.ImageLoadingExceptionReporter = value;
+			}
+		}
 
 		/// <summary>
 		/// Sets the language used in searching for an image by words.


### PR DESCRIPTION
- Many cases where image file has the wrong extension now open normally
- Many cases that previously wrongly reported OutOfMemoryException now report TagLib.CorruptFileException
- Client can provide own function to handle failing to load image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/978)
<!-- Reviewable:end -->
