### PR TITLE
Replace MarkdownDeep with Markdig

### DIFF
--- a/SIL.Windows.Forms/Properties/AssemblyInfo.cs
+++ b/SIL.Windows.Forms/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using SIL.Acknowledgements;
 
 [assembly: System.CLSCompliant(true)]
@@ -11,9 +11,9 @@ using SIL.Acknowledgements;
 [assembly: Acknowledgement("L10NSharp", Url = "https://github.com/sillsdev/l10nsharp/",
 	Copyright = "Copyright © SIL International 2010-2014", LicenseUrl = "https://opensource.org/licenses/MIT",
 	Location = "./L10NSharp.dll")]
-[assembly: Acknowledgement("MarkdownDeep", Url = "https://www.nuget.org/packages/MarkdownDeep.NET/",
-	LicenseUrl = "https://opensource.org/licenses/Apache-2.0", Copyright = "Copyright © 2010-2011 Topten Software",
-	Location = "./MarkdownDeep.dll")]
+[assembly: Acknowledgement("Markdig", Url = "https://github.com/lunet-io/markdig",
+	LicenseUrl = "https://github.com/lunet-io/markdig/blob/master/license.txt", Copyright = "Copyright © 2018-2019, Alexandre Mutel",
+	Location = "./Markdig.dll")]
 
 // LGPL-2.1 license is actually for Enchant, not for Enchant.Net
 [assembly: Acknowledgement("Enchant.Net", Url = "https://github.com/AbiWord/enchantdotnet",

--- a/SIL.Windows.Forms/ReleaseNotes/ShowReleaseNotesDialog.cs
+++ b/SIL.Windows.Forms/ReleaseNotes/ShowReleaseNotesDialog.cs
@@ -1,8 +1,8 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
-using MarkdownDeep;
+using Markdig;
 using SIL.IO;
 
 namespace SIL.Windows.Forms.ReleaseNotes
@@ -16,6 +16,8 @@ namespace SIL.Windows.Forms.ReleaseNotes
 	/// </remarks>
 	public partial class ShowReleaseNotesDialog : Form
 	{
+		private static readonly MarkdownPipeline pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+
 		private readonly string _path;
 		private TempFile _temp;
 		private readonly Icon _icon;
@@ -37,8 +39,7 @@ namespace SIL.Windows.Forms.ReleaseNotes
 			_temp = TempFile.WithExtension("htm");
 			if (ApplyMarkdown)
 			{
-				var md = new Markdown();
-				File.WriteAllText(_temp.Path, GetBasicHtmlFromMarkdown(md.Transform(contents)));
+				File.WriteAllText(_temp.Path, GetBasicHtmlFromMarkdown(Markdown.ToHtml(contents, pipeline)));
 			}
 			else if (contents.Contains("<html>") && contents.Contains("<body"))
 			{

--- a/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
@@ -120,10 +120,6 @@
     <Reference Include="L10NSharp, Version=4.1.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
       <HintPath>..\packages\L10NSharp.4.1.0-beta0036\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
-    <Reference Include="MarkdownDeep, Version=1.5.7366.28328, Culture=neutral, PublicKeyToken=a3790ba34fe8597c">
-      <HintPath>..\packages\MarkdownDeep.NET.Patched.1.5.0.2\lib\net35\MarkdownDeep.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />

--- a/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms-Designer.csproj
@@ -120,13 +120,29 @@
     <Reference Include="L10NSharp, Version=4.1.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28, processorArchitecture=MSIL">
       <HintPath>..\packages\L10NSharp.4.1.0-beta0036\lib\net461\L10NSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Markdig.Signed, Version=0.22.0.0, Culture=neutral, PublicKeyToken=870da25a133885f8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Markdig.Signed.0.22.0\lib\net452\Markdig.Signed.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.VisualBasic" Condition="'$(OS)'=='Windows_NT'" />
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -34,7 +34,7 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/feature/nuget/C
     <PackageReference Include="DialogAdapters.Gtk2" Version="0.1.9" />
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
     <PackageReference Include="L10NSharp" Version="4.1.0-beta0036" />
-    <PackageReference Include="MarkdownDeep.NET.Patched" Version="1.5.0.2" />
+    <PackageReference Include="Markdig.Signed" Version="0.22.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="TagLibSharp" Version="2.2.0" />
     <PackageReference Include="GitVersionTask" Version="5.3.4">

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -7,7 +7,6 @@
   <package id="GLibSharp-signed" version="3.22.24.37" requireReinstallation="true" />
   <package id="GtkSharp-signed" version="3.22.24.37" requireReinstallation="true" />
   <package id="L10NSharp" version="4.1.0-beta0036" targetFramework="net461" />
-  <package id="MarkdownDeep.NET.Patched" version="1.5.0.2" targetFramework="net461" />
   <package id="Mono.Posix" version="5.4.0.201" requireReinstallation="true" />
   <package id="SIL.BuildTasks" version="2.3.1" targetFramework="net461" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />

--- a/SIL.Windows.Forms/packages.config
+++ b/SIL.Windows.Forms/packages.config
@@ -7,7 +7,12 @@
   <package id="GLibSharp-signed" version="3.22.24.37" requireReinstallation="true" />
   <package id="GtkSharp-signed" version="3.22.24.37" requireReinstallation="true" />
   <package id="L10NSharp" version="4.1.0-beta0036" targetFramework="net461" />
+  <package id="Markdig.Signed" version="0.22.0" targetFramework="net461" />
   <package id="Mono.Posix" version="5.4.0.201" requireReinstallation="true" />
   <package id="SIL.BuildTasks" version="2.3.1" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
In order to replace MarkdownDeep, which doesn't seem to be maintained and hasn't had an update in a very long time, Todd Hoatson has revised the ShowReleaseNotesDialog form by using the signed version of Markdig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/990)
<!-- Reviewable:end -->
