### PR TITLE
[API] Remove XML Namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- [SIL.Core] Utility methods to remove XML namespaces
 - [SIL.Core.Desktop] Serializable class `UpdateSettings` (settings for getting updates)
 - [SIL.Windows.Forms] `CssLinkHref` property to `ShowReleaseNotesDialog` to allow linking to CSS file for
     displaying Markdown output.

--- a/SIL.Core/Xml/XmlUtils.cs
+++ b/SIL.Core/Xml/XmlUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -8,6 +7,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
+using SIL.Linq;
 
 namespace SIL.Xml
 {
@@ -1136,6 +1136,33 @@ namespace SIL.Xml
 				(codePoint >= 0xE000 && codePoint <= 0xFFFD) ||
 				(codePoint >= 0x10000/* && character <= 0x10FFFF*/) //it's impossible to get a code point bigger than 0x10FFFF because Char.ConvertToUtf32 would have thrown an exception
 			);
+		}
+
+		/// <summary>
+		/// Removes namespaces from the Xml document (makes querying easier)
+		/// </summary>
+		public static XDocument RemoveNamespaces(this XDocument document)
+		{
+			document.Root?.RemoveNamespaces();
+			return document;
+		}
+
+		/// <summary>
+		/// Removes namespaces from the Xml element and its children (makes querying easier)
+		/// </summary>
+		public static XElement RemoveNamespaces(this XElement element)
+		{
+			RemoveNamespaces(element.DescendantsAndSelf());
+			return element;
+		}
+
+		private static void RemoveNamespaces(IEnumerable<XElement> elements)
+		{
+			foreach (var element in elements)
+			{
+				element.Attributes().Where(attribute => attribute.IsNamespaceDeclaration).ForEach(attribute => attribute.Remove());
+				element.Name = element.Name.LocalName;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Add a utility method to remove XML namespaces

(cherry picked from commit 11e7dc941c0c2d0579ae26f799d071fe3d7d88ad)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1079)
<!-- Reviewable:end -->
