### PR TITLE
SP-2193: Added handler for DataError in ContributorsListControl grid

### DIFF
--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
@@ -29,6 +29,16 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 		public ContributorsListControl()
 		{
 			InitializeComponent();
+			_grid.DataError += _grid_DataError;
+		}
+
+		private void _grid_DataError(object sender, DataGridViewDataErrorEventArgs e)
+		{
+		    if (e.Exception != null &&
+				e.Context == DataGridViewDataErrorContexts.Commit)
+			{
+				MessageBox.Show(e.Exception.Message);
+			}
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
@@ -161,13 +161,15 @@ namespace SIL.Windows.Forms.TestApp
 		/// ------------------------------------------------------------------------------------
 		private void UpdateNames(object sender, EventArgs e)
 		{
+			// The following illustrates how to avoid an InvalidOperationException when the
+			// grid is not in a state where it passes validation.
+			if (!_contributorsControl.Validate())
+				return;
+
 			var contribs = _model.Contributions;
-			for (var i = 0; i < _contributorNames.RowCount; i++)
+			for (var i = 0; i < _contributorNames.RowCount && i < contribs.Count; i++)
 			{
-				if (i < contribs.Count)
-				{
-					contribs[i].ContributorName = (string)_contributorNames.Rows[i].Cells[0].Value;
-				}
+				contribs[i].ContributorName = (string)_contributorNames.Rows[i].Cells[0].Value;
 			}
 
 			_model.SetContributionList(contribs);

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+using SIL.Windows.Forms.ClearShare;
+using SIL.Windows.Forms.ClearShare.WinFormsUI;
+
+namespace SIL.Windows.Forms.TestApp
+{
+	public partial class ContributorsForm : Form
+	{
+		private TableLayoutPanel _tableLayout;
+		private ContributorsListControl _contributorsControl;
+		private ContributorsListControlViewModel _model;
+
+		private class AutoCompleter : IAutoCompleteValueProvider
+		{
+			public IEnumerable<string> GetValuesForKey(string key)
+			{
+				if (key == "person")
+				{
+					yield return "Andrew";
+					yield return "Fred";
+					yield return "Tom";
+				}
+			}
+		}
+
+		public ContributorsForm()
+		{
+			_model = new ContributorsListControlViewModel(new AutoCompleter(), () => { });
+			var dataGridView = new DataGridView();
+
+			_contributorsControl = new ContributorsListControl(_model);
+			_contributorsControl.Dock = DockStyle.Fill;
+			_contributorsControl.Location = new System.Drawing.Point(0, 0);
+			_contributorsControl.Name = "_contributorsControl";
+
+			_contributorsControl.ValidatingContributor += HandleValidatingContributor;
+
+			// set the column header text
+			string[] headerText =
+			{
+				"Name",
+				"Role",
+				"Date",
+				"Comments"
+			};
+
+			for (var i = 0; i < headerText.Length; i++)
+				_contributorsControl.SetColumnHeaderText(i, headerText[i]);
+
+			InitializeComponent();
+
+			var contribs = new ContributionCollection(new [] { new Contribution("Fred", new Role("a", "Author", "guy who writes stuff")) });
+			_model.SetContributionList(contribs);
+		}
+
+		private void InitializeComponent()
+		{
+			SuspendLayout();
+			AutoScaleDimensions = new SizeF(6F, 13F);
+			AutoScaleMode = AutoScaleMode.Font;
+			ClientSize = new Size(700, 350);
+			Controls.Add(_contributorsControl);
+			Name = "ContributorsForm";
+			Text = "Contributors";
+
+			ResumeLayout(false);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private KeyValuePair<string, string> HandleValidatingContributor(ContributorsListControl sender,
+			Contribution contribution, CancelEventArgs e)
+		{
+			var kvp = CheckIfContributorIsValid(contribution);
+			e.Cancel = !string.IsNullOrEmpty(kvp.Key);
+			return kvp;
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private static KeyValuePair<string, string> CheckIfContributorIsValid(Contribution contribution)
+		{
+			if (contribution != null)
+			{
+				if (string.IsNullOrEmpty(contribution.ContributorName))
+					return new KeyValuePair<string, string>("name", "Enter a name.");
+
+				if (contribution.Role == null)
+					return new KeyValuePair<string, string>("role", "Choose a role.");
+			}
+
+			return new KeyValuePair<string, string>();
+		}
+	}
+}

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using SIL.Windows.Forms.ClearShare;
 using SIL.Windows.Forms.ClearShare.WinFormsUI;
+using SIL.Windows.Forms.Widgets.BetterGrid;
 
 namespace SIL.Windows.Forms.TestApp
 {
@@ -12,23 +14,28 @@ namespace SIL.Windows.Forms.TestApp
 		private TableLayoutPanel _tableLayout;
 		private ContributorsListControl _contributorsControl;
 		private ContributorsListControlViewModel _model;
+		private BetterGrid _contributorNames;
 
 		private class AutoCompleter : IAutoCompleteValueProvider
 		{
+			public BetterGrid Source {get; set;}
+
 			public IEnumerable<string> GetValuesForKey(string key)
 			{
 				if (key == "person")
 				{
-					yield return "Andrew";
-					yield return "Fred";
-					yield return "Tom";
+					foreach (DataGridViewRow row in Source.Rows)
+					{
+						yield return row.Cells[0].Value as string;
+					}
 				}
 			}
 		}
 
 		public ContributorsForm()
 		{
-			_model = new ContributorsListControlViewModel(new AutoCompleter(), () => { });
+			var autoCompleter = new AutoCompleter();
+			_model = new ContributorsListControlViewModel(autoCompleter, () => { });
 			var dataGridView = new DataGridView();
 
 			_contributorsControl = new ContributorsListControl(_model);
@@ -51,6 +58,7 @@ namespace SIL.Windows.Forms.TestApp
 				_contributorsControl.SetColumnHeaderText(i, headerText[i]);
 
 			InitializeComponent();
+			autoCompleter.Source = _contributorNames;
 
 			var contribs = new ContributionCollection(new [] { new Contribution("Fred", new Role("a", "Author", "guy who writes stuff")) });
 			_model.SetContributionList(contribs);
@@ -62,11 +70,68 @@ namespace SIL.Windows.Forms.TestApp
 			AutoScaleDimensions = new SizeF(6F, 13F);
 			AutoScaleMode = AutoScaleMode.Font;
 			ClientSize = new Size(700, 350);
-			Controls.Add(_contributorsControl);
+
+			_tableLayout = new TableLayoutPanel
+			{
+				Name = "_tableLayout",
+				Dock = DockStyle.Top,
+				AutoSize = true,
+				BackColor = Color.Transparent,
+				ColumnCount = 2,
+				RowCount = 2
+			};
+			_tableLayout.SuspendLayout();
+			_tableLayout.ColumnStyles.Add(new ColumnStyle());
+			_tableLayout.Location = new Point(0, 0);
+
+			var btnUpdateContributorNames = new Label();
+			btnUpdateContributorNames.Text = "Hover over this text to Update Contributors";
+			btnUpdateContributorNames.MouseEnter += UpdateNames;
+			btnUpdateContributorNames.AutoSize = true;
+			btnUpdateContributorNames.Anchor = AnchorStyles.Right;
+
+			_contributorNames = new BetterGrid();
+			((ISupportInitialize)_contributorNames).BeginInit();
+			_contributorNames.AllowUserToAddRows = false;
+			_contributorNames.AllowUserToDeleteRows = false;
+			_contributorNames.AllowUserToResizeRows = false;
+			_contributorNames.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
+			_contributorNames.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+			_contributorNames.Dock = System.Windows.Forms.DockStyle.Fill;
+			_contributorNames.DrawTextBoxEditControlBorder = false;
+			_contributorNames.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
+			_contributorNames.Location = new System.Drawing.Point(1, 1);
+			_contributorNames.Name = "_contributorNames";
+			_contributorNames.RowHeadersVisible = false;
+			var colName = new DataGridViewColumn(new DataGridViewTextBoxCell());
+			colName.HeaderText = "Name";
+			_contributorNames.Columns.Add(colName);
+			_contributorNames.RowCount = 3;
+			_contributorNames.Rows[0].Cells[0].Value = "Andrew";
+			_contributorNames.Rows[1].Cells[0].Value = "Fred";
+			_contributorNames.Rows[2].Cells[0].Value = "Tom";
+
+			_tableLayout.Controls.Add(_contributorsControl, 0, 0);
+			_tableLayout.SetColumnSpan(_contributorsControl, 2);
+			_tableLayout.Controls.Add(_contributorNames, 0, 1);
+			_tableLayout.Controls.Add(btnUpdateContributorNames, 1, 1);
+			
+			_tableLayout.ColumnStyles[0].SizeType = SizeType.Percent;
+			_tableLayout.ColumnStyles.Add(new ColumnStyle { SizeType = SizeType.AutoSize });
+
+			_tableLayout.RowStyles.Add(new RowStyle { SizeType = SizeType.Percent, Height = 50 });
+			_tableLayout.RowStyles.Add(new RowStyle { SizeType = SizeType.Percent, Height = 50 });
+
+			_tableLayout.Dock = DockStyle.Fill;
+
+			Controls.Add(_tableLayout);
+
 			Name = "ContributorsForm";
 			Text = "Contributors";
 
-			ResumeLayout(false);
+			((ISupportInitialize)_contributorNames).EndInit();
+			_tableLayout.ResumeLayout(true);
+			ResumeLayout(true);
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -91,6 +156,21 @@ namespace SIL.Windows.Forms.TestApp
 			}
 
 			return new KeyValuePair<string, string>();
+		}
+
+		/// ------------------------------------------------------------------------------------
+		private void UpdateNames(object sender, EventArgs e)
+		{
+			var contribs = _model.Contributions;
+			for (var i = 0; i < _contributorNames.RowCount; i++)
+			{
+				if (i < contribs.Count)
+				{
+					contribs[i].ContributorName = (string)_contributorNames.Rows[i].Cells[0].Value;
+				}
+			}
+
+			_model.SetContributionList(contribs);
 		}
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
@@ -71,10 +71,11 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSettingProtectionDialog = new System.Windows.Forms.Button();
 			this.btnFlexibleMessageBox = new System.Windows.Forms.Button();
 			this.recordPlayButton = new System.Windows.Forms.Button();
+			this.btnTestContributorsList = new System.Windows.Forms.Button();
 			this.SuspendLayout();
-			//
+			// 
 			// btnFolderBrowserControl
-			//
+			// 
 			this.btnFolderBrowserControl.Location = new System.Drawing.Point(12, 12);
 			this.btnFolderBrowserControl.Name = "btnFolderBrowserControl";
 			this.btnFolderBrowserControl.Size = new System.Drawing.Size(157, 23);
@@ -82,9 +83,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnFolderBrowserControl.Text = "FolderBrowserControl";
 			this.btnFolderBrowserControl.UseVisualStyleBackColor = true;
 			this.btnFolderBrowserControl.Click += new System.EventHandler(this.OnFolderBrowserControlClicked);
-			//
+			// 
 			// btnLookupISOCodeDialog
-			//
+			// 
 			this.btnLookupISOCodeDialog.Location = new System.Drawing.Point(12, 41);
 			this.btnLookupISOCodeDialog.Name = "btnLookupISOCodeDialog";
 			this.btnLookupISOCodeDialog.Size = new System.Drawing.Size(157, 23);
@@ -92,9 +93,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnLookupISOCodeDialog.Text = "LanguageLookupDialog";
 			this.btnLookupISOCodeDialog.UseVisualStyleBackColor = true;
 			this.btnLookupISOCodeDialog.Click += new System.EventHandler(this.OnLanguageLookupDialogClicked);
-			//
+			// 
 			// btnWritingSystemSetupDialog
-			//
+			// 
 			this.btnWritingSystemSetupDialog.Location = new System.Drawing.Point(12, 70);
 			this.btnWritingSystemSetupDialog.Name = "btnWritingSystemSetupDialog";
 			this.btnWritingSystemSetupDialog.Size = new System.Drawing.Size(157, 23);
@@ -102,9 +103,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnWritingSystemSetupDialog.Text = "WritingSystemSetupDialog";
 			this.btnWritingSystemSetupDialog.UseVisualStyleBackColor = true;
 			this.btnWritingSystemSetupDialog.Click += new System.EventHandler(this.OnWritingSystemSetupDialogClicked);
-			//
+			// 
 			// btnImageToolbox
-			//
+			// 
 			this.btnImageToolbox.Location = new System.Drawing.Point(12, 99);
 			this.btnImageToolbox.Name = "btnImageToolbox";
 			this.btnImageToolbox.Size = new System.Drawing.Size(157, 23);
@@ -112,9 +113,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnImageToolbox.Text = "Image Toolbox";
 			this.btnImageToolbox.UseVisualStyleBackColor = true;
 			this.btnImageToolbox.Click += new System.EventHandler(this.OnImageToolboxClicked);
-			//
+			// 
 			// btnSilAboutBox
-			//
+			// 
 			this.btnSilAboutBox.Location = new System.Drawing.Point(12, 128);
 			this.btnSilAboutBox.Name = "btnSilAboutBox";
 			this.btnSilAboutBox.Size = new System.Drawing.Size(157, 23);
@@ -122,9 +123,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSilAboutBox.Text = "SIL AboutBox";
 			this.btnSilAboutBox.UseVisualStyleBackColor = true;
 			this.btnSilAboutBox.Click += new System.EventHandler(this.OnSilAboutBoxClicked);
-			//
+			// 
 			// btnShowReleaseNotes
-			//
+			// 
 			this.btnShowReleaseNotes.Location = new System.Drawing.Point(12, 185);
 			this.btnShowReleaseNotes.Name = "btnShowReleaseNotes";
 			this.btnShowReleaseNotes.Size = new System.Drawing.Size(157, 23);
@@ -132,16 +133,16 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnShowReleaseNotes.Text = "Show Release Notes";
 			this.btnShowReleaseNotes.UseVisualStyleBackColor = true;
 			this.btnShowReleaseNotes.Click += new System.EventHandler(this.OnShowReleaseNotesClicked);
-			//
+			// 
 			// superToolTip1
-			//
+			// 
 			this.superToolTip1.FadingInterval = 10;
-			//
+			// 
 			// label1
-			//
+			// 
 			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(12, 367);
+			this.label1.Location = new System.Drawing.Point(12, 398);
 			this.label1.Name = "label1";
 			this.label1.Size = new System.Drawing.Size(149, 13);
 			superToolTipInfo2.BackgroundGradientBegin = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(0)))));
