### PR TITLE
Allow overriding WS root path

### DIFF
--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -147,7 +147,9 @@ namespace SIL.WritingSystems
 		///<summary>
 		/// The DefaultBasePath is %CommonApplicationData%\SIL\WritingSystemRepository
 		/// On Windows 7 this is \ProgramData\SIL\WritingSystemRepository\
-		/// On Linux this must be in ~/.local/share so that it may be edited
+		/// On Linux this must be in ~/.local/share so that it may be edited.
+		/// The root may be overridden by environment variable to help in flatpak where
+		/// LocalApplicationData is application-specific.
 		///</summary>
 		public static string DefaultBasePath
 		{
@@ -156,9 +158,9 @@ namespace SIL.WritingSystems
 				// This allows unit tests to set the _defaultBasePath (through reflection)
 				if (string.IsNullOrEmpty(_defaultBasePath))
 				{
-					string basePath = Platform.IsLinux
-						? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
-						: Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+					string basePath = Environment.GetEnvironmentVariable("WSR_ROOT_PATH") ??
+						(Platform.IsLinux ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) :
+						Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
 					_defaultBasePath = Path.Combine(basePath, "SIL", "WritingSystemRepository");
 				}
 


### PR DESCRIPTION
In flatpak,
`Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)`
returns an application-specific path, like
"/home/user/.var/app/my-app/data". Allow overriding the beginning of
the basepath to continue using "/home/user/.local/share/..." to share
writing systems among applications.

+semver:minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1111)
<!-- Reviewable:end -->
