### PR TITLE
Separate non-Roman verse setting to restore USX compliance in VerseRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.DblBundle] `TextBundle<TM, TL>.GetFonts` (to replace deprecated `CopyFontFiles`)
 - [SIL.DblBundle] `TextBundle<TM, TL>.GetLdml` (to replace deprecated `CopyLdmlFile`)
 - [SIL.Scripture] `ScrVers.Save` overload to allow serialization to a `TextWriter`.
+- [SIL.Scripture] `VerseRef.TrySetVerseUnicode` to set 'verse' and 'verseRef' variables with non-Roman numerals.
 - [SIL.Core] `XmlSerializationHelper.Serialize<T>` to allow serialization to a `TextWriter`.
 - [SIL.Core] `XmlSerializationHelper.Deserialize<T>` to allow deserialization from a `TextReader`.
 - [SIL.Core] `Platform.IsGnomeShell` to detect if executing in a Gnome Shell

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -2067,6 +2067,38 @@ namespace SIL.Scripture.Tests
 			Assert.AreEqual(new VerseRef("EXO 6:4"), new VerseRef("EXO 6:4-10").UnBridge());
 			Assert.AreEqual(new VerseRef("EXO 6:150monkeys"), new VerseRef("EXO 6:150monkeys").UnBridge());
 		}
+
+		/// <summary>
+		/// Tests the Verse property's set method with numerals from various Unicode-supported scripts
+		/// </summary>
+		[Test]
+		public void SetVerse_InterpretUnicodeNumerals()
+		{
+			VerseRef vref = new VerseRef("EXO 6:5");
+			Assert.AreEqual(5, vref.VerseNum);
+
+			vref.Verse = "५"; // Devanagari numeral
+			Assert.AreEqual(5, vref.VerseNum);
+
+			vref.Verse = "૧૬"; // Gujarati numeral
+			Assert.AreEqual(16, vref.VerseNum);
+
+			vref.Verse = "൬"; // Malayalam numeral
+			Assert.AreEqual(6, vref.VerseNum);
+
+			vref.Verse = "᠔"; // Mongolian numeral
+			Assert.AreEqual(4, vref.VerseNum);
+
+			vref.Verse = "๙"; // Thai numeral
+			Assert.AreEqual(9, vref.VerseNum);
+
+			vref.Verse = "A"; // Latin non-numeral
+			Assert.AreEqual(-1, vref.VerseNum);
+
+			vref.Verse = "ะ"; // Thai non-numeral
+			Assert.AreEqual(-1, vref.VerseNum);
+		}
+
 		#endregion
 
 		#region InRange

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -2077,11 +2077,11 @@ namespace SIL.Scripture.Tests
 		[TestCase("᠔", ExpectedResult = 4, TestName = "Mongolian numeral")]
 		[TestCase("A", ExpectedResult = -1, TestName = "Latin non-numeral")]
 		[TestCase("ะ", ExpectedResult = -1, TestName = "Thai non-numeral")]
-		public int SetVerse_InterpretUnicodeNumerals(string verseStr)
+		public int SetVerseUnicode_InterpretNumerals(string verseStr)
 		{
 			VerseRef vref = new VerseRef("EXO 6:1");
 
-			vref.Verse = verseStr;
+			vref.SetVerseUnicode(verseStr);
 			return vref.VerseNum;
 		}
 

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -2071,18 +2071,18 @@ namespace SIL.Scripture.Tests
 		/// <summary>
 		/// Tests the Verse property's set method with numerals from various Unicode-supported scripts
 		/// </summary>
-		[TestCase("५", 5, TestName = "Devanagari numeral")]
-		[TestCase("૧૬", 16, TestName = "Gujarati numeral")]
-		[TestCase("5",5, TestName = "Latin numeral")]
-		[TestCase("᠔", 4, TestName = "Mongolian numeral")]
-		[TestCase("A", -1, TestName = "Latin non-numeral")]
-		[TestCase("ะ", -1, TestName = "Thai non-numeral")]
-		public void SetVerse_InterpretUnicodeNumerals(string verseStr, int parsedVerse)
+		[TestCase("५", ExpectedResult = 5, TestName = "Devanagari numeral")]
+		[TestCase("૧૬", ExpectedResult = 16, TestName = "Gujarati numeral")]
+		[TestCase("5", ExpectedResult = 5, TestName = "Latin numeral")]
+		[TestCase("᠔", ExpectedResult = 4, TestName = "Mongolian numeral")]
+		[TestCase("A", ExpectedResult = -1, TestName = "Latin non-numeral")]
+		[TestCase("ะ", ExpectedResult = -1, TestName = "Thai non-numeral")]
+		public int SetVerse_InterpretUnicodeNumerals(string verseStr)
 		{
 			VerseRef vref = new VerseRef("EXO 6:1");
 
 			vref.Verse = verseStr;
-			Assert.AreEqual(parsedVerse, vref.VerseNum);
+			return vref.VerseNum;
 		}
 
 		#endregion

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -2069,7 +2069,7 @@ namespace SIL.Scripture.Tests
 		}
 
 		/// <summary>
