### PR TITLE
Add langTag filtering in CheckForNewerGlobalWritingSystems

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlInFolderWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlInFolderWritingSystemRepositoryTests.cs
@@ -1075,7 +1075,7 @@ namespace SIL.WritingSystems.Tests
 				ws.DateModified = expectedDateTime;
 				environment.LocalRepository.Set(ws);
 				ws.RightToLeftScript = true;
-				ws.DefaultCollation = new SystemCollationDefinition { LanguageTag = enUsTag };
+				ws.DefaultCollation = new SystemCollationDefinition {LanguageTag = enUsTag};
 				ws.AcceptChanges();
 
 				// SUT

--- a/SIL.WritingSystems/ILocalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/ILocalWritingSystemRepository.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace SIL.WritingSystems
 {
@@ -12,7 +12,8 @@ namespace SIL.WritingSystems
 		/// Returns copies of all of the global writing systems that are newer than their corresponding local writing systems. These
 		/// writing systems can be used to replace the existing local writing systems.
 		/// </summary>
-		IEnumerable<WritingSystemDefinition> CheckForNewerGlobalWritingSystems();
+		/// <param name="languageTags">Only check these language tags</param>
+		IEnumerable<WritingSystemDefinition> CheckForNewerGlobalWritingSystems(IEnumerable<string> languageTags = null);
 
 		/// <summary>
 		/// Gets the global writing system repository.
@@ -25,7 +26,7 @@ namespace SIL.WritingSystems
 	/// </summary>
 	public interface ILocalWritingSystemRepository<T> : ILocalWritingSystemRepository, IWritingSystemRepository<T> where T : WritingSystemDefinition
 	{
-		new IEnumerable<T> CheckForNewerGlobalWritingSystems();
+		new IEnumerable<T> CheckForNewerGlobalWritingSystems(IEnumerable<string> languageTags = null);
 		new IWritingSystemRepository<T> GlobalWritingSystemRepository { get; } 
 	}
 }

--- a/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
+++ b/SIL.WritingSystems/LdmlInFolderWritingSystemRepository.cs
@@ -520,9 +520,9 @@ namespace SIL.WritingSystems
 			}
 		}
 
