### PR TITLE
improve logging, platform check

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,11 +16,24 @@
 			"console": "integratedTerminal"
 		},
 		{
+			// Attaches to a program listening for a debugger, such as from running:
+			// mono --debug --debugger-agent="address=localhost:55555,transport=dt_socket,server=y,suspend=n" foo/App.exe
 			"name": "Attach",
 			"type": "mono",
 			"request": "attach",
 			"address": "localhost",
 			"port": 55555
-		}
+		},
+		{
+			"name": "Launch TestAppKeyboard.exe",
+			"env": {
+			  // Use this mono.
+			  // "PATH": "/opt/mono5-sil/bin:${env:PATH}",
+			},
+			"type": "mono",
+			"request": "launch",
+			"program": "${workspaceRoot}/output/DebugMonoStrongName/TestAppKeyboard.exe",
+			"cwd": "${workspaceRoot}",
+		  },
 	]
 }

--- a/SIL.Core.Desktop/Reporting/Logger.cs
+++ b/SIL.Core.Desktop/Reporting/Logger.cs
@@ -394,6 +394,10 @@ namespace SIL.Reporting
 		/// ------------------------------------------------------------------------------------
 		public static void WriteEvent(string message, params object[] args)
 		{
+			if (Environment.GetEnvironmentVariable("SIL_REPORTING_LOGGING") == "foreground")
+			{
+				Console.WriteLine(FormatMessage(message, args));
+			}
 			if (Singleton != null)
 				Singleton.WriteEventCore(message,args);
 		}

--- a/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
+++ b/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
@@ -286,7 +286,6 @@ namespace SIL.Tests.PlatformUtilities
 			return Platform.IsFlatpak;
 		}
 
-
 		[Platform(Include = "Linux", Reason = "Linux specific test")]
 		// Ubuntu 20.04 Gnome Shell
 		[TestCase("ubuntu:GNOME", ExpectedResult = true)]
@@ -329,6 +328,17 @@ namespace SIL.Tests.PlatformUtilities
 			return Platform.IsGnomeFlashback;
 		}
 
+		[Platform(Include = "Linux", Reason = "Linux specific test")]
+		[TestCase("org.example.MyApp", ExpectedResult = true, TestName = "In flatpak")]
+		[TestCase(null, ExpectedResult = false, TestName = "Not in flatpak")]
+		public bool UnixOrMacVersion_ReportsIfFlatpak(string flatpakIdEnv)
+		{
+			Environment.SetEnvironmentVariable("FLATPAK_ID", flatpakIdEnv);
+			// SUT
+			string result = Platform.UnixOrMacVersion();
+
+			return result.Contains("Flatpak");
+		}
 	}
 }
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 SIL International
+// Copyright (c) 2015 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.IO;
+using SIL.Reporting;
 using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -224,6 +225,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 					{
 						keyboard.SetIsAvailable(true);
 						keyboard.IBusKeyboardEngine = ibusKeyboard;
+						Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Set keyboard as available: {keyboard}");
 					}
 					curKeyboards.Remove(id);
 				}
@@ -231,6 +233,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				{
 					keyboard = new IbusKeyboardDescription(id, ibusKeyboard, SwitchingAdaptor);
 					KeyboardController.Instance.Keyboards.Add(keyboard);
+					Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Registered keyboard: {keyboard}");
 				}
 				keyboard.SystemIndex = keyboards[ibusKeyboard.LongName];
 			}

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using IBusDotNet;
+using SIL.Reporting;
 using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -114,6 +115,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 					{
 						keyboard.SetIsAvailable(true);
 						keyboard.IBusKeyboardEngine = ibusKeyboard;
+						Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Set keyboard as available: {keyboard}");
 					}
 
 					// Remove this keyboard from list so that we don't set it inactive
@@ -126,6 +128,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 						SwitchingAdaptor) as IbusKeyboardDescription;
 					KeyboardController.Instance.Keyboards.Add(keyboard);
 					addedKeyboards.Add(layout);
+					Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Registered keyboard: {keyboard}");
 				}
 
 				keyboard.SystemIndex = installedKeyboards[layout];

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SIL.Reporting;
 using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -66,6 +67,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 						{
 							keyboard.SetIsAvailable(true);
 							keyboard.IBusKeyboardEngine = ibusKeyboard;
+							Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Set keyboard as available: {keyboard}");
 						}
 						curKeyboards.Remove(id);
 					}
@@ -73,6 +75,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 					{
 						keyboard = new IbusKeyboardDescription(id, ibusKeyboard, SwitchingAdaptor);
 						KeyboardController.Instance.Keyboards.Add(keyboard);
+						Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Registered keyboard: {keyboard}");
 					}
 					keyboard.SystemIndex = keyboards[ibusKeyboard.LongName];
 				}

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -100,6 +100,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 					existingKeyboard.SetName(description);
 					existingKeyboard.SetInputLanguage(inputLanguage);
 					existingKeyboard.GroupIndex = (int) iGroup;
+					Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Set keyboard as available: {existingKeyboard}");
 				}
 				curKeyboards.Remove(id);
 			}
@@ -108,7 +109,10 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				var keyboard = new XkbKeyboardDescription(id, description, layout.LayoutId, layout.LocaleId, true,
 					inputLanguage, engine, (int) iGroup);
 				if (!KeyboardController.Instance.Keyboards.Contains(keyboard.Id))
+				{
 					KeyboardController.Instance.Keyboards.Add(keyboard);
+					Logger.WriteEvent($"{System.Reflection.MethodBase.GetCurrentMethod().DeclaringType.Name}: Registered keyboard {keyboard}");
+				}
 			}
 		}
 

--- a/TestApps/TestAppKeyboard/Program.cs
+++ b/TestApps/TestAppKeyboard/Program.cs
@@ -1,5 +1,6 @@
 ﻿﻿using System;
 using System.Windows.Forms;
+using SIL.Reporting;
 
 namespace TestAppKeyboard
 {
@@ -11,6 +12,7 @@ namespace TestAppKeyboard
 		[STAThread]
 		static void Main()
 		{
+			Logger.Init();
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
 			Application.Run(new KeyboardForm());

--- a/TestApps/TestAppKeyboard/TestAppKeyboard.csproj
+++ b/TestApps/TestAppKeyboard/TestAppKeyboard.csproj
@@ -345,6 +345,9 @@
       <Project>{f7df58e2-5b67-498a-9f64-b5f1584a5ab9}</Project>
       <Name>SIL.Windows.Forms.WritingSystems</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\SIL.Core.Desktop\SIL.Core.Desktop.csproj">
+      <Name>SIL.Core.Desktop</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">


### PR DESCRIPTION
===
These changes are not central to the fixes for flatpak keyboarding and so I put them in a separate PR. 

Notably, this allows you to show libpalaso logs instead of tuck them away at `/tmp/SIL/My\ App\ Name/foo.txt`. This is even more helpful when the app is running in a container where you need to do extra steps to see that part of the filesystem while the application is running.

A check in Platform was improved for flatpak.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1128)
<!-- Reviewable:end -->
