### PR TITLE
Made VerseControl usable by Paratext plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core.Desktop] Serializable class `UpdateSettings` (settings for getting updates)
 - [SIL.Windows.Forms] `CssLinkHref` property to `ShowReleaseNotesDialog` to allow linking to CSS file for
     displaying Markdown output.
+- [SIL.Scripture] IScrVerseRef interface (largely extracted from VerseRef)
 
 ### Changed
 
 - [SIL.WritingSystems] Update langtags.json to the latest
+- [SIL.Scripture] Made VerseRef class implement new IScrVerseRef interface
+- [SIL.Forms.Scripture] Changed VerseControl to use IScrVerseRef and not depend directly on ScrVers
 
 ### Fixed
 

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BBBCCCVVV/@EntryIndexedValue">BBBCCCVVV</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BCV/@EntryIndexedValue">BCV</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GUI/@EntryIndexedValue">GUI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GUID/@EntryIndexedValue">GUID</s:String>
@@ -9,7 +10,9 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=acknowledgements/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=analytics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Annotatable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=bbbcccvvv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BBCCCVVV/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deuterocanon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ethnologue/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenames/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=glist/@EntryIndexedValue">True</s:Boolean>
@@ -23,6 +26,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=parsable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Saami/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SLDR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subitem/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Scripture.Tests/VerseRefTests.cs
+++ b/SIL.Scripture.Tests/VerseRefTests.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Xml.Serialization;
 using NUnit.Framework;
 using SIL.Xml;
 
@@ -924,7 +921,7 @@ namespace SIL.Scripture.Tests
 
 			// Have no idea what LAO is, but it's not in the English vrs file,
 			// so Paratext considers it to have 1 chapter, and since it's the
-			// last book in the Deutoerocanon, we can't advance.
+			// last book in the Deuterocanon, we can't advance.
 			vref = new VerseRef("LAO 1:0", ScrVers.English);
 			Assert.IsFalse(vref.NextChapter());
 			Assert.AreEqual("LAO", vref.Book);
@@ -933,7 +930,7 @@ namespace SIL.Scripture.Tests
 		}
 
 		/// <summary>
-		/// Tests the NextChapter method with a set of books (contrained to the odd-numbered
+		/// Tests the NextChapter method with a set of books (constrained to the odd-numbered
 		/// books in the Torah)
 		/// </summary>
 		[Test]

--- a/SIL.Scripture/IScrVerseRef.cs
+++ b/SIL.Scripture/IScrVerseRef.cs
@@ -44,7 +44,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Returns verse ref with no bridging, but maintaining segments like "1a".
 		/// </summary>
-		public IScrVerseRef UnBridge();
+		IScrVerseRef UnBridge();
 
 		/// <summary>
 		/// Simplifies this verse ref so that it has no bridging of verses or 
@@ -92,6 +92,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Tries to move to the next chapter.
 		/// </summary>
+		/// <param name="present">Set of books present or selected.</param>
 		/// <returns>true if successful</returns>
 		bool NextChapter(BookSet present);
 
@@ -104,6 +105,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Tries to move to the previous chapter.
 		/// </summary>
+		/// <param name="present">Set of books present or selected.</param>
 		/// <returns>true if successful</returns>
 		bool PreviousChapter(BookSet present);
 
@@ -116,6 +118,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Tries to move to the next verse (or verse segment, if available in the current versification).
 		/// </summary>
+		/// <param name="present">Set of books present or selected.</param>
 		/// <returns>true if successful, false if at end of scripture</returns>
 		bool NextVerse(BookSet present);
 
@@ -128,6 +131,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Tries to move to the previous verse (or verse segment, if available in the current versification).
 		/// </summary>
+		/// <param name="present">Set of books present or selected.</param>
 		/// <returns>true if successful, false if at beginning of scripture</returns>
 		bool PreviousVerse(BookSet present);
 

