### PR TITLE
[feature/nuget - keyboarding] Dynamically load libgnome-desktop

### DIFF
--- a/SIL.Archiving/SIL.Archiving.csproj
+++ b/SIL.Archiving/SIL.Archiving.csproj
@@ -35,7 +35,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="L10NSharp" Version="4.1.0-beta0036" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core.Desktop\SIL.Core.Desktop.csproj" />

--- a/SIL.Core.Desktop/SIL.Core.Desktop.csproj
+++ b/SIL.Core.Desktop/SIL.Core.Desktop.csproj
@@ -35,7 +35,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NDesk.DBus" Version="0.15.0" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core\SIL.Core.csproj" />

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -32,7 +32,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
   </ItemGroup>

--- a/SIL.DblBundle.Tests/SIL.DblBundle.Tests.csproj
+++ b/SIL.DblBundle.Tests/SIL.DblBundle.Tests.csproj
@@ -35,7 +35,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
 
   </ItemGroup>
 

--- a/SIL.DblBundle/SIL.DblBundle.csproj
+++ b/SIL.DblBundle/SIL.DblBundle.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core\SIL.Core.csproj" />

--- a/SIL.DictionaryServices/SIL.DictionaryServices.csproj
+++ b/SIL.DictionaryServices/SIL.DictionaryServices.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Lexicon/SIL.Lexicon.csproj
+++ b/SIL.Lexicon/SIL.Lexicon.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Lift/SIL.Lift.csproj
+++ b/SIL.Lift/SIL.Lift.csproj
@@ -34,7 +34,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="RelaxNG" Version="3.2.3" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core.Desktop\SIL.Core.Desktop.csproj" />

--- a/SIL.Linux.Logging/SIL.Linux.Logging.csproj
+++ b/SIL.Linux.Logging/SIL.Linux.Logging.csproj
@@ -34,7 +34,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Media/SIL.Media.csproj
+++ b/SIL.Media/SIL.Media.csproj
@@ -36,7 +36,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NAudio" Version="1.10.0" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core\SIL.Core.csproj" />

