### PR TITLE
Handle transient languages with invalid .NET data

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -178,11 +178,11 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 			}
 			try
 			{
-				profilesEnumerator = ProfileManager.EnumProfiles((short)culture.KeyboardLayoutId);
+				profilesEnumerator = ProfileManager.EnumProfiles((short)inputLanguage.Handle);
 			}
 			catch
 			{
-				Debug.WriteLine($"Error looking up keyboards for language {culture.Name} - {(short)culture.KeyboardLayoutId}");
+				Debug.WriteLine($"Error looking up keyboards for language {culture.Name} - {(short)inputLanguage.Handle}");
 				yield break;
 			}
 


### PR DESCRIPTION
In some circumstances, it appears that `inputLanguage.culture.KeyboardLayoutId` property has a mismatch with the `inputLanguage.Handle` property, and is returning the wrong value (e.g. `0x04090409` instead of `0x04092000`), and we should instead be enumerating on the basis of the input value from `inputLanguage`.

This was spotted in testing by June, who found that Keyman keyboards associated with transient languages were not listed as available for use in PT.

About transient languages: https://docs.microsoft.com/en-us/globalization/locale/locale-names

Using the `inputLanguage.Handle` property removes this lookup and should return the same results.

It would be good to know if this is a bug in .NET or something else that's environmental. I have tested on Win 10 1909 and Win 10 2004 and the values are correct in both cases on my test machines (in either case), and this was only going wrong on June's machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/998)
<!-- Reviewable:end -->
