### PR TITLE
Upgrading SIL.Core.Desktop, SIL.Lift, and SIL.Linux.Logging to .NET Standard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.WritingSystems] Allow specifying an alias to another Writing System for changing between upper- and lowercase
 - [SIL.Core] Extension method to get longest useful substring
 - [SIL.Core] Extension method IsLikelyWordForming to include letters, format characters, PUA and marks (diacritics, etc.)
+- [SIL.Core.Desktop, SIL.Lift, SIL.Linux.Logging] Added .NET Standard 2.0 target.
+- [SIL.Core.Desktop] USBDrive API is only supported in .NET Framework.
 - [SIL.Windows.Forms] Caller can override the default save image metadata action from the image toolbox
 
 ### Changed

--- a/SIL.Core.Desktop/IO/DirectoryUtilities.cs
+++ b/SIL.Core.Desktop/IO/DirectoryUtilities.cs
@@ -126,8 +126,8 @@ namespace SIL.IO
 
 			// get current settings
 			var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
-			var fileInfo = new FileInfo(fullDirectoryPath);
-			var security = fileInfo.GetAccessControl(AccessControlSections.Access);
+			var directory = new DirectoryInfo(fullDirectoryPath);
+			var security = directory.GetAccessControl(AccessControlSections.Access);
 			var currentRules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
 
 			// if everyone already has full control, return now
@@ -150,7 +150,7 @@ namespace SIL.IO
 															PropagationFlags.None,
 															AccessControlType.Allow);
 				security.AddAccessRule(fullControl);
-				fileInfo.SetAccessControl(security);
+				directory.SetAccessControl(security);
 
 				returnVal = true;
 			}

--- a/SIL.Core.Desktop/IO/DirectoryUtilities.cs
+++ b/SIL.Core.Desktop/IO/DirectoryUtilities.cs
@@ -126,7 +126,8 @@ namespace SIL.IO
 
 			// get current settings
 			var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
-			var security = Directory.GetAccessControl(fullDirectoryPath, AccessControlSections.Access);
+			var fileInfo = new FileInfo(fullDirectoryPath);
+			var security = fileInfo.GetAccessControl(AccessControlSections.Access);
 			var currentRules = security.GetAccessRules(true, true, typeof(SecurityIdentifier));
 
 			// if everyone already has full control, return now
@@ -149,7 +150,7 @@ namespace SIL.IO
 															PropagationFlags.None,
 															AccessControlType.Allow);
 				security.AddAccessRule(fullControl);
-				Directory.SetAccessControl(fullDirectoryPath, security);
+				fileInfo.SetAccessControl(security);
 
 				returnVal = true;
 			}

--- a/SIL.Core.Desktop/IO/FileLocator.cs
+++ b/SIL.Core.Desktop/IO/FileLocator.cs
@@ -237,7 +237,7 @@ namespace SIL.IO
 				return null;
 
 			var value = key.GetValue(string.Empty) as string;
-			key.Close();
+			key.Dispose();
 
 			if (value == null)
 				return null;
@@ -252,7 +252,7 @@ namespace SIL.IO
 			}
 
 			value = key?.GetValue(string.Empty) as string;
-			key?.Close();
+			key?.Dispose();
 
 			if (value == null)
 				return null;

--- a/SIL.Core.Desktop/Progress/Commands/AsyncCommand.cs
+++ b/SIL.Core.Desktop/Progress/Commands/AsyncCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 //For UML diagram, see ProgressSystem.uml (done in StarUML)
 
@@ -146,9 +147,9 @@ namespace SIL.Progress.Commands
 		/// Override this method to invoke the actual
 		/// long operation using your preferred async mode.
 		/// </summary>
-		protected abstract void BeginInvokeCore();
+		protected abstract Task BeginInvokeCore();
 
-		protected abstract void BeginInvokeCore2(ProgressState progress);
+		protected abstract Task BeginInvokeCore2(ProgressState progress);
 
 		/// <summary>
 		/// Raises the Finish event.

--- a/SIL.Core.Desktop/Progress/Commands/BasicCommand.cs
+++ b/SIL.Core.Desktop/Progress/Commands/BasicCommand.cs
@@ -58,14 +58,14 @@ namespace SIL.Progress.Commands
 				_progressCallback,
 				_primaryStatusTextCallback,
 				_secondaryStatusTextCallback));