--- a/SIL.Scripture/IScrVerseRef.cs
+++ b/SIL.Scripture/IScrVerseRef.cs
@@ -1,0 +1,145 @@
+namespace SIL.Scripture
+{
+	public interface IScrVerseRef
+	{
+		/// <summary>
+		/// Get or set Book based on book number.
+		/// </summary>
+		/// <exception cref="VerseRefException">If BookNum is set to an invalid value</exception>
+		int BookNum { get; set; }
+		/// <summary>
+		/// Gets chapter number. -1 if not valid
+		/// </summary>
+		/// <exception cref="VerseRefException">If ChapterNum is negative</exception>
+		int ChapterNum { get; set; }
+		/// <summary>
+		/// Gets verse start number. -1 if not valid
+		/// </summary>
+		/// <exception cref="VerseRefException">If VerseNum is negative</exception>
+		int VerseNum { get; set; }
+
+		/// <summary>
+		/// Gets the book of the reference. This is the 
+		/// three-letter abbreviation in capital letters. e.g. "MAT"
+		/// </summary>
+		string Book { get; }
+		/// <summary>
+		/// Gets the chapter of the reference. e.g. "3"
+		/// </summary>
+		string Chapter { get; }
+		/// <summary>
+		///  Gets the verse of the reference e.g. "11"
+		/// </summary>
+		/// <remarks>The USX standard only expects support for Latin numerals {0-9}* in verse numbers.</remarks>
+		string Verse { get; }
+
+		int LastChapter { get; }
+		int LastVerse { get; }
+
+		/// <summary>
+		/// Gets whether the versification of this reference has verse segments
+		/// </summary>
+		bool VersificationHasVerseSegments { get; }
+
+		/// <summary>
+		/// Returns verse ref with no bridging, but maintaining segments like "1a".
+		/// </summary>
+		public IScrVerseRef UnBridge();
+
+		/// <summary>
+		/// Simplifies this verse ref so that it has no bridging of verses or 
+		/// verse segments like "1a".
+		/// </summary>
+		void Simplify();
+
+		/// <summary>
+		/// Gets a new object having the specified book, chapter and verse values (with the
+		/// same versification).
+		/// </summary>
+		IScrVerseRef Create(string book, string chapter, string verse);
+
+		/// <summary>
+		/// Makes a clone of the reference
+		/// </summary>
+		IScrVerseRef Clone();
+
+		/// <summary>
+		/// Tries to move to the next book among a set of books present.
+		/// </summary>
+		/// <param name="present">Set of books present or selected.</param>
+		/// <returns>true if successful</returns>
+		bool NextBook(BookSet present);
+
+		/// <summary>
+		/// Tries to move to the next book in the entire canon superset.
+		/// </summary>
+		/// <returns>True if successful.</returns>
+		bool NextBook();
+
+		/// <summary>
+		/// Tries to move to the previous book among a set of books present.
+		/// </summary>
+		/// <param name="present">Set of books present or selected.</param>
+		/// <returns>true if successful</returns>
+		bool PreviousBook(BookSet present);
+
+		/// <summary>
+		/// Tries to move to the previous book in the entire canon superset.
+		/// </summary>
+		/// <returns>true if successful</returns>
+		bool PreviousBook();
+
+		/// <summary>
+		/// Tries to move to the next chapter.
+		/// </summary>
+		/// <returns>true if successful</returns>
+		bool NextChapter(BookSet present);
+
+		/// <summary>
+		/// Tries to move to the next chapter.
+		/// </summary>
+		/// <returns>true if successful</returns>
+		bool NextChapter();
+
+		/// <summary>
+		/// Tries to move to the previous chapter.
+		/// </summary>
+		/// <returns>true if successful</returns>
+		bool PreviousChapter(BookSet present);
+
+		/// <summary>
+		/// Tries to move to the previous chapter.
+		/// </summary>
+		/// <returns>true if successful</returns>
+		bool PreviousChapter();
+
+		/// <summary>
+		/// Tries to move to the next verse (or verse segment, if available in the current versification).
+		/// </summary>
+		/// <returns>true if successful, false if at end of scripture</returns>
+		bool NextVerse(BookSet present);
+
+		/// <summary>
+		/// Tries to move to the next verse (or verse segment, if available in the current versification).
+		/// </summary>
+		/// <returns>true if successful, false if at end of scripture</returns>
+		bool NextVerse();
+
+		/// <summary>
+		/// Tries to move to the previous verse (or verse segment, if available in the current versification).
+		/// </summary>
+		/// <returns>true if successful, false if at beginning of scripture</returns>
+		bool PreviousVerse(BookSet present);
+
+		/// <summary>
+		/// Tries to move to the previous verse (or verse segment, if available in the current versification).
+		/// </summary>
+		/// <returns>true if successful, false if at beginning of scripture</returns>
+		bool PreviousVerse();
+
+		/// <summary>
+		/// Advances to the last segment associated with this verse, if any.
+		/// </summary>
+		void AdvanceToLastSegment();
+	}
+}

