### PR TITLE
HT-402: Moved lock to cover check for initial _recordingState in BeginRecording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.WritingSystems] Upgraded to version 5.0 (beta) of `L10NSharp.dll`
 - [SIL.Windows.Forms] Upgraded to version 5.0 (beta) of `L10NSharp.dll`
 - [SIL.Core] Corrected logic in extension method GetLongestUsefulCommonSubstring
+- [SIL.Media] Allow RecordingDeviceIndicator to find new sound input device when there was no selected device (state == NotYetStarted)
 
 ### Fixed
 

--- a/SIL.Media.Tests/AudioFactoryTests.cs
+++ b/SIL.Media.Tests/AudioFactoryTests.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using NUnit.Framework;
+using SIL.IO;
+
+namespace SIL.Media.Tests
+{
+	// These will not work if a speaker is not available.
+	[TestFixture]
+	[Category("SkipOnTeamCity")]
+	[Category("AudioTests")]
+	public class AudioFactoryTests
+	{
+		[Test]
+		public void Construct_FileDoesNotExist_OK()
+		{
+			// ReSharper disable once UnusedVariable
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName())) { }
+		}
+
+		[Test]
+		public void Construct_FileDoesExistButEmpty_OK()
+		{
+			using (var f = new TempFile())
+			{
+				// ReSharper disable once UnusedVariable
+				using (var x = AudioFactory.CreateAudioSession(f.Path)) { }
+			}
+		}
+
+
+		[Test]
+		public void Construct_FileDoesNotExist_DoesNotCreateFile()
+		{
+			var path = Path.GetRandomFileName();
+			// ReSharper disable once UnusedVariable
+			using (var x = AudioFactory.CreateAudioSession(path)) { }
+			Assert.IsFalse(File.Exists(path)); // File doesn't exist after disposal
+		}
+	}
+}

--- a/SIL.Media.Tests/AudioRecorderTests.cs
+++ b/SIL.Media.Tests/AudioRecorderTests.cs
@@ -61,8 +61,8 @@ namespace SIL.Media.Tests
 
 					for (var i = 0; i < 3 && !recordingStopped; i++)
 					{
+						Thread.Sleep(90);
 						Application.DoEvents();
-						Thread.Sleep(200);
 					}
 
 					Assert.That(recordingStopped);
