### PR TITLE
Fix AcknowledgementsProvider

### DIFF
--- a/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
+++ b/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
@@ -59,13 +59,7 @@ namespace SIL.Acknowledgements
 					}
 					catch (BadImageFormatException bife)
 					{
-						Debug.WriteLine("BadImageFormatException on file: " + execFile + " " + bife.Message);
-						if (bife.Message.StartsWith("The module was expected to contain an assembly manifest.") ||
-							bife.Message.StartsWith("Could not load file or assembly"))
-						{
-							continue;
-						}
-						throw;
+						Debug.WriteLine($"BadImageFormatException on file '{execFile}': {bife.Message}");
 					}
 				}
 			}
@@ -90,7 +84,8 @@ namespace SIL.Acknowledgements
 					Debug.WriteLine("Duplicate Acknowledgement key skipped. Key="+ acknowledgement.Key + " Html=" + acknowledgement.Html);
 					Debug.WriteLine("  Kept first Acknowledgement Key=" + ackRetained.Key + " Html=" + ackRetained.Html);
 				}
-				else ackAttrDict.Add(acknowledgement.Key, acknowledgement);
+				else
+					ackAttrDict.Add(acknowledgement.Key, acknowledgement);
 			}
 		}
 

--- a/TestApps/SIL.Windows.Forms.TestApp/README.md
+++ b/TestApps/SIL.Windows.Forms.TestApp/README.md
@@ -1,0 +1,11 @@
+# SIL.Windows.Forms Test App
+
+## Running on Linux
+
+Before running this test app on Linux, source the `environ` file.
+
+Alternatively you can manually set three environment variables:
+
+- `LD_PRELOAD` to the path to `libgeckofix.so` (`.../output/Debug/net461/Firefox/libgeckofix.so`).
+- `LD_LIBRARY_PATH` to `.../output/Debug/net461/Firefox:/usr/lib`
+- `XULRUNNER` to `.../output/Debug/net461/Firefox`

--- a/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
+++ b/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Geckofx45" Version="45.0.34" />
-    <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" />
-    <PackageReference Include="Geckofx45.64" Version="45.0.34" />
-    <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" />
+    <PackageReference Include="Geckofx45" Version="45.0.34" Condition="'$(OS)'!='Unix' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'!='X64'" GeneratePathProperty="true" />
+    <PackageReference Include="Geckofx45.64" Version="45.0.34" Condition="'$(OS)'!='Unix' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'" GeneratePathProperty="true" />
+    <PackageReference Include="Geckofx45.32.Linux" Version="45.0.37" Condition="'$(OS)'=='Unix' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'!='X64'" GeneratePathProperty="true" />
+    <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" Condition="'$(OS)'=='Unix' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'" GeneratePathProperty="true" />
     <PackageReference Include="GitVersionTask" Version="5.3.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\..\SIL.Core\SIL.Core.csproj" />
     <ProjectReference Include="..\..\SIL.Lexicon\SIL.Lexicon.csproj" />
     <ProjectReference Include="..\..\SIL.Media\SIL.Media.csproj" />
+    <ProjectReference Include="..\..\SIL.Windows.Forms.GeckoBrowserAdapter\SIL.Windows.Forms.GeckoBrowserAdapter.csproj" />
     <ProjectReference Include="..\..\SIL.Windows.Forms.Keyboarding\SIL.Windows.Forms.Keyboarding.csproj" />
     <ProjectReference Include="..\..\SIL.Windows.Forms.WritingSystems\SIL.Windows.Forms.WritingSystems.csproj" />
     <ProjectReference Include="..\..\SIL.Windows.Forms\SIL.Windows.Forms.csproj" />
@@ -46,6 +47,26 @@
       <IcuFiles Include="$(OutputPath)/icu*56.dll" />
     </ItemGroup>
     <Delete Files="@(IcuFiles)" />
+  </Target>
+
+  <Target Name="CopyGeckoFxSupportFiles" AfterTargets="CopyFilesToOutputDirectory">
+    <!-- This copy is necessary because the Geckofx45.targets uses a deprecated method of copying files -->
+    <PropertyGroup>
+      <!-- NOTE: when building with mono 5 GeneratePathProperty doesn't work -->
+      <PkgGeckofx45_32_Linux Condition="'$(PkgGeckofx45_32_Linux)'==''">$(HOME)/.nuget/packages/geckofx45.32.linux/45.0.37</PkgGeckofx45_32_Linux>
+      <PkgGeckofx45_64_Linux Condition="'$(PkgGeckofx45_64_Linux)'==''">$(HOME)/.nuget/packages/geckofx45.64.linux/45.0.37</PkgGeckofx45_64_Linux>
+    </PropertyGroup>
+    <!-- NOTE: we can't use "$(Platform)!='x64'" because Platform is AnyCPU! -->
+    <ItemGroup Condition="'$(OS)'!='Unix'">
+      <Firefox Include="$(PkgGeckofx45)/content/Firefox/*.*" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'!='X64'" />
+      <Firefox Include="$(PkgGeckofx45_64)/content/Firefox/*.*" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(OS)'=='Unix'">
+      <Firefox Include="$(PkgGeckofx45_32_Linux)/content/Firefox*/*.*" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'!='X64'" />
+      <Firefox Include="$(PkgGeckofx45_64_Linux)/content/Firefox*/*.*" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'" />
+    </ItemGroup>
+    <Message Text="Copying Gecko Files" />
+    <Copy SourceFiles="@(Firefox)" DestinationFolder="$(OutputPath)/Firefox" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/TestApps/SIL.Windows.Forms.TestApp/environ
+++ b/TestApps/SIL.Windows.Forms.TestApp/environ
@@ -42,9 +42,9 @@ MONO_PATH="${GDK_SHARP}:${GECKOFX}"
 ################################################################################################
 
 # Add the build output to paths
-PATH="${BASE}/output/${BUILD}:${PATH}"
-LD_LIBRARY_PATH="${BASE}/output/${BUILD}:${LD_LIBRARY_PATH}"
-MONO_PATH="${BASE}/output/${BUILD}:${MONO_PATH}"
+PATH="${BASE}/output/${BUILD}/net461:${PATH}"
+LD_LIBRARY_PATH="${BASE}/output/${BUILD}/net461:${LD_LIBRARY_PATH}"
+MONO_PATH="${BASE}/output/${BUILD}/net461:${MONO_PATH}"
 
 ################################################################################################
 


### PR DESCRIPTION
For some reason (probably newer mono version) we get a different exception message when the AcknowledgmentsProvider can't load a file. I can't see a reason why we'd have to check the exception message, so now we always ignore a BadImageException.

This change also fixes the SWF test app so that it properly works with Gecko on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1054)
<!-- Reviewable:end -->
