### PR TITLE
Don't crash finding ramp in corrupted installs

### DIFF
--- a/SIL.Core.Desktop/IO/FileLocator.cs
+++ b/SIL.Core.Desktop/IO/FileLocator.cs
@@ -251,8 +251,8 @@ namespace SIL.IO
 					return null;
 			}
 
-			value = key.GetValue(string.Empty) as string;
-			key.Close();
+			value = key?.GetValue(string.Empty) as string;
+			key?.Close();
 
 			if (value == null)
 				return null;


### PR DESCRIPTION
* Add extra null checks to prevent crashes on systems where
  a faulty ramp uninstallation has corrupted the registry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1058)
<!-- Reviewable:end -->
