### PR TITLE
Prevent a race condition crash in a unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.Windows.Forms] Fix bug where changing ImageCollection search language too soon could crash.
+- [SIL.Windows.Forms] Fix bug where image license could not be changed from Creative Commons.
 - [SIL.Windows.Forms] Fix bug where PalasoImage disposes of its Image prematurely
 - [SIL.Windows.Forms.Keyboarding] Avoid crashes in cases where Ibus connection dropped
 - [SIL.WritingSystems] Fix case mismatch with needsCompiling attribute

--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageCollectionManager.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageCollectionManager.cs
@@ -137,15 +137,7 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 		{
 			foundExactMatches = false;
 
-			// On a dev machine, the index loading feels instantaneous with AOR,
-			// but if the user were on a super slow computer, and entered a query quickly, he would
-			// get a spinning cursor until they are done.
-			const int kMaxSecondsToWaitForIndexLoading = 20;
-			var whenToGiveUp = DateTime.Now.AddSeconds(kMaxSecondsToWaitForIndexLoading);
-			while(!_indicesLoaded && DateTime.Now < whenToGiveUp)
-			{
-				Thread.Sleep(10);
-			}
+			WaitForLoadingToFinish();
 			// If still not done, give up and return no results.
 			if(!_indicesLoaded)
 			{
@@ -182,12 +174,28 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 			return finalResult;
 		}
 
+		private void WaitForLoadingToFinish()
+		{
+			// On a dev machine, the index loading feels instantaneous with AOR,
+			// but if the user were on a super slow computer, and entered a query quickly, he would
+			// get a spinning cursor until they are done.
+			const int kMaxSecondsToWaitForIndexLoading = 20;
+			var whenToGiveUp = DateTime.Now.AddSeconds(kMaxSecondsToWaitForIndexLoading);
+			while (!_indicesLoaded && DateTime.Now < whenToGiveUp)
+			{
+				Thread.Sleep(10);
+			}
+		}
+
 
 		/// <summary>
 		/// Load the index again, this time for the a different language id
 		/// </summary>
 		public void ChangeSearchLanguageAndReloadIndex(string searchLanguageId)
 		{
+			// Usually not needed, but reduce the possibility of a crash from trying to set the
+			// same index twice.  See https://issues.bloomlibrary.org/youtrack/issue/BL-9825.
+			WaitForLoadingToFinish();
 			_searchLanguage = searchLanguageId;
 			foreach (var c in Collections)
 			{


### PR DESCRIPTION
This could possibly prevent such a crash in a real program as well.
See https://issues.bloomlibrary.org/youtrack/issue/BL-9825 for a crash
during a unit test that this should prevent 99.999% of the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1075)
<!-- Reviewable:end -->