-		/// Tests the Verse property's set method with numerals from various Unicode-supported scripts
+		/// Tests the TrySetVerseUnicode method with numerals from various Unicode-supported scripts
 		/// </summary>
 		[TestCase("५", ExpectedResult = 5, TestName = "Devanagari numeral")]
 		[TestCase("૧૬", ExpectedResult = 16, TestName = "Gujarati numeral")]
@@ -2077,11 +2077,32 @@ namespace SIL.Scripture.Tests
 		[TestCase("᠔", ExpectedResult = 4, TestName = "Mongolian numeral")]
 		[TestCase("A", ExpectedResult = -1, TestName = "Latin non-numeral")]
 		[TestCase("ะ", ExpectedResult = -1, TestName = "Thai non-numeral")]
-		public int SetVerseUnicode_InterpretNumerals(string verseStr)
+		[TestCase("二十", ExpectedResult = 20, TestName = "Japanese numeral", IgnoreReason = "Non-decimal numeral systems not yet implemented.")]
+		[TestCase("יא", ExpectedResult = 11, TestName = "Hebrew numeral", IgnoreReason = "Non-decimal numeral systems not yet implemented.")]
+		[TestCase("\U0001113A\U00011138", ExpectedResult = 42, TestName = "Chakma numeral", IgnoreReason = "Surrogate pair handling not yet implemented.")]
+		public int TrySetVerseUnicode_InterpretNumerals(string verseStr)
 		{
 			VerseRef vref = new VerseRef("EXO 6:1");
 
-			vref.SetVerseUnicode(verseStr);
+			bool success = vref.TrySetVerseUnicode(verseStr);
+			Assert.AreEqual(success, vref.VerseNum != -1);
+
+			return vref.VerseNum;
+		}
+
+		/// <summary>
+		/// Tests the Verse property's set method with various input strings
+		/// </summary>
+		[TestCase("5", ExpectedResult = 5, TestName = "Latin numeral")]
+		[TestCase("524", ExpectedResult = 524, TestName = "Large Latin numeral")]
+		[TestCase("A", ExpectedResult = -1, TestName = "Latin non-numeral")]
+		[TestCase("૧૬", ExpectedResult = -1, TestName = "Non-Latin numeral")]
+		public int SetVerse_InterpretNumerals(string verseStr)
+		{
+			VerseRef vref = new VerseRef("EXO 6:1");
+
+			vref.Verse = verseStr;
+
 			return vref.VerseNum;
 		}
 

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -2077,9 +2077,11 @@ namespace SIL.Scripture.Tests
 		[TestCase("᠔", ExpectedResult = 4, TestName = "Mongolian numeral")]
 		[TestCase("A", ExpectedResult = -1, TestName = "Latin non-numeral")]
 		[TestCase("ะ", ExpectedResult = -1, TestName = "Thai non-numeral")]
