### PR TITLE
Use XDG_RUNTIME_DIR for GlobalMutex on Linux

### DIFF
--- a/SIL.Core/Threading/GlobalMutex.cs
+++ b/SIL.Core/Threading/GlobalMutex.cs
@@ -169,7 +169,13 @@ namespace SIL.Threading
 
 			public LinuxGlobalMutexAdapter(string name)
 			{
-				_name = Path.Combine("/var/lock", name);
+				// Note that XDG_RUNTIME_DIR is not system-wide but per-user.
+				string lockDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR") ?? "/var/lock";
+				string silCoreLockDir = $"{lockDir}/sil-lock";
+				if (!Directory.Exists(silCoreLockDir)) {
+					Directory.CreateDirectory(silCoreLockDir);
+				}
+				_name = Path.Combine(silCoreLockDir, name);
 			}
 
 			public bool Init(bool initiallyOwned)


### PR DESCRIPTION
- On Ubuntu, /var/lock exists and is +t, writable by users, and so
isn't a problem there. But /var/lock isn't user-writable on other
Linux systems, like Fedora and Clear Linux. But each of these set
XDG_RUNTIME_DIR, and the user can write there.
- XDG_RUNTIME_DIR isn't a _global_ location for lock files. So if it
is important for GlobalMutex to provide a multi-user, system-wide lock
file, we may need to consider using /dev/shm, /tmp, or /var/tmp.

===
Without this problem, FieldWorks (flatpak) launches and works on Fedora :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1114)
<!-- Reviewable:end -->