@@ -160,9 +161,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.superToolTip1.SetSuperStuff(this.label1, superToolTipInfoWrapper2);
 			this.label1.TabIndex = 1;
 			this.label1.Text = "Hover over me to see a tooltip";
-			//
+			// 
 			// btnMetaDataEditor
-			//
+			// 
 			this.btnMetaDataEditor.Location = new System.Drawing.Point(12, 214);
 			this.btnMetaDataEditor.Name = "btnMetaDataEditor";
 			this.btnMetaDataEditor.Size = new System.Drawing.Size(157, 23);
@@ -170,9 +171,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnMetaDataEditor.Text = "Meta Data Editor";
 			this.btnMetaDataEditor.UseVisualStyleBackColor = true;
 			this.btnMetaDataEditor.Click += new System.EventHandler(this.OnShowMetaDataEditorClicked);
-			//
+			// 
 			// btnSelectFile
-			//
+			// 
 			this.btnSelectFile.Location = new System.Drawing.Point(12, 243);
 			this.btnSelectFile.Name = "btnSelectFile";
 			this.btnSelectFile.Size = new System.Drawing.Size(157, 23);
@@ -180,9 +181,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSelectFile.Text = "Select File";
 			this.btnSelectFile.UseVisualStyleBackColor = true;
 			this.btnSelectFile.Click += new System.EventHandler(this.OnSelectFileClicked);