-		[TestCase("二十", ExpectedResult = 20, TestName = "Japanese numeral", IgnoreReason = "Non-decimal numeral systems not yet implemented.")]
-		[TestCase("יא", ExpectedResult = 11, TestName = "Hebrew numeral", IgnoreReason = "Non-decimal numeral systems not yet implemented.")]
-		[TestCase("\U0001113A\U00011138", ExpectedResult = 42, TestName = "Chakma numeral", IgnoreReason = "Surrogate pair handling not yet implemented.")]
+		[TestCase("᠔-᠔", ExpectedResult = 4, TestName = "Mongolian complex verse")]
+		[TestCase("᠔ᠠ", ExpectedResult = 4, TestName = "Mongolian complex verse - lettered")]
+		[TestCase("二十", ExpectedResult = 20, TestName = "Japanese numeral", IgnoreReason = "Non-decimal numeral systems not yet implemented. (See issue #1000.)")]
+		[TestCase("יא", ExpectedResult = 11, TestName = "Hebrew numeral", IgnoreReason = "Non-decimal numeral systems not yet implemented. (See issue #1000.)")]
+		[TestCase("\U0001113A\U00011138", ExpectedResult = 42, TestName = "Chakma numeral", IgnoreReason = "Surrogate pair handling not yet implemented. (See issue #1000.)")]
 		public int TrySetVerseUnicode_InterpretNumerals(string verseStr)
 		{
 			VerseRef vref = new VerseRef("EXO 6:1");
@@ -2097,6 +2099,10 @@ namespace SIL.Scripture.Tests
 		[TestCase("524", ExpectedResult = 524, TestName = "Large Latin numeral")]
 		[TestCase("A", ExpectedResult = -1, TestName = "Latin non-numeral")]
 		[TestCase("૧૬", ExpectedResult = -1, TestName = "Non-Latin numeral")]
+		[TestCase("1-", ExpectedResult = 1, TestName = "Complex verse - incomplete")]
+		[TestCase("2.3", ExpectedResult = 2, TestName = "Complex verse - decimal")]
+		[TestCase("5-7", ExpectedResult = 5, TestName = "Complex verse - complete")]
+		[TestCase("7a", ExpectedResult = 7, TestName = "Complex verse - lettered")]
 		public int SetVerse_InterpretNumerals(string verseStr)
 		{
 			VerseRef vref = new VerseRef("EXO 6:1");

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -2071,32 +2071,18 @@ namespace SIL.Scripture.Tests
 		/// <summary>
 		/// Tests the Verse property's set method with numerals from various Unicode-supported scripts
 		/// </summary>
-		[Test]
-		public void SetVerse_InterpretUnicodeNumerals()
+		[TestCase("५", 5, TestName = "Devanagari numeral")]
+		[TestCase("૧૬", 16, TestName = "Gujarati numeral")]
+		[TestCase("5",5, TestName = "Latin numeral")]
+		[TestCase("᠔", 4, TestName = "Mongolian numeral")]
+		[TestCase("A", -1, TestName = "Latin non-numeral")]
+		[TestCase("ะ", -1, TestName = "Thai non-numeral")]
+		public void SetVerse_InterpretUnicodeNumerals(string verseStr, int parsedVerse)
 		{
-			VerseRef vref = new VerseRef("EXO 6:5");
-			Assert.AreEqual(5, vref.VerseNum);
+			VerseRef vref = new VerseRef("EXO 6:1");
 
-			vref.Verse = "५"; // Devanagari numeral
-			Assert.AreEqual(5, vref.VerseNum);
-
-			vref.Verse = "૧૬"; // Gujarati numeral
-			Assert.AreEqual(16, vref.VerseNum);
-
-			vref.Verse = "൬"; // Malayalam numeral
-			Assert.AreEqual(6, vref.VerseNum);
-
-			vref.Verse = "᠔"; // Mongolian numeral
-			Assert.AreEqual(4, vref.VerseNum);
-
-			vref.Verse = "๙"; // Thai numeral
-			Assert.AreEqual(9, vref.VerseNum);
-
-			vref.Verse = "A"; // Latin non-numeral
-			Assert.AreEqual(-1, vref.VerseNum);
-
-			vref.Verse = "ะ"; // Thai non-numeral
-			Assert.AreEqual(-1, vref.VerseNum);
+			vref.Verse = verseStr;
+			Assert.AreEqual(parsedVerse, vref.VerseNum);
 		}
 
 		#endregion

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -245,8 +245,7 @@ namespace SIL.Scripture
 			get { return verse ?? (IsDefault || verseNum < 0 ? string.Empty : verseNum.ToString()); }
 			set
 			{
-				short vNum;
-				verse = !TryGetVerseNum(value, out vNum) ? value.Replace(rtlMark, "") : null;
+				verse = !TryGetVerseNum(value, out short vNum) ? value.Replace(rtlMark, "") : null;
 				verseNum = vNum;
 				if (verseNum >= 0)
 					return;
@@ -1345,17 +1344,17 @@ namespace SIL.Scripture
 		/// <returns><c>true</c> if the entire string could be parsed as a single,
 		/// simple verse number in any supported script; <c>false</c> if the verse string represented
 		/// a verse bridge, contained segment letters, or was invalid</returns>
-		public void SetVerseUnicode(string value)
+		public bool TrySetVerseUnicode(string value)
 		{
 			{
-				short vNum;
-				verse = !TryGetVerseNum(value, out vNum, false) ? value.Replace(rtlMark, "") : null;
+				verse = !TryGetVerseNum(value, out short vNum, false) ? value.Replace(rtlMark, "") : null;
 				verseNum = vNum;
 				if (verseNum >= 0)
-					return;
+					return true;
 
 				Trace.TraceWarning("Just failed to parse a verse number: " + value);
 				TryGetVerseNum(verse, out verseNum, false);
+				return false;
 			}
 		}
 

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -243,7 +243,7 @@ namespace SIL.Scripture
 		public string Verse
 		{
 			get => verse ?? (IsDefault || verseNum < 0 ? string.Empty : verseNum.ToString()); 
-			set => TrySetVerse(value);
+			set => TrySetVerse(value, true); // The USX standard only expects support for Latin numerals {0-9}* in verse numbers.
 		}
 
 		/// <summary>
@@ -279,14 +279,14 @@ namespace SIL.Scripture
 		/// This is used by Verse.set and TrySetVerseUnicode
 		/// </summary>
 		/// <returns><c>true</c> if the verse was set successfully </returns>
-		bool TrySetVerse(string value, bool romanOnly = true)
+		bool TrySetVerse(string value, bool romanOnly)
 		{
-			verse = !TryGetVerseNum(value, out verseNum, romanOnly) ? value.Replace(rtlMark, "") : null;
+			verse = !TryGetVerseNum(value, romanOnly, out verseNum) ? value.Replace(rtlMark, "") : null;
 			if (verseNum >= 0)
 				return true;
 
 			Trace.TraceWarning("Just failed to parse a verse number: " + value);
-			TryGetVerseNum(verse, out verseNum, romanOnly);
+			TryGetVerseNum(verse, romanOnly, out verseNum);
 			return false;
 		}
 
@@ -296,7 +296,7 @@ namespace SIL.Scripture
 		/// <returns><c>true</c> if the entire string could be parsed as a single,
 		/// simple verse number (1-999); <c>false</c> if the verse string represented
 		/// a verse bridge, contained segment letters, or was invalid</returns>
-		static bool TryGetVerseNum(string verseStr, out short vNum, bool romanOnly = true)
+		static bool TryGetVerseNum(string verseStr, bool romanOnly , out short vNum)
 		{
 			if (string.IsNullOrEmpty(verseStr))
 			{

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -242,17 +242,8 @@ namespace SIL.Scripture
 		[XmlIgnore]
 		public string Verse
 		{
-			get { return verse ?? (IsDefault || verseNum < 0 ? string.Empty : verseNum.ToString()); }
-			set
-			{
-				verse = !TryGetVerseNum(value, out short vNum) ? value.Replace(rtlMark, "") : null;
-				verseNum = vNum;
-				if (verseNum >= 0)
-					return;
-
-				Trace.TraceWarning("Just failed to parse a verse number: " + value);
-				TryGetVerseNum(verse, out verseNum);
-			}
+			get => verse ?? (IsDefault || verseNum < 0 ? string.Empty : verseNum.ToString()); 
+			set => TrySetVerse(value);
 		}
 
 		/// <summary>
@@ -281,6 +272,22 @@ namespace SIL.Scripture
 					Console.WriteLine("Invalid deserialized reference: " + e.InvalidVerseRef);
 				}
 			}
+		}
+
+		/// <summary>
+		/// Tries to set verse and verseNum by parsing the `value` string.
+		/// This is used by Verse.set and TrySetVerseUnicode
+		/// </summary>
+		/// <returns><c>true</c> if the verse was set successfully </returns>
+		bool TrySetVerse(string value, bool romanOnly = true)
+		{
+			verse = !TryGetVerseNum(value, out verseNum, romanOnly) ? value.Replace(rtlMark, "") : null;
+			if (verseNum >= 0)
+				return true;
+
+			Trace.TraceWarning("Just failed to parse a verse number: " + value);
+			TryGetVerseNum(verse, out verseNum, romanOnly);
+			return false;
 		}
 
 		/// <summary>
@@ -1346,16 +1353,7 @@ namespace SIL.Scripture
 		/// a verse bridge, contained segment letters, or was invalid</returns>
 		public bool TrySetVerseUnicode(string value)
 		{
-			{
-				verse = !TryGetVerseNum(value, out short vNum, false) ? value.Replace(rtlMark, "") : null;
-				verseNum = vNum;
-				if (verseNum >= 0)
-					return true;
-
-				Trace.TraceWarning("Just failed to parse a verse number: " + value);
-				TryGetVerseNum(verse, out verseNum, false);
-				return false;
-			}
+			return TrySetVerse(value, false);
 		}
 
 		/// <summary>

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -302,14 +302,14 @@ namespace SIL.Scripture
 			for (int i = 0; i < verseStr.Length; i++)
 			{
 				char ch = verseStr[i];
-				if (ch < '0' || ch > '9')
+				if (!char.IsDigit(ch))
 				{
 					if (i == 0)
 						vNum = -1;
 					return false;
 				}
 
-				vNum = (short)(vNum * 10 + ch - '0');
+				vNum = (short)(vNum * 10 + char.GetNumericValue(ch));
 				if (vNum > bcvMaxValue)
 				{
 					// whoops, we got too big!


### PR DESCRIPTION
Done in response to issues with PR #997

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/999)
<!-- Reviewable:end -->
