### PR TITLE
API: Add options to FLExibleMessageBox

### DIFF
--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -24,5 +24,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Saami/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SLDR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subitem/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=taskbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=versifications/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=xklavier/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/SIL.Windows.Forms/FlexibleMessageBox.cs
+++ b/SIL.Windows.Forms/FlexibleMessageBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -59,7 +59,7 @@ namespace SIL.Windows.Forms
 	 * History:
 	 *	Adapted for use in libpalaso
 	 *  - Added override to default handling of LinkClicked event
-	 *  - Made localizatin extenisible without altering code
+	 *  - Made localization extensible without altering code
 	 *	Version 1.3 - 19.Dezember 2014
 	 *  - Added refactoring function GetButtonText()
 	 *  - Used CurrentUICulture instead of InstalledUICulture
@@ -82,6 +82,17 @@ namespace SIL.Windows.Forms
 	 *	Version 1.0 - 15.April 2013
 	 *   - Initial Version
 	 */
+
+	/// <summary>
+	/// Options that can be selected for a single Showing
+	/// </summary>
+	[Flags]
+	public enum FlexibleMessageBoxOptions
+	{
+		None = 0,
+		AlwaysOnTop
+	}
+
 	public class FlexibleMessageBox
 	{
 		#region Public statics
@@ -105,7 +116,7 @@ namespace SIL.Windows.Forms
 		/// Defines the maximum height for all FlexibleMessageBox instances in percent of the working area.
 		///
 		/// Allowed values are 0.2 - 1.0 where:
-		/// 0.2 means:  The FlexibleMessageBox can be at most half as high as the working area.
+		/// 0.2 means:  The FlexibleMessageBox can be at most 20% of the height of the working area.
 		/// 1.0 means:  The FlexibleMessageBox can be as high as the working area.
 		///
 		/// Default is: 0.9 (90% of the working area height)
@@ -122,6 +133,11 @@ namespace SIL.Windows.Forms
 		/// Default is: SystemFonts.MessageBoxFont
 		/// </summary>
 		public static Font Font = SystemFonts.MessageBoxFont;
+
+		/// <summary>
+		/// Whether FlexibleMessageBoxes will be have its own entry in the taskbar
+		/// </summary>
+		public static bool ShowInTaskbar { get; set; }
 
 		/// <summary>
 		/// Callers that use a localization strategy other than L10NSharp can use this property to obtain a full
@@ -166,11 +182,6 @@ namespace SIL.Windows.Forms
 				Cursor.Current = Cursors.WaitCursor;
 				Process.Start(e.LinkText);
 			}
