### PR TITLE
Prevent second exception when handling parser exception (PTX-15835)

### DIFF
--- a/SIL.WritingSystems/SimpleRulesParser.cs
+++ b/SIL.WritingSystems/SimpleRulesParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -196,10 +196,17 @@ namespace SIL.WritingSystems
 			}
 			catch (ParserErrorException e)
 			{
-				string errString = sc.InputString.Split(new char[] { '\n' })[e.ParserError.Line - 1];
-				int startingPos = Math.Max((int)e.ParserError.Column - 2, 0);
-				errString = errString.Substring(startingPos, Math.Min(10, errString.Length - startingPos));
-				message = String.Format("{0}: '{1}'", e.ParserError.ErrorText, errString);
+				string[] lines = sc.InputString.Split(new char[] {'\n'});
+				if (e.ParserError.Line > 0 && e.ParserError.Line <= lines.Length)
+				{
+					string errString = lines[e.ParserError.Line - 1];
+					int startingPos = Math.Max((int) e.ParserError.Column - 2, 0);
+					errString = errString.Substring(startingPos, Math.Min(10, errString.Length - startingPos));
+					message = String.Format("{0}: '{1}'", e.ParserError.ErrorText, errString);
+				}
+				else
+					message = e.ParserError.ErrorText;
+
 				return false;
 			}
 			catch (Exception e)


### PR DESCRIPTION
We have had exception reports when Paratext is saving language data that has passed the Paratext checks, but causes an error in the SimpleRulesParser. This change prevents a second exception from being created because the exception from the Spart parser must not contain the expected data.

Hopefully with this change, we will get a better message and be able to figure out what the problem data is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1081)
<!-- Reviewable:end -->
