### PR TITLE
Improve Mac Support

### DIFF
--- a/SIL.Archiving.Tests/ArchivingFileSystemTests.cs
+++ b/SIL.Archiving.Tests/ArchivingFileSystemTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System;
+using System.IO;
+using NUnit.Framework;
+using SIL.Archiving.Generic;
+using SIL.IO;
+
+namespace SIL.Archiving.Tests
+{
+	[TestFixture]
+	public class ArchivingFileSystemTests
+	{
+		[Test]
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		public void CheckFolderChangesToAppData()
+		{
+			var resultFolder = ArchivingFileSystem.CheckFolder("/var/lib/SIL/test");
+			if (Directory.Exists("/var/lib/SIL/test"))
+			{
+				Assert.Ignore("This system has write access to the /var/lib folder and doesn't execute the SUT");
+			}
+			else
+			{
+				Assert.AreEqual(
+					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+						"SIL", "test"),
+					resultFolder);
+				RobustIO.DeleteDirectory(resultFolder);
+			}
+		}
+	}
+}

--- a/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
+++ b/SIL.Core.Tests/IO/FileLock/SimpleFileLockTests.cs
@@ -14,9 +14,9 @@ namespace SIL.Tests.IO.FileLock
 		private static readonly string LockPath = Path.Combine(Path.GetTempPath(), "SimpleFileLockTests");
 		// some tests require the Id of an active process.
 		// on Windows, we use 0, which is the system idle process.
-		// on Linux, we use 1, which is the init process.
+		// on Unix, we use 1, which is the init process.
 		// we know that these will always be active.
-		private static readonly int ActiveProcessId = Platform.IsLinux ? 1 : 0;
+		private static readonly int ActiveProcessId = Platform.IsUnix ? 1 : 0;
 
 		[SetUp]
 		public void SetUp()
@@ -162,7 +162,7 @@ namespace SIL.Tests.IO.FileLock
 		/// </summary>
 		private string GetSafeActiveProcessName()
 		{
-			return Platform.IsLinux && (ActiveProcessId == 1) ? "init" : Process.GetProcessById(ActiveProcessId).ProcessName;
+			return Platform.IsUnix && (ActiveProcessId == 1) ? "init" : Process.GetProcessById(ActiveProcessId).ProcessName;
 		}
 
 		[Test]

--- a/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
@@ -17,7 +17,6 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
-		[Platform(Exclude = "Linux", Reason="Test tries to create directory under /var/lib where user doesn't have write permissions by default")]
 		public void DefaultInitializer_HasCorrectPath()
 		{
 			GlobalWritingSystemRepository repo = GlobalWritingSystemRepository.Initialize();

--- a/SIL.WritingSystems.Tests/Migration/GlobalWritingSystemRepositoryMigratorTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/GlobalWritingSystemRepositoryMigratorTests.cs
@@ -33,7 +33,7 @@ namespace SIL.WritingSystems.Tests.Migration
 
 			public void WriteVersion1LdmlFile(string language)
 			{
-				string folderPath = Path.Combine(Platform.IsLinux ? GlobalWritingSystemRepositoryMigrator.LdmlPathLinuxVersion2 : _baseFolder.Path, "1");
+				string folderPath = Path.Combine(Platform.IsUnix ? GlobalWritingSystemRepositoryMigrator.LdmlPathLinuxVersion2 : _baseFolder.Path, "1");
 				Directory.CreateDirectory(folderPath);
 				string filePath = Path.Combine(folderPath, String.Format("{0}.ldml", language));
 				string content = LdmlContentForTests.Version1(language, "", "", "");
@@ -42,7 +42,7 @@ namespace SIL.WritingSystems.Tests.Migration
 
 			public void WriteVersion2LdmlFile(string language)
 			{
-				string folderPath = Path.Combine(Platform.IsLinux ? GlobalWritingSystemRepositoryMigrator.LdmlPathLinuxVersion2 : _baseFolder.Path, "2");
+				string folderPath = Path.Combine(Platform.IsUnix ? GlobalWritingSystemRepositoryMigrator.LdmlPathLinuxVersion2 : _baseFolder.Path, "2");
 				Directory.CreateDirectory(folderPath);
 				string filePath = Path.Combine(folderPath, String.Format("{0}.ldml", language));
 				string content = LdmlContentForTests.Version2(language, "", "", "");

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -156,7 +156,7 @@ namespace SIL.WritingSystems
 				// This allows unit tests to set the _defaultBasePath (through reflection)
 				if (string.IsNullOrEmpty(_defaultBasePath))
 				{
-					string basePath = Platform.IsLinux
+					var basePath = Platform.IsMac ? "/Users/Shared" : Platform.IsLinux
 						? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
 						: Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
 					_defaultBasePath = Path.Combine(basePath, "SIL", "WritingSystemRepository");
@@ -178,7 +178,7 @@ namespace SIL.WritingSystems
 		public static void CreateGlobalWritingSystemRepositoryDirectory(string path)
 		{
 			DirectoryInfo di = Directory.CreateDirectory(path);
-			if (!Platform.IsLinux && !path.StartsWith(Path.GetTempPath()))
+			if (!Platform.IsUnix && !path.StartsWith(Path.GetTempPath()))
 			{
 				// NOTE: GetAccessControl/ModifyAccessRule/SetAccessControl is not implemented in Mono
 				DirectorySecurity ds = di.GetAccessControl();

--- a/SIL.WritingSystems/Migration/GlobalWritingSystemRepositoryMigrator.cs
+++ b/SIL.WritingSystems/Migration/GlobalWritingSystemRepositoryMigrator.cs
@@ -87,8 +87,8 @@ namespace SIL.WritingSystems.Migration
 				}
 			}
 
-			// 3) Harvest LDML files from old Linux location in "/var/lib"
-			if (Platform.IsLinux)
+			// 3) Harvest LDML files from old Unix location in "/var/lib"
+			if (Platform.IsUnix)
 			{
 				for (int version = 2; version >= 0; --version)
 				{
@@ -118,11 +118,11 @@ namespace SIL.WritingSystems.Migration
 			}
 		}
 
-		private void CopyLdmlFromFolder(string sourcePath)
+		private void CopyLdmlFromFolder(string oldSourcePath)
 		{
 			if (!Directory.Exists(SourcePath))
 				GlobalWritingSystemRepository.CreateGlobalWritingSystemRepositoryDirectory(SourcePath);
-			DirectoryHelper.Copy(sourcePath, SourcePath);
+			DirectoryHelper.Copy(oldSourcePath, SourcePath);
 		}
 	}
 }

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -98,7 +98,7 @@ namespace SIL.WritingSystems
 		{
 			get
 			{
-				string basePath = Platform.IsLinux ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+				string basePath = Platform.IsMac ? "/Users/Shared" : Platform.IsLinux ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
 					: Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
 				return Path.Combine(basePath, "SIL", "SldrCache");
 			}
@@ -677,7 +677,7 @@ namespace SIL.WritingSystems
 				return;
 
 			DirectoryInfo di = Directory.CreateDirectory(SldrCachePath);
-			if (!Platform.IsLinux && !SldrCachePath.StartsWith(Path.GetTempPath()))
+			if (!Platform.IsUnix && !SldrCachePath.StartsWith(Path.GetTempPath()))
 			{
 				// NOTE: GetAccessControl/ModifyAccessRule/SetAccessControl is not implemented in Mono
 				DirectorySecurity ds = di.GetAccessControl();


### PR DESCRIPTION
* Use IsUnix instead of IsLinux for code involving file paths
  to allow these libraries to execute on a Mac

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1056)
<!-- Reviewable:end -->
