### PR TITLE
Don't automatically copy files from Icu4c

### DIFF
--- a/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
+++ b/SIL.WritingSystems.Tests/SIL.WritingSystems.Tests.csproj
@@ -27,15 +27,13 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/master/CHANGELO
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Icu4c.Win.Min" Version="56.1.82" />
+    <PackageReference Include="GitVersionTask" Version="5.3.4" PrivateAssets="All" />
+    <PackageReference Include="Icu4c.Win.Min" Version="56.1.82" IncludeAssets="build" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NDesk.DBus" Version="0.15.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="Spart" Version="1.0.0" />
-    <PackageReference Include="GitVersionTask" Version="5.3.4">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4" PrivateAssets="All" />
+    <PackageReference Include="Spart" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change prevents the dlls from Icu4c.Win.Min to automatically
get copied to the output directory when a client consumes the
SIL.WritingSystems.Tests nuget package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1046)
<!-- Reviewable:end -->