@@ -79,7 +79,6 @@ namespace SIL.Media.Tests
 		{
 			using (var ctrl = new Control())
 			{
-				bool recordingStopped = false;
 				var f = new TempFile();
 				var recorder = new AudioRecorder(1);
 				try
@@ -111,7 +110,6 @@ namespace SIL.Media.Tests
 		{
 			using (var ctrl = new Control())
 			{
-				bool recordingStopped = false;
 				var f = new TempFile();
 				var recorder = new AudioRecorder(1);
 				try
@@ -158,11 +156,15 @@ namespace SIL.Media.Tests
 
 					ctrl.CreateControl();
 
-					for (var i = 0; i < 3 && !monitoringStarted; i++)
-					{
-						Application.DoEvents();
-						Thread.Sleep(200);
-					}
+					// Note: This loop appears to be unnecessary. CreateControl apparently does not
+					// return until the code in the HandleCreated handler executes to completion.
+					// But in case this ever fails, try uncommenting this code to get it to pass.
+					//for (var i = 0; i < 3 && !monitoringStarted; i++)
+					//{
+					//	Thread.Sleep(20);
+					//	Application.DoEvents();
+					//}
+					Assert.That(monitoringStarted);
 
 					recorder.BeginRecording(f.Path);
 					Thread.Sleep(100);

--- a/SIL.Media.Tests/AudioRecorderTests.cs
+++ b/SIL.Media.Tests/AudioRecorderTests.cs
@@ -1,493 +1,178 @@
-using System;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
-using System.Media;
+using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using NUnit.Framework;
 using SIL.IO;
-using SIL.Media.Tests.Properties;
-using SIL.TestUtilities;
+using SIL.Media.Naudio;
 
 namespace SIL.Media.Tests
 {
 	// Some of these tests require a speaker. Others require a microphone.
 	// None of them will work if neither a speaker nor a microphone is available.
 	[TestFixture]
-	[NUnit.Framework.Category("SkipOnTeamCity")]
-	[NUnit.Framework.Category("AudioTests")]
+	[Category("SkipOnTeamCity")]
+	[Category("AudioTests")]
 	public class AudioRecorderTests
 	{
+		
 		[Test]
-		public void Construct_FileDoesNotExist_OK()
-		{
-			// ReSharper disable once UnusedVariable
-			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName())) { }
-		}
-
-		[Test]
-		public void Construct_FileDoesExistButEmpty_OK()
+		public void BeginRecording_OnNonUiThread_Throws()
 		{
 			using (var f = new TempFile())
 			{
-				// ReSharper disable once UnusedVariable
-				using (var x = AudioFactory.CreateAudioSession(f.Path)) { }
-			}
-		}
-
-
-		[Test]
-		public void Construct_FileDoesNotExist_DoesNotCreateFile()
-		{
-			var path = Path.GetRandomFileName();
-			// ReSharper disable once UnusedVariable
-			using (var x = AudioFactory.CreateAudioSession(path)) { }
-			Assert.IsFalse(File.Exists(path)); // File doesn't exist after disposal
-		}
-
-		[Test]
-		public void StopRecording_NotRecording_Throws()
-		{
-			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
-			{
-				Assert.Throws<ApplicationException>(() => x.StopRecordingAndSaveAsWav());
-			}
-		}
-
-		[Test]
-		public void StopPlaying_WhilePlaying_Ok()
-		{
-			using (var session = new RecordingSession(1000))
-			{
-				session.Recorder.Play();
-				Thread.Sleep(100);
-				session.Recorder.StopPlaying();
-			}
-		}
-
-		[Test]
-		public void Record_AfterRecordThenStop_Ok()
-		{
-			using (var session = new RecordingSession(100))
-			{
-				session.Recorder.StartRecording();
-				Thread.Sleep(100);
-				session.Recorder.StopRecordingAndSaveAsWav();
-			}
-		}
-
-		[Test]
-		public void Play_WhileRecording_Throws()
-		{
-			using (var session = new RecordingSession())
-			{
-				Assert.Throws<ApplicationException>(() => session.Recorder.Play());
-			}
-		}
-
-		[Test]
-		public void CanRecord_FileDoesNotExist_True()
-		{
-			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
-			{
-				Assert.IsTrue(x.CanRecord);
-			}
-		}
-
-		[Test]
-		public void CanStop_NonExistentFile_False()
-		{
-			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
-			{
-				Assert.IsFalse(x.CanStop);
-			}
-		}
-
-		[Test]
-		public void CanRecord_ConstructWithEmptyFile_True()
-		{
-			using (var f = new TempFile())
-			{
-				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				using (var recorder = new AudioRecorder(1))
 				{
-					Assert.IsTrue(x.CanRecord);
+					recorder.SelectedDevice = RecordingDevice.Devices.First() as RecordingDevice;
+					Assert.That(() => recorder.BeginRecording(f.Path, false), Throws.Exception);
 				}
 			}
 		}
 
 		[Test]
-		public void Play_FileEmpty_Throws()
+		public void BeginRecording_ThenStop_RecordingSavedToFile()
 		{
-			using (var f = new TempFile())
+			using (var ctrl = new Control())
 			{
-				using (var x = AudioFactory.CreateAudioSession(f.Path))
-				{
-					Assert.Throws<FileLoadException>(() => x.Play());
-				}
-			}
-		}
-
-		[Test]
-		public void Play_FileDoesNotExist_Throws()
-		{
-			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
-			{
-				Assert.Throws<FileNotFoundException>(() => x.Play());
-			}
-		}
-
-		[Test]
-		public void CanStop_WhilePlaying_True()
-		{
-			using (var session = new RecordingSession(1000))
-			{
-				session.Recorder.Play();
-				Thread.Sleep(100);
-				Assert.IsTrue(session.Recorder.CanStop);
-			}
-		}
-
-
-		[Test]
-		public void RecordAndStop_FileAlreadyExists_FileReplaced()
-		{
-			using (var f = new TempFile())
-			{
-				var oldInfo = new FileInfo(f.Path);
-				var oldLength = oldInfo.Length;
-				Assert.AreEqual(0, oldLength);
-				var oldTimestamp = oldInfo.LastWriteTimeUtc;
-				using (var x = AudioFactory.CreateAudioSession(f.Path))
-				{
-					x.StartRecording();
-					Thread.Sleep(1000);
-					x.StopRecordingAndSaveAsWav();
-				}
-				var newInfo = new FileInfo(f.Path);
-				Assert.Greater(newInfo.LastWriteTimeUtc, oldTimestamp);
-				Assert.Greater(newInfo.Length, oldLength);
-			}
-		}
-
-		[Test]
-		public void IsRecording_WhileRecording_True()
-		{
-			using (var f = new TempFile())
-			{
-				using (var x = AudioFactory.CreateAudioSession(f.Path))
-				{
-					x.StartRecording();
-					Thread.Sleep(100);
-					Assert.IsTrue(x.IsRecording);
-					x.StopRecordingAndSaveAsWav();
-				}
-			}
-		}
-
-		[Test]
-		[Platform(Exclude = "Linux", Reason = "AudioAlsaSession doesn't implement ISimpleAudioWithEvents")]
-		public void RecordThenPlay_SmokeTest()
-		{
-			using (var f = new TempFile())
-			{
-				var w = new BackgroundWorker();
-				// ReSharper disable once RedundantDelegateCreation
-				w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
-
-				using (var x = AudioFactory.CreateAudioSession(f.Path))
-				{
-					x.StartRecording();
-					w.RunWorkerAsync();
-					Thread.Sleep(1000);
-					x.StopRecordingAndSaveAsWav();
-					bool stopped = false;
-					bool isPlayingInEventHandler = false;
-					(x as ISimpleAudioWithEvents).PlaybackStopped += (o, args) =>
-					{
-						// assert here is swallowed, probably because not receiving exceptions from background worker.
-						// We want to check that isPlaying is false even during the event handler.
-						isPlayingInEventHandler = x.IsPlaying;
-						stopped = true;
-					};
-					var watch = Stopwatch.StartNew();
-					x.Play();
-					while (!stopped)
-					{
-						Thread.Sleep(20);
-						Application.DoEvents();
-						if (watch.ElapsedMilliseconds > 2000)
-						{
-							x.StopPlaying();
-							Assert.Fail("stop event not received");
-						}
-					}
-					// After playback is stopped we shouldn't be reporting that it is playing
-					Assert.That(isPlayingInEventHandler, Is.False);
-					Assert.That(x.IsPlaying, Is.False);
-				}
-			}
-		}
-
-		[Test]
-		public void Play_GiveThaiFileName_ShouldHearTwoSounds()
-		{
-			using (var d = new TemporaryFolder("palaso media test"))
-			{
-				var soundPath = d.Combine("ก.wav");
-				File.Create(soundPath).Close();
-				using (var f = TempFile.TrackExisting(soundPath))
-				{
-					var w = new BackgroundWorker();
-					// ReSharper disable once RedundantDelegateCreation
-					w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
-
-					using (var x = AudioFactory.CreateAudioSession(f.Path))
-					{
-						x.StartRecording();
-						w.RunWorkerAsync();
-						Thread.Sleep(2000);
-						x.StopRecordingAndSaveAsWav();
-					}
-
-					using (var y = AudioFactory.CreateAudioSession(f.Path))
-					{
-						y.Play();
-						Thread.Sleep(1000);
-						y.StopPlaying();
-					}
-				}
-			}
-		}
-
-
-		/// <summary>
-		/// for testing things while recording is happening
-		/// </summary>
-		class RecordingSession : IDisposable
-		{
-			private TempFile _tempFile;
-			private ISimpleAudioSession _recorder;
-
-			public RecordingSession()
-			{
-				_tempFile = new TempFile();
-				_recorder = AudioFactory.CreateAudioSession(_tempFile.Path);
-				_recorder.StartRecording();
-				Thread.Sleep(100);
-			}
-
-			public RecordingSession(int millisecondsToRecordBeforeStopping)
-				: this()
-			{
-				if (millisecondsToRecordBeforeStopping == 0) millisecondsToRecordBeforeStopping = 1000;
-				Thread.Sleep(millisecondsToRecordBeforeStopping);
-				_recorder.StopRecordingAndSaveAsWav();
-			}
-
-			public ISimpleAudioSession Recorder
-			{
-				get { return _recorder; }
-			}
-
-			public void Dispose()
-			{
+				bool recordingStopped = false;
+				var f = new TempFile();
 				try
 				{
-					if (_recorder.IsRecording)
+					var recorder = new AudioRecorder(1);
+					// Note: BeginRecording
+					ctrl.HandleCreated += delegate
 					{
-						_recorder.StopRecordingAndSaveAsWav();
+						recorder.SelectedDevice =
+							RecordingDevice.Devices.First() as RecordingDevice;
+						recorder.BeginRecording(f.Path, false);
+						Thread.Sleep(100);
+						recorder.Stop();
+					};
+
+					recorder.Stopped += delegate
+					{
+						Assert.That(f.Path, Does.Exist);
+						Assert.That(new FileInfo(f.Path).Length, Is.GreaterThan(0));
+						recordingStopped = true;
+						recorder.Dispose();
+					};
+
+					ctrl.CreateControl();
+
+					for (var i = 0; i < 3 && !recordingStopped; i++)
+					{
+						Application.DoEvents();
+						Thread.Sleep(200);
 					}
+
+					Assert.That(recordingStopped);
 				}
 				finally
 				{
-					_recorder.Dispose();
-					_tempFile.Dispose();
+					f.Dispose();
 				}
 			}
 		}
 
 		[Test]
-		public void CanStop_WhileRecording_True()
+		public void BeginRecording_WhileRecording_ThrowsInvalidOperationException()
 		{
-			using (var session = new RecordingSession())
+			using (var ctrl = new Control())
 			{
-				Assert.IsTrue(session.Recorder.CanStop);
-			}
-		}
-
-		[Test]
-		public void CanPlay_WhileRecording_False()
-		{
-			using (var session = new RecordingSession())
-			{
-				Assert.IsFalse(session.Recorder.CanPlay);
-			}
-		}
-
-		[Test]
-		public void CanRecord_WhileRecording_False()
-		{
-			using (var session = new RecordingSession())
-			{
-				Assert.IsFalse(session.Recorder.CanRecord);
-			}
-		}
-
-		[Test]
-		public void StartRecording_WhileRecording_Throws()
-		{
-			using (var session = new RecordingSession())
-			{
-				Assert.Throws<ApplicationException>(() => session.Recorder.StartRecording());
-			}
-		}
-
-		[Test]
-		public void CanRecord_WhilePlaying_False()
-		{
-			using (var session = new RecordingSession(1000))
-			{
-				session.Recorder.Play();
-				Thread.Sleep(100);
-				Assert.IsTrue(session.Recorder.IsPlaying);
-				Assert.IsFalse(session.Recorder.CanRecord);
-			}
-		}
-
-		[Test]
-		public void CanPlay_WhilePlaying_False()
-		{
-			using (var session = new RecordingSession(1000))
-			{
-				session.Recorder.Play();
-				Thread.Sleep(100);
-				Assert.IsFalse(session.Recorder.CanPlay);
-			}
-		}
-
-		[Test]
-		public void IsRecording_AfterRecording_False()
-		{
-			using (var f = new TempFile())
-			{
-				using (ISimpleAudioSession x = RecordSomething(f))
+				bool recordingStopped = false;
+				var f = new TempFile();
+				var recorder = new AudioRecorder(1);
+				try
 				{
-					Assert.IsFalse(x.IsRecording);
+					// Note: BeginRecording
+					ctrl.HandleCreated += delegate
+					{
+						recorder.SelectedDevice =
+							RecordingDevice.Devices.First() as RecordingDevice;
+						recorder.BeginRecording(f.Path, false);
+					};
+
+					ctrl.CreateControl();
+
+					Thread.Sleep(10);
+					Assert.That(() => recorder.BeginRecording("blah.wav"), Throws.InvalidOperationException);
+
+				}
+				finally
+				{
+					recorder.Dispose();
+					f.Dispose();
 				}
 			}
 		}
 
 		[Test]
-		public void RecordThenStop_CanPlay_IsTrue()
+		public void BeginMonitoring_WhileRecording_ThrowsInvalidOperationException()
 		{
-			using (var f = new TempFile())
+			using (var ctrl = new Control())
 			{
-				using (ISimpleAudioSession x = RecordSomething(f))
+				bool recordingStopped = false;
+				var f = new TempFile();
+				var recorder = new AudioRecorder(1);
+				try
 				{
-					Assert.IsTrue(x.CanPlay);
+					// Note: BeginRecording
+					ctrl.HandleCreated += delegate
+					{
+						recorder.SelectedDevice =
+							RecordingDevice.Devices.First() as RecordingDevice;
+						recorder.BeginRecording(f.Path, false);
+					};
+
+					ctrl.CreateControl();
+
+					Thread.Sleep(10);
+					Assert.That(() => recorder.BeginMonitoring(), Throws.InvalidOperationException);
+
+				}
+				finally
+				{
+					recorder.Dispose();
+					f.Dispose();
 				}
 			}
 		}
 
 		[Test]
-		public void RecordThenPlay_OK()
+		public void BeginRecording_OnNonUiThreadAfterMonitoringStartedOnUIThread_NoException()
 		{
-			using (var f = new TempFile())
+			using (var ctrl = new Control())
 			{
-				using (ISimpleAudioSession x = RecordSomething(f))
+				bool monitoringStarted = false;
+				var f = new TempFile();
+				var recorder = new AudioRecorder(1);
+				try
 				{
-					x.Play();
+					ctrl.HandleCreated += delegate
+					{
+						recorder.SelectedDevice =
+							RecordingDevice.Devices.First() as RecordingDevice;
+						recorder.BeginMonitoring();
+						monitoringStarted = true;
+					};
+
+					ctrl.CreateControl();
+
+					for (var i = 0; i < 3 && !monitoringStarted; i++)
+					{
+						Application.DoEvents();
+						Thread.Sleep(200);
+					}
+
+					recorder.BeginRecording(f.Path);
 					Thread.Sleep(100);
-					x.StopPlaying();
-				}
-			}
-		}
-
-		private ISimpleAudioSession RecordSomething(TempFile f)
-		{
-			var x = AudioFactory.CreateAudioSession(f.Path);
-			x.StartRecording();
-			Thread.Sleep(100);
-			x.StopRecordingAndSaveAsWav();
-			return x;
-		}
-
-		[Test]
-		public void Play_DoesPlay ()
-		{
-			using (var file = TempFile.FromResource(Resources.finished, ".wav"))
-			{
-				using (var x = AudioFactory.CreateAudioSession(file.Path))
-				{
-					Assert.DoesNotThrow(() => x.Play());
-					Assert.DoesNotThrow(() => x.StopPlaying());
-				}
-			}
-		}
-
-		[Test]
-		[Platform(Exclude = "Linux", Reason = "AudioAlsaSession doesn't implement ISimpleAudioWithEvents")]
-		public void Play_DoesPlayMp3_SmokeTest()
-		{
-			// file disposed after playback stopped
-			var file = TempFile.FromResource(Resources.ShortMp3, ".mp3");
-			using (var x = AudioFactory.CreateAudioSession(file.Path))
-			{
-				(x as ISimpleAudioWithEvents).PlaybackStopped += (e, f) =>
-				{
-					Debug.WriteLine(f);
+					recorder.Stop();
 					Thread.Sleep(100);
-					file.Dispose();
-				};
-				Assert.That(x.IsPlaying, Is.False);
-				Assert.DoesNotThrow(() => x.Play());
-				Assert.That(x.IsPlaying, Is.True);
-				Assert.DoesNotThrow(() => x.StopPlaying());
-				Assert.That(x.IsPlaying, Is.False);
-			}
-		}
-
-		[Test]
-		public void Record_DoesRecord ()
-		{
-			using (var folder = new TemporaryFolder("Record_DoesRecord"))
-			{
-				string fpath = Path.Combine(folder.Path, "dump.ogg");
-				using (var x = AudioFactory.CreateAudioSession(fpath))
-				{
-					Assert.DoesNotThrow(() => x.StartRecording());
-					Assert.IsTrue(x.IsRecording);
-					Thread.Sleep(1000);
-					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
 				}
-			}
-		}
-
-		[Test]
-		[NUnit.Framework.Category("ByHand")]
-		[Explicit] // This test is to be run manually to test long recordings. After the first beep, recite John 3:16"
-		public void Record_LongRecording()
-		{
-			using (var folder = new TemporaryFolder("Record_LongRecording"))
-			{
-				string fpath = Path.Combine(folder.Path, "long.wav");
-				using (var x = AudioFactory.CreateAudioSession(fpath))
+				finally
 				{
-					SystemSounds.Beep.Play();
-					Assert.DoesNotThrow(() => x.StartRecording());
-					Assert.IsTrue(x.IsRecording);
-					Thread.Sleep(10000); // Records 10 seconds
-					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
-					SystemSounds.Beep.Play();
-					Assert.IsTrue(x.CanPlay);
-					Assert.DoesNotThrow(() => x.Play());
-					Thread.Sleep(4000); // Plays the first 4 seconds
-					Assert.DoesNotThrow(() => x.StopPlaying());
-					Thread.Sleep(500); // Pause
-					Assert.DoesNotThrow(() => x.Play());
-					Thread.Sleep(6000); // Plays the first 6 seconds
-					Assert.DoesNotThrow(() => x.StopPlaying());
+					recorder.Dispose();
+					f.Dispose();
 				}
 			}
 		}

--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -1,0 +1,475 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Media;
+using System.Threading;
+using System.Windows.Forms;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.Media.Tests.Properties;
+using SIL.TestUtilities;
+
+namespace SIL.Media.Tests
+{
+	// Some of these tests require a speaker. Others require a microphone.
+	// None of them will work if neither a speaker nor a microphone is available.
+	[TestFixture]
+	[NUnit.Framework.Category("SkipOnTeamCity")]
+	[NUnit.Framework.Category("AudioTests")]
+	public class AudioSessionTests
+	{
+		[Test]
+		public void StopRecordingAndSaveAsWav_NotRecording_Throws()
+		{
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.Throws<ApplicationException>(() => x.StopRecordingAndSaveAsWav());
+			}
+		}
+
+		[Test]
+		public void StopPlaying_WhilePlaying_NoExceptionThrown()
+		{
+			using (var session = new RecordingSession(1000))
+			{
+				session.Recorder.Play();
+				Thread.Sleep(100);
+				session.Recorder.StopPlaying();
+			}
+		}
+
+		[Test]
+		public void StopRecordingAndSaveAsWav_WhileRecording_NoExceptionThrown()
+		{
+			using (var session = new RecordingSession(100))
+			{
+				session.Recorder.StartRecording();
+				Thread.Sleep(100);
+				session.Recorder.StopRecordingAndSaveAsWav();
+			}
+		}
+
+		[Test]
+		public void Play_WhileRecording_Throws()
+		{
+			using (var session = new RecordingSession())
+			{
+				Assert.Throws<ApplicationException>(() => session.Recorder.Play());
+			}
+		}
+
+		[Test]
+		public void CanRecord_FileDoesNotExist_True()
+		{
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.That(x.FilePath, Does.Not.Exist, "SETUP condition not met");
+				Assert.IsTrue(x.CanRecord);
+			}
+		}
+
+		[Test]
+		public void CanStop_NonExistentFile_False()
+		{
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.That(x.FilePath, Does.Not.Exist, "SETUP condition not met");
+				Assert.IsFalse(x.CanStop);
+			}
+		}
+
+		[Test]
+		public void CanRecord_ConstructWithEmptyFile_True()
+		{
+			using (var f = new TempFile())
+			{
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					Assert.That(x.FilePath, Is.EqualTo(f.Path), "SETUP condition not met");
+					Assert.That(x.FilePath, Does.Exist, "SETUP condition not met");
+					Assert.IsTrue(x.CanRecord);
+				}
+			}
+		}
+
+		[Test]
+		public void Play_FileEmpty_Throws()
+		{
+			using (var f = new TempFile())
+			{
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					Assert.That(x.FilePath, Is.EqualTo(f.Path), "SETUP condition not met");
+					Assert.That(x.FilePath, Does.Exist, "SETUP condition not met");
+					Assert.Throws<FileLoadException>(() => x.Play());
+				}
+			}
+		}
+
+		[Test]
+		public void Play_FileDoesNotExist_Throws()
+		{
+			using (var x = AudioFactory.CreateAudioSession(Path.GetRandomFileName()))
+			{
+				Assert.That(x.FilePath, Does.Not.Exist, "SETUP condition not met");
+				Assert.Throws<FileNotFoundException>(() => x.Play());
+			}
+		}
+
+		[Test]
+		public void CanStop_WhilePlaying_True()
+		{
+			using (var session = new RecordingSession(1000))
+			{
+				session.Recorder.Play();
+				Thread.Sleep(100);
+				Assert.IsTrue(session.Recorder.CanStop);
+			}
+		}
+
+
+		[Test]
+		public void RecordAndStop_FileAlreadyExists_FileReplaced()
+		{
+			using (var f = new TempFile())
+			{
+				var oldInfo = new FileInfo(f.Path);
+				var oldLength = oldInfo.Length;
+				Assert.AreEqual(0, oldLength);
+				var oldTimestamp = oldInfo.LastWriteTimeUtc;
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					x.StartRecording();
+					Thread.Sleep(1000);
+					x.StopRecordingAndSaveAsWav();
+				}
+				var newInfo = new FileInfo(f.Path);
+				Assert.Greater(newInfo.LastWriteTimeUtc, oldTimestamp);
+				Assert.Greater(newInfo.Length, oldLength);
+			}
+		}
+
+		[Test]
+		public void IsRecording_WhileRecording_True()
+		{
+			using (var f = new TempFile())
+			{
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					x.StartRecording();
+					Thread.Sleep(100);
+					Assert.IsTrue(x.IsRecording);
+					x.StopRecordingAndSaveAsWav();
+				}
+			}
+		}
+
+		[Test]
+		[Platform(Exclude = "Linux", Reason = "AudioAlsaSession doesn't implement ISimpleAudioWithEvents")]
+		public void RecordThenPlay_SmokeTest()
+		{
+			using (var f = new TempFile())
+			{
+				var w = new BackgroundWorker();
+				// ReSharper disable once RedundantDelegateCreation
+				w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
+
+				using (var x = AudioFactory.CreateAudioSession(f.Path))
+				{
+					x.StartRecording();
+					w.RunWorkerAsync();
+					Thread.Sleep(1000);
+					x.StopRecordingAndSaveAsWav();
+					bool stopped = false;
+					bool isPlayingInEventHandler = false;
+					(x as ISimpleAudioWithEvents).PlaybackStopped += (o, args) =>
+					{
+						// assert here is swallowed, probably because not receiving exceptions from background worker.
+						// We want to check that isPlaying is false even during the event handler.
+						isPlayingInEventHandler = x.IsPlaying;
+						stopped = true;
+					};
+					var watch = Stopwatch.StartNew();
+					x.Play();
+					while (!stopped)
+					{
+						Thread.Sleep(20);
+						Application.DoEvents();
+						if (watch.ElapsedMilliseconds > 2000)
+						{
+							x.StopPlaying();
+							Assert.Fail("stop event not received");
+						}
+					}
+					// After playback is stopped we shouldn't be reporting that it is playing
+					Assert.That(isPlayingInEventHandler, Is.False);
+					Assert.That(x.IsPlaying, Is.False);
+				}
+			}
+		}
+
+		[Test]
+		public void Play_GiveThaiFileName_ShouldHearTwoSounds()
+		{
+			using (var d = new TemporaryFolder("palaso media test"))
+			{
+				var soundPath = d.Combine("ก.wav");
+				File.Create(soundPath).Close();
+				using (var f = TempFile.TrackExisting(soundPath))
+				{
+					var w = new BackgroundWorker();
+					// ReSharper disable once RedundantDelegateCreation
+					w.DoWork += new DoWorkEventHandler((o, args) => SystemSounds.Exclamation.Play());
+
+					using (var x = AudioFactory.CreateAudioSession(f.Path))
+					{
+						x.StartRecording();
+						w.RunWorkerAsync();
+						Thread.Sleep(2000);
+						x.StopRecordingAndSaveAsWav();
+					}
+
+					using (var y = AudioFactory.CreateAudioSession(f.Path))
+					{
+						y.Play();
+						Thread.Sleep(1000);
+						y.StopPlaying();
+					}
+				}
+			}
+		}
+
+
+		/// <summary>
+		/// for testing things while recording is happening
+		/// </summary>
+		class RecordingSession : IDisposable
+		{
+			private TempFile _tempFile;
+			private ISimpleAudioSession _recorder;
+
+			public RecordingSession()
+			{
+				_tempFile = new TempFile();
+				_recorder = AudioFactory.CreateAudioSession(_tempFile.Path);
+				_recorder.StartRecording();
+				Thread.Sleep(100);
+			}
+
+			public RecordingSession(int millisecondsToRecordBeforeStopping)
+				: this()
+			{
+				if (millisecondsToRecordBeforeStopping == 0) millisecondsToRecordBeforeStopping = 1000;
+				Thread.Sleep(millisecondsToRecordBeforeStopping);
+				_recorder.StopRecordingAndSaveAsWav();
+			}
+
+			public ISimpleAudioSession Recorder
+			{
+				get { return _recorder; }
+			}
+
+			public void Dispose()
+			{
+				try
+				{
+					if (_recorder.IsRecording)
+					{
+						_recorder.StopRecordingAndSaveAsWav();
+					}
+				}
+				finally
+				{
+					_recorder.Dispose();
+					_tempFile.Dispose();
+				}
+			}
+		}
+
+		[Test]
+		public void CanStop_WhileRecording_True()
+		{
+			using (var session = new RecordingSession())
+			{
+				Assert.IsTrue(session.Recorder.CanStop);
+			}
+		}
+
+		[Test]
+		public void CanPlay_WhileRecording_False()
+		{
+			using (var session = new RecordingSession())
+			{
+				Assert.IsFalse(session.Recorder.CanPlay);
+			}
+		}
+
+		[Test]
+		public void CanRecord_WhileRecording_False()
+		{
+			using (var session = new RecordingSession())
+			{
+				Assert.IsFalse(session.Recorder.CanRecord);
+			}
+		}
+
+		[Test]
+		public void StartRecording_WhileRecording_Throws()
+		{
+			using (var session = new RecordingSession())
+			{
+				Assert.Throws<ApplicationException>(() => session.Recorder.StartRecording());
+			}
+		}
+
+		[Test]
+		public void CanRecord_WhilePlaying_False()
+		{
+			using (var session = new RecordingSession(1000))
+			{
+				session.Recorder.Play();
+				Thread.Sleep(100);
+				Assert.IsTrue(session.Recorder.IsPlaying);
+				Assert.IsFalse(session.Recorder.CanRecord);
+			}
+		}
+
+		[Test]
+		public void CanPlay_WhilePlaying_False()
+		{
+			using (var session = new RecordingSession(1000))
+			{
+				session.Recorder.Play();
+				Thread.Sleep(100);
+				Assert.IsFalse(session.Recorder.CanPlay);
+			}
+		}
+
+		[Test]
+		public void IsRecording_AfterRecording_False()
+		{
+			using (var f = new TempFile())
+			{
+				using (ISimpleAudioSession x = RecordSomething(f))
+				{
+					Assert.IsFalse(x.IsRecording);
+				}
+			}
+		}
+
+		[Test]
+		public void RecordThenStop_CanPlay_IsTrue()
+		{
+			using (var f = new TempFile())
+			{
+				using (ISimpleAudioSession x = RecordSomething(f))
+				{
+					Assert.IsTrue(x.CanPlay);
+				}
+			}
+		}
+
+		[Test]
+		public void RecordThenPlay_OK()
+		{
+			using (var f = new TempFile())
+			{
+				using (ISimpleAudioSession x = RecordSomething(f))
+				{
+					x.Play();
+					Thread.Sleep(100);
+					x.StopPlaying();
+				}
+			}
+		}
+
+		private ISimpleAudioSession RecordSomething(TempFile f)
+		{
+			var x = AudioFactory.CreateAudioSession(f.Path);
+			x.StartRecording();
+			Thread.Sleep(100);
+			x.StopRecordingAndSaveAsWav();
+			return x;
+		}
+
+		[Test]
+		public void Play_DoesPlay ()
+		{
+			using (var file = TempFile.FromResource(Resources.finished, ".wav"))
+			{
+				using (var x = AudioFactory.CreateAudioSession(file.Path))
+				{
+					Assert.DoesNotThrow(() => x.Play());
+					Assert.DoesNotThrow(() => x.StopPlaying());
+				}
+			}
+		}
+
+		[Test]
+		[Platform(Exclude = "Linux", Reason = "AudioAlsaSession doesn't implement ISimpleAudioWithEvents")]
+		public void Play_DoesPlayMp3_SmokeTest()
+		{
+			// file disposed after playback stopped
+			var file = TempFile.FromResource(Resources.ShortMp3, ".mp3");
+			using (var x = AudioFactory.CreateAudioSession(file.Path))
+			{
+				(x as ISimpleAudioWithEvents).PlaybackStopped += (e, f) =>
+				{
+					Debug.WriteLine(f);
+					Thread.Sleep(100);
+					file.Dispose();
+				};
+				Assert.That(x.IsPlaying, Is.False);
+				Assert.DoesNotThrow(() => x.Play());
+				Assert.That(x.IsPlaying, Is.True);
+				Assert.DoesNotThrow(() => x.StopPlaying());
+				Assert.That(x.IsPlaying, Is.False);
+			}
+		}
+
+		[Test]
+		public void Record_DoesRecord ()
+		{
+			using (var folder = new TemporaryFolder("Record_DoesRecord"))
+			{
+				string fpath = Path.Combine(folder.Path, "dump.ogg");
+				using (var x = AudioFactory.CreateAudioSession(fpath))
+				{
+					Assert.DoesNotThrow(() => x.StartRecording());
+					Assert.IsTrue(x.IsRecording);
+					Thread.Sleep(1000);
+					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
+				}
+			}
+		}
+
+		[Test]
+		[NUnit.Framework.Category("ByHand")]
+		[Explicit] // This test is to be run manually to test long recordings. After the first beep, recite John 3:16"
+		public void Record_LongRecording()
+		{
+			using (var folder = new TemporaryFolder("Record_LongRecording"))
+			{
+				string fpath = Path.Combine(folder.Path, "long.wav");
+				using (var x = AudioFactory.CreateAudioSession(fpath))
+				{
+					SystemSounds.Beep.Play();
+					Assert.DoesNotThrow(() => x.StartRecording());
+					Assert.IsTrue(x.IsRecording);
+					Thread.Sleep(10000); // Records 10 seconds
+					Assert.DoesNotThrow(() => x.StopRecordingAndSaveAsWav());
+					SystemSounds.Beep.Play();
+					Assert.IsTrue(x.CanPlay);
+					Assert.DoesNotThrow(() => x.Play());
+					Thread.Sleep(4000); // Plays the first 4 seconds
+					Assert.DoesNotThrow(() => x.StopPlaying());
+					Thread.Sleep(500); // Pause
+					Assert.DoesNotThrow(() => x.Play());
+					Thread.Sleep(6000); // Plays the first 6 seconds
+					Assert.DoesNotThrow(() => x.StopPlaying());
+				}
+			}
+		}
+	}
+}

