### PR TITLE
+semver:minor Added ParentFormBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] `CssLinkHref` property to `ShowReleaseNotesDialog` to allow linking to CSS file for
     displaying Markdown output.
 - [SIL.Scripture] IScrVerseRef interface (largely extracted from VerseRef)
+- [SIL.Windows.Forms] ParentFormBase to allow showing a child form that is modal with respect to the parent but not application modal
 
 ### Changed
 

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -12,6 +12,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Annotatable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bbbcccvvv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BBCCCVVV/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=bidi/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deuterocanon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ethnologue/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenames/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Core.Tests/Extensions/StringExtensionTests.cs
+++ b/SIL.Core.Tests/Extensions/StringExtensionTests.cs
@@ -60,7 +60,7 @@ namespace SIL.Tests.Extensions
 		[Test]
 		public void EscapeAnyUnicodeCharactersIllegalInXml_HasMixOfXmlAndIllegalChars_GivesXmlWithEscapedChars()
 		{
-			var s  ="This <span href=\"reference\">is well \u001F formed</span> XML!";
+			var s = "This <span href=\"reference\">is well \u001F formed</span> XML!";
 			Assert.AreEqual("This <span href=\"reference\">is well &#x1F; formed</span> XML!",
 				s.EscapeAnyUnicodeCharactersIllegalInXml());
 		}
@@ -78,7 +78,7 @@ namespace SIL.Tests.Extensions
 //			writer.WriteElementString("x", x.InnerText);
 //
 //			writer.WriteNode(z);
-		 }
+		}
 
 		[Test]
 		public void Format_NormalSafeString_GivesSameAsStringFormat()
@@ -92,6 +92,7 @@ namespace SIL.Tests.Extensions
 		{
 			Assert.That("{node}".FormatWithErrorStringInsteadOfException().Equals("{node}"));
 		}
+
 		[Test]
 		public void Format_UnSafeString_GivesErrorString()
 		{
@@ -101,23 +102,27 @@ namespace SIL.Tests.Extensions
 		[Test]
 		public void ToUpperFirstLetter_Empty_EmptyString()
 		{
-			Assert.AreEqual("","".ToUpperFirstLetter());
+			Assert.AreEqual("", "".ToUpperFirstLetter());
 		}
+
 		[Test]
 		public void ToUpperFirstLetter_OneCharacter_UpperCase()
 		{
 			Assert.AreEqual("X", "x".ToUpperFirstLetter());
 		}
+
 		[Test]
 		public void ToUpperFirstLetter_Digit_ReturnsSame()
 		{
 			Assert.AreEqual("1abc", "1abc".ToUpperFirstLetter());
 		}
+
 		[Test]
 		public void ToUpperFirstLetter_AlreadyUpper_ReturnsSame()
 		{
 			Assert.AreEqual("Abc", "Abc".ToUpperFirstLetter());
 		}
+
 		[Test]
 		public void ToUpperFirstLetter_typical_MakesUppercase()
 		{
@@ -180,7 +185,7 @@ namespace SIL.Tests.Extensions
 
 		private static IEnumerable<char> GetInvalidFilenameCharacters() =>
 			System.IO.Path.GetInvalidFileNameChars();
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Tests that we get a valid filename when the filename contains invalid characters.

--- a/SIL.Windows.Forms/ParentFormBase.cs
+++ b/SIL.Windows.Forms/ParentFormBase.cs
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------------------------
+#region // Copyright (c) 2021, SIL International.   
+// <copyright from='2021' to='2021 company='SIL International'>
+//		Copyright (c) 2021, SIL International.   
+//
+//		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
+// </copyright> 
+#endregion
+// 
+// File: ParentFormBase.cs
+// ---------------------------------------------------------------------------------------------
+using System;
+using System.Media;
+using System.Windows.Forms;
+using JetBrains.Annotations;
+
+namespace SIL.Windows.Forms
+{
+	/// <summary>
+	/// Base class for forms which need to show a child form that is modal with respect to
+	/// the parent form but is not application modal.
+	/// </summary>
+	[PublicAPI]
+	public class ParentFormBase : Form
+	{
+		private Form ModalChild { get; set; }
+
+		[PublicAPI]
+		protected bool IsShowingModalForm => ModalChild != null;
+
+		protected delegate void ModalChildEventHandler();
+
+		protected event ModalChildEventHandler OnModalFormShown;
+
+		protected event ModalChildEventHandler OnModalFormClosed;
+
+		protected override void OnActivated(EventArgs e)
+		{
+			if (ModalChild == null)
+				base.OnActivated(e);
+			else
+			{
+				SystemSounds.Beep.Play();
+				ModalChild.Activate();
+				ModalChild.BringToFront();
+			}
+		}
+
+		protected void ShowModalChild<T>(T childForm, Action<T> onClosed = null) where T : Form
+		{
+			ModalChild = childForm;
+			foreach (var ctrl in childForm.Controls)
+			{
+				// This is not 100% guaranteed to be right, since it is possible that a button could
+				// have no DialogResult set at the outset, but during the course of the user's interaction with
+				// the dialog box, a DialogResult could be assigned dynamically. But this is unlikely (does not
+				// currently happen in Transcelerator) so by checking the DialogResult up-front, we avoid having
+				// to hook up this click handler for other buttons.
+				if (ctrl is Button btn && btn.DialogResult != DialogResult.None)
+					btn.Click += (sender, args) =>
+					{
+						var clickedButton = (Button)sender;
+						// There's always the slight possibility that the DialogResult was changed in the code to be None.
+						if (clickedButton.DialogResult != DialogResult.None)
+						{
+							ModalChild.DialogResult = clickedButton.DialogResult;
+							var dialog = ModalChild;
+							ModalChild = null;
+							dialog.Close();
+						}
+					};
+			}
+			childForm.Closed += (dialog, args) =>
+			{
+				ModalChild = null;
+				T dlg = (T)dialog;
+				onClosed?.Invoke(dlg);
+				dlg.Dispose();
+				OnModalFormClosed?.Invoke();
+			};
+			childForm.HandleCreated += (sender, args) =>
+			{
+				childForm.WindowState = FormWindowState.Normal;
+				childForm.BringToFront();
+				childForm.Activate();
+			};
+			childForm.Show(this);
+			OnModalFormShown?.Invoke();
+		}
+	}
+}

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="DialogAdapters.Gtk2" Version="0.1.9" />
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="L10NSharp" Version="4.2.0-*" />
     <PackageReference Include="Markdig.Signed" Version="0.22.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
This base class allows a form to show a child form that is modal with respect to the parent but not application modal.

Note that this was written for Transcelerator, but it is potentially useful for other "standalone" Paratext plugins. And there may be good uses for it elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1095)
<!-- Reviewable:end -->