-			//
+			// 
 			// _silAboutBoxGecko
-			//
+			// 
 			this._silAboutBoxGecko.Location = new System.Drawing.Point(12, 157);
 			this._silAboutBoxGecko.Name = "_silAboutBoxGecko";
 			this._silAboutBoxGecko.Size = new System.Drawing.Size(157, 23);
@@ -190,9 +191,9 @@ namespace SIL.Windows.Forms.TestApp
 			this._silAboutBoxGecko.Text = "SIL AboutBox (Gecko)";
 			this._silAboutBoxGecko.UseVisualStyleBackColor = true;
 			this._silAboutBoxGecko.Click += new System.EventHandler(this.OnSilAboutBoxGeckoClicked);
-			//
+			// 
 			// btnSettingProtectionDialog
-			//
+			// 
 			this.btnSettingProtectionDialog.Location = new System.Drawing.Point(12, 272);
 			this.btnSettingProtectionDialog.Name = "btnSettingProtectionDialog";
 			this.btnSettingProtectionDialog.Size = new System.Drawing.Size(157, 23);
@@ -200,9 +201,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSettingProtectionDialog.Text = "SettingProtectionDialog";
 			this.btnSettingProtectionDialog.UseVisualStyleBackColor = true;
 			this.btnSettingProtectionDialog.Click += new System.EventHandler(this.btnSettingProtectionDialog_Click);
