### PR TITLE
Get nuget packaging build target working

### DIFF
--- a/ReadmeDesignerProjects.md
+++ b/ReadmeDesignerProjects.md
@@ -1,8 +1,8 @@
 # WinForms designer
 
 Starting with .NET Core 3.1 it's now possible to use WinForms in sdk-style
-csproj files. However, support for opening files in Designer is still not
-fully implemented.
+csproj files. Support for opening files in Designer should now be
+implemented in Visual Studio 2019.
 
 JetBrains Rider is able to open files in design mode on Windows.
 Current versions of Visual Studio 2019 are also able to open files in

--- a/SIL.Core.Tests/SIL.Core.Tests.csproj
+++ b/SIL.Core.Tests/SIL.Core.Tests.csproj
@@ -22,6 +22,7 @@
 See full changelog at https://github.com/sillsdev/libpalaso/master/nuget/CHANGELOG.md]]>
     </AppendToReleaseNotesProperty>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The Pack build target wasn't working likely due to a bug in msbuild https://github.com/dotnet/msbuild/issues/4303 This is a workaround for the issue. Also updated the readme for designer projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1041)
<!-- Reviewable:end -->