--- a/SIL.Scripture/SIL.Scripture.csproj
+++ b/SIL.Scripture/SIL.Scripture.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
   </ItemGroup>

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -380,7 +380,7 @@ namespace SIL.Scripture
 		public void AdvanceToLastSegment()
 		{
 			string[] segments = GetSegments(null);
-			if (segments != null && segments.Length > 0)
+			if (segments?.Length > 0)
 				Verse += segments[segments.Length - 1];
 		}
 
@@ -815,7 +815,7 @@ namespace SIL.Scripture
 
 		public bool NextChapter(BookSet present)
 		{
-			return NextChapter(present);
+			return NextChapter(present, false);
 		}
 
 		public bool NextChapter()

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -4,6 +4,7 @@ using System.Xml.Serialization;
 using System.Linq;
 using System.Diagnostics;
 using System.Text;
+using JetBrains.Annotations;
 
 namespace SIL.Scripture
 {
@@ -13,14 +14,19 @@ namespace SIL.Scripture
 	public struct VerseRef : IComparable<VerseRef>, IComparable, IScrVerseRef
 	{
 		#region Constants
+		[PublicAPI]
 #if DEBUG
 		public static readonly ScrVers defaultVersification = null;
 #else
 		public static readonly ScrVers defaultVersification = ScrVers.English;
 #endif
+		[PublicAPI]
 		public const char verseRangeSeparator = '-';
+		[PublicAPI]
 		public const char verseSequenceIndicator = ',';
+		[PublicAPI]
 		public static readonly string[] verseRangeSeparators = new[] { verseRangeSeparator.ToString() };
+		[PublicAPI]
 		public static readonly string[] verseSequenceIndicators = new[] { verseSequenceIndicator.ToString() };
 
 		private const int chapterDigitShifter = 1000;
@@ -158,6 +164,7 @@ namespace SIL.Scripture
 		/// TODO bro Do we need to make this 0 for intro material?
 		/// </summary>
 		[XmlIgnore]
+		[PublicAPI]
 		public int FirstChapter
 		{
 			get { return 1; }
@@ -180,6 +187,7 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <remarks>Does not handle verse ranges</remarks>
 		[XmlIgnore]
+		[PublicAPI]
 		public bool IsExcluded
 		{
 			get { return versification.IsExcluded(BBBCCCVVV); }
@@ -190,6 +198,7 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <remarks>Does not handle verse ranges</remarks>
 		[XmlIgnore]
+		[PublicAPI]
 		public bool HasSegmentsDefined
 		{
 			get { return versification != null && versification.VerseSegments(BBBCCCVVV) != null; }
@@ -368,6 +377,7 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <param name="defaultSegments">verse segments defined for the current language</param>
 		/// <returns></returns>
+		[PublicAPI]
 		public string[] GetSegments(string[] defaultSegments)
 		{
 			if (versification == null)
@@ -390,6 +400,7 @@ namespace SIL.Scripture
 		/// <param name="validSegments">valid segments defined for the language or null if not defined or available</param>
 		/// <returns>validated segment (according to default segments or versification, if available for verse);
 		/// empty string if no segment or if segment did not validate</returns>
+		[PublicAPI]
 		public string Segment(string[] validSegments)
 		{
 			string seg = Segment();
@@ -426,6 +437,7 @@ namespace SIL.Scripture
 		/// Get segment from verse string.
 		/// </summary>
 		/// <returns>non-validated segment, or empty string if no segment found</returns>
+		[PublicAPI]
 		public string Segment()
 		{
 			if (string.IsNullOrEmpty(verse) || !char.IsDigit(verse[0]))
@@ -465,6 +477,7 @@ namespace SIL.Scripture
 		/// Returns verse ref with no bridging, but maintaining segments like "1a".
 		/// </summary>
 		/// <returns></returns>
+		[PublicAPI]
 		public VerseRef UnBridge()
 		{
 			return AllVerses().FirstOrDefault();
@@ -504,6 +517,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Get the valid status for this reference.
 		/// </summary>
+		[PublicAPI]
 		public ValidStatusType ValidStatus
 		{
 			get { return ValidateVerse(verseRangeSeparators, verseSequenceIndicators); }
@@ -543,6 +557,7 @@ namespace SIL.Scripture
 		/// Attempts to change the versification to the specified versification
 		/// </summary>
 		/// <param name="newVersification">new versification to use</param>
+		[PublicAPI]
 		public void ChangeVersification(ScrVers newVersification)
 		{
 			if (!HasMultiple)
@@ -559,6 +574,7 @@ namespace SIL.Scripture
 		/// Change the versification of an entry with Verse like 1-3 or 1,3a.
 		/// Can't really work in the most general case because the verse parts could become separate chapters.
 		/// </summary>
+		[PublicAPI]
 		public bool ChangeVersificationWithRanges(ScrVers newVersification)
 		{
 			VerseRef temp;
@@ -615,6 +631,7 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <param name="verseStr">string to parse e.g. "MAT 3:11"</param>
 		/// <exception cref="VerseRefException"></exception>
+		[PublicAPI]
 		public void Parse(string verseStr)
 		{
 			verseStr = verseStr.Replace(rtlMark, "");
@@ -689,7 +706,7 @@ namespace SIL.Scripture
 		/// so lets leave this public.
 		/// </summary>
 		/// <exception cref="VerseRefException">If BookNum is set to an invalid value</exception>
-		[XmlIgnore()]
+		[XmlIgnore]
 		public int BookNum
 		{
 			get { return bookNum; }
@@ -705,7 +722,7 @@ namespace SIL.Scripture
 		/// Gets chapter number. -1 if not valid
 		/// </summary>
 		/// <exception cref="VerseRefException">If ChapterNum is negative</exception>
-		[XmlIgnore()]
+		[XmlIgnore]
 		public int ChapterNum
 		{
 			get { return chapterNum; }
@@ -721,7 +738,7 @@ namespace SIL.Scripture
 		/// Gets verse start number. -1 if not valid
 		/// </summary>
 		/// <exception cref="VerseRefException">If VerseNum is negative</exception>
-		[XmlIgnore()]
+		[XmlIgnore]
 		public int VerseNum
 		{
 			get { return verseNum; }
@@ -786,7 +803,7 @@ namespace SIL.Scripture
 		}
 
 		// ---------- CHAPTER NEXT AND PREVIOUS ----------
-
+		[PublicAPI]
 		public bool NextChapter(BookSet present, bool skipExcluded)
 		{
 			// If current book doesn't exist, try jump to next.
@@ -864,6 +881,7 @@ namespace SIL.Scripture
 		/// Moves to the next verse (or verse segment, if available in the current versification).
 		/// </summary>
 		/// <returns>true if successful, false if at end of scripture</returns>
+		[PublicAPI]
 		public bool NextVerse(BookSet present, bool skipExcluded)
 		{
 			// avoid incrementing through a blank book
@@ -1061,6 +1079,7 @@ namespace SIL.Scripture
 		/// <param name="other">the other VerseRef to compare to this one</param>
 		/// <param name="compareAllVerses">if <c>true</c>, compare both the starting and, if it exists, 
 		/// the ending verse in a verse bridge; if <c>false</c> compare only the first verse number in a bridge</param>
+		[PublicAPI]
 		public int CompareTo(VerseRef other, bool compareAllVerses)
 		{
 			return CompareTo(other, null, compareAllVerses, true);
@@ -1077,6 +1096,7 @@ namespace SIL.Scripture
 		/// <param name="compareSegments">if set to <c>true</c> compare segments; <c>false</c> to ignore 
 		/// segment differences.</param>
 		/// <returns></returns>
+		[PublicAPI]
 		public int CompareTo(VerseRef other, string[] segmentOrder, bool compareAllVerses, bool compareSegments)
 		{
 			if (other.Versification != Versification)
@@ -1154,7 +1174,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// GetVerses gets a list of verses from the verses specified in this VerseRef.
 		/// </summary>
-		internal List<int> GetVerses()
+		private List<int> GetVerses()
 		{
 			// Get verses from the verse strings
 			List<int> verseList = new List<int>();
@@ -1504,6 +1524,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Determines if the verse string is in a valid format (does not consider versification).
 		/// </summary>
+		[PublicAPI]
 		public static bool IsVerseParseable(string verse)
 		{
 			return verse.Length != 0 && char.IsDigit(verse[0]) && verse[verse.Length - 1] != verseRangeSeparator &&
@@ -1516,6 +1537,7 @@ namespace SIL.Scripture
 		/// <param name="str">The string to attempt to parse</param>
 		/// <param name="vref">The result of the parse if successful, or null if it failed</param>
 		/// <returns>True if the specified string was successfully parsed, false otherwise</returns>
+		[PublicAPI]
 		public static bool TryParse(string str, out VerseRef vref)
 		{
 			try
@@ -1533,6 +1555,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Validates a verse number using the supplied separators rather than the defaults.
 		/// </summary>
+		[PublicAPI]
 		public ValidStatusType ValidateVerse(string[] verseRangeSeparators, string[] verseSequenceSeparators)
 		{
 			if (string.IsNullOrEmpty(verse))

--- a/SIL.Scripture/VerseRef.cs
+++ b/SIL.Scripture/VerseRef.cs
@@ -10,7 +10,7 @@ namespace SIL.Scripture
 	/// <summary>
 	/// Stores a reference to a specific verse in Scripture.
 	/// </summary>
-	public struct VerseRef : IComparable<VerseRef>, IComparable
+	public struct VerseRef : IComparable<VerseRef>, IComparable, IScrVerseRef
 	{
 		#region Constants
 #if DEBUG
@@ -56,7 +56,6 @@ namespace SIL.Scripture
 		#endregion
 
 		#region Constructors
-
 
 		/// <summary>
 		/// Creates an empty reference with the specified versification
@@ -378,6 +377,13 @@ namespace SIL.Scripture
 			return segsForThisVerse ?? defaultSegments;
 		}
 
+		public void AdvanceToLastSegment()
+		{
+			string[] segments = GetSegments(null);
+			if (segments != null && segments.Length > 0)
+				Verse += segments[segments.Length - 1];
+		}
+
 		/// <summary>
 		/// Get the segment from the verse.
 		/// </summary>
@@ -478,7 +484,7 @@ namespace SIL.Scripture
 		/// <summary>
 		/// Gets or sets the versification of the reference.
 		/// Setting this value does not attempt to convert between
-		/// versifications. To do so, use the ChangeVersification function
+		/// versifications. To do so, use one of the ChangeVersification methods
 		/// </summary>
 		[XmlIgnore]
 		public ScrVers Versification
@@ -728,7 +734,6 @@ namespace SIL.Scripture
 			}
 		}
 
-
 		// ---------- BOOK NEXT AND PREVIOUS ----------
 
 		// NOTES ABOUT ALL NAVIGATION FUNCTIONS:
@@ -782,7 +787,7 @@ namespace SIL.Scripture
 
 		// ---------- CHAPTER NEXT AND PREVIOUS ----------
 
-		public bool NextChapter(BookSet present, bool skipExcluded = false)
+		public bool NextChapter(BookSet present, bool skipExcluded)
 		{
 			// If current book doesn't exist, try jump to next.
 			if (!present.IsSelected(bookNum))
@@ -806,6 +811,11 @@ namespace SIL.Scripture
 			}
 
 			return true;
+		}
+
+		public bool NextChapter(BookSet present)
+		{
+			return NextChapter(present);
 		}
 
 		public bool NextChapter()
@@ -1520,8 +1530,6 @@ namespace SIL.Scripture
 			}
 		}
 
-		#endregion
-
 		/// <summary>
 		/// Validates a verse number using the supplied separators rather than the defaults.
 		/// </summary>
@@ -1545,8 +1553,22 @@ namespace SIL.Scripture
 				prevVerse = bbbcccvvv;
 			}
 			return ValidStatusType.Valid; // TODO: make Valid tests Valid Status tests
-
 		}
+
+		#endregion
+
+		#region IScrVerseRef-specific implementation
+		public IScrVerseRef Create(string book, string chapter, string verse)
+		{
+			return new VerseRef(book, chapter, verse, Versification);
+		}
+
+		IScrVerseRef IScrVerseRef.Clone() => Clone();
+
+		IScrVerseRef IScrVerseRef.UnBridge() => UnBridge();
+
+		public bool VersificationHasVerseSegments => Versification.HasVerseSegments;
+		#endregion
 	}
 
 	#region VerseRefException class


### PR DESCRIPTION
Added IScrVerseRef interface (largely extracted from VerseRef)
Made VerseRef class implement new IScrVerseRef interface
Changed VerseControl to use IScrVerseRef and not depend directly on ScrVers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1086)
<!-- Reviewable:end -->