-			//
+			// 
 			// btnFlexibleMessageBox
-			//
+			// 
 			this.btnFlexibleMessageBox.Location = new System.Drawing.Point(12, 302);
 			this.btnFlexibleMessageBox.Name = "btnFlexibleMessageBox";
 			this.btnFlexibleMessageBox.Size = new System.Drawing.Size(157, 23);
@@ -210,9 +211,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnFlexibleMessageBox.Text = "Flexible Message Box";
 			this.btnFlexibleMessageBox.UseVisualStyleBackColor = true;
 			this.btnFlexibleMessageBox.Click += new System.EventHandler(this.btnFlexibleMessageBox_Click);
-			//
+			// 
 			// recordPlayButton
-			//
+			// 
 			this.recordPlayButton.Location = new System.Drawing.Point(12, 331);
 			this.recordPlayButton.Name = "recordPlayButton";
 			this.recordPlayButton.Size = new System.Drawing.Size(157, 23);
@@ -221,12 +222,23 @@ namespace SIL.Windows.Forms.TestApp
 			this.recordPlayButton.UseVisualStyleBackColor = true;
 			this.recordPlayButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.recordPlayButton_MouseDown);
 			this.recordPlayButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.recordPlayButton_MouseUp);
-			//
+			// 
+			// btnTestContributorsList
+			// 
+			this.btnTestContributorsList.Location = new System.Drawing.Point(12, 360);
+			this.btnTestContributorsList.Name = "btnTestContributorsList";
+			this.btnTestContributorsList.Size = new System.Drawing.Size(157, 23);
+			this.btnTestContributorsList.TabIndex = 6;
+			this.btnTestContributorsList.Text = "Test Contributos List...";
+			this.btnTestContributorsList.UseVisualStyleBackColor = true;
+			this.btnTestContributorsList.Click += new System.EventHandler(this.btnTestContributorsList_Click);
+			// 
 			// TestAppForm
