### PR TITLE
Fix crash casting uint to int when using GeckoFx60

### DIFF
--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoFxWebBrowserAdapter.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoFxWebBrowserAdapter.cs
@@ -511,10 +511,10 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 					{
 						countLengthProp = geckoNodeListType.GetProperty("Length", typeof(int)); // GeckoFx 45 used an int for this property
 					}
-					var countLength = (int)countLengthProp.GetValue(children, BindingFlags.Default, null, null, null);
+					var countLength = Convert.ToInt32(countLengthProp.GetValue(children, BindingFlags.Default, null, null, null));
 					if(countLength > 0)
 					{
-						var lastChildProp = geckoNodeListType.GetProperty("Item"); //Magic
+						var lastChildProp = geckoNodeListType.GetProperty("Item"); // Magic
 						var lastchild = lastChildProp.GetValue(children, new object[] { countLength - 1 });
 						var scrollIntoView = geckoHtmlElementType.GetMethod("ScrollIntoView");
 						scrollIntoView.Invoke(lastchild, BindingFlags.Default, null, null, null);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1070)
<!-- Reviewable:end -->
