### PR TITLE
Changed underlying implementation in SettingsProtectionHelper to use a HashSet…

### DIFF
--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace SIL.Windows.Forms.SettingProtection
 {
@@ -24,7 +24,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			if(!_isDisposed)
 			{
 				_isDisposed = true;
-				_controlIsUnderSettingsProtection.Clear();
+				_componentsUnderSettingsProtection.Clear();
 			}
 		}
 


### PR DESCRIPTION
…instead of a Dictionary to track managed controls. This is simpler and slightly more efficient. It does cause a very subtle change in an edge case, but the previous behavior was almost certainly unintended: previously a component that was added to the dictionary with a value of false (meaning that it was not supposed to be managed) would always be made explicitly visible every time UpdateDisplay was called. This meant that an application could not explicitly hide it (for some other reason) and keep it hidden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1118)
<!-- Reviewable:end -->
