### PR TITLE
flatpak: keyboarding: flatpak-spawn keyboard config tool

### DIFF
--- a/SIL.Windows.Forms.Keyboarding.Tests/KeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/KeyboardRetrievingHelperTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.Windows.Forms.Keyboarding.Linux;
+
+namespace SIL.Windows.Forms.Keyboarding.Tests
+{
+	[TestFixture]
+	[Platform(Include="Linux", Reason="Linux specific tests")]
+	public class KeyboardRetrievingHelperTests
+	{
+		[Test]
+		public void ToFlatpakSpawn_Works()
+		{
+			string program = "/usr/bin/myprogram";
+			string origProgram = program;
+			string arguments = "my args here";
+			string origArguments = arguments;
+			// SUT
+			KeyboardRetrievingHelper.ToFlatpakSpawn(ref program, ref arguments);
+			Assert.That(program, Is.EqualTo("flatpak-spawn"));
+			Assert.That(arguments, Is.EqualTo($"--host --directory=/ {origProgram} {origArguments}"));
+		}
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
+++ b/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
@@ -293,6 +293,7 @@
     <Compile Include="LinuxKeyboardControllerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnityKeyboardRetrievingHelperTests.cs" />
+    <Compile Include="KeyboardRetrievingHelperTests.cs" />
     <Compile Include="WindowsKeyboardControllerTests.cs" />
     <Compile Include="XkbKeyboardAdapterTests.cs" />
     <Compile Include="XklEngineTests.cs" />

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using IBusDotNet;
 using SIL.Keyboarding;
+using SIL.PlatformUtilities;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
@@ -88,8 +89,28 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		protected virtual string GetKeyboardSetupApplication(out string arguments)
 		{
+			string prefix = "";
+			if (Platform.IsFlatpak)
+			{
+				prefix = "/run/host";
+			}
+
+			string program = null;
 			arguments = null;
-			return File.Exists(IbusSetupApp) ? IbusSetupApp : null;
+			if (File.Exists($"{prefix}{IbusSetupApp}"))
+			{
+				program = IbusSetupApp;
+			}
+			else
+			{
+				return null;
+			}
+
+			if (Platform.IsFlatpak)
+			{
+				KeyboardRetrievingHelper.ToFlatpakSpawn(ref program, ref arguments);
+			}
+			return program;
 		}
 
 		private static bool HasKeyman => File.Exists(KeymanConfigApp);

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
@@ -63,6 +63,13 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		public static string GetKeyboardSetupApplication(out string arguments)
 		{
+			string prefix = "";
+			if (Platform.IsFlatpak)
+			{
+				prefix = "/run/host";
+			}
+
+			string program = null;
 			arguments = "region layouts";
 			var programs = Platform.IsGnomeShell
 				? new[] {
@@ -73,7 +80,12 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 					"/usr/bin/unity-control-center",
 					"/usr/bin/gnome-control-center"
 				};
-			return programs.FirstOrDefault(File.Exists);
+			program = programs.FirstOrDefault((string path) => File.Exists($"{prefix}{path}"));
+			if (program != null && Platform.IsFlatpak)
+			{
+				KeyboardRetrievingHelper.ToFlatpakSpawn(ref program, ref arguments);
+			}
+			return program;
 		}
 		#endregion
 


### PR DESCRIPTION
When running in flatpak, prefix host paths when looking for programs
installed in /usr, and use flatpak-spawn to launch external programs
such as the keyboard configuration tools.

commit-id:7ba8be9b

---

**Stack**:
- #1150
- #1149
- #1144
- #1143 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*