### PR TITLE
LT-19174: Fix Linux crash when archiving to RAMP

### DIFF
--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -1837,6 +1837,15 @@ namespace SIL.Archiving
 					dir = Path.Combine(dir, "share");
 			}
 
+			if (!Platform.IsWindows)
+			{
+				//Ramp 3.0 Package doesn't have languages.yaml
+				if (!Directory.Exists(Path.Combine(dir, "data")))
+				{
+					return string.Empty;
+				}
+			}
+
 			// get the data directory
 			dir = Path.Combine(dir, "data");
 			if (!Directory.Exists(dir))


### PR DESCRIPTION
RAMP 3.0 does not contain a languages.yaml file. For Windows there
is existing code that returns an empty string. Added the same check
to return an empty string on Linux.
Note: The Windows fix for the same issue was added in Commit ef527269

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1125)
<!-- Reviewable:end -->
