### PR TITLE
Fix bug where PalasoImage disposes of its Image prematurely

### DIFF
--- a/SIL.Windows.Forms.Tests/ImageToolbox/PalasoImageTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/PalasoImageTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -93,6 +93,21 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 				() => PalasoImage.FromImage(null));
 		}
 
+		[Test]
+		public void ImageSetter_SameValue_NotDisposed()
+		{
+			using (var pi = PalasoImage.FromImage(new Bitmap(1, 1)))
+			{
+				// System under test
+				pi.Image = pi.Image;
+
+				// If disposed of, calling the Width getter should throw an exception
+				// Note: Don't check against pi.Disposed. That belongs to the PalasoImage class.
+				// This test checks for if the PalasoImage's Image member has been disposed of,
+				// not whether or not the PalasoImage is disposed of.
+				Assert.DoesNotThrow(() => { int w = pi.Image.Width; });
+			}
+		}
 
 		[Test]
 		public void LoadAndSave_DeleteAfter_NothingLocked()

--- a/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
+++ b/SIL.Windows.Forms/ImageToolbox/PalasoImage.cs
@@ -93,7 +93,8 @@ namespace SIL.Windows.Forms.ImageToolbox
 			}
 			set
 			{
-				if(_image!=null)
+				// Note: If being re-assigned to same value as before, you don't want to dispose it, otherwise {value} will basically be gone
+				if(_image!=null && _image!=value)
 				{
 					_image.Tag = "**** Disposed by palasoImage";
 					_image.Dispose();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1067)
<!-- Reviewable:end -->
