### PR TITLE
keyboarding thru flatpak

### DIFF
--- a/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
+++ b/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
@@ -199,8 +199,9 @@ namespace SIL.Tests.PlatformUtilities
 			ExpectedResult = "gnome (ubuntu [display server: Wayland])", TestName = "Ubuntu 20.04 (Gnome + Wayland)")]
 		[TestCase("X-Cinnamon", null, "cinnamon", "", ExpectedResult = "x-cinnamon (cinnamon)", TestName = "Wasta 20 (Cinnamon)")]
 		[TestCase("ubuntu:GNOME", null, "ubuntu", "", ExpectedResult = "gnome (ubuntu)", TestName = "Wasta 20 (Gnome)")]
+		[TestCase("ubuntu:GNOME", "/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share", "ubuntu", null, "org.example.MyApp", ExpectedResult = "gnome (ubuntu [container: flatpak])", TestName = "Ubuntu 20.04 (Gnome) in Flatpak")]
 		public string DesktopEnvironmentInfoString_SimulateDesktopEnvironments(string currDesktop,
-			string dataDirs, string gdmSession, string mirServerName)
+			string dataDirs, string gdmSession, string mirServerName, string flatpakId = null)
 		{
 			// See http://askubuntu.com/a/227669 for actual values on different systems
 
@@ -209,6 +210,7 @@ namespace SIL.Tests.PlatformUtilities
 			Environment.SetEnvironmentVariable("XDG_DATA_DIRS", dataDirs);
 			Environment.SetEnvironmentVariable("GDMSESSION", gdmSession);
 			Environment.SetEnvironmentVariable("MIR_SERVER_NAME", mirServerName);
+			Environment.SetEnvironmentVariable("FLATPAK_ID", flatpakId);
 
 			// SUT
 			return Platform.DesktopEnvironmentInfoString;
@@ -252,6 +254,21 @@ namespace SIL.Tests.PlatformUtilities
 		{
 			Assert.That(Platform.IsCinnamon, Is.False);
 		}
+
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		// In flatpak
+		[TestCase("org.example.MyApp", ExpectedResult = true)]
+		// Not in flatpak
+		[TestCase(null, ExpectedResult = false)]
+		public bool IsFlatpak(string flatpakId)
+		{
+			// Setup
+			Environment.SetEnvironmentVariable("FLATPAK_ID", flatpakId);
+
+			// SUT
+			return Platform.IsFlatpak;
+		}
+
 	}
 }
 

--- a/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
+++ b/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2014 SIL International
+// Copyright (c) 2014 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -153,10 +153,24 @@ namespace SIL.Tests.PlatformUtilities
 			Result = "kde", TestName = "Only XDG_DATA_DIRS set")]
 		[TestCase(null, null, "something", Result = "something", TestName = "Only GDMSESSION set")]
 		[TestCase(null, null, null, Result = "", TestName = "Nothing set")]
