### PR TITLE
[keyboarding] Fix keyboard switching in Gnome (LT-20428)

### DIFF
--- a/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
@@ -21,7 +21,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 			};
 			var sut = new UnityKeyboardRetrievingHelper(() => installedKeyboards);
 			Assert.That(() => sut.InitKeyboards(s => true,
-				keyboards => registeredKeyboards = keyboards),
+				(keyboards, _) => registeredKeyboards = keyboards),
 				Throws.Nothing);
 			Assert.That(registeredKeyboards, Is.EquivalentTo(new Dictionary<string, int> {
 				{ "us", 0 },
@@ -40,7 +40,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 			};
 			var sut = new UnityKeyboardRetrievingHelper(() => installedKeyboards);
 			Assert.That(() => sut.InitKeyboards(s => true,
-				keyboards => registeredKeyboards = keyboards),
+					(keyboards, _) => registeredKeyboards = keyboards),
 				Throws.Nothing); // LT-20410
 			Assert.That(registeredKeyboards, Is.EquivalentTo(new Dictionary<string, int> {
 				{ "km:/home/user/.local/share/keyman/khmer_angkor/khmer_angkor.kmx", 0 },

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -23,7 +23,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		public CombinedIbusKeyboardRetrievingAdaptor()
 		{
-			KeyboardRetrievingHelper.InitGlib();
 		}
 
 		/// <summary>
@@ -135,7 +134,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			{
 				try
 				{
-					if (!KeyboardRetrievingHelper.SchemaIsInstalled(GSettingsSchema))
+					if (!GlibHelper.SchemaIsInstalled(GSettingsSchema))
 						return false;
 					_settingsGeneral = Unmanaged.g_settings_new(GSettingsSchema);
 					if (_settingsGeneral == IntPtr.Zero)

--- a/SIL.Windows.Forms.Keyboarding/Linux/GList.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GList.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	/// <summary>
+	/// Doubly-linked list of strings.
+	/// </summary>
+	/// <remarks>This wraps the glist struct defined in glibc and helps to interact with native
+	/// code.</remarks>
+	internal struct GList
+	{
+#pragma warning disable 649 // Field is never assigned to (it is however through FromPtr)
+		private IntPtr data;
+		private IntPtr next;
+		private IntPtr prev;
+#pragma warning restore 649
+
+		public string Data => Marshal.PtrToStringAuto(data);
+
+		public GList? Next => FromPtr(next);
+
+		public GList? Prev => FromPtr(prev);
+
+		public bool HasNext => next != IntPtr.Zero;
+
+		public bool HasPrev => prev != IntPtr.Zero;
+
+		public static GList? FromPtr(IntPtr ptr)
+		{
+			if (ptr == IntPtr.Zero)
+				return null;
+			return Marshal.PtrToStructure<GList>(ptr);
+		}
+
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/GlibHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GlibHelper.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2015-2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	public static class GlibHelper
+	{
+		/// <summary>
+		/// Returns <c>true</c> if the <paramref name="schema"/> is installed on the machine,
+		/// otherwise <c>false</c>.
+		/// </summary>
+		public static bool SchemaIsInstalled(string schema)
+		{
+			return Unmanaged.g_settings_schema_source_lookup(Unmanaged.g_settings_schema_source_get_default(),
+				schema, recursive: true) != IntPtr.Zero;
+		}
+
+		/// <summary>
+		/// Convert a GVariant handle that points to a list of strings to a C# string array.
+		/// Without leaking memory in the process!
+		/// </summary>
+		/// <remarks>
+		/// No check is made to verify that the input value actually points to a list of strings.
+		/// </remarks>
+		public static string[] GetStringArrayFromGVariantArray(IntPtr value)
+		{
+			if (value == IntPtr.Zero)
+				return new string[0];
+			var size = Unmanaged.g_variant_n_children(value);
+			var list = new string[size];
+			for (uint i = 0; i < size; ++i)
+			{
+				var child = Unmanaged.g_variant_get_child_value(value, i);
+				// handle must not be freed -- it points into the actual GVariant memory for child!
+				int length;
+				var handle = Unmanaged.g_variant_get_string(child, out length);
+				var rawbytes = new byte[length];
+				Marshal.Copy(handle, rawbytes, 0, length);
+				list[i] = Encoding.UTF8.GetString(rawbytes);
+				Unmanaged.g_variant_unref(child);
+				//Console.WriteLine("DEBUG GetStringArrayFromGVariant(): list[{0}] = \"{1}\" (length = {2})", i, list[i], length);
+			}
+			return list;
+		}
+
+		/// <summary>
+		/// Convert a GVariant handle that points to a list of lists of two strings into
+		/// a C# string array.  The original strings in the inner lists are separated by
+		/// double semicolons in the output elements of the C# string array.
+		/// </summary>
+		/// <remarks>
+		/// No check is made to verify that the input value actually points to a list of
+		/// lists of two strings.
+		/// </remarks>
+		public static string[] GetStringArrayFromGVariantListArray(IntPtr value)
+		{
+			if (value == IntPtr.Zero)
+				return new string[0];
+			var size = Unmanaged.g_variant_n_children(value);
+			var list = new string[size];
+			for (uint i = 0; i < size; ++i)
+			{
+				var duple = Unmanaged.g_variant_get_child_value(value, i);
+				var values = GetStringArrayFromGVariantArray(duple);
+				Debug.Assert(values.Length == 2);
+				list[i] = $"{values[0]};;{values[1]}";
+				Unmanaged.g_variant_unref(duple);
+				//Console.WriteLine("DEBUG GetStringArrayFromGVariantListArray(): list[{0}] = \"{1}\"", i, list[i]);
+			}
+			return list;
+		}
+
+		public static string[] GetStringArrayFromGList(IntPtr value)
+		{
+			var list = new List<string>();
+
+			if (value == IntPtr.Zero)
+				return list.ToArray();
+
+			var glist = GList.FromPtr(value);
+			for (; glist != null; glist = glist.Value.Next)
+			{
+				list.Add(glist.Value.Data);
+			}
+
+			return list.ToArray();
+		}
+
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -1,6 +1,10 @@
 // Copyright (c) 2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IBusDotNet;
 using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -10,13 +14,173 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	/// The keyboard retrieving part is identical to previous versions but switching keyboards
 	/// changed with 18.04.
 	/// </summary>
-	public class GnomeShellIbusKeyboardRetrievingAdaptor: UnityIbusKeyboardRetrievingAdaptor
+	public class GnomeShellIbusKeyboardRetrievingAdaptor: IbusKeyboardRetrievingAdaptor
 	{
-		protected override IKeyboardSwitchingAdaptor CreateSwitchingAdaptor()
+		private readonly UnityKeyboardRetrievingHelper _helper = new UnityKeyboardRetrievingHelper();
+
+		/// <summary>
+		/// Initializes a new instance of the
+		/// <see cref="SIL.Windows.Forms.Keyboarding.Linux.GnomeShellIbusKeyboardRetrievingAdaptor"/> class.
+		/// </summary>
+		public GnomeShellIbusKeyboardRetrievingAdaptor()
 		{
-			return new GnomeShellIbusKeyboardSwitchingAdaptor(IbusCommunicator);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the
+		/// <see cref="SIL.Windows.Forms.Keyboarding.Linux.GnomeShellIbusKeyboardRetrievingAdaptor"/> class.
+		/// </summary>
+		/// <param name="ibusCommunicator">Ibus communicator.</param>
+		/// <remarks>This overload is used in unit tests</remarks>
+		protected GnomeShellIbusKeyboardRetrievingAdaptor(IIbusCommunicator ibusCommunicator): base(ibusCommunicator)
+		{
 		}
 
 		public override bool IsApplicable => _helper.IsApplicable && Platform.IsGnomeShell;
+
+		public override KeyboardAdaptorType Type => KeyboardAdaptorType.System | KeyboardAdaptorType.OtherIm;
+
+		public override void Initialize()
+		{
+			// We come here twice, for both KeyboardType.System and KeyboardType.OtherIm.
+			// We want to create a new switching adaptor only the first time otherwise we're
+			// getting into trouble
+			if (SwitchingAdaptor != null)
+				return;
+
+			SwitchingAdaptor = new GnomeShellIbusKeyboardSwitchingAdaptor(IbusCommunicator);
+			KeyboardRetrievingHelper.AddIbusVersionAsErrorReportProperty();
+			InitKeyboards();
+		}
+
+		protected override void InitKeyboards()
+		{
+			_helper.InitKeyboards(type => true, RegisterKeyboards);
+		}
+
+		private void RegisterKeyboards(IDictionary<string, uint> installedKeyboards,
+			UnityKeyboardRetrievingHelper.IbusKeyboardEntry firstKeyboard)
+		{
+			if (installedKeyboards.Count <= 0)
+				return;
+
+			// The list of keyboards we knew before registering the new keyboards
+			var priorKeyboardsList =
+				KeyboardController.Instance.Keyboards.OfType<IbusKeyboardDescription>().ToDictionary(kd => kd.Id);
+			// The list of keyboards that are installed on this system but we haven't encountered yet
+			var missingLayouts = new List<string>(installedKeyboards.Keys);
+
+			// The list of keyboards we registered
+			var addedKeyboards = new List<string>();
+
+			foreach (var ibusKeyboard in GetAllIBusKeyboards())
+			{
+				Type type;
+				string layout;
+
+				// ENHANCE: Keyman keyboards contain the path, possibly with username. We should
+				// make that more fault tolerant so that we find that keyboard in curKeyboards
+				// even when running under a different user or installed globally/locally.
+				var id = $"{ibusKeyboard.Language}_{ibusKeyboard.LongName}";
+
+				if (ibusKeyboard.LongName.StartsWith("xkb"))
+				{
+					type = typeof(IbusXkbKeyboardDescription);
+					layout = string.IsNullOrEmpty(ibusKeyboard.LayoutVariant)
+							? ibusKeyboard.Layout
+							: $"{ibusKeyboard.Layout}+{ibusKeyboard.LayoutVariant}";
+				}
+				else
+				{
+					type = typeof(IbusKeyboardDescription);
+					layout = ibusKeyboard.LongName;
+				}
+
+				// Don't add a keyboard that is not installed locally
+				if (!IsKeyboardAvailable(installedKeyboards, layout))
+					continue;
+
+				// Don't add same keyboard twice
+				if (addedKeyboards.Contains(layout))
+					continue;
+
+				// we found this keyboard, so remove it from list
+				missingLayouts.Remove(layout);
+
+				IbusKeyboardDescription keyboard;
+				if (priorKeyboardsList.TryGetValue(id, out keyboard))
+				{
+					if (!keyboard.IsAvailable)
+					{
+						keyboard.SetIsAvailable(true);
+						keyboard.IBusKeyboardEngine = ibusKeyboard;
+					}
+
+					// Remove this keyboard from list so that we don't set it inactive
+					priorKeyboardsList.Remove(id);
+				}
+				else
+				{
+					// Add keyboard to keyboards list
+					keyboard = Activator.CreateInstance(type, id, ibusKeyboard,
+						SwitchingAdaptor) as IbusKeyboardDescription;
+					KeyboardController.Instance.Keyboards.Add(keyboard);
+					addedKeyboards.Add(layout);
+				}
+
+				keyboard.SystemIndex = installedKeyboards[layout];
+
+				if (firstKeyboard.Layout == layout)
+					((GnomeShellIbusKeyboardSwitchingAdaptor) SwitchingAdaptor).SetDefaultKeyboard(
+						keyboard);
+			}
+
+			// All keyboards that we knew before (e.g. from writing systems) and didn't encounter
+			// are not available on this system
+			foreach (var existingKeyboard in priorKeyboardsList.Values)
+				existingKeyboard.SetIsAvailable(false);
+
+			// output a warning for all keyboards that were in installedKeyboards but that we couldn't
+			// process because they didn't have the properties we expected.
+			foreach (var layout in missingLayouts)
+				Console.WriteLine($"{GetType().Name}: Didn't find {layout}");
+		}
+
+		private static bool IsKeyboardAvailable(
+			IDictionary<string, uint> availableKeyboards, string layout)
+		{
+			return !string.IsNullOrEmpty(layout) && availableKeyboards.ContainsKey(layout);
+		}
+
+		protected override IBusEngineDesc[] GetAllIBusKeyboards()
+		{
+			var keyboards = new List<IBusEngineDesc>(base.GetAllIBusKeyboards());
+
+			var gnomeXkbInfo = new GnomeXkbInfo();
+			var xkbKeyboards = gnomeXkbInfo.GetAllLayouts();
+			foreach (var xkbKeyboard in xkbKeyboards)
+			{
+				string displayName;
+				string shortName;
+				string xkbLayout;
+				string xkbVariant;
+				gnomeXkbInfo.GetLayoutInfo(xkbKeyboard, out displayName, out shortName,
+					out xkbLayout, out xkbVariant);
+				keyboards.Add(new XkbIbusEngineDesc {
+					LongName = $"xkb:{xkbKeyboard}",
+					Description = displayName,
+					Name = displayName,
+					Language = shortName,
+					Layout = xkbLayout,
+					LayoutVariant = xkbVariant
+				});
+			}
+			return keyboards.ToArray();
+		}
+
+		protected override string GetKeyboardSetupApplication(out string arguments)
+		{
+			return KeyboardRetrievingHelper.GetKeyboardSetupApplication(out arguments);
+		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeXkbInfo.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeXkbInfo.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	internal class GnomeXkbInfo
+	{
+		private readonly IntPtr _gnomeXkbInfo;
+
+		public GnomeXkbInfo()
+		{
+			_gnomeXkbInfo = Unmanaged.gnome_xkb_info_new();
+		}
+
+		public IEnumerable<string> GetAllLayouts()
+		{
+			var list = Unmanaged.gnome_xkb_info_get_all_layouts(_gnomeXkbInfo);
+
+			var array = GlibHelper.GetStringArrayFromGList(list);
+			Unmanaged.g_list_free(list);
+			return array;
+		}
+
+		public bool GetLayoutInfo(string id, out string displayName, out string shortName,
+			out string xkbLayout, out string xkbVariant)
+		{
+			IntPtr displayNamePtr;
+			IntPtr shortNamePtr;
+			IntPtr xkbLayoutPtr;
+			IntPtr xkbVariantPtr;
+			var exists = Unmanaged.gnome_xkb_info_get_layout_info(_gnomeXkbInfo,
+				Marshal.StringToHGlobalAuto(id), out displayNamePtr, out shortNamePtr,
+				out xkbLayoutPtr, out xkbVariantPtr);
+
+			if (!exists)
+			{
+				displayName = null;
+				shortName = null;
+				xkbLayout = null;
+				xkbVariant = null;
+				return false;
+			}
+
+			displayName = Marshal.PtrToStringAuto(displayNamePtr);
+			shortName = Marshal.PtrToStringAuto(shortNamePtr);
+			xkbLayout = Marshal.PtrToStringAuto(xkbLayoutPtr);
+			xkbVariant = Marshal.PtrToStringAuto(xkbVariantPtr);
+			return exists;
+		}
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
@@ -10,7 +10,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 	{
 		private const string OtherLanguage = "Other Language";
 
-		private IBusEngineDesc _ibusKeyboard;
+		protected IBusEngineDesc _ibusKeyboard;
 
 		public IbusKeyboardDescription(string id, string layout, string locale, IKeyboardSwitchingAdaptor engine)
 			: base (id, FormatKeyboardIdentifier(layout, locale), layout, locale, false, engine)
@@ -36,6 +36,8 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			return string.Format("{0} - {1}", languageName, layout);
 		}
 
+		protected virtual string KeyboardIdentifier => FormatKeyboardIdentifier(_ibusKeyboard.Name, _ibusKeyboard.Language);
+
 		public string ParentLayout
 		{
 			get { return IBusKeyboardEngine.Layout; }
@@ -47,7 +49,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			set
 			{
 				_ibusKeyboard = value;
-				Name = FormatKeyboardIdentifier(_ibusKeyboard.Name, _ibusKeyboard.Language);
+				Name = KeyboardIdentifier;
 			}
 		}
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
@@ -72,7 +72,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			return ibusWrapper.ListActiveEngines();
 		}
 
-		internal IBusEngineDesc[] GetAllIBusKeyboards()
+		protected virtual IBusEngineDesc[] GetAllIBusKeyboards()
 		{
 			if (!_ibusComm.Connected)
 				return new IBusEngineDesc[0];

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusXkbKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusXkbKeyboardDescription.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using IBusDotNet;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	/// <summary>
+	/// Keyboard description for XKB keyboards handled by IBus
+	/// </summary>
+	internal class IbusXkbKeyboardDescription: IbusKeyboardDescription
+	{
+		public IbusXkbKeyboardDescription(string id, IBusEngineDesc ibusKeyboard, IKeyboardSwitchingAdaptor engine)
+			: base(id, ibusKeyboard, engine)
+		{
+		}
+
+		protected override string KeyboardIdentifier => _ibusKeyboard.Name;
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -46,7 +46,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			_helper.InitKeyboards(type => type != "xkb", RegisterKeyboards);
 		}
 
-		private void RegisterKeyboards(IDictionary<string, uint> keyboards)
+		private void RegisterKeyboards(IDictionary<string, uint> keyboards, UnityKeyboardRetrievingHelper.IbusKeyboardEntry _)
 		{
 			if (keyboards.Count <= 0)
 				return;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
@@ -22,7 +22,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			bool okay = true;
 			try
 			{
-				okay &= KeyboardRetrievingHelper.SchemaIsInstalled(schema);
+				okay &= GlibHelper.SchemaIsInstalled(schema);
 				if (!okay)
 					return;
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
@@ -41,7 +41,8 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			_helper.InitKeyboards(type => type == "xkb", RegisterKeyboards);
 		}
 
-		private void RegisterKeyboards(IDictionary<string, uint> keyboards)
+		private void RegisterKeyboards(IDictionary<string, uint> keyboards,
+			UnityKeyboardRetrievingHelper.IbusKeyboardEntry _)
 		{
 			if (keyboards.Count <= 0)
 				return;

--- a/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -57,5 +58,159 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		[DllImport("libglib-2.0.so")]
 		internal extern static bool g_variant_get_boolean(IntPtr value);
+
+		[DllImport("libglib-2.0.so")]
+		internal static extern void g_list_free(IntPtr list);
+
+		#region libgnome-desktop
+		private class LibGnomeDesktopMethodsContainer
+		{
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+			internal delegate IntPtr gnome_xkb_info_newDelegate();
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+			internal delegate IntPtr gnome_xkb_info_get_all_layoutsDelegate(IntPtr self);
+
+			[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+			internal delegate bool gnome_xkb_info_get_layout_infoDelegate(IntPtr self, IntPtr id,
+				out IntPtr displayName, out IntPtr shortName, out IntPtr xkbLayout,
+				out IntPtr xkbVariant);
+
+			internal gnome_xkb_info_newDelegate             gnome_xkb_info_new;
+			internal gnome_xkb_info_get_all_layoutsDelegate gnome_xkb_info_get_all_layouts;
+			internal gnome_xkb_info_get_layout_infoDelegate gnome_xkb_info_get_layout_info;
+		}
+
+		private static LibGnomeDesktopMethodsContainer _LibGnomeDesktopMethods;
+
+		private static LibGnomeDesktopMethodsContainer LibGnomeDesktopMethods => _LibGnomeDesktopMethods ??
+			(_LibGnomeDesktopMethods = new LibGnomeDesktopMethodsContainer());
+
+		private static IntPtr _LibGnomeDesktopHandle;
+
+		private static IntPtr LibGnomeDesktopHandle
+		{
+			get
+			{
+				if (_LibGnomeDesktopHandle == IntPtr.Zero)
+				{
+					_LibGnomeDesktopHandle =
+						LoadLibrary("libgnome-desktop-3.so", new[] { "17", "19" });
+				}
+
+				return _LibGnomeDesktopHandle;
+			}
+		}
+
+		internal static void LibGnomeDesktopCleanup()
+		{
+			if (_LibGnomeDesktopHandle != IntPtr.Zero)
+				dlclose(_LibGnomeDesktopHandle);
+
+			_LibGnomeDesktopHandle = IntPtr.Zero;
+		}
+
+		internal static IntPtr gnome_xkb_info_new()
+		{
+			if (LibGnomeDesktopMethods.gnome_xkb_info_new == null)
+			{
+				LibGnomeDesktopMethods.gnome_xkb_info_new =
+					GetMethod<LibGnomeDesktopMethodsContainer.gnome_xkb_info_newDelegate>
+						(LibGnomeDesktopHandle, nameof(gnome_xkb_info_new));
+			}
+
+			return LibGnomeDesktopMethods.gnome_xkb_info_new();
+		}
+
+		internal static IntPtr gnome_xkb_info_get_all_layouts(IntPtr self)
+		{
+			if (LibGnomeDesktopMethods.gnome_xkb_info_get_all_layouts == null)
+			{
+				LibGnomeDesktopMethods.gnome_xkb_info_get_all_layouts =
+					GetMethod<LibGnomeDesktopMethodsContainer.gnome_xkb_info_get_all_layoutsDelegate>
+						(LibGnomeDesktopHandle, nameof(gnome_xkb_info_get_all_layouts));
+			}
+
+			return LibGnomeDesktopMethods.gnome_xkb_info_get_all_layouts(self);
+		}
+
+		internal static bool gnome_xkb_info_get_layout_info(IntPtr self, IntPtr id,
+			out IntPtr displayName, out IntPtr shortName, out IntPtr xkbLayout,
+			out IntPtr xkbVariant)
+		{
+			if (LibGnomeDesktopMethods.gnome_xkb_info_get_layout_info == null)
+			{
+				LibGnomeDesktopMethods.gnome_xkb_info_get_layout_info =
+					GetMethod<LibGnomeDesktopMethodsContainer.gnome_xkb_info_get_layout_infoDelegate>
+						(LibGnomeDesktopHandle, nameof(gnome_xkb_info_get_layout_info));
+			}
+
+			return LibGnomeDesktopMethods.gnome_xkb_info_get_layout_info(self, id, out displayName,
+				out shortName, out xkbLayout, out xkbVariant);
+		}
+
+		#endregion
+
+		#region Methods for dynamically loading a library
+
+		private const int RTLD_NOW = 2;
+
+		private const string LIBDL_NAME = "libdl.so.2";
+
+		[DllImport(LIBDL_NAME, SetLastError = true)]
+		private static extern IntPtr dlopen(string file, int mode);
+
+		[DllImport(LIBDL_NAME, SetLastError = true)]
+		private static extern int dlclose(IntPtr handle);
+
+		[DllImport(LIBDL_NAME, SetLastError = true)]
+		private static extern IntPtr dlsym(IntPtr handle, string name);
+
+		[DllImport(LIBDL_NAME, EntryPoint = "dlerror")]
+		private static extern IntPtr _dlerror();
+
+		private static string dlerror()
+		{
+			// Don't free the string returned from _dlerror()!
+			var ptr = _dlerror();
+			return Marshal.PtrToStringAnsi(ptr);
+		}
+		#endregion
+
+		#region Dynamic loading of unmanaged library methods
+		private static IntPtr LoadLibrary(string libraryName, string[] versionCandidates)
+		{
+			foreach (var version in versionCandidates)
+			{
+				var libName = $"{libraryName}.{version}";
+
+				var handle = dlopen(libName, RTLD_NOW);
+				if (handle != IntPtr.Zero)
+					return handle;
+			}
+
+			throw new FileLoadException(
+				$"Can't load library {libraryName}. Tried versions {string.Join(", ", versionCandidates)}.)",
+				libraryName);
+		}
+
+		private static T GetMethod<T>(IntPtr handle, string methodName) where T : class
+		{
+			var methodPointer = dlsym(handle, methodName);
+
+			if (methodPointer != IntPtr.Zero)
+			{
+				// NOTE: Starting in .NET 4.5.1, Marshal.GetDelegateForFunctionPointer(IntPtr, Type) is obsolete.
+#if NET40
+				return Marshal.GetDelegateForFunctionPointer(
+					methodPointer, typeof(T)) as T;
+#else
+				return Marshal.GetDelegateForFunctionPointer<T>(methodPointer);
+#endif
+			}
+
+			return default(T);
+		}
+		#endregion
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbIbusEngineDesc.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbIbusEngineDesc.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using IBusDotNet;
+
+namespace SIL.Windows.Forms.Keyboarding.Linux
+{
+	internal class XkbIbusEngineDesc: IBusEngineDesc
+	{
+		public string Name { get; set; }
+		public string LongName { get; set; }
+		public string Description { get; set; }
+		public string Language { get; set; }
+		public string License { get; set; }
+		public string Author { get; set; }
+		public string Icon { get; set; }
+		public string Layout { get; set; }
+		public string Hotkeys { get; set; }
+		public uint Rank { get; set; }
+		public string Symbol { get; set; }
+		public string Setup { get; set; }
+		public string LayoutVariant { get; set; }
+		public string LayoutOption { get; set; }
+		public string Version { get; set; }
+		public string TextDomain { get; set; }
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -216,41 +216,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		protected virtual string GetKeyboardSetupApplication(out string arguments)
 		{
-			// NOTE: if we get false results (e.g. because the user has installed multiple
-			// desktop environments) we could check for the currently running desktop
-			// (Platform.DesktopEnvironment) and return the matching program
-			arguments = null;
-			// XFCE
-			if (File.Exists("/usr/bin/xfce4-keyboard-settings"))
-				return "/usr/bin/xfce4-keyboard-settings";
-			// Cinnamon
-			if (File.Exists("/usr/lib/cinnamon-settings/cinnamon-settings.py") && File.Exists("/usr/bin/python"))
-			{
-				arguments = "/usr/lib/cinnamon-settings/cinnamon-settings.py " +
-					(Platform.DesktopEnvironment == "cinnamon"
-						? "region layouts" // Wasta 12
-						: "keyboard"); // Wasta 14;
-				return "/usr/bin/python";
-			}
-			// Cinnamon in Wasta 20.04
-			if (File.Exists("/usr/bin/cinnamon-settings"))
-			{
-				arguments = "keyboard -t layouts";
-				return "/usr/bin/cinnamon-settings";
-			}
-			// GNOME
-			if (File.Exists("/usr/bin/gnome-control-center"))
-			{
-				arguments = "region layouts";
-				return "/usr/bin/gnome-control-center";
-			}
-			// KDE
-			if (File.Exists("/usr/bin/kcmshell4"))
-			{
-				arguments = "kcm_keyboard";
-				return "/usr/bin/kcmshell4";
-			}
-			return null;
+			return KeyboardRetrievingHelper.GetKeyboardSetupApplication(out arguments);
 		}
 
 		public Action GetSecondaryKeyboardSetupAction() => null;

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -377,9 +377,13 @@
     <Compile Include="Linux\AlternateLanguageCodes.cs" />
     <Compile Include="Linux\CombinedIbusKeyboardRetrievingAdaptor.cs" />
     <Compile Include="Linux\CombinedIbusKeyboardSwitchingAdaptor.cs" />
+    <Compile Include="Linux\GlibHelper.cs" />
+    <Compile Include="Linux\GList.cs" />
     <Compile Include="Linux\GnomeShellIbusKeyboardRetrievingAdaptor.cs" />
     <Compile Include="Linux\GnomeShellIbusKeyboardSwitchingAdaptor.cs" />
+    <Compile Include="Linux\GnomeXkbInfo.cs" />
     <Compile Include="Linux\IbusKeyboardSwitchingAdaptor.cs" />
+    <Compile Include="Linux\IbusXkbKeyboardDescription.cs" />
     <Compile Include="Linux\IUnityKeyboardSwitchingAdaptor.cs" />
     <Compile Include="Linux\KeyboardRetrievingHelper.cs" />
     <Compile Include="Linux\UnityIbusKeyboardRetrievingAdaptor.cs" />
@@ -388,6 +392,7 @@
     <Compile Include="Linux\UnityXkbKeyboardRetrievingAdaptor.cs" />
     <Compile Include="Linux\UnityXkbKeyboardSwitchingAdaptor.cs" />
     <Compile Include="Linux\Unmanaged.cs" />
+    <Compile Include="Linux\XkbIbusEngineDesc.cs" />
     <Compile Include="Linux\XkbKeyboardSwitchingAdaptor.cs" />
     <Compile Include="NullKeyboardDescription.cs" />
     <Compile Include="Linux\GlobalCachedInputContext.cs" />


### PR DESCRIPTION
This change fixes keyboard detection and switching in Gnome Shell.
Some fixes for other environments modified the base class which
broke keyboarding in Gnome Shell. Additionally some of the assumptions
were wrong - it's surprising that things worked earlier...

This change is basically a backport of the changes that were done
earlier on the feature/nuget branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/985)
<!-- Reviewable:end -->