--- a/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
+++ b/SIL.Scripture.Tests/SIL.Scripture.Tests.csproj
@@ -35,7 +35,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="RhinoMocks" Version="3.6.1" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Scripture/SIL.Scripture.csproj
+++ b/SIL.Scripture/SIL.Scripture.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.TestUtilities/SIL.TestUtilities.csproj
+++ b/SIL.TestUtilities/SIL.TestUtilities.csproj
@@ -35,7 +35,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
+++ b/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
@@ -36,7 +36,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="L10NSharp" Version="4.1.0-beta0036" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/SIL.Windows.Forms.GeckoBrowserAdapter.csproj
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/SIL.Windows.Forms.GeckoBrowserAdapter.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms.Keyboarding.Tests/GnomeKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/GnomeKeyboardRetrievingHelperTests.cs
@@ -11,6 +11,12 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 	[Platform(Include="Linux", Reason="Linux specific tests")]
 	public class GnomeKeyboardRetrievingHelperTests
 	{
+		[OneTimeTearDown]
+		public void OneTimeTearDown()
+		{
+			Unmanaged.LibGnomeDesktopCleanup();
+		}
+
 		[Test]
 		public void InitKeyboards_XkbAndIbus()
 		{

--- a/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
+++ b/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
@@ -25,7 +25,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ibusdotnet" Version="2.0.1" />
+    <PackageReference Include="ibusdotnet" Version="2.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="NDesk.DBus" Version="0.15.0" />

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -17,7 +17,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// The keyboard retrieving part is identical to previous versions but switching keyboards
 	/// changed with 18.04.
 	/// </summary>
-	public class GnomeShellIbusKeyboardRetrievingAdaptor: IbusKeyboardRetrievingAdaptor
+	public class GnomeShellIbusKeyboardRetrievingAdaptor: IbusKeyboardRetrievingAdaptor, IDisposable
 	{
 		private readonly GnomeKeyboardRetrievingHelper _helper = new GnomeKeyboardRetrievingHelper();
 
@@ -37,6 +37,17 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// <remarks>This overload is used in unit tests</remarks>
 		protected GnomeShellIbusKeyboardRetrievingAdaptor(IIbusCommunicator ibusCommunicator): base(ibusCommunicator)
 		{
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+
+			if (disposing && !IsDisposed)
+			{
+				// dispose managed and unmanaged objects
+				Unmanaged.LibGnomeDesktopCleanup();
+			}
 		}
 
 		public override bool IsApplicable => _helper.IsApplicable && Platform.IsGnomeShell;
@@ -89,8 +100,8 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				{
 					type = typeof(IbusXkbKeyboardDescription);
 					layout = string.IsNullOrEmpty(ibusKeyboard.LayoutVariant)
-							? ibusKeyboard.Layout
-							: $"{ibusKeyboard.Layout}+{ibusKeyboard.LayoutVariant}";
+						? ibusKeyboard.Layout
+						: $"{ibusKeyboard.Layout}+{ibusKeyboard.LayoutVariant}";
 				}
 				else
 				{

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -185,5 +185,11 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			}
 			return keyboards.ToArray();
 		}
+
+		protected override string GetKeyboardSetupApplication(out string arguments)
+		{
+			return KeyboardRetrievingHelper.GetKeyboardSetupApplication(out arguments);
+		}
+
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2015-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
+using System.IO;
+using SIL.PlatformUtilities;
 using SIL.Reporting;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -30,6 +32,52 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				if (settingsGeneral != IntPtr.Zero)
 					Unmanaged.g_object_unref(settingsGeneral);
 			}
+		}
+
+		public static string GetKeyboardSetupApplication(out string arguments)
+		{
+			// NOTE: if we get false results (e.g. because the user has installed multiple
+			// desktop environments) we could check for the currently running desktop
+			// (Platform.DesktopEnvironment) and return the matching program
+			arguments = null;
+			// XFCE
+			if (File.Exists("/usr/bin/xfce4-keyboard-settings"))
+				return "/usr/bin/xfce4-keyboard-settings";
+			// Cinnamon
+			if (File.Exists("/usr/lib/cinnamon-settings/cinnamon-settings.py") && File.Exists("/usr/bin/python"))
+			{
+				arguments = "/usr/lib/cinnamon-settings/cinnamon-settings.py " +
+							(Platform.DesktopEnvironment == "cinnamon"
+								? "region layouts" // Wasta 12
+								: "keyboard");     // Wasta 14;
+				return "/usr/bin/python";
+			}
+			// Cinnamon in Wasta 20.04
+			if (File.Exists("/usr/bin/cinnamon-settings"))
+			{
+				arguments = "keyboard -t layouts";
+				return "/usr/bin/cinnamon-settings";
+			}
+			// GNOME
+			if (File.Exists("/usr/bin/gnome-control-center"))
+			{
+				arguments = "region layouts";
+				return "/usr/bin/gnome-control-center";
+			}
+			// KDE
+			if (File.Exists("/usr/bin/kcmshell4"))
+			{
+				arguments = "kcm_keyboard";
+				return "/usr/bin/kcmshell4";
+			}
+			// Unity
+			if (File.Exists("/usr/bin/unity-control-center"))
+			{
+				arguments = "region layouts";
+				return "/usr/bin/unity-control-center";
+			}
+
+			return null;
 		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -61,15 +63,156 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		[DllImport("libglib-2.0.so")]
 		internal static extern void g_list_free(IntPtr list);
 
-		[DllImport("libgnome-desktop-3.so.17")]
-		internal static extern IntPtr gnome_xkb_info_new();
+		#region libgnome-desktop
+		private class LibGnomeDesktopMethodsContainer
+		{
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+			internal delegate IntPtr gnome_xkb_info_newDelegate();
 
-		[DllImport("libgnome-desktop-3.so.17")]
-		internal static extern IntPtr gnome_xkb_info_get_all_layouts(IntPtr self);
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+			internal delegate IntPtr gnome_xkb_info_get_all_layoutsDelegate(IntPtr self);
 
-		[DllImport("libgnome-desktop-3.so.17")]
-		internal static extern bool gnome_xkb_info_get_layout_info(IntPtr self, IntPtr id,
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+			internal delegate bool gnome_xkb_info_get_layout_infoDelegate(IntPtr self, IntPtr id,
+				out IntPtr displayName, out IntPtr shortName, out IntPtr xkbLayout,
+				out IntPtr xkbVariant);
+
+			internal gnome_xkb_info_newDelegate             gnome_xkb_info_new;
+			internal gnome_xkb_info_get_all_layoutsDelegate gnome_xkb_info_get_all_layouts;
+			internal gnome_xkb_info_get_layout_infoDelegate gnome_xkb_info_get_layout_info;
+		}
+
+		private static LibGnomeDesktopMethodsContainer _LibGnomeDesktopMethods;
+
+		private static LibGnomeDesktopMethodsContainer LibGnomeDesktopMethods => _LibGnomeDesktopMethods ??
+			(_LibGnomeDesktopMethods = new LibGnomeDesktopMethodsContainer());
+
+		private static IntPtr _LibGnomeDesktopHandle;
+
+		private static IntPtr LibGnomeDesktopHandle
+		{
+			get
+			{
+				if (_LibGnomeDesktopHandle == IntPtr.Zero)
+				{
+					_LibGnomeDesktopHandle =
+						LoadLibrary("libgnome-desktop-3.so", new[] { "17", "19" });
+				}
+
+				return _LibGnomeDesktopHandle;
+			}
+		}
+
+		internal static void LibGnomeDesktopCleanup()
+		{
+			if (_LibGnomeDesktopHandle != IntPtr.Zero)
+				dlclose(_LibGnomeDesktopHandle);
+
+			_LibGnomeDesktopHandle = IntPtr.Zero;
+		}
+
+		internal static IntPtr gnome_xkb_info_new()
+		{
+			if (LibGnomeDesktopMethods.gnome_xkb_info_new == null)
+			{
+				LibGnomeDesktopMethods.gnome_xkb_info_new =
+					GetMethod<LibGnomeDesktopMethodsContainer.gnome_xkb_info_newDelegate>
+						(LibGnomeDesktopHandle, nameof(gnome_xkb_info_new));
+			}
+
+			return LibGnomeDesktopMethods.gnome_xkb_info_new();
+		}
+
+		internal static IntPtr gnome_xkb_info_get_all_layouts(IntPtr self)
+		{
+			if (LibGnomeDesktopMethods.gnome_xkb_info_get_all_layouts == null)
+			{
+				LibGnomeDesktopMethods.gnome_xkb_info_get_all_layouts =
+					GetMethod<LibGnomeDesktopMethodsContainer.gnome_xkb_info_get_all_layoutsDelegate>
+						(LibGnomeDesktopHandle, nameof(gnome_xkb_info_get_all_layouts));
+			}
+
+			return LibGnomeDesktopMethods.gnome_xkb_info_get_all_layouts(self);
+		}
+
+		internal static bool gnome_xkb_info_get_layout_info(IntPtr self, IntPtr id,
 			out IntPtr displayName, out IntPtr shortName, out IntPtr xkbLayout,
-			out IntPtr xkbVariant);
+			out IntPtr xkbVariant)
+		{
+			if (LibGnomeDesktopMethods.gnome_xkb_info_get_layout_info == null)
+			{
+				LibGnomeDesktopMethods.gnome_xkb_info_get_layout_info =
+					GetMethod<LibGnomeDesktopMethodsContainer.gnome_xkb_info_get_layout_infoDelegate>
+						(LibGnomeDesktopHandle, nameof(gnome_xkb_info_get_layout_info));
+			}
+
+			return LibGnomeDesktopMethods.gnome_xkb_info_get_layout_info(self, id, out displayName,
+				out shortName, out xkbLayout, out xkbVariant);
+		}
+
+		#endregion
+
+		#region Methods for dynamically loading a library
+
+		private const int RTLD_NOW = 2;
+
+		private const string LIBDL_NAME = "libdl.so.2";
+
+		[DllImport(LIBDL_NAME, SetLastError = true)]
+		private static extern IntPtr dlopen(string file, int mode);
+
+		[DllImport(LIBDL_NAME, SetLastError = true)]
+		private static extern int dlclose(IntPtr handle);
+
+		[DllImport(LIBDL_NAME, SetLastError = true)]
+		private static extern IntPtr dlsym(IntPtr handle, string name);
+
+		[DllImport(LIBDL_NAME, EntryPoint = "dlerror")]
+		private static extern IntPtr _dlerror();
+
+		private static string dlerror()
+		{
+			// Don't free the string returned from _dlerror()!
+			var ptr = _dlerror();
+			return Marshal.PtrToStringAnsi(ptr);
+		}
+		#endregion
+
+		#region Dynamic loading of unmanaged library methods
+		private static IntPtr LoadLibrary(string libraryName, string[] versionCandidates)
+		{
+			foreach (var version in versionCandidates)
+			{
+				var libName = $"{libraryName}.{version}";
+
+				var handle = dlopen(libName, RTLD_NOW);
+				if (handle != IntPtr.Zero)
+					return handle;
+			}
+
+			throw new FileLoadException(
+				$"Can't load library {libraryName}. Tried versions {string.Join(", ", versionCandidates)}.)",
+				libraryName);
+		}
+
+		private static T GetMethod<T>(IntPtr handle, string methodName) where T : class
+		{
+			var methodPointer = dlsym(handle, methodName);
+
+			if (methodPointer != IntPtr.Zero)
+			{
+				// NOTE: Starting in .NET 4.5.1, Marshal.GetDelegateForFunctionPointer(IntPtr, Type) is obsolete.
+#if NET40
+				return Marshal.GetDelegateForFunctionPointer(
+					methodPointer, typeof(T)) as T;
+#else
+				return Marshal.GetDelegateForFunctionPointer<T>(methodPointer);
+#endif
+			}
+
+			return default(T);
+		}
+		#endregion
+
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -200,35 +200,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		protected virtual string GetKeyboardSetupApplication(out string arguments)
 		{
-			// NOTE: if we get false results (e.g. because the user has installed multiple
-			// desktop environments) we could check for the currently running desktop
-			// (Platform.DesktopEnvironment) and return the matching program
-			arguments = null;
-			// XFCE
-			if (File.Exists("/usr/bin/xfce4-keyboard-settings"))
-				return "/usr/bin/xfce4-keyboard-settings";
-			// Cinnamon
-			if (File.Exists("/usr/lib/cinnamon-settings/cinnamon-settings.py") && File.Exists("/usr/bin/python"))
-			{
-				arguments = "/usr/lib/cinnamon-settings/cinnamon-settings.py " +
-					(Platform.DesktopEnvironment == "cinnamon"
-						? "region layouts" // Wasta 12
-						: "keyboard"); // Wasta 14;
-				return "/usr/bin/python";
-			}
-			// GNOME
-			if (File.Exists("/usr/bin/gnome-control-center"))
-			{
-				arguments = "region layouts";
-				return "/usr/bin/gnome-control-center";
-			}
-			// KDE
-			if (File.Exists("/usr/bin/kcmshell4"))
-			{
-				arguments = "kcm_keyboard";
-				return "/usr/bin/kcmshell4";
-			}
-			return null;
+			return KeyboardRetrievingHelper.GetKeyboardSetupApplication(out arguments);
 		}
 
 		public bool IsSecondaryKeyboardSetupApplication => false;

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -31,7 +31,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="GitVersionTask" Version="5.3.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ibusdotnet" Version="2.0.1" />
+    <PackageReference Include="ibusdotnet" Version="2.0.3" />
     <PackageReference Include="icu.net" Version="2.6.0" />
     <PackageReference Include="L10NSharp" Version="4.1.0-beta0036" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -36,7 +36,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="L10NSharp" Version="4.1.0-beta0036" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms.Scripture/SIL.Windows.Forms.Scripture.csproj
+++ b/SIL.Windows.Forms.Scripture/SIL.Windows.Forms.Scripture.csproj
@@ -33,7 +33,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms.WritingSystems.Tests/SIL.Windows.Forms.WritingSystems.Tests.csproj
+++ b/SIL.Windows.Forms.WritingSystems.Tests/SIL.Windows.Forms.WritingSystems.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="GitVersionTask" Version="5.3.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ibusdotnet" Version="2.0.1" />
+    <PackageReference Include="ibusdotnet" Version="2.0.3" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="NDesk.DBus" Version="0.15.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />

--- a/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems.csproj
+++ b/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems.csproj
@@ -34,7 +34,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     </PackageReference>
     <PackageReference Include="L10NSharp" Version="4.1.0-beta0036" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
     <PackageReference Include="System.Globalization" Version="4.3.0" />
   </ItemGroup>
 

--- a/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="..\packages\SIL.BuildTasks.2.3.4\build\SIL.BuildTasks.props" Condition="Exists('..\packages\SIL.BuildTasks.2.3.4\build\SIL.BuildTasks.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -909,6 +910,12 @@
     <None Include="Resources\cc0.png" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\SIL.BuildTasks.2.3.4\build\SIL.BuildTasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SIL.BuildTasks.2.3.4\build\SIL.BuildTasks.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -40,8 +40,8 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="GitVersionTask" Version="5.3.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SIL.BuildTasks" Version="[2.3.1,)" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.BuildTasks" Version="2.3.4" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -9,6 +9,6 @@
   <package id="L10NSharp" version="4.1.0-beta0036" targetFramework="net461" />
   <package id="MarkdownDeep.NET.Patched" version="1.5.0.2" targetFramework="net461" />
   <package id="Mono.Posix" version="5.4.0.201" requireReinstallation="true" />
-  <package id="SIL.BuildTasks" version="2.3.1" targetFramework="net461" />
+  <package id="SIL.BuildTasks" version="2.3.4" targetFramework="net461" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
 </packages>

--- a/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
+++ b/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
@@ -35,7 +35,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="GitVersionTask" Version="5.3.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SIL.WritingSystems/SIL.WritingSystems.csproj
+++ b/SIL.WritingSystems/SIL.WritingSystems.csproj
@@ -31,7 +31,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="SIL.ReleaseTasks" Version="[2.3.1,)" PrivateAssets="All" />
+    <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
     <PackageReference Include="icu.net" Version="2.6.0" />
     <PackageReference Include="Spart" Version="1.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />

--- a/TestApps/TestAppKeyboard/KeyboardForm.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.cs
@@ -22,9 +22,17 @@ namespace TestAppKeyboard
 			KeyboardController.RegisterControl(testAreaB, eventHandler);
 			KeyboardController.RegisterControl(testAreaC, eventHandler);
 
+			Console.WriteLine();
+			Console.WriteLine("Adding keyboards for Test Area A");
 			LoadKeyboards(keyboardsA);
+			Console.WriteLine();
+			Console.WriteLine("Adding keyboards for Test Area B");
 			LoadKeyboards(keyboardsB);
+			Console.WriteLine();
+			Console.WriteLine("Adding keyboards for Test Area C");
 			LoadKeyboards(keyboardsC);
+			Console.WriteLine();
+			Console.WriteLine("Adding keyboards for Current Keyboard dropdown");
 			LoadKeyboards(currentKeyboard);
 		}
 


### PR DESCRIPTION
Ubuntu 18.04 and 20.04 use different versions of `libgnome-desktop.so`. This change dynamically loads the methods we need which allows this code to run with both versions. This fixes #958.

Also update ibusdotnet. This fixes a problem with detecting ibus keyboards on Ubuntu 20.04. This Ubuntu version puts a comment in the ibus configuration file which older versions of ibusdotnet didn't properly handle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/984)
<!-- Reviewable:end -->
