### PR TITLE
Avoid crashes in cases where Ibus connection dropped

### DIFF
--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusCommunicator.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusCommunicator.cs
@@ -97,7 +97,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		#endregion
 
 		/// <summary>
-		/// Wrap an ibus with protection incase DBus connection is dropped.
+		/// Wrap an ibus call with protection in case DBus connection is dropped.
 		/// </summary>
 		protected void ProtectedIBusInvoke(Action action)
 		{
@@ -109,9 +109,12 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			{
 				m_ibus = null;
 				m_inputContext = null;
+				m_connection?.Dispose();
+				m_connection = null;
 				NotifyUserOfIBusConnectionDropped();
 			}
-			catch (System.NullReferenceException)
+			// REVIEW: Is there a valid reason to catch NullReference here?
+			catch (NullReferenceException)
 			{
 			}
 		}
@@ -329,7 +332,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// focused.</exception>
 		public string GetFocusedInputContext()
 		{
-			return m_ibus.CurrentInputContext();
+			return m_ibus?.CurrentInputContext();
 		}
 
 		/// <summary></summary>


### PR DESCRIPTION
* Fix Flex bug LT-20429 by disposing and clearing out the connection
  if we get a DBusConectionErrorException[*sic*]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1066)
<!-- Reviewable:end -->
