### PR TITLE
Prevent a crash closing the ImageToolboxDialog with the X button

### DIFF
--- a/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
@@ -410,7 +410,9 @@ namespace SIL.Windows.Forms.ImageToolbox
 			{
 				SetMode(Modes.SingleImage);
 			}
-
+			// This control can get loaded when the overall dialog is being disposed.
+			// See https://issues.bloomlibrary.org/youtrack/issue/BL-10314 if you don't believe me.
+			Load -= new EventHandler(AcquireImageControl_Load);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Using Alt-F4 to close the dialog also provoked the crash in the same
circumstances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1091)
<!-- Reviewable:end -->