-			await EndWork(workTask).ConfigureAwait(false);
+			await EndWork(workTask).ConfigureAwait(false); //resume execution on any thread
 		}
 
 		protected override async Task BeginInvokeCore2(ProgressState progress)
 		{
 			WorkInvoker2 worker = DoWork2;
 			var workTask = Task.Run(() => worker.Invoke(progress));
-			await EndWork(workTask).ConfigureAwait(false);
+			await EndWork(workTask).ConfigureAwait(false); //resume execution on any thread
 		}
 
 		protected abstract void DoWork(
@@ -81,7 +81,7 @@ namespace SIL.Progress.Commands
 		{
 			try
 			{
-				await workTask.ConfigureAwait(false);
+				await workTask.ConfigureAwait(false); //resume execution on any thread
 				OnFinish(EventArgs.Empty);
 			}
 			catch (Exception e)

--- a/SIL.Core.Desktop/Progress/Commands/BasicCommand.cs
+++ b/SIL.Core.Desktop/Progress/Commands/BasicCommand.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Diagnostics;
-using System.Runtime.Remoting.Messaging;
+using System.Threading.Tasks;
 
 //For UML diagram, see ProgressSystem.uml (done in StarUML)
 
@@ -51,24 +50,22 @@ namespace SIL.Progress.Commands
 		/// <summary>
 		/// Implementation of the async work invoker
 		/// </summary>
-		/// <remarks>
-		/// We're using the delegate BeginInvoke() / EndInvoke() pattern here
-		/// </remarks>
-		protected override void BeginInvokeCore()
+		protected override async Task BeginInvokeCore()
 		{
-			WorkInvoker worker = new WorkInvoker( DoWork );
-			worker.BeginInvoke(
+			WorkInvoker worker = DoWork;
+			var workTask = Task.Run(() => worker.Invoke(
 				_initializeCallback,
-				_progressCallback ,
-				_primaryStatusTextCallback ,
-				_secondaryStatusTextCallback,
-				new AsyncCallback( EndWork ), null );
+				_progressCallback,
+				_primaryStatusTextCallback,
+				_secondaryStatusTextCallback));
+			await EndWork(workTask).ConfigureAwait(false);
 		}
 
-		protected override void BeginInvokeCore2(ProgressState progress)
+		protected override async Task BeginInvokeCore2(ProgressState progress)
 		{
-			WorkInvoker2 worker = new WorkInvoker2(DoWork2);
-			worker.BeginInvoke(progress, new AsyncCallback(EndWork2), null);
+			WorkInvoker2 worker = DoWork2;
+			var workTask = Task.Run(() => worker.Invoke(progress));
+			await EndWork(workTask).ConfigureAwait(false);
 		}
 
 		protected abstract void DoWork(
@@ -80,36 +77,11 @@ namespace SIL.Progress.Commands
 
 		protected abstract void DoWork2(ProgressState progress);
 
-		private void EndWork( IAsyncResult result )
+		private async Task EndWork(Task workTask)
 		{
-			AsyncResult asyncResult = (AsyncResult)result;
-			WorkInvoker asyncDelegate = (WorkInvoker)asyncResult.AsyncDelegate;
 			try
 			{
-				asyncDelegate.EndInvoke( result );
-				OnFinish( EventArgs.Empty );
-			}
-			catch( Exception e )
-			{
-				// Marshal exceptions back to the UI
-				OnError( new ErrorEventArgs( e ) );
-			}
-//            catch
-//            {
-//                // Do our exception handling; include a default catch
-//                // block because this is the final handler on the stack for this
-//                // thread, and we need to log these kinds of problems
-//                OnError( new ErrorEventArgs( null ) );
-//            }
-		}
-		private void EndWork2(IAsyncResult result)
-		{
-			Debug.WriteLine("BasicCOmmand:EndWork2");
-			AsyncResult asyncResult = (AsyncResult)result;
-			WorkInvoker2 asyncDelegate = (WorkInvoker2)asyncResult.AsyncDelegate;
-			try
-			{
-				asyncDelegate.EndInvoke(result);
+				await workTask.ConfigureAwait(false);
 				OnFinish(EventArgs.Empty);
 			}
 			catch (Exception e)
@@ -117,16 +89,7 @@ namespace SIL.Progress.Commands
 				// Marshal exceptions back to the UI
 				OnError(new ErrorEventArgs(e));
 			}
-			//            catch
-			//            {
-			//                // Do our exception handling; include a default catch
-			//                // block because this is the final handler on the stack for this
-			//                // thread, and we need to log these kinds of problems
-			//                OnError( new ErrorEventArgs( null ) );
-			//            }
 		}
-
-
 	}
 
 	/// <summary>

--- a/SIL.Core.Desktop/SIL.Core.Desktop.csproj
+++ b/SIL.Core.Desktop/SIL.Core.Desktop.csproj
@@ -6,12 +6,15 @@
     <Company>SIL</Company>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="NDesk.DBus" Version="0.15.0" />
+    <PackageReference Include="NDesk.DBus" Version="0.15.0" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core\SIL.Core.csproj" />

--- a/SIL.Core.Desktop/SIL.Core.Desktop.csproj
+++ b/SIL.Core.Desktop/SIL.Core.Desktop.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core\SIL.Core.csproj" />

--- a/SIL.Core.Desktop/UsbDrive/Linux/IUDiskDevice.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/IUDiskDevice.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD
+using System;
 using NDesk.DBus;
 using org.freedesktop.DBus;
 
@@ -522,3 +523,4 @@ namespace SIL.UsbDrive.Linux
 </node>
 */
 #endregion
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Linux/IUDisks.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/IUDisks.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD
+using System;
 using NDesk.DBus;
 using org.freedesktop.DBus;
 
@@ -306,3 +307,4 @@ namespace SIL.UsbDrive.Linux
 </node>
 */
 #endregion
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Linux/UDiskDevice.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UDiskDevice.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD
+using System;
 using System.Collections.Generic;
 using NDesk.DBus;
 using DBusProperties = org.freedesktop.DBus.Properties;
@@ -84,3 +85,4 @@ namespace SIL.UsbDrive.Linux
 
 	}
 }
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Linux/UDisks.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UDisks.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) 2009-2016 SIL International
+﻿#if !NETSTANDARD
+// Copyright (c) 2009-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -74,3 +75,4 @@ namespace SIL.UsbDrive.Linux
 		}
 	}
 }
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoHAL.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoHAL.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD
+using System;
 using System.Collections.Generic;
 using System.IO;
 using NDesk.DBus;
