### PR TITLE
Add path information to exceptions thrown by TempFile.InfolderOf

### DIFF
--- a/SIL.Core/IO/TempFile.cs
+++ b/SIL.Core/IO/TempFile.cs
@@ -202,11 +202,18 @@ namespace SIL.IO
 		/// <param name="inputPath">path to an (existing) file</param>
 		public static TempFile InFolderOf(string inputPath)
 		{
-			var folder = System.IO.Path.GetDirectoryName(inputPath);
-			if (String.IsNullOrEmpty(folder))
-				folder = ".";
-			var path = System.IO.Path.Combine(folder, System.IO.Path.GetRandomFileName());
-			return TrackExisting(path);
+			try
+			{
+				var folder = System.IO.Path.GetDirectoryName(inputPath);
+				if (String.IsNullOrEmpty(folder))
+					folder = ".";
+				var path = System.IO.Path.Combine(folder, System.IO.Path.GetRandomFileName());
+				return TrackExisting(path);
+			}
+			catch (Exception e)
+			{
+				throw new Exception($"TempFile.InFolderOf(\"{inputPath}\") failed", e);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This would have made BL-10784 easier to diagnose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1124)
<!-- Reviewable:end -->
