### PR TITLE
Update libpalaso to use Gtk3 as required for Geckofx60

### DIFF
--- a/ExtractCopyright.Tests/ExtractCopyrightTests.cs
+++ b/ExtractCopyright.Tests/ExtractCopyrightTests.cs
@@ -259,6 +259,7 @@ Build-Depends: debhelper (>= 9.0.0), cli-common-dev (>= 0.8),
  mono4-sil, libgdiplus4-sil,
  libenchant-dev, libxklavier-dev, libdconf-dev,
  libicu-dev,
+libgtk3.0-cil, libgtk-3-dev,
  libgtk2.0-cil (>= 2.12.10), libgtk2.0-dev (>= 2.14), libasound2-dev,
  icu-devtools | libicu-dev (<< 52)
 
@@ -266,7 +267,8 @@ Package: bloom-desktop-alpha
 Architecture: any
 Depends: ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends},
  mono4-sil, libgdiplus4-sil, gtklp,
- chmsee, libtidy5,
+libgtk-3-0, libgtk3.0-cil, libgtk2.0-0, libgtk2.0-cil,
+ chmsee | xchm | kchmviewer, libtidy-sil,
  fonts-sil-andika-new-basic | fonts-sil-andikanewbasic,
  optipng, libsndfile1,
  wmctrl, lame

--- a/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
@@ -716,13 +716,13 @@ namespace SIL.Windows.Forms.Reporting
 		}
 
 		// Workaround for Xamarin bug #4959
-		[DllImport("libgdk-x11-2.0")]
+		[DllImport("libgdk-3.so.0")]
 		private static extern IntPtr gdk_atom_intern(string atomName, bool onlyIfExists);
-		[DllImport("libgtk-x11-2.0")]
+		[DllImport("libgtk-3.so.0")]
 		private static extern IntPtr gtk_clipboard_get(IntPtr atom);
-		[DllImport("libgtk-x11-2.0")]
+		[DllImport("libgtk-3.so.0")]
 		private static extern void gtk_clipboard_store(IntPtr clipboard);
-		[DllImport("libgtk-x11-2.0")]
+		[DllImport("libgtk-3.so.0")]
 		private static extern void gtk_clipboard_set_text(IntPtr clipboard, [MarshalAs(UnmanagedType.LPStr)] string text, int len);
 
 		private bool SendViaEmail()

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DialogAdapters.Gtk2" Version="0.1.9" />
+    <PackageReference Include="DialogAdapters" Version="0.1.9" />
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="L10NSharp" Version="4.2.0-*" />
@@ -35,14 +35,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)'!='Windows_NT'">
-    <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <HintPath>\usr\lib\cli\gdk-sharp-2.0\gdk-sharp.dll</HintPath>
+    <Reference Include="gdk-sharp">
+      <HintPath>\usr\lib\cli\gdk-sharp-3.0\gdk-sharp.dll</HintPath>
     </Reference>
-    <Reference Include="glib-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <HintPath>\usr\lib\cli\glib-sharp-2.0\glib-sharp.dll</HintPath>
+    <Reference Include="glib-sharp">
+      <HintPath>\usr\lib\cli\glib-sharp-3.0\glib-sharp.dll</HintPath>
     </Reference>
-    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
-      <HintPath>\usr\lib\cli\gtk-sharp-2.0\gtk-sharp.dll</HintPath>
+    <Reference Include="gtk-sharp">
+      <HintPath>\usr\lib\cli\gtk-sharp-3.0\gtk-sharp.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Posix" />
   </ItemGroup>


### PR DESCRIPTION
This restores PortableClipboard operations for Bloom 5.0 and 5.1Beta.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1102)
<!-- Reviewable:end -->
