### PR TITLE
[SIL.Windows.Forms] Make GtkSharp and Mono.Posix build-only deps

### DIFF
--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -53,8 +53,8 @@ See full changelog at https://github.com/sillsdev/libpalaso/blob/master/CHANGELO
 
   <ItemGroup Condition="'$(OS)'=='Windows_NT'">
     <!--These references are required to compile on Windows -->
-    <PackageReference Include="GtkSharp-signed" Version="3.22.24.37" />
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" />
+    <PackageReference Include="GtkSharp-signed" Version="3.22.24.37" PrivateAssets="All" />
+    <PackageReference Include="Mono.Posix" Version="5.4.0.201" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)'!='Windows_NT'">


### PR DESCRIPTION
We need the GtkSharp-signed and Mono.Posix packages for building on
Windows, but not at runtime. On Linux these assemblies are available
as part of Mono, but depending on the Windows versions will break
things. This change sets the `PrivateAssets` attribute for the two
Windows packages. This will allow to build on Windows, but will prevent
a package dependency on these two packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1053)
<!-- Reviewable:end -->