--- a/SIL.Media/AudioFactory.cs
+++ b/SIL.Media/AudioFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 using SIL.Media.AlsaAudio;

--- a/SIL.Media/Naudio/AudioRecorder.cs
+++ b/SIL.Media/Naudio/AudioRecorder.cs
@@ -258,7 +258,7 @@ namespace SIL.Media.Naudio
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// as far as naudio is concerned, we are still "recording" (i.e., accepting waveIn
+		/// as far as NAudio is concerned, we are still "recording" (i.e., accepting waveIn
 		/// data), but we want to stop writing the data to the file.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -282,16 +282,16 @@ namespace SIL.Media.Naudio
 		/// ------------------------------------------------------------------------------------
 		public virtual void BeginRecording(string waveFileName, bool appendToFile)
 		{
-			if (_recordingState == RecordingState.NotYetStarted)
-				BeginMonitoring();
-
-			if (_recordingState != RecordingState.Monitoring)
-			{
-				throw new InvalidOperationException("Can't begin recording while we are in this state: " + _recordingState.ToString());
-			}
-
 			lock (this)
 			{
+				if (_recordingState == RecordingState.NotYetStarted)
+					BeginMonitoring();
+
+				if (_recordingState != RecordingState.Monitoring)
+				{
+					throw new InvalidOperationException("Can't begin recording while we are in this state: " + _recordingState.ToString());
+				}
+
 				if (_waveInBuffersChanged)
 				{
 					CloseWaveIn();

--- a/SIL.Media/Naudio/AudioRecorder.cs
+++ b/SIL.Media/Naudio/AudioRecorder.cs
@@ -177,8 +177,17 @@ namespace SIL.Media.Naudio
 		/// Begins monitoring incoming data from the selected device but not
 		/// processing it for the purpose of recording to a file.
 		/// </summary>
-		/// <exception cref="InvalidOperationException">Called when in an invalid state. This
-		/// should only be called once for a new WaveIn device. Note that
+		/// <exception cref="InvalidOperationException">Called when in an invalid state. It is
+		/// only valid to call this method when the <see cref="RecordingState"/> is
+		/// <see cref="Media.RecordingState.NotYetStarted"/> or
+		/// <see cref="SIL.Media.RecordingState.Stopped"/>. In other words, this
+		/// should be called (either directly or as a side-effect of setting the
+		/// <see cref="SelectedDevice"/> or calling <see cref="BeginRecording(string)"/> only
+		/// once to create and initialize a new WaveIn device. For example, if merely setting
+		/// <see cref="SelectedDevice"/> for an <see cref="AudioRecorder"/> that is already
+		/// monitoring, do not call this method again. Likewise, when completing a recording
+		/// normally or aborting it (at the caller's request), this will automatically go back
+		/// into a <see cref="SIL.Media.RecordingState.Monitoring"/> state.
 		/// <see cref="BeginRecording(string)"/> also begins monitoring, so if that is called
 		/// directly, this method should not be called.</exception>
 		/// <remarks>Other than the documented exceptions, any otherwise unhandled exception
@@ -201,7 +210,8 @@ namespace SIL.Media.Naudio
 				return;
 			}
 			if (!monitoringStarted)
-				throw new InvalidOperationException("only call this once for a new WaveIn device");
+				throw new InvalidOperationException("Only call this once for a new WaveIn device" +
+					" (i.e., when RecordingState is NotYetStarted or Stopped.");
 
 		}
 

--- a/SIL.Media/Naudio/UI/RecordingDeviceIndicator.cs
+++ b/SIL.Media/Naudio/UI/RecordingDeviceIndicator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Drawing;
@@ -12,11 +12,6 @@ namespace SIL.Media.Naudio.UI
 	/// as for example when a new microphone is plugged in; (b) switches to the default one if the current
 	/// one is unplugged. You can customize the icons using the __Image properties.
 	/// </summary>
-	/// <remarks>
-	/// Enhance JohnT: Possibly the RecordingDeviceIndicator could become a RecordingDeviceButton and could respond to a click by cycling through
-	/// the available devices, or pop up a chooser...though that is probably overdoing things, users
-	/// are unlikely to have more than two. Currently there is no click behavior.
-	/// </remarks>
 	public partial class RecordingDeviceIndicator : UserControl
 	{
 		private IAudioRecorder _recorder;
@@ -123,8 +118,9 @@ namespace SIL.Media.Naudio.UI
 			if(_recorder == null)
 				return;
 			// Don't try to change horses in the middle of the stream if recording is in progress.
-			if(_recorder.RecordingState != RecordingState.Monitoring &&
-				_recorder.RecordingState != RecordingState.Stopped)
+			if(_recorder.RecordingState == RecordingState.Recording ||
+				_recorder.RecordingState == RecordingState.RequestedStop ||
+				_recorder.RecordingState == RecordingState.Stopping)
 				return;
 			bool foundCurrentDevice = false;
 			var devices = RecordingDevice.Devices.ToList();


### PR DESCRIPTION
I'm looking into HT-402. I don't have any good reason to believe this could be the cause of that problem, but it does seem like this lock should be done earlier lest the value change between the time we check it and the time we set it. I don't think this could inadvertently result in a new deadlock. If it does, then it probably shows there is a real problem, but because none of the unit tests probably are capable of testing this well even if they tried, it is worth careful scrutiny.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1139)
<!-- Reviewable:end -->