-		[TestCase("ubuntu:GNOME", null, "ubuntu", ExpectedResult = "gnome", TestName = "Ubuntu 20.04 (Gnome)")]
-		[TestCase("ubuntu:GNOME", null, "ubuntu-wayland", ExpectedResult = "gnome", TestName = "Ubuntu 20.04 (Gnome + Wayland)")]
-		[TestCase("X-Cinnamon", null, "cinnamon", ExpectedResult = "x-cinnamon", TestName = "Wasta 20 (Cinnamon)")]
-		[TestCase("ubuntu:GNOME", null, "ubuntu", ExpectedResult = "gnome", TestName = "Wasta 20 (Gnome)")]
+		[TestCase("X-Cinnamon",
+			"/usr/share/gnome:/usr/share/cinnamon:/home/user/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share",
+			"cinnamon", Result = "x-cinnamon",
+			TestName = "Wasta 18.04")]
+		[TestCase("ubuntu:GNOME",
+			"/usr/share/ubuntu:/home/vagrant/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop",
+			"ubuntu", ExpectedResult = "gnome", TestName = "Ubuntu 20.04 (Gnome Shell)")]
+		[TestCase("GNOME-Classic:GNOME",
+			"/usr/share/gnome-classic:/home/vagrant/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop",
+			"gnome-classic", ExpectedResult = "gnome", TestName = "Ubuntu 20.04 (Gnome Classic)")]
+		[TestCase("GNOME-Flashback:GNOME",
+			"/usr/share/gnome-flashback-metacity:/home/vagrant/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop",
+			"gnome-flashback-metacity", ExpectedResult = "gnome", TestName = "Ubuntu 20.04 (Gnome Flashback)")]
+		[TestCase("ubuntu:GNOME", null, "ubuntu-wayland", ExpectedResult = "gnome",
+			TestName = "Ubuntu 20.04 (Gnome + Wayland)")]
+		[TestCase("X-Cinnamon", null, "cinnamon", ExpectedResult = "x-cinnamon",
+			TestName = "Wasta 20 (Cinnamon)")]
+		[TestCase("ubuntu:GNOME", null, "ubuntu", ExpectedResult = "gnome", TestName = "Wasta 20 (Gnome Shell)")]
 		public string DesktopEnvironment_SimulateDesktops(string currDesktop,
 			string dataDirs, string gdmSession)
 		{
@@ -199,7 +213,10 @@ namespace SIL.Tests.PlatformUtilities
 			ExpectedResult = "gnome (ubuntu [display server: Wayland])", TestName = "Ubuntu 20.04 (Gnome + Wayland)")]
 		[TestCase("X-Cinnamon", null, "cinnamon", "", ExpectedResult = "x-cinnamon (cinnamon)", TestName = "Wasta 20 (Cinnamon)")]
 		[TestCase("ubuntu:GNOME", null, "ubuntu", "", ExpectedResult = "gnome (ubuntu)", TestName = "Wasta 20 (Gnome)")]
-		[TestCase("ubuntu:GNOME", "/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share", "ubuntu", null, "org.example.MyApp", ExpectedResult = "gnome (ubuntu [container: flatpak])", TestName = "Ubuntu 20.04 (Gnome) in Flatpak")]
+		[TestCase("ubuntu:GNOME",
+			"/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share",
+			"ubuntu", null, "org.example.MyApp", ExpectedResult = "gnome (ubuntu [container: flatpak])",
+			TestName = "Ubuntu 20.04 (Gnome) in Flatpak")]
 		public string DesktopEnvironmentInfoString_SimulateDesktopEnvironments(string currDesktop,
 			string dataDirs, string gdmSession, string mirServerName, string flatpakId = null)
 		{
@@ -267,6 +284,49 @@ namespace SIL.Tests.PlatformUtilities
 
 			// SUT
 			return Platform.IsFlatpak;
+		}
+
+
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		// Ubuntu 20.04 Gnome Shell
+		[TestCase("ubuntu:GNOME", ExpectedResult = true)]
+		// Ubuntu 20.04 Gnome Classic
+		[TestCase("GNOME-Classic:GNOME", ExpectedResult = true)]
+		// Ubuntu 20.04 Gnome Flashback
+		[TestCase("GNOME-Flashback:GNOME", ExpectedResult = false)]
+		public bool IsGnomeShell(string xdgCurrentDesktop)
+		{
+			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", xdgCurrentDesktop);
+			// SUT
+			return Platform.IsGnomeShell;
+		}
+
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		// Ubuntu 20.04 Gnome Shell
+		[TestCase("ubuntu:GNOME", ExpectedResult = false)]
+		// Ubuntu 20.04 Gnome Classic
+		[TestCase("GNOME-Classic:GNOME", ExpectedResult = true)]
+		// Ubuntu 20.04 Gnome Flashback
+		[TestCase("GNOME-Flashback:GNOME", ExpectedResult = false)]
+		public bool IsGnomeClassic(string xdgCurrentDesktop)
+		{
+			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", xdgCurrentDesktop);
+			// SUT
+			return Platform.IsGnomeClassic;
+		}
+
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		// Ubuntu 20.04 Gnome Shell
+		[TestCase("ubuntu:GNOME", ExpectedResult = false)]
+		// Ubuntu 20.04 Gnome Classic
+		[TestCase("GNOME-Classic:GNOME", ExpectedResult = false)]
+		// Ubuntu 20.04 Gnome Flashback
+		[TestCase("GNOME-Flashback:GNOME", ExpectedResult = true)]
+		public bool IsGnomeFlashback(string xdgCurrentDesktop)
+		{
+			Environment.SetEnvironmentVariable("XDG_CURRENT_DESKTOP", xdgCurrentDesktop);
+			// SUT
+			return Platform.IsGnomeFlashback;
 		}
 
 	}

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -149,6 +149,11 @@ namespace SIL.PlatformUtilities
 				if (gdmSession.ToLowerInvariant().EndsWith("-wayland"))
 					return $"{currentDesktop} ({gdmSession.Split('-')[0]} [display server: Wayland])";
 