-			//
+			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(187, 395);
+			this.ClientSize = new System.Drawing.Size(187, 426);
+			this.Controls.Add(this.btnTestContributorsList);
 			this.Controls.Add(this.recordPlayButton);
 			this.Controls.Add(this.btnFlexibleMessageBox);
 			this.Controls.Add(this.btnSettingProtectionDialog);
@@ -263,5 +275,6 @@ namespace SIL.Windows.Forms.TestApp
 		private System.Windows.Forms.Button btnSettingProtectionDialog;
 		private System.Windows.Forms.Button btnFlexibleMessageBox;
 		private System.Windows.Forms.Button recordPlayButton;
+		private System.Windows.Forms.Button btnTestContributorsList;
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -336,5 +336,11 @@ and displays it as HTML.
 				MessageBox.Show("play started");
 			}
 		}
+
+		private void btnTestContributorsList_Click(object sender, EventArgs e)
+		{
+			using (var dlg = new ContributorsForm())
+				dlg.ShowDialog();
+		}
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.resx
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.resx
@@ -120,4 +120,7 @@
   <metadata name="superToolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>23, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
 </root>


### PR DESCRIPTION
 This prevents a null Role from causing an error to be displayed when formatting that cell in a new row.
Added to the TestApp so it would be easy to see how ContributorsListControl is to be used and to enable debugging it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1060)
<!-- Reviewable:end -->