-		public override IEnumerable<T> CheckForNewerGlobalWritingSystems()
+		public override IEnumerable<T> CheckForNewerGlobalWritingSystems(IEnumerable<string> languageTags = null)
 		{
-			foreach (T ws in base.CheckForNewerGlobalWritingSystems())
+			foreach (T ws in base.CheckForNewerGlobalWritingSystems(languageTags))
 			{
 				// load local settings using custom data mappers, so these settings won't be lost if these writing systems are used to
 				// replace the existing local writing systems

--- a/SIL.WritingSystems/LocalWritingSystemRepositoryBase.cs
+++ b/SIL.WritingSystems/LocalWritingSystemRepositoryBase.cs
@@ -7,18 +7,15 @@ namespace SIL.WritingSystems
 	public abstract class LocalWritingSystemRepositoryBase<T> : WritingSystemRepositoryBase<T>, ILocalWritingSystemRepository<T> where T : WritingSystemDefinition
 	{
 		private readonly Dictionary<string, DateTime> _writingSystemsToIgnore;
-		private readonly IWritingSystemRepository<T> _globalRepository;
+		public IWritingSystemRepository<T> GlobalWritingSystemRepository { get; }
 
 		protected LocalWritingSystemRepositoryBase(IWritingSystemRepository<T> globalRepository)
 		{
-			_globalRepository = globalRepository;
+			GlobalWritingSystemRepository = globalRepository;
 			_writingSystemsToIgnore = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
 		}
 
-		protected IDictionary<string, DateTime> WritingSystemsToIgnore
-		{
-			get { return _writingSystemsToIgnore; }
-		}
+		protected IDictionary<string, DateTime> WritingSystemsToIgnore => _writingSystemsToIgnore;
 
 		protected override void RemoveDefinition(T ws)
 		{
@@ -40,17 +37,17 @@ namespace SIL.WritingSystems
 			if (_writingSystemsToIgnore.TryGetValue(ws.LanguageTag, out lastDateModified) && ws.DateModified > lastDateModified)
 				_writingSystemsToIgnore.Remove(ws.LanguageTag);
 
-			if (_globalRepository != null)
+			if (GlobalWritingSystemRepository != null)
 			{
 				T globalWs;
-				if (_globalRepository.TryGet(ws.Id, out globalWs))
+				if (GlobalWritingSystemRepository.TryGet(ws.Id, out globalWs))
 				{
 					if (ws.DateModified > globalWs.DateModified)
 					{
 						T newWs = WritingSystemFactory.Create(ws, cloneId: true);
 						try
 						{
-							_globalRepository.Replace(ws.Id, newWs);
+							GlobalWritingSystemRepository.Replace(ws.Id, newWs);
 						}
 						catch (Exception)
 						{
@@ -59,16 +56,16 @@ namespace SIL.WritingSystems
 						}
 					}
 				}
-				else if(_globalRepository.CanSet(ws)) // Don't try to set it in the global store if it claims we can't.
+				else if(GlobalWritingSystemRepository.CanSet(ws)) // Don't try to set it in the global store if it claims we can't.
 				{
-					_globalRepository.Set(WritingSystemFactory.Create(ws, cloneId: true));
+					GlobalWritingSystemRepository.Set(WritingSystemFactory.Create(ws, cloneId: true));
 				}
 			}
 		}
 
 		private IEnumerable<T> WritingSystemsNewerInGlobalRepository()
 		{
-			foreach (T ws in _globalRepository.AllWritingSystems)
+			foreach (T ws in GlobalWritingSystemRepository.AllWritingSystems)
 			{
 				if (WritingSystems.ContainsKey(ws.Id))
 				{
@@ -81,40 +78,35 @@ namespace SIL.WritingSystems
 			}
 		}
 
-		public virtual IEnumerable<T> CheckForNewerGlobalWritingSystems()
+		public virtual IEnumerable<T> CheckForNewerGlobalWritingSystems(IEnumerable<string> languageTags = null)
 		{
-			if (_globalRepository != null)
+			if (GlobalWritingSystemRepository != null)
 			{
+				var writingSystemsNewerInGlobalStore = languageTags != null
+					? WritingSystemsNewerInGlobalRepository().Where(ws => languageTags.Contains(ws.LanguageTag))
+					: WritingSystemsNewerInGlobalRepository();
 				var results = new List<T>();
-				foreach (T wsDef in WritingSystemsNewerInGlobalRepository())
+				foreach (T wsDef in writingSystemsNewerInGlobalStore)
 				{
 					LastChecked(wsDef.Id ?? wsDef.LanguageTag, wsDef.DateModified);
 					results.Add(wsDef); // REVIEW Hasso 2013.12: add only if not equal?
 				}
+
 				return results;
 			}
 			return Enumerable.Empty<T>();
 		}
 
-		public IWritingSystemRepository<T> GlobalWritingSystemRepository
-		{
-			get { return _globalRepository; }
-		}
-
 		public override void Save()
 		{
-			if (_globalRepository != null)
-				_globalRepository.Save();
+			GlobalWritingSystemRepository?.Save();
 		}
 
-		IEnumerable<WritingSystemDefinition> ILocalWritingSystemRepository.CheckForNewerGlobalWritingSystems()
+		IEnumerable<WritingSystemDefinition> ILocalWritingSystemRepository.CheckForNewerGlobalWritingSystems(IEnumerable<string> languageTags)
 		{
-			return CheckForNewerGlobalWritingSystems();
+			return CheckForNewerGlobalWritingSystems(languageTags);
 		}
 
-		IWritingSystemRepository ILocalWritingSystemRepository.GlobalWritingSystemRepository
-		{
-			get { return GlobalWritingSystemRepository; }
-		}
+		IWritingSystemRepository ILocalWritingSystemRepository.GlobalWritingSystemRepository => GlobalWritingSystemRepository;
 	}
 }


### PR DESCRIPTION
 Users of FieldWorks wanted to be able to update specific
 writing systems from the global store

* Change signature of CheckForNewerGlobalWritingSystems to allow
  a list of language tags to be used to filter the results
* Add unit tests for CheckForNewerGlobalWritingSystems
* Also do some minor code cleanup

 This is a breaking api change, but only for liblcm - which we will
 change concurrently

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/996)
<!-- Reviewable:end -->
