### PR TITLE
Allow CloneableTests to test classes' IValueEquatable fields

### DIFF
--- a/SIL.TestUtilities.Tests/ValueEquatableComparerTests.cs
+++ b/SIL.TestUtilities.Tests/ValueEquatableComparerTests.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using SIL.WritingSystems;
+
+namespace SIL.TestUtilities.Tests
+{
+	[TestFixture]
+	public class ValueEquatableComparerTests
+	{
+		[TestCase(1, 1, TestName = "integers equal")]
+		[TestCase(1.0, 1.0)]
+		[TestCase("test", "test")]
+		[TestCase(null, null)]
+		[TestCase(new [] { 1, 2, 3 }, new[] { 1, 2, 3 })]
+		public void Compare_Equal(object x, object y) => Assert.That(x, Is.EqualTo(y).Using(ValueEquatableComparer.Instance));
+
+		[TestCase(1, 2)]
+		[TestCase(1, 1.1)]
+		[TestCase(1, 1.0, TestName = "same value, different types")] // ENHANCE (Hasso) 2022.02: handle this case
+		[TestCase(null, true)]
+		[TestCase("to", null)]
+		public void Compare_Unequal(object x, object y) => Assert.That(x, Is.Not.EqualTo(y).Using(ValueEquatableComparer.Instance));
+
+		[Test]
+		public void Compare_IValueEquatable()
+		{
+			Assert.That(new CharacterSetDefinition("type"), Is.EqualTo(new CharacterSetDefinition("type")).Using(ValueEquatableComparer.Instance));
+			Assert.That(new CharacterSetDefinition("type"), Is.Not.EqualTo(new CharacterSetDefinition("!")).Using(ValueEquatableComparer.Instance));
+			Assert.That(new CharacterSetDefinition("type"), Is.Not.EqualTo(null).Using(ValueEquatableComparer.Instance));
+			Assert.That(null!, Is.Not.EqualTo(new CharacterSetDefinition("type")).Using(ValueEquatableComparer.Instance));
+
+			Sldr.Initialize(true);
+			Assert.That(new WritingSystemDefinition("th"), Is.EqualTo(new WritingSystemDefinition("th")).Using(ValueEquatableComparer.Instance));
+			Assert.That(new WritingSystemDefinition("th"), Is.Not.EqualTo(new WritingSystemDefinition("en")).Using(ValueEquatableComparer.Instance));
+
+			Assert.That(new WritingSystemDefinition("th"), Is.Not.EqualTo(new CharacterSetDefinition("th")).Using(ValueEquatableComparer.Instance));
+		}
+	}
+}

--- a/SIL.TestUtilities.Tests/ValueEquatableComparerTests.cs
+++ b/SIL.TestUtilities.Tests/ValueEquatableComparerTests.cs
@@ -8,6 +8,7 @@ namespace SIL.TestUtilities.Tests
 	{
 		[TestCase(1, 1, TestName = "integers equal")]
 		[TestCase(1.0, 1.0)]
+		[TestCase(1, 1.0, TestName = "same value, different types")]
 		[TestCase("test", "test")]
 		[TestCase(null, null)]
 		[TestCase(new [] { 1, 2, 3 }, new[] { 1, 2, 3 })]
@@ -15,7 +16,6 @@ namespace SIL.TestUtilities.Tests
 
 		[TestCase(1, 2)]
 		[TestCase(1, 1.1)]
-		[TestCase(1, 1.0, TestName = "same value, different types")] // ENHANCE (Hasso) 2022.02: handle this case
 		[TestCase(null, true)]
 		[TestCase("to", null)]
 		public void Compare_Unequal(object x, object y) => Assert.That(x, Is.Not.EqualTo(y).Using(ValueEquatableComparer.Instance));

--- a/SIL.TestUtilities/ValueEquatableComparer.cs
+++ b/SIL.TestUtilities/ValueEquatableComparer.cs
@@ -1,12 +1,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using NUnit.Framework;
 
 namespace SIL.TestUtilities
 {
 	/// <summary>
 	/// Comparer for two objects that might implement the IValueEquatable&lt;T&gt; interface.
-	/// KNOWN LIMITATION: This blocks NUnit's handling of equal values of different type, e.g. 1 and 1.0d
 	/// </summary>
 	public class ValueEquatableComparer : IComparer
 	{
@@ -18,12 +18,13 @@ namespace SIL.TestUtilities
 		/// </summary>
 		public int Compare(object x, object y)
 		{
-			if (x == null && y == null)
+			if (Is.EqualTo(y).ApplyTo(x).IsSuccess)
 				return 0;
 			if (x?.GetType() != y?.GetType())
 				return 1;
 
 			// search reflectively for ValueEquals
+			// ReSharper disable once PossibleNullReferenceException - Is.EqualTo handles if both are null; checking types handles if one is null.
 			var type = x.GetType();
 			MethodInfo valueEquals = null;
 			while (valueEquals == null && type != null)

--- a/SIL.TestUtilities/ValueEquatableComparer.cs
+++ b/SIL.TestUtilities/ValueEquatableComparer.cs
@@ -6,6 +6,7 @@ namespace SIL.TestUtilities
 {
 	/// <summary>
 	/// Comparer for two objects that might implement the IValueEquatable&lt;T&gt; interface.
+	/// KNOWN LIMITATION: This blocks NUnit's handling of equal values of different type, e.g. 1 and 1.0d
 	/// </summary>
 	public class ValueEquatableComparer : IComparer
 	{
@@ -19,7 +20,7 @@ namespace SIL.TestUtilities
 		{
 			if (x == null && y == null)
 				return 0;
-			if (x == null || y == null || x.GetType() != y.GetType())
+			if (x?.GetType() != y?.GetType())
 				return 1;
 
 			// search reflectively for ValueEquals


### PR DESCRIPTION
object.Equals returns false for two distinct but equal IValueEquatable<T>'s if T does not override .Equals and .GetHashCode (IValueEquatable<T> is specifically for cases when we do not want to override GetHashCode)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1131)
<!-- Reviewable:end -->
