### PR TITLE
Use more generic environment variable for WS root

### DIFF
--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -158,7 +158,7 @@ namespace SIL.WritingSystems
 				// This allows unit tests to set the _defaultBasePath (through reflection)
 				if (string.IsNullOrEmpty(_defaultBasePath))
 				{
-					string basePath = Environment.GetEnvironmentVariable("WSR_ROOT_PATH") ??
+					string basePath = Environment.GetEnvironmentVariable("USER_DATA_HOME") ??
 						(Platform.IsLinux ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) :
 						Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
 					_defaultBasePath = Path.Combine(basePath, "SIL", "WritingSystemRepository");


### PR DESCRIPTION
- `USER_DATA_HOME` is more generic for re-use in other parts of
libpalaso if found to be helpful.
- The name of `USER_DATA_HOME` is intended to mean that it's the
user's `XDG_DATA_HOME`. Normally there would not need to be any
distinction, but when running in flatpak, the XDG_DATA_HOME is
application-specific. In this situation, the USER_DATA_HOME could be
set (by the application using libpalaso) to the location of the user's
XDG_DATA_HOME that is external to the flatpak.

===
For further discussion, see PR #1111. 
This PR is probably really a "breaking change", but as long as no one else discovered and started implementing the WSR_ROOT_PATH from a week and a half ago, this is just a revision of the added feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1113)
<!-- Reviewable:end -->
