### PR TITLE
Fixed code for positioning modal child window

### DIFF
--- a/SIL.Windows.Forms/ParentFormBase.cs
+++ b/SIL.Windows.Forms/ParentFormBase.cs
@@ -135,8 +135,8 @@ namespace SIL.Windows.Forms
 			if (childForm.StartPosition == FormStartPosition.CenterParent)
 			{
 				childForm.StartPosition = FormStartPosition.Manual;
-				childForm.Location = new Point(Math.Max(0, Location.X + (Width - childForm.Width) / 2),
-					Math.Max(0, Location.Y + (Height - childForm.Height) / 2));
+				childForm.Location = new Point(Math.Max(Location.X, Location.X + (Width - childForm.Width) / 2),
+					Math.Max(Location.Y, Location.Y + (Height - childForm.Height) / 2));
 			}
 			childForm.Show(this);
 			OnModalFormShown?.Invoke();


### PR DESCRIPTION
when parent is on screen whose coordinates are negative (wrt primary screen).
Note: Technically, this code should perhaps determine what screen the parent is on and then use that screen's upper left corner as the minimum location, but typically a child window will be smaller than the parent, so it will seldom matter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1116)
<!-- Reviewable:end -->
