### PR TITLE
+semver:major Upgraded to version 5.0.0-beta0059 of `L10NSharp.dll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.SettingProtection] Deprecated ManageComponent method
 - [SIL.Scripture] VerseRef.TrySetVerseUnicode: Improve handling of non-decimal numerals and surrogate pair numerals (#1000)
 - [SIL.Windows.Forms.WritingSystems] Ignore deprecated region subtags in `ScriptRegionVariantView`(#763)
+- [SIL.Windows.Forms.DblBundle] Upgraded to version 5.0 (beta) of `L10NSharp.dll`
+- [SIL.Windows.Forms.Keyboarding] Upgraded to version 5.0 (beta) of `L10NSharp.dll`
+- [SIL.Windows.Forms.WritingSystems] Upgraded to version 5.0 (beta) of `L10NSharp.dll`
+- [SIL.Windows.Forms] Upgraded to version 5.0 (beta) of `L10NSharp.dll`
+
 
 ### Fixed
 

--- a/SIL.Archiving/SIL.Archiving.csproj
+++ b/SIL.Archiving/SIL.Archiving.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.13.7" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
-    <PackageReference Include="L10NSharp" Version="4.2.0-*" />
+    <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
   </ItemGroup>

--- a/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
+++ b/SIL.Windows.Forms.DblBundle/SIL.Windows.Forms.DblBundle.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
-    <PackageReference Include="L10NSharp" Version="4.2.0-*" />
+    <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
   </ItemGroup>

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
     <PackageReference Include="ibusdotnet" Version="2.0.3" />
     <PackageReference Include="icu.net" Version="2.7.1" />
-    <PackageReference Include="L10NSharp" Version="4.2.0-*" />
+    <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />

--- a/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems.csproj
+++ b/SIL.Windows.Forms.WritingSystems/SIL.Windows.Forms.WritingSystems.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
-    <PackageReference Include="L10NSharp" Version="4.2.0-*" />
+    <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
     <PackageReference Include="System.Globalization" Version="4.3.0" />

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="DialogAdapters.Gtk2" Version="0.1.9" />
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="L10NSharp" Version="4.2.0-*" />
+    <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
     <PackageReference Include="Markdig.Signed" Version="0.22.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="TagLibSharp" Version="2.2.0" />

--- a/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
+++ b/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Geckofx45.64.Linux" Version="45.0.37" Condition="'$(OS)'=='Unix' And '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)'=='X64'" GeneratePathProperty="true" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
     <PackageReference Include="Icu4c.Win.Min" Version="56.1.82" />
-    <PackageReference Include="L10NSharp" Version="4.2.0-*" />
+    <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Although nothing in libpalaso uses the new (breaking change) version of StringsLocalized, I can't seem to find a way to make the Designer happy in other apps that refer to the new version of L10nSharp but also reference controls in libpalaso that reference the older version. (This is not a runtime problem - just a Design-time issue.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1130)
<!-- Reviewable:end -->
