### PR TITLE
Fix case mismatch with needsCompiling attribute

### DIFF
--- a/SIL.WritingSystems.Tests/LdmlContentForTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlContentForTests.cs
@@ -573,7 +573,7 @@ namespace SIL.WritingSystems.Tests
 	<collations>
 		<defaultCollation>standard</defaultCollation>
 		<collation type='standard'>
-			<special xmlns:sil='urn://www.sil.org/ldml/0.1' sil:needscompiling='true'>
+			<special xmlns:sil='urn://www.sil.org/ldml/0.1' sil:" + LdmlDataMapper.NeedsCompiling + @"='true'>
 				<sil:simple><![CDATA[
 					a/A
 					b/B

--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -855,7 +855,7 @@ namespace SIL.WritingSystems.Tests
 				XElement simpleElem = specialElem.Element(Sil + "simple");
 				Assert.That((string)defaultCollationElem, Is.EqualTo("standard"));
 				Assert.That((string)collationElem.Attribute("type"), Is.EqualTo("standard"));
-				Assert.That((string)specialElem.Attribute(Sil + "needsCompiling"), Is.EqualTo("true"));
+				Assert.That((string)specialElem.Attribute(Sil + LdmlDataMapper.NeedsCompiling), Is.EqualTo("true"));
 				Assert.That((string)simpleElem, Is.EqualTo(simpleRules.Replace("\r\n", "\n")));
 
 				var validatedCd = new SimpleRulesCollationDefinition("standard")

--- a/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
+++ b/SIL.WritingSystems.Tests/Migration/LdmlInFolderWritingSystemRepositoryMigratorTests.cs
@@ -1282,6 +1282,30 @@ namespace SIL.WritingSystems.Tests.Migration
 		}
 
 		[Test]
+		public void Migrate_CustomSimpleSort_MigrationDoesNotAddSystemCollationToLexiconSettings()
+		{
+			using (var environment = new TestEnvironment())
+			{
+				var projectSettingsfile = Path.Combine(environment.LdmlPath, "test.ulsx");
+
+				var dataMappers = new ICustomDataMapper<WritingSystemDefinition>[]
+				{
+					new ProjectLexiconSettingsWritingSystemDataMapper<WritingSystemDefinition>(new FileSettingsStore(projectSettingsfile))
+				};
+
+				environment.WriteLdmlFile("test.ldml", LdmlContentForTests.Version0WithCollationInfo(WritingSystemDefinitionV0.SortRulesType.CustomSimple));
+				var migrator = new LdmlInFolderWritingSystemRepositoryMigrator(environment.LdmlPath, environment.OnMigrateCallback);
+				migrator.Migrate();
+
+				var repo = new TestLdmlInFolderWritingSystemRepository(environment.LdmlPath, dataMappers);
+				migrator.ResetRemovedProperties(repo);
+				repo.Save();
+
+				AssertThatXmlIn.File(Path.Combine(environment.LdmlPath, projectSettingsfile)).HasNoMatchForXpath("/ProjectLexiconSettings/WritingSystems/WritingSystem/SystemCollation");
+			}
+		}
+
+		[Test]
 		public void Migrate_LanguageNameIsNotSet_LanguageNameIsSetToWhatIanaSubtagRegistrySays()
 		{
 			using (var environment = new TestEnvironment())

--- a/SIL.WritingSystems/LdmlDataMapper.cs
+++ b/SIL.WritingSystems/LdmlDataMapper.cs
@@ -43,6 +43,8 @@ namespace SIL.WritingSystems
 		/// </summary>
 		public const int CurrentLdmlLibraryVersion = 3;
 
+		internal const string NeedsCompiling = "needsCompiling";
+
 		private static readonly XNamespace Palaso = "urn://palaso.org/ldmlExtensions/v1";
 		private static readonly XNamespace Sil = "urn://www.sil.org/ldml/0.1";
 
@@ -833,7 +835,7 @@ namespace SIL.WritingSystems
 		private static SimpleRulesCollationDefinition ReadCollationRulesForCustomSimple(XElement collationElem, XElement specialElem, string collationType)
 		{
 			XElement simpleElem = specialElem.Element(Sil + "simple");
-			bool needsCompiling = (bool?) specialElem.Attribute(Sil + "needscompiling") ?? false;
+			bool needsCompiling = (bool?) specialElem.Attribute(Sil + NeedsCompiling) ?? false;
 			var scd = new SimpleRulesCollationDefinition(collationType) {SimpleRules = ((string) simpleElem).Replace("\n", "\r\n")};
 			if (!needsCompiling)
 			{
@@ -1415,7 +1417,7 @@ namespace SIL.WritingSystems
 
 			XElement specialElem = GetOrCreateSpecialElement(collationElem);
 			// SLDR generally doesn't include needsCompiling if false
-			specialElem.SetAttributeValue(Sil + "needsCompiling", scd.IsValid ? null : "true");
+			specialElem.SetAttributeValue(Sil + NeedsCompiling, scd.IsValid ? null : "true");
 			specialElem.Add(new XElement(Sil + "simple", new XCData(scd.SimpleRules)));
 		}
 		

--- a/SIL.WritingSystems/Migration/WritingSystemsLdmlV2To3Migration/LdmlVersion2MigrationStrategy.cs
+++ b/SIL.WritingSystems/Migration/WritingSystemsLdmlV2To3Migration/LdmlVersion2MigrationStrategy.cs
@@ -19,7 +19,7 @@ namespace SIL.WritingSystems.Migration.WritingSystemsLdmlV2To3Migration
 	/// <summary>
 	/// This class is used to migrate an LdmlFile from LDML palaso version 2 to 3. 
 	/// Also note that the files are not written until all writing systems have been migrated in order to deal correctly
-	/// with duplicate Ieft Language tags that might result from migration.
+	/// with duplicate ietf Language tags that might result from migration.
 	/// </summary>
 	internal class LdmlVersion2MigrationStrategy : MigrationStrategyBase
 	{
@@ -53,8 +53,7 @@ namespace SIL.WritingSystems.Migration.WritingSystemsLdmlV2To3Migration
 			string spellCheckingId = writingSystemDefinitionV1.SpellCheckingId;
 			string defaultFontName = writingSystemDefinitionV1.DefaultFontName;
 			string languageName = writingSystemDefinitionV1.LanguageName.IsOneOf("Unknown Language", "Language Not Listed") ? string.Empty : writingSystemDefinitionV1.LanguageName;
-			string variant, privateUse;
-			IetfLanguageTag.SplitVariantAndPrivateUse(writingSystemDefinitionV1.Variant, out variant, out privateUse);
+			IetfLanguageTag.SplitVariantAndPrivateUse(writingSystemDefinitionV1.Variant, out var variant, out var privateUse);
 			var langTagCleaner = new IetfLanguageTagCleaner(writingSystemDefinitionV1.Language, writingSystemDefinitionV1.Script, writingSystemDefinitionV1.Region,
 				variant, privateUse);
 			langTagCleaner.Clean();


### PR DESCRIPTION
* Introduce variable to be sure that the migration and the collation
  reading code use the same case to fix Flex bug LT-20558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1063)
<!-- Reviewable:end -->
