### PR TITLE
Upgrade GitVersionTask to GitVersion.MsBuild

### DIFF
--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -53,8 +53,8 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/master/CHANGELO
 
   <ItemGroup Condition="'$(OS)'=='Windows_NT'">
     <!--These references are required to compile on Windows -->
-    <PackageReference Include="GtkSharp-signed" Version="3.22.24.37" />
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" />
+    <PackageReference Include="GtkSharp-signed" Version="3.22.24.37" PrivateAssets="All" />
+    <PackageReference Include="Mono.Posix" Version="5.4.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)'!='Windows_NT'">


### PR DESCRIPTION
GitVersionTask is deprecated in favor of GitVersion.MsBuild, which has a version that is supposed to also run on Ubuntu 20.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1052)
<!-- Reviewable:end -->