+				if (Platform.IsFlatpak)
+				{
+					additionalInfo += " [container: flatpak]";
+				}
+
 				return $"{currentDesktop} ({gdmSession}{additionalInfo})";
 			}
 		}
@@ -338,6 +343,15 @@ namespace SIL.PlatformUtilities
 
 				var pids = RunTerminalCommand("pidof", "gnome-shell");
 				return !string.IsNullOrEmpty(pids);
+
+		/// <summary>
+		/// Is the software running in a flatpak container?
+		/// </summary>
+		public static bool IsFlatpak
+		{
+			get
+			{
+				return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FLATPAK_ID"));
 			}
 		}
 	}

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -123,6 +123,14 @@ namespace SIL.PlatformUtilities
 					currentDesktop = Environment.GetEnvironmentVariable("GDMSESSION");
 				else if (currentDesktop.ToLowerInvariant() == "ubuntu:gnome")
 					currentDesktop = "gnome";
+				else if (currentDesktop.ToLowerInvariant() == "gnome-classic:gnome")
+				{
+					currentDesktop = "gnome";
+				}
+				else if (currentDesktop.ToLowerInvariant() == "gnome-flashback:gnome")
+				{
+					currentDesktop = "gnome";
+				}
 				return currentDesktop?.ToLowerInvariant();
 			}
 		}
@@ -333,16 +341,57 @@ namespace SIL.PlatformUtilities
 			return output.Trim();
 		}
 
-
+		/// <summary>
+		/// Is the software running in the GNOME Shell desktop environment?
+		/// This property will also be true if the software is running in the
+		/// GNOME Classic desktop environment.
+		/// </summary>
+		/// <remarks>
+		/// Although GNOME Classic distinguishes itself from GNOME Shell, such as
+		/// with different environment variables, both appear to use the gnome-shell
+		/// binary, and both work with the Gnome Shell parts of
+		/// SIL.Windows.Forms.Keyboarding. GNOME Classic may primarily be a different
+		/// set of extensions being used in GNOME Shell to provide a different
+		/// desktop UI and certain behaviour (like application switching).
+		/// </remarks>
 		public static bool IsGnomeShell
 		{
 			get
 			{
 				if (!IsLinux)
 					return false;
+				if (Platform.DesktopEnvironment == "gnome" && !IsGnomeFlashback)
+				{
+					return true;
+				}
+				return false;
+			}
+		}
 