@@ -141,3 +142,4 @@ namespace SIL.UsbDrive.Linux
 		}
 	}
 }
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -78,3 +79,4 @@ namespace SIL.UsbDrive.Linux
 
 	}
 }
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks2.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks2.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) 2016 SIL International
+﻿#if !NETSTANDARD
+// Copyright (c) 2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -145,3 +146,4 @@ namespace SIL.UsbDrive.Linux
 		}
 	}
 }
+#endif

--- a/SIL.Core.Desktop/UsbDrive/UsbDriveInfo.cs
+++ b/SIL.Core.Desktop/UsbDrive/UsbDriveInfo.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) 2009-2016 SIL International
+﻿#if !NETSTANDARD
+// Copyright (c) 2009-2016 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -121,3 +122,4 @@ namespace SIL.UsbDrive
 	}
 
 }
+#endif

--- a/SIL.Core.Desktop/UsbDrive/Windows/UsbDriveInfoWindows.cs
+++ b/SIL.Core.Desktop/UsbDrive/Windows/UsbDriveInfoWindows.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETSTANDARD
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Management;
@@ -112,3 +113,4 @@ namespace SIL.UsbDrive.Windows
 		}
 	}
 }
+#endif

--- a/SIL.Lift/SIL.Lift.csproj
+++ b/SIL.Lift/SIL.Lift.csproj
@@ -3,6 +3,7 @@
     <RootNamespace>SIL.Lift</RootNamespace>
     <AssemblyTitle>SIL.Lift</AssemblyTitle>
     <Description>SIL.Lift contains classes for reading and writing Lexicon Interchange FormaT (LIFT) data. This assembly currently supports LIFT 0.13.</Description>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />

--- a/SIL.Lift/Utilities.cs
+++ b/SIL.Lift/Utilities.cs
@@ -63,11 +63,13 @@ namespace SIL.Lift
 			{
 				transform.Transform(outputOfPassOne, new XsltArgumentList(), output);
 			}
+			#if NET461
 			TempFileCollection tempfiles = transform.TemporaryFiles;
 			if (tempfiles != null) // tempfiles will be null when debugging is not enabled
 			{
 				tempfiles.Delete();
 			}
+			#endif
 			File.Delete(outputOfPassOne);
 
 			return outputOfPassTwo;

--- a/SIL.Linux.Logging/SIL.Linux.Logging.csproj
+++ b/SIL.Linux.Logging/SIL.Linux.Logging.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>SIL.Linux.Logging</RootNamespace>
     <AssemblyTitle>SIL.Linux.Logging</AssemblyTitle>
     <Description>SIL.Linux.Logging provides a library to log to the syslog service.</Description>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +13,8 @@
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
     <Reference Include="Mono.Posix" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
 

--- a/SIL.Linux.Logging/SIL.Linux.Logging.csproj
+++ b/SIL.Linux.Logging/SIL.Linux.Logging.csproj
@@ -4,12 +4,12 @@
     <RootNamespace>SIL.Linux.Logging</RootNamespace>
     <AssemblyTitle>SIL.Linux.Logging</AssemblyTitle>
     <Description>SIL.Linux.Logging provides a library to log to the syslog service.</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.6.8" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
   </ItemGroup>
 

--- a/SIL.Linux.Logging/SIL.Linux.Logging.csproj
+++ b/SIL.Linux.Logging/SIL.Linux.Logging.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>SIL.Linux.Logging</RootNamespace>
     <AssemblyTitle>SIL.Linux.Logging</AssemblyTitle>
     <Description>SIL.Linux.Logging provides a library to log to the syslog service.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I didn't dual-target SIL.Linux.Logging to Framework 4.6.1 (as appears to be the pattern), because the .NET Standard version of SIL.Core contains Mono.Posix.NetStandard, which required me to remove the Mono.Posix reference here. If this is desired, I can spend more time on it. **Edit: 4.6.1 support added back.**

I also added a preprocessor directive to Utilities.cs for Framework only, since .NET Standard doesn't support the .TemporaryFiles property.

For more information, see:
https://docs.microsoft.com/en-us/dotnet/api/system.xml.xsl.xslcompiledtransform.temporaryfiles?view=netframework-4.6.1
https://github.com/sillsdev/lift-standard/blame/4c3cd07950b58615549fd6005426304942d0b1f1/LIFTDotNet/LiftIO/Utilities.cs#L54

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1145)
<!-- Reviewable:end -->