-			catch (Exception)
-			{
-				//Let the caller of FlexibleMessageBoxForm decide what to do with this exception...
-				throw;
-			}
 			finally
 			{
 				Cursor.Current = Cursors.Default;
@@ -185,10 +196,10 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(string text, LinkClickedEventHandler linkClickedAction = null)
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(string text, LinkClickedEventHandler linkClickedAction = null, FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(null, text, string.Empty, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(null, text, string.Empty, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
 		/// <summary>
 		/// Shows the specified message box.
@@ -198,11 +209,11 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(IWin32Window owner, string text, LinkClickedEventHandler linkClickedAction = null)
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(IWin32Window owner, string text, LinkClickedEventHandler linkClickedAction = null,
+			FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(owner, text, string.Empty, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(owner, text, string.Empty, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
 		/// <summary>
 		/// Shows the specified message box.
@@ -212,11 +223,11 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(string text, string caption, LinkClickedEventHandler linkClickedAction = null)
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(string text, string caption, LinkClickedEventHandler linkClickedAction = null,
+			FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(null, text, caption, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(null, text, caption, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
 		/// <summary>
 		/// Shows the specified message box.
@@ -227,11 +238,11 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(IWin32Window owner, string text, string caption, LinkClickedEventHandler linkClickedAction = null)
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(IWin32Window owner, string text, string caption, LinkClickedEventHandler linkClickedAction = null,
+			FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(owner, text, caption, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(owner, text, caption, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
 		/// <summary>
 		/// Shows the specified message box.
@@ -242,11 +253,11 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, LinkClickedEventHandler linkClickedAction = null)
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, LinkClickedEventHandler linkClickedAction = null,
+			FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(null, text, caption, buttons, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(null, text, caption, buttons, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
 		/// <summary>
 		/// Shows the specified message box.
@@ -258,11 +269,11 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, LinkClickedEventHandler linkClickedAction = null)
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons,
+			LinkClickedEventHandler linkClickedAction = null, FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, MessageBoxIcon.None, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
 		/// <summary>
 		/// Shows the specified message box.
@@ -274,48 +285,49 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
 		/// <returns></returns>
-		public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, LinkClickedEventHandler linkClickedAction = null)
-		{
-			return FlexibleMessageBoxForm.Show(null, text, caption, buttons, icon, MessageBoxDefaultButton.Button1, linkClickedAction);
-		}
-		/// <summary>
-		/// Shows the specified message box.
-		/// </summary>
-		/// <param name="owner">The owner.</param>
-		/// <param name="text">The text.</param>
-		/// <param name="caption">The caption.</param>
-		/// <param name="buttons">The buttons.</param>
-		/// <param name="icon">The icon.</param>
-		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
-		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
-		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
-		public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons,
-			MessageBoxIcon icon, LinkClickedEventHandler linkClickedAction = null)
-		{
-			return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, icon, MessageBoxDefaultButton.Button1, linkClickedAction);
-		}
-		/// <summary>
-		/// Shows the specified message box.
-		/// </summary>
-		/// <param name="text">The text.</param>
-		/// <param name="caption">The caption.</param>
-		/// <param name="buttons">The buttons.</param>
-		/// <param name="icon">The icon.</param>
-		/// <param name="defaultButton">The default button.</param>
-		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
-		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
-		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
 		public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon,
-			MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction = null)
+			LinkClickedEventHandler linkClickedAction = null, FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(null, text, caption, buttons, icon, defaultButton, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(null, text, caption, buttons, icon, MessageBoxDefaultButton.Button1, linkClickedAction, options);
 		}
+		/// <summary>
+		/// Shows the specified message box.
+		/// </summary>
+		/// <param name="owner">The owner.</param>
+		/// <param name="text">The text.</param>
+		/// <param name="caption">The caption.</param>
+		/// <param name="buttons">The buttons.</param>
+		/// <param name="icon">The icon.</param>
+		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
+		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
+		/// highlighted in the message.</param>
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons,
+			MessageBoxIcon icon, LinkClickedEventHandler linkClickedAction = null, FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
+		{
+			return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, icon, MessageBoxDefaultButton.Button1, linkClickedAction, options);
+		}
+		/// <summary>
+		/// Shows the specified message box.
+		/// </summary>
+		/// <param name="text">The text.</param>
+		/// <param name="caption">The caption.</param>
+		/// <param name="buttons">The buttons.</param>
+		/// <param name="icon">The icon.</param>
+		/// <param name="defaultButton">The default button.</param>
+		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
+		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
+		/// highlighted in the message.</param>
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
+		public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon,
+			MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction = null,
+			FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
+		{
+			return FlexibleMessageBoxForm.Show(null, text, caption, buttons, icon, defaultButton, linkClickedAction, options);
+		}
+
 		/// <summary>
 		/// Shows the specified message box.
 		/// </summary>
@@ -328,12 +340,12 @@ namespace SIL.Windows.Forms
 		/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 		/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 		/// highlighted in the message.</param>
-		/// <returns>The dialog result.</returns>
-		/// <returns>The dialog result.</returns>
+		/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
 		public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons,
-			MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction = null)
+			MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction = null,
+			FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 		{
-			return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, icon, defaultButton, linkClickedAction);
+			return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, icon, defaultButton, linkClickedAction, options);
 		}
 		#endregion
 		#region Internal form class
@@ -514,13 +526,14 @@ namespace SIL.Windows.Forms
 			/// Initializes a new instance of the <see cref="FlexibleMessageBoxForm"/> class.
 			/// </summary>
 			private FlexibleMessageBoxForm(IWin32Window owner, string text, string caption, MessageBoxButtons buttons,
-				MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction)
+				MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction,
+				FlexibleMessageBoxOptions options)
 			{
 				InitializeComponent();
 				KeyPreview = true;
 				KeyUp += FlexibleMessageBoxForm_KeyUp;
 
-				ShowInTaskbar = false;
+				ShowInTaskbar = FlexibleMessageBox.ShowInTaskbar;
 				// Bind the caption and the message text
 				CaptionText = caption;
 				MessageText = text;
@@ -546,6 +559,7 @@ namespace SIL.Windows.Forms
 				if (owner == null)
 					CenterDialogOnScreen(screen);
 
+				HandleOptions(options);
 			}
 			#endregion
 
@@ -751,7 +765,18 @@ namespace SIL.Windows.Forms
 						break;
 				}
 			}
-			#endregion
+
+			/// <summary>
+			/// Configures the dialog as specified by the options
+			/// </summary>
+			private void HandleOptions(FlexibleMessageBoxOptions options)
+			{
+				if ((options & FlexibleMessageBoxOptions.AlwaysOnTop) == FlexibleMessageBoxOptions.AlwaysOnTop)
+				{
+					TopMost = true;
+				}
+			}
+			#endregion Private helper functions
 
 			#region Private event handlers
 			/// <summary>
@@ -824,6 +849,7 @@ namespace SIL.Windows.Forms
 			#endregion
 
 			#region Show function
+
 			/// <summary>
 			/// Shows the specified message box.
 			/// </summary>
@@ -836,16 +862,18 @@ namespace SIL.Windows.Forms
 			/// <param name="linkClickedAction">optional handler if user clicks a hyperlink (as determined by RichTextBox). Set to
 			/// <seealso cref="BasicLinkClickedEventHandler"/> to get basic handling. If <c>null</c>, URLs will not be detected or
 			/// highlighted in the message.</param>
-			/// <returns>The dialog result.</returns>
-			/// <returns>The dialog result.</returns>
+			/// <param name="options">Optional options for displaying the message box (different from System.Windows.Forms.MessageBoxOptions)</param>
 			/// <exception cref="Exception">Exceptions might be thrown by the <paramref name="linkClickedAction"/></exception>
 			internal static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons,
-				MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction = null)
+				MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, LinkClickedEventHandler linkClickedAction = null,
+				FlexibleMessageBoxOptions options = FlexibleMessageBoxOptions.None)
 			{
 				// Create a new instance of the FlexibleMessageBox form
 				using (var flexibleMessageBoxForm = new FlexibleMessageBoxForm(owner, text, caption, buttons,
-					icon, defaultButton, linkClickedAction))
-					return flexibleMessageBoxForm.ShowDialog(owner);				
+					icon, defaultButton, linkClickedAction, options))
+				{
+					return flexibleMessageBoxForm.ShowDialog(owner);
+				}
 			}
 			#endregion
 		} //class FlexibleMessageBoxForm

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -253,8 +253,9 @@ and displays it as HTML.
 			switch (option)
 			{
 				case 0:
-					FlexibleMessageBox.Show(this, msg, handler);
-					break;
+					msg += "\nThis message box is always on top!";
+					FlexibleMessageBox.Show(this, msg, handler, FlexibleMessageBoxOptions.AlwaysOnTop);
+					return true;
 				case 1:
 					FlexibleMessageBox.Show(this, msg, caption, handler);
 					break;
@@ -278,7 +279,8 @@ and displays it as HTML.
 					msg += "\nClick Retry to display another version of the message box.";
 					return FlexibleMessageBox.Show(msg, caption, MessageBoxButtons.RetryCancel, handler) == DialogResult.Retry;
 				case 8:
-					FlexibleMessageBox.Show(msg, caption, MessageBoxButtons.OK, MessageBoxIcon.Stop, handler);
+					msg += "\nThis message box is always on top!";
+					FlexibleMessageBox.Show(msg, caption, MessageBoxButtons.OK, MessageBoxIcon.Stop, handler, FlexibleMessageBoxOptions.AlwaysOnTop);
 					break;
 				default:
 					msg += "\nWould you like to display another version of the message box?";


### PR DESCRIPTION
- Add a static property to determine whether FlexibleMessageBoxes
  are shown in the taskbar (default is still false)
- Add a parameter to allow forcing a specific FlexibleMessageBox
  to be on top of other windows even when it is not focused
  (This seems to extreme to make a global setting for all FMB's)

+semver: minor

(cherry picked from commit 9afd4505dab529128fb889b1764016e653621e56)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1110)
<!-- Reviewable:end -->