-				var pids = RunTerminalCommand("pidof", "gnome-shell");
-				return !string.IsNullOrEmpty(pids);
+		/// <summary>
+		/// Is the software running in the GNOME Classic desktop environment?
+		/// (Not meaning it's not running "in GNOME Shell", but is there evidence
+		/// that specifically GNOME Classic is being used?)
+		/// </summary>
+		public static bool IsGnomeClassic
+		{
+			get
+			{
+				return Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP") == "GNOME-Classic:GNOME";
+			}
+		}
+
+
+		/// <summary>
+		/// Is the software running in the GNOME Flashback desktop environment?
+		/// </summary>
+		public static bool IsGnomeFlashback
+		{
+			get
+			{
+				return Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP") == "GNOME-Flashback:GNOME";
+			}
+		}
 
 		/// <summary>
 		/// Is the software running in a flatpak container?

--- a/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
@@ -48,5 +48,30 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 			}));
 		}
 
+		[TestCase("(<<[('xkb', 'us'), " +
+			"('xkb', 'ru'), " +
+			"('ibus', 'und-Latn:/home/USER/.local/share/keyman/sil_ipa/sil_ipa.kmx'), " +
+			"('ibus', 'table:thai')]>>,)\n",
+			new string[] {
+				"xkb;;us",
+				"xkb;;ru",
+				"ibus;;und-Latn:/home/USER/.local/share/keyman/sil_ipa/sil_ipa.kmx",
+				"ibus;;table:thai"
+			},
+			TestName = "Parses mixed list of xkb, keyman, and ibus keyboards")]
+		[TestCase("(<<[('xkb', 'us')]>>,)\n",
+			new string[] {"xkb;;us"}, TestName = "Parses list of one item")]
+		// Gnome doesn't let you delete the last remaining keyboard in the list. But gracefully fail in case we
+		// get an unexpected list with nothing.
+		[TestCase("(<<[]>>,)\n", new string[] {})]
+		[TestCase("(<<>>,)\n", new string[] {})]
+		[TestCase("(,)\n", new string[] {})]
+		[TestCase("()\n", new string[] {})]
+		[TestCase("\n", new string[] {})]
+		[TestCase("", new string[] {})]
+		public void ParseGDBusKeyboardList(string keyboardList, string[] expected)
+		{
+			Assert.That(UnityKeyboardRetrievingHelper.ParseGDBusKeyboardList(keyboardList), Is.EqualTo(new List<string>(expected)));
+		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.IO;
 using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -71,7 +73,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		private static void LoadDefaultXkbSettings()
 		{
 			var startInfo = new ProcessStartInfo();
-			startInfo.FileName = "/usr/bin/setxkbmap";
+			startInfo.FileName = CombinedIbusKeyboardSwitchingAdaptor.SetxkbmapPath;
 			startInfo.Arguments = "-query";
 			startInfo.RedirectStandardOutput = true;
 			startInfo.UseShellExecute = false;

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.IO;
 using System.Text;
 using SIL.Extensions;
 
@@ -35,6 +36,24 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		}
 
 		/// <summary>
+		/// Absolute path to setxkbmap command.
+		/// </summary>
+		internal static string SetxkbmapPath
+		{
+			get
+			{
+				// Use command from flatpak /app prefix if present.
+				string prefix = "/app";
+				string restOfCommandPath = "bin/setxkbmap";
+				if (!File.Exists(Path.Combine(prefix, restOfCommandPath)))
+				{
+					prefix = "/usr";
+				}
+				return Path.Combine(prefix, restOfCommandPath);
+			}
+		}
+
+		/// <summary>
 		/// Set the XKB layout to use henceforward using the setxkbmap program.
 		/// </summary>
 		/// <remarks>
@@ -43,7 +62,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		private static void SetXkbLayout(string layout, string variant, string option)
 		{
 			var startInfo = new ProcessStartInfo();
-			startInfo.FileName = "/usr/bin/setxkbmap";
+			startInfo.FileName = SetxkbmapPath;
 			var bldr = new StringBuilder();
 			bldr.AppendFormat ("-layout {0}", layout);
 			if (!String.IsNullOrEmpty(variant))


### PR DESCRIPTION
===
Along with a needed ibusdotnet change, this should make keyboarding work in flatpak when the host is running Gnome on Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1127)
<!-- Reviewable:end -->
