### PR TITLE
Ensure components are made visible when no longer being managed by SettingsProtectionHelper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Options for `FlexibleMessageBox` to show in the taskbar and to show on top of other windows
 - [SIL.Windows.Forms.DblBundle] virtual method `SelectProjectDlgBase.CreateFileDialog()` to allow
   customization in derived class (#797)
+- [SIL.Windows.Forms.SettingProtection] overload of SetSettingsProtection method that takes a ToolStripItem
 
 ### Changed
 
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   get loaded dynamically at runtime
 - [SIL.Windows.Forms] `PortableClipboard` uses unmanaged libgtk/libgdk methods instead of using
   gtk-sharp
+- [SIL.Windows.Forms.SettingProtection] Deprecated ManageComponent method
 
 ### Fixed
 

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -89,6 +89,28 @@ namespace SIL.Windows.Forms.SettingProtection
 					"Only components which are Controls or ToolStripItems can be under settings protection.");
 		}
 
+		private void SetSettingsProtectionInternal(Component controlOrToolStripItem, bool isProtected)
+		{
+			if (controlOrToolStripItem == null)
+				throw new ArgumentNullException();
+
+			if (!(controlOrToolStripItem is ToolStripItem) && !(controlOrToolStripItem is Control))
+				throw new ArgumentException("Only components which are Controls or ToolStripItems can be managed.",
+					nameof(controlOrToolStripItem));
+
+			if (isProtected)
+			{
+				_componentsUnderSettingsProtection.Add(controlOrToolStripItem);
+				// No need to call ShowOrHideComponent explicitly. It will get called when the
+				// timer fires.
+			}
+			else
+			{
+				_componentsUnderSettingsProtection.Remove(controlOrToolStripItem);
+				ShowOrHideComponent(controlOrToolStripItem, true);
+			}
+		}
+
 		private void _checkForCtrlKeyTimer_Tick(object sender, EventArgs e)
 		{
 			UpdateDisplay();
@@ -106,19 +128,8 @@ namespace SIL.Windows.Forms.SettingProtection
 		}
 
 		[PublicAPI]
-		public void SetSettingsProtection(Control c, bool isProtected)
-		{
-			if (c == null)
-				throw new ArgumentNullException();
-
-			if (isProtected)
-				_componentsUnderSettingsProtection.Add(c);
-			else
-			{
-				_componentsUnderSettingsProtection.Remove(c);
-				ShowOrHideComponent(c, true);
-			}
-		}
+		public void SetSettingsProtection(Control c, bool isProtected) =>
+			SetSettingsProtectionInternal(c, isProtected);
 		#endregion
 
 		#region IComponent Members
@@ -147,7 +158,8 @@ namespace SIL.Windows.Forms.SettingProtection
 		#endregion
 
 		/// <summary>
-		/// Allows you to dynamically add a control or ToolStripItem, rather than having to use the winforms Designer
+		/// Deprecated: Allows you to dynamically add a control or ToolStripItem, rather than
+		/// having to use the winforms Designer
 		/// </summary>
 		/// <remarks>
 		/// Equivalent to calling SetSettingsProtection with isProtected true.
@@ -158,38 +170,17 @@ namespace SIL.Windows.Forms.SettingProtection
 		/// For another type of component to be supported, it would have to have a Visible property
 		/// (or some other property or method that could be used to hide or show it) and explicit
 		/// code would need to be added to allow for it.</exception>
-		[PublicAPI]
-		public void ManageComponent(Component controlOrToolStripItem)
-		{
-			if (controlOrToolStripItem is Control ctrl)
-				SetSettingsProtection(ctrl, true);
-			else if (controlOrToolStripItem is ToolStripItem item)
-				SetSettingsProtection(item, true);
-			else if (controlOrToolStripItem == null)
-				throw new ArgumentNullException(nameof(controlOrToolStripItem));
-			else
-				throw new ArgumentException("Only components which are Controls or ToolStripItems can be managed.",
-					nameof(controlOrToolStripItem));
-		}
+		[PublicAPI, Obsolete("Use SetSettingsProtection instead")]
+		public void ManageComponent(Component controlOrToolStripItem) =>
+			SetSettingsProtectionInternal(controlOrToolStripItem, true);
 
 		/// <summary>
 		/// Allows you to dynamically make a ToolStripItem protected (i.e., managed) or not,
 		/// rather than having to use the winforms Designer
 		/// </summary>
-		/// <exception cref="ArgumentNullException">controlOrToolStripItem was null</exception>
+		/// <exception cref="ArgumentNullException">toolStripItem was null</exception>
 		[PublicAPI]
-		public void SetSettingsProtection(ToolStripItem c, bool isProtected)
-		{
-			if (c == null)
-				throw new ArgumentNullException();
-
-			if (isProtected)
-				_componentsUnderSettingsProtection.Add(c);
-			else
-			{
-				_componentsUnderSettingsProtection.Remove(c);
-				ShowOrHideComponent(c, true);
-			}
-		}
+		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected) =>
+			SetSettingsProtectionInternal(toolStripItem, isProtected);
 	}
 }

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -74,14 +74,19 @@ namespace SIL.Windows.Forms.SettingProtection
 			{
 				bool visible = !SettingsProtectionSingleton.Settings.NormallyHidden || ((Control.ModifierKeys & keys) == keys);
 
-				if (component is Control control)
-					control.Visible = visible;
-				else if (component is ToolStripItem item)
-					item.Visible = visible;
-				else
-					throw new InvalidCastException(
-						"Only components which are Controls or ToolStripItems can be under settings protection.");
+				ShowOrHideComponent(component, visible);
 			}
+		}
+
+		private static void ShowOrHideComponent(Component component, bool visible)
+		{
+			if (component is Control control)
+				control.Visible = visible;
+			else if (component is ToolStripItem item)
+				item.Visible = visible;
+			else
+				throw new InvalidCastException(
+					"Only components which are Controls or ToolStripItems can be under settings protection.");
 		}
 
 		private void _checkForCtrlKeyTimer_Tick(object sender, EventArgs e)
@@ -109,7 +114,10 @@ namespace SIL.Windows.Forms.SettingProtection
 			if (isProtected)
 				_componentsUnderSettingsProtection.Add(c);
 			else
+			{
 				_componentsUnderSettingsProtection.Remove(c);
+				ShowOrHideComponent(c, true);
+			}
 		}
 		#endregion
 
@@ -178,7 +186,10 @@ namespace SIL.Windows.Forms.SettingProtection
 			if (isProtected)
 				_componentsUnderSettingsProtection.Add(c);
 			else
+			{
 				_componentsUnderSettingsProtection.Remove(c);
+				ShowOrHideComponent(c, true);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Note: this code was supposed to be part of previous merge, but was inadvertently omitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1119)
<!-- Reviewable:end -->
