### PR TITLE
Internationalization and layout fixes in exception/problem reporting dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ icu4c.readme.txt
 
 .vs/
 /SIL.Windows.Forms/bin-Designer/**
+launchSettings.json
+/l10n/*.xlf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Corrected logic in extension method GetLongestUsefulCommonSubstring
 - [SIL.Windows.Forms.ClearShare.WinFormsUI] Default to CC-BY for new CC licenses
 - [SIL.Media] Allow RecordingDeviceIndicator to find new sound input device when there was no selected device (state == NotYetStarted)
+- [SIL.Windows.Forms] Internationalized the ExceptionReportingDialog.
 
 ### Fixed
 
@@ -67,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] Copy `SIL.Windows.Forms.Keyboarding.dll.config` to output directory
 - [SIL.WritingSystems] Fix case mismatch with `needsCompiling` attribute
 - [SIL.Windows.Forms.ClearShare.WinFormsUI] Restore default version (4.0) for CC licenses after CC0 was used
+- [SIL.Windows.Forms] Layout issues in the ExceptionReportingDialog to prevent overlapping text.
 
 ## [8.0.0] - 2021-03-04
 

--- a/DistFiles/Palaso.en.xlf
+++ b/DistFiles/Palaso.en.xlf
@@ -1,0 +1,902 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns:sil="http://sil.org/software/XLiff" version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" product-version="9.0.0" original="Palaso.dll" datatype="plaintext">
+    <body>
+      <trans-unit id="AboutDialog.BuiltOnDate">
+        <source xml:lang="en">Built on {0}</source>
+        <note>ID: AboutDialog.BuiltOnDate</note>
+        <note>{0} is the date the application was built</note>
+      </trans-unit>
+      <trans-unit id="AboutDialog.NoUpdates">
+        <source xml:lang="en">No Updates</source>
+        <note>ID: AboutDialog.NoUpdates</note>
+      </trans-unit>
+      <trans-unit id="AboutDialog.WindowTitle">
+        <source xml:lang="en">About {0}</source>
+        <note>ID: AboutDialog.WindowTitle</note>
+        <note>{0} is the application name</note>
+      </trans-unit>
+      <trans-unit id="AboutDialog._checkForUpdates">
+        <source xml:lang="en">Check For Updates</source>
+        <note>ID: AboutDialog._checkForUpdates</note>
+      </trans-unit>
+      <trans-unit id="AboutDialog._releaseNotesLabel">
+        <source xml:lang="en">Release Notes</source>
+        <note>ID: AboutDialog._releaseNotesLabel</note>
+      </trans-unit>
+      <trans-unit id="Application.AlreadyRunning.General">
+        <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
+        <note>ID: Application.AlreadyRunning.General</note>
+      </trans-unit>
+      <trans-unit id="Application.AlreadyRunning.Specific">
+        <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
+        <note>ID: Application.AlreadyRunning.Specific</note>
+        <note>{0} is the application name</note>
+      </trans-unit>
+      <trans-unit id="Application.ProblemStarting.General">
+        <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
+        <note>ID: Application.ProblemStarting.General</note>
+      </trans-unit>
+      <trans-unit id="Application.ProblemStarting.Specific">
+        <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
+        <note>ID: Application.ProblemStarting.Specific</note>
+        <note>{0} is the application name</note>
+      </trans-unit>
+      <trans-unit id="Application.WaitingFinish.General">
+        <source xml:lang="en">Waiting for other application to finish...</source>
+        <note>ID: Application.WaitingFinish.General</note>
+      </trans-unit>
+      <trans-unit id="Application.WaitingFinish.Specific">
+        <source xml:lang="en">Waiting for other {0} to finish...</source>
+        <note>ID: Application.WaitingFinish.Specific</note>
+        <note>{0} is the application name</note>
+      </trans-unit>
+      <trans-unit id="ArchivingDlg._chkMetadataOnly">
+        <source xml:lang="en">Metadata only</source>
+        <note>ID: ArchivingDlg._chkMetadataOnly</note>
+      </trans-unit>
+      <trans-unit id="ArchivingDlg._chkMetadataOnly_ToolTip_">
+        <source xml:lang="en">Select this to prevent copying actual data files into archive</source>
+        <note>ID: ArchivingDlg._chkMetadataOnly_ToolTip_</note>
+      </trans-unit>
+      <trans-unit id="Common.AbortButton">
+        <source xml:lang="en">&amp;Abort</source>
+        <note>ID: Common.AbortButton</note>
+      </trans-unit>
+      <trans-unit id="Common.CancelButton">
+        <source xml:lang="en">&amp;Cancel</source>
+        <note>ID: Common.CancelButton</note>
+      </trans-unit>
+      <trans-unit id="Common.IgnoreButton">
+        <source xml:lang="en">&amp;Ignore</source>
+        <note>ID: Common.IgnoreButton</note>
+      </trans-unit>
+      <trans-unit id="Common.No">
+        <source xml:lang="en">No</source>
+        <note>ID: Common.No</note>
+      </trans-unit>
+      <trans-unit id="Common.NoButton">
+        <source xml:lang="en">&amp;No</source>
+        <note>ID: Common.NoButton</note>
+      </trans-unit>
+      <trans-unit id="Common.OKButton">
+        <source xml:lang="en">&amp;OK</source>
+        <note>ID: Common.OKButton</note>
+      </trans-unit>
+      <trans-unit id="Common.RetryButton">
+        <source xml:lang="en">&amp;Retry</source>
+        <note>ID: Common.RetryButton</note>
+      </trans-unit>
+      <trans-unit id="Common.Yes">
+        <source xml:lang="en">Yes</source>
+        <note>ID: Common.Yes</note>
+      </trans-unit>
+      <trans-unit id="Common.YesButton">
+        <source xml:lang="en">&amp;Yes</source>
+        <note>ID: Common.YesButton</note>
+      </trans-unit>
+      <trans-unit id="CustomIdentifierView.betterLabel1">
+        <source xml:lang="en">RFC5646 code:</source>
+        <note>ID: CustomIdentifierView.betterLabel1</note>
+        <note>label describes the code for a custom identifier. Translate only 'code'</note>
+      </trans-unit>
+      <trans-unit id="CustomIdentifierView.linkLabel1">
+        <source xml:lang="en">Read about language identifiers on the web</source>
+        <note>ID: CustomIdentifierView.linkLabel1</note>
+        <note>text used in the link to a webpage that describes the language identifiers</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.FileMissingFromBundle">
+        <source xml:lang="en">Required {0} file not found. File is not a valid Text Release Bundle:</source>
+        <note>ID: DblBundle.FileMissingFromBundle</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.MetadataInvalid">
+        <source xml:lang="en">Unable to read metadata. File is not a valid Text Release Bundle:</source>
+        <note>ID: DblBundle.MetadataInvalid</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.MetadataInvalidVersion">
+        <source xml:lang="en">Unable to read metadata. Type: {0}. Version: {1}. File is not a valid Text Release Bundle:</source>
+        <note>ID: DblBundle.MetadataInvalidVersion</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.NotTextReleaseBundle">
+        <source xml:lang="en">This metadata in this bundle indicates that it is of type "{0}". Only Text Release Bundles are currently supported.</source>
+        <note>ID: DblBundle.NotTextReleaseBundle</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.SourceReleaseBundle">
+        <source xml:lang="en">This bundle appears to be a source bundle. Only Text Release Bundles are currently supported.</source>
+        <note>ID: DblBundle.SourceReleaseBundle</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.StylesheetInvalid">
+        <source xml:lang="en">Unable to read stylesheet. File is not a valid Text Release Bundle:</source>
+        <note>ID: DblBundle.StylesheetInvalid</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.UnableToExtractBundle">
+        <source xml:lang="en">Unable to read contents of Text Release Bundle:</source>
+        <note>ID: DblBundle.UnableToExtractBundle</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.UnableToLoadAnyBooks">
+        <source xml:lang="en">Unable to load any books. File may not be a valid Text Release Bundle or it may contain a problem:</source>
+        <note>ID: DblBundle.UnableToLoadAnyBooks</note>
+      </trans-unit>
+      <trans-unit id="DblBundle.UnknownLanguageName">
+        <source xml:lang="en">Unknown</source>
+        <note>ID: DblBundle.UnknownLanguageName</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.AllFilesLabel">
+        <source xml:lang="en">All Files</source>
+        <note>ID: DialogBoxes.ArchivingDlg.AllFilesLabel</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CancellingMsg">
+        <source xml:lang="en">Canceling...</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CancellingMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CopyingFilesMsg">
+        <source xml:lang="en">Copying files</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CopyingFilesMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingArchiveErrorMsg">
+        <source xml:lang="en">There was an error attempting to create the RAMP file.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingArchiveErrorMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingIMDIPackageErrorMsg">
+        <source xml:lang="en">There was a problem starting process to create IMDI package.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingIMDIPackageErrorMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingInternalReapMetsFileErrorMsg">
+        <source xml:lang="en">There was an error attempting to create the RAMP/REAP mets file.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingInternalReapMetsFileErrorMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingZipFileErrorMsg">
+        <source xml:lang="en">There was a problem starting process to create zip file.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingZipFileErrorMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.FileExcludedFromPackage">
+        <source xml:lang="en">File excluded from {0} package: </source>
+        <note>ID: DialogBoxes.ArchivingDlg.FileExcludedFromPackage</note>
+        <note>Parameter is the type of archive (e.g., RAMP/IMDI)</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIActorsGroup">
+        <source xml:lang="en">Actors</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIActorsGroup</note>
+        <note>This is the heading displayed in the Archive Using IMDI dialog box for the files for the actors/participants</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIArchiveType">
+        <source xml:lang="en">IMDI</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIArchiveType</note>
+        <note>This is the abbreviation for Isle Metadata Initiative (https://www.mpi.nl/imdi/). Typically this probably does not need to be localized.</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIOverviewText">
+        <source xml:lang="en">{0} ({1}) is a metadata standard to describe multi-media and multi-modal language resources. The standard provides interoperability for browsable and searchable corpus structures and resource descriptions.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIOverviewText</note>
+        <note>Parameter 0  is 'Isle Metadata Initiative' (the first occurrence will be turned into a hyperlink); Parameter 1 is 'IMDI'</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIProgramInfoText">
+        <source xml:lang="en">This tool will help you use {0} to archive your {1} data. When the {1} package has been created, you can launch {0} and enter any additional information before doing the actual submission.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIProgramInfoText</note>
+        <note>Parameter 0 is the name of the program that will be launched to further prepare the IMDI data for submission; Parameter 1 is the name of the calling (host) program (SayMore, FLEx, etc.)</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ISO3CodeRequired">
+        <source xml:lang="en">ISO 639-3 3-letter language code required.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ISO3CodeRequired</note>
+        <note>Message displayed when an invalid language code is given.</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.InvalidLanguageCode">
+        <source xml:lang="en">Invalid ISO 639-3 code: {0}</source>
+        <note>ID: DialogBoxes.ArchivingDlg.InvalidLanguageCode</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IsleMetadataInitiative">
+        <source xml:lang="en">Isle Metadata Initiative</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IsleMetadataInitiative</note>
+        <note>Typically this probably does not need to be localized.</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.NoIMDIProgramInfoText">
+        <source xml:lang="en">The {0} package will be created in {1}.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.NoIMDIProgramInfoText</note>
+        <note>Parameter 0 is 'IMDI'; Parameter 1 is the path where the package is created.</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.PathNotWritableMsg">
+        <source xml:lang="en">The path is not writable: {0}</source>
+        <note>ID: DialogBoxes.ArchivingDlg.PathNotWritableMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.PrearchivingStatusMsg">
+        <source xml:lang="en">The following files will be added to the archive:</source>
+        <note>ID: DialogBoxes.ArchivingDlg.PrearchivingStatusMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.PreparingFilesMsg">
+        <source xml:lang="en">Analyzing component files</source>
+        <note>ID: DialogBoxes.ArchivingDlg.PreparingFilesMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ProgramsFileTypeLabel">
+        <source xml:lang="en">Programs</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ProgramsFileTypeLabel</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.RAMPArchiveType">
+        <source xml:lang="en">RAMP (SIL Only)</source>
+        <note>ID: DialogBoxes.ArchivingDlg.RAMPArchiveType</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.RAMPOverviewText">
+        <source xml:lang="en">{0} is a utility for entering metadata and uploading submissions to SIL's internal archive, REAP. If you have access to this archive, this tool will help you use {0} to archive your {1} data. {2} When the {0} package has been created, you can  launch {0} and enter any additional information before doing the actual submission.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.RAMPOverviewText</note>
+        <note>Parameter 0  is the word 'RAMP' (the first one will be turned into a hyperlink); Parameter 1 is the name of the calling (host) program (SayMore, FLEx, etc.); Parameter 2 is additional app-specifc information.</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.RampNotFoundMsg">
+        <source xml:lang="en">The RAMP program cannot be found!</source>
+        <note>ID: DialogBoxes.ArchivingDlg.RampNotFoundMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ReadyToCallIMDIMsg">
+        <source xml:lang="en">Exported to {0}. This path is now on your clipboard. If you are using Arbil, go to File, Import, then paste this path in.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ReadyToCallIMDIMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ReadyToCallRampMsg">
+        <source xml:lang="en">Ready to hand the package to RAMP</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ReadyToCallRampMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.SavingFilesInPackageMsg">
+        <source xml:lang="en">Saving files in {0} package</source>
+        <note>ID: DialogBoxes.ArchivingDlg.SavingFilesInPackageMsg</note>
+        <note>Parameter is the type of archive (e.g., RAMP/IMDI)</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.SearchingForRampMsg">
+        <source xml:lang="en">Searching for the RAMP program...</source>
+        <note>ID: DialogBoxes.ArchivingDlg.SearchingForRampMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.StartingIMDIErrorMsg">
+        <source xml:lang="en">There was an error attempting to open the archive package in {0}.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.StartingIMDIErrorMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.StartingRampErrorMsg">
+        <source xml:lang="en">There was an error attempting to open the archive package in {0}.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.StartingRampErrorMsg</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.WindowTitle">
+        <source xml:lang="en">{0}: Archive using {1}</source>
+        <note>ID: DialogBoxes.ArchivingDlg.WindowTitle</note>
+        <note>Parameter is application name</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg._buttonCancel">
+        <source xml:lang="en">Cancel</source>
+        <note>ID: DialogBoxes.ArchivingDlg._buttonCancel</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg._buttonCreatePackage">
+        <source xml:lang="en">&amp;1) Create Package</source>
+        <note>ID: DialogBoxes.ArchivingDlg._buttonCreatePackage</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg._buttonLaunchRamp">
+        <source xml:lang="en">&amp;2) Launch {0}</source>
+        <note>ID: DialogBoxes.ArchivingDlg._buttonLaunchRamp</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems">
+        <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
+        <note>Param {0} is a description of the things being deleted (e.g., "The selected files")</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem">
+        <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
+        <note>Param {0} is a file name</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle">
+        <source xml:lang="en">Confirm Delete</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn">
+        <source xml:lang="en">&amp;Cancel</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn">
+        <source xml:lang="en">&amp;Delete</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.FileDlg.AllFilesLabel">
+        <source xml:lang="en">All Files</source>
+        <note>ID: DialogBoxes.FileDlg.AllFilesLabel</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.ArchivingIMDILocationDescription">
+        <source xml:lang="en">Select a base folder where the IMDI directory structure should be created.</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.ArchivingIMDILocationDescription</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.ChangeDestinationFolder">
+        <source xml:lang="en">Change Folder</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.ChangeDestinationFolder</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.ChangeProgramToLaunch">
+        <source xml:lang="en">Change Program to Launch</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.ChangeProgramToLaunch</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.CloseButtonLabel">
+        <source xml:lang="en">Close</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.CloseButtonLabel</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.CreatePackageButtonLabel">
+        <source xml:lang="en">Create Package</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.CreatePackageButtonLabel</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.SelectIMDIProgram">
+        <source xml:lang="en">Select the program to launch after IMDI package is created</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.SelectIMDIProgram</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.SelectProjectDlg.ProjectFilesLabel">
+        <source xml:lang="en">{0} Project Files</source>
+        <note>ID: DialogBoxes.SelectProjectDlg.ProjectFilesLabel</note>
+        <note>{0} is the product name</note>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.SelectProjectDlg.ResourceBundleFileTypeLabel">
+        <source xml:lang="en">Text Resource Bundle files</source>
+        <note>ID: DialogBoxes.SelectProjectDlg.ResourceBundleFileTypeLabel</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ContinueButtonLabel">
+        <source xml:lang="en">Continue</source>
+        <note>ID: ExceptionReportingDialog.ContinueButtonLabel</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.EmailInstructions">
+        <source xml:lang="en">(Please e-mail this to)</source>
+        <note>ID: ExceptionReportingDialog.EmailInstructions</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.NotificationTextLethal">
+        <source xml:lang="en">Well, this is embarrassing.</source>
+        <note>ID: ExceptionReportingDialog.NotificationTextLethal</note>
+        <note>For more formal cultures, something less cheeky might be better. In most cases, this will be replaced by a more useful message, but there are situations where a user could see this.</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.NotificationTextNonLethal">
+        <source xml:lang="en">Take Courage. It'll work out.</source>
+        <note>ID: ExceptionReportingDialog.NotificationTextNonLethal</note>
+        <note>For more formal cultures, something less cheeky might be better. In most cases, this will be replaced by a more useful message, but there are situations where a user could see this.</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para1">
+        <source xml:lang="en">If you don't care who reads your bug report, you can disregard this notice.</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para1</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para2">
+        <source xml:lang="en">When you submit a crash report or other issue, it goes into our issue tracking system, "Jira", which is available via the web at https://jira.sil.org/issues.(This is a normal way to handle issues in an open-source project.)</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para2</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para3">
+        <source xml:lang="en">Our issue-tracking system is not searchable by those without an account. Therefore, search engines (like Google) will not find your bug reports.</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para3</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para4">
+        <source xml:lang="en">However, anyone can make an account and then read your report. So if you have something private to say, please send it to one of the developers privately with a note that you don't want the issue in our issue tracking system. If necessary, we can make a place-holder for your issue without the private information so the issue can still be tracked and not get lost.</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para4</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.PrivacyNoticeCaption">
+        <source xml:lang="en">Privacy Notice</source>
+        <note>ID: ExceptionReportingDialog.PrivacyNoticeCaption</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel">
+        <source xml:lang="en">&amp;Copy</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabelLethal">
+        <source xml:lang="en">&amp;Copy and Exit</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabelLethal</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.CopyToClipboard">
+        <source xml:lang="en">Copy to clipboard</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.CopyToClipboard</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.Email">
+        <source xml:lang="en">Send using my email program</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.Email</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel">
+        <source xml:lang="en">&amp;Email</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabelLethal">
+        <source xml:lang="en">&amp;Email and Exit</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabelLethal</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.WindowTitle">
+        <source xml:lang="en">Error</source>
+        <note>ID: ExceptionReportingDialog.WindowTitle</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._detailsForDevelopers">
+        <source xml:lang="en">Details for the developers:</source>
+        <note>ID: ExceptionReportingDialog._detailsForDevelopers</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._lblPleaseHelp">
+        <source xml:lang="en">To help us fix the problem, we need to gather information on what went wrong.</source>
+        <note>ID: ExceptionReportingDialog._lblPleaseHelp</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._lblStepsToReproduce">
+        <source xml:lang="en">Can you list the steps to take to make this happen again, or tell us anything that might be helpful?</source>
+        <note>ID: ExceptionReportingDialog._lblStepsToReproduce</note>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._privacyNoticeButton">
+        <source xml:lang="en">Privacy Notice...</source>
+        <note>ID: ExceptionReportingDialog._privacyNoticeButton</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.AlmostMatchingImages">
+        <source xml:lang="en">Found {0} images with names close to “{1}”</source>
+        <note>ID: ImageToolbox.AlmostMatchingImages</note>
+        <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Camera">
+        <source xml:lang="en">Camera</source>
+        <note>ID: ImageToolbox.Camera</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata">
+        <source xml:lang="en">Use {0}</source>
+        <note>ID: ImageToolbox.CopyExemplarMetadata</note>
+        <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Crop">
+        <source xml:lang="en">Crop</source>
+        <note>ID: ImageToolbox.Crop</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.DownloadArtOfReading">
+        <source xml:lang="en">Download Art Of Reading Installer</source>
+        <note>ID: ImageToolbox.DownloadArtOfReading</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.EditMetadataLink">
+        <source xml:lang="en">Edit...</source>
+        <note>ID: ImageToolbox.EditMetadataLink</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.EnterSearchTerms">
+        <source xml:lang="en">In the box above, type what you are searching for, then press ENTER.</source>
+        <note>ID: ImageToolbox.EnterSearchTerms</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.FileButton">
+        <source xml:lang="en">File</source>
+        <note>ID: ImageToolbox.FileButton</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.FileChooserTitle">
+        <source xml:lang="en">Choose Picture File</source>
+        <note>ID: ImageToolbox.FileChooserTitle</note>
+        <note>Title shown for a file chooser dialog brought up by the ImageToolbox</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Galleries">
+        <source xml:lang="en">Galleries</source>
+        <note>ID: ImageToolbox.Galleries</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem">
+        <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
+        <note>ID: ImageToolbox.GenericGettingImageProblem</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.GenericProblem">
+        <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
+        <note>ID: ImageToolbox.GenericProblem</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.GetPicture">
+        <source xml:lang="en">Get Picture</source>
+        <note>ID: ImageToolbox.GetPicture</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.ImageGalleries">
+        <source xml:lang="en">Image Galleries</source>
+        <note>ID: ImageToolbox.ImageGalleries</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle">
+        <source xml:lang="en">Image Toolbox</source>
+        <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.InstallArtOfReading">
+        <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
+        <note>ID: ImageToolbox.InstallArtOfReading</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.MatchingImages">
+        <source xml:lang="en">Found {0} images</source>
+        <note>ID: ImageToolbox.MatchingImages</note>
+        <note>The {0} will be replaced by the number of matching images</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.NewMultilingual">
+        <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili?  It is free and available for downloading.</source>
+        <note>ID: ImageToolbox.NewMultilingual</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.NoGalleries">
+        <source xml:lang="en">This computer doesn't appear to have any galleries installed yet.</source>
+        <note>ID: ImageToolbox.NoGalleries</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.NoMatchingImages">
+        <source xml:lang="en">Found no matching images</source>
+        <note>ID: ImageToolbox.NoMatchingImages</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.PictureFiles">
+        <source xml:lang="en">picture files</source>
+        <note>ID: ImageToolbox.PictureFiles</note>
+        <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.ProblemLoadingImage">
+        <source xml:lang="en">Sorry, there was a problem loading that image.</source>
+        <note>ID: ImageToolbox.ProblemLoadingImage</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata">
+        <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
+        <note>ID: ImageToolbox.PromptForMissingMetadata</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Scanner">
+        <source xml:lang="en">Scanner</source>
+        <note>ID: ImageToolbox.Scanner</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.SearchLanguage">
+        <source xml:lang="en">The search box is currently set to {0}</source>
+        <note>ID: ImageToolbox.SearchLanguage</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.SetUpMetadataLink">
+        <source xml:lang="en">Set up metadata...</source>
+        <note>ID: ImageToolbox.SetUpMetadataLink</note>
+      </trans-unit>
+      <trans-unit id="IpaIdentifierView.betterLabel1">
+        <source xml:lang="en">Purpose:</source>
+        <note>ID: IpaIdentifierView.betterLabel1</note>
+        <note>In writing system setup when IPA special option is selected: Label for the purpose combo box</note>
+      </trans-unit>
+      <trans-unit id="IpaIdentifierView.linkLabel1">
+        <source xml:lang="en">Read about IPA transcription on the web</source>
+        <note>ID: IpaIdentifierView.linkLabel1</note>
+        <note>In writing system setup when IPA special option is selected: text used in link to a webpage describing IPA transcription</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2">
+        <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+        <source xml:lang="en">Ethnologue.com</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
+        <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes">
+        <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle">
+        <source xml:lang="en">About The ISO Language Registry</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CodeHeader">
+        <source xml:lang="en">Code</source>
+        <note>ID: LanguageLookup.CodeHeader</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CountryCount">
+        <source xml:lang="en">{0} Countries</source>
+        <note>ID: LanguageLookup.CountryCount</note>
+        <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CountryHeader">
+        <source xml:lang="en">Country</source>
+        <note>ID: LanguageLookup.CountryHeader</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel">
+        <source xml:lang="en">You can change how the language name will be displayed here:</source>
+        <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle">
+        <source xml:lang="en">Look up Language Code</source>
+        <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.PrimaryNameHeader">
+        <source xml:lang="en">Name</source>
+        <note>ID: LanguageLookup.PrimaryNameHeader</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel">
+        <source xml:lang="en">Show regional dialects</source>
+        <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.UnlistedLanguage">
+        <source xml:lang="en">Unlisted Language</source>
+        <note>ID: LanguageLookup.UnlistedLanguage</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink">
+        <source xml:lang="en">Can't find your language?</source>
+        <note>ID: LanguageLookup._cannotFindLanguageLink</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup._scriptsAndVariantsLabel">
+        <source xml:lang="en">my script variant label</source>
+        <note>ID: LanguageLookup._scriptsAndVariantsLabel</note>
+      </trans-unit>
+      <trans-unit id="LanguageLookup._scriptsAndVariantsLink">
+        <source xml:lang="en">Script and Variant</source>
+        <note>ID: LanguageLookup._scriptsAndVariantsLink</note>
+      </trans-unit>
+      <trans-unit id="MemoryWarning">
+        <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
+        <note>ID: MemoryWarning</note>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.Creator">
+        <source xml:lang="en">Creator: {0}</source>
+        <note>ID: MetadataDisplay.Creator</note>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.CreatorLabel">
+        <source xml:lang="en">Creator</source>
+        <note>ID: MetadataDisplay.CreatorLabel</note>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.LicenseInfo">
+        <source xml:lang="en">License Info</source>
+        <note>ID: MetadataDisplay.LicenseInfo</note>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.NoLicense">
+        <source xml:lang="en">No license specified</source>
+        <note>ID: MetadataDisplay.NoLicense</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.AllowCommercialUse">
+        <source xml:lang="en">Allow commercial uses of your work?</source>
+        <note>ID: MetadataEditor.AllowCommercialUse</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.AllowDerivatives">
+        <source xml:lang="en">Allow modifications of your work?</source>
+        <note>ID: MetadataEditor.AllowDerivatives</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CopyrightHolder">
+        <source xml:lang="en">Copyright Holder</source>
+        <note>ID: MetadataEditor.CopyrightHolder</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CopyrightYear">
+        <source xml:lang="en">Copyright Year</source>
+        <note>ID: MetadataEditor.CopyrightYear</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CreativeCommons">
+        <source xml:lang="en">Creative Commons</source>
+        <note>ID: MetadataEditor.CreativeCommons</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental">
+        <source xml:lang="en">Intergovernmental Version</source>
+        <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CreatorLabel">
+        <source xml:lang="en">Creator</source>
+        <note>ID: MetadataEditor.CreatorLabel</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CustomLicense">
+        <source xml:lang="en">Custom</source>
+        <note>ID: MetadataEditor.CustomLicense</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.License">
+        <source xml:lang="en">License</source>
+        <note>ID: MetadataEditor.License</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.PublicDomain">
+        <source xml:lang="en">The copyright holder waives all rights</source>
+        <note>ID: MetadataEditor.PublicDomain</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.TitleNoCredit">
+        <source xml:lang="en">Copyright and License</source>
+        <note>ID: MetadataEditor.TitleNoCredit</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.TitleWithCredit">
+        <source xml:lang="en">Credit, Copyright, and License</source>
+        <note>ID: MetadataEditor.TitleWithCredit</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.UnknownLicense">
+        <source xml:lang="en">Contact the copyright holder for any permissions</source>
+        <note>ID: MetadataEditor.UnknownLicense</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.YesShareAlike">
+        <source xml:lang="en">Yes, as long as others share alike</source>
+        <note>ID: MetadataEditor.YesShareAlike</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.additionalRequestsLabel">
+        <source xml:lang="en">Additional Requests</source>
+        <note>ID: MetadataEditor.additionalRequestsLabel</note>
+        <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.betterLinkLabel1">
+        <source xml:lang="en">more info</source>
+        <note>ID: MetadataEditor.betterLinkLabel1</note>
+        <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.linkToPublicDomainCC0">
+        <source xml:lang="en">about {0} Public Domain</source>
+        <note>ID: MetadataEditor.linkToPublicDomainCC0</note>
+        <note>{0} is replaced by an untranslatable abbreviation functioning as an adjective ("CC0")</note>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons">
+        <source xml:lang="en">Not Enforceable</source>
+        <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
+      </trans-unit>
+      <trans-unit id="ProblemNotificationDialog.Caption">
+        <source xml:lang="en">Problem</source>
+        <note>ID: ProblemNotificationDialog.Caption</note>
+      </trans-unit>
+      <trans-unit id="Project.CannotRemove">
+        <source xml:lang="en">Cannot remove the selected project because it is currently open</source>
+        <note>ID: Project.CannotRemove</note>
+      </trans-unit>
+      <trans-unit id="Project.CannotRemoveCaption">
+        <source xml:lang="en">Cannot Remove from List</source>
+        <note>ID: Project.CannotRemoveCaption</note>
+      </trans-unit>
+      <trans-unit id="ProjectsList.Language">
+        <source xml:lang="en">Language</source>
+        <note>ID: ProjectsList.Language</note>
+      </trans-unit>
+      <trans-unit id="ProjectsList.RecordingProject">
+        <source xml:lang="en">Recording Project</source>
+        <note>ID: ProjectsList.RecordingProject</note>
+      </trans-unit>
+      <trans-unit id="ScriptsAndVariants.ScriptsAndVariantsDialog._cancelButton">
+        <source xml:lang="en">Cancel</source>
+        <note>ID: ScriptsAndVariants.ScriptsAndVariantsDialog._cancelButton</note>
+      </trans-unit>
+      <trans-unit id="ScriptsAndVariants.ScriptsAndVariantsDialog._okButton">
+        <source xml:lang="en">OK</source>
+        <note>ID: ScriptsAndVariants.ScriptsAndVariantsDialog._okButton</note>
+      </trans-unit>
+      <trans-unit id="ScriptsAndVariantsDialog.ScriptsAndVariants">
+        <source xml:lang="en">Script and Variant</source>
+        <note>ID: ScriptsAndVariantsDialog.ScriptsAndVariants</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
+        <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
+        <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.CtrlShiftHint">
+        <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
+        <note>ID: SettingsProtection.CtrlShiftHint</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.CtrlShiftHint.MenuItem">
+        <source xml:lang="en">The menu item will show up when you hold down the Ctrl and Shift keys together.</source>
+        <note>ID: SettingsProtection.CtrlShiftHint.MenuItem</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.LauncherButtonLabel">
+        <source xml:lang="en">Settings...</source>
+        <note>ID: SettingsProtection.LauncherButtonLabel</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">
+        <source xml:lang="en">Hide the button that opens settings.</source>
+        <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox.MenuItem">
+        <source xml:lang="en">Hide the menu item that opens settings.</source>
+        <note>ID: SettingsProtection.NormallyHiddenCheckbox.MenuItem</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword">
+        <source xml:lang="en">Factory Password</source>
+        <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation">
+        <source xml:lang="en">To prevent accidental changes which could cause this program to stop working for you, these settings have been locked.</source>
+        <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle">
+        <source xml:lang="en">Settings Protection Password</source>
+        <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordNotice">
+        <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always visit the {1} support page.</source>
+        <note>ID: SettingsProtection.PasswordNotice</note>
+        <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNoticeWithSupportUrl". Param 0: Factory password; Param 1: product name</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordNoticeWithSupportUrl">
+        <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always visit the {1} support page: {2}</source>
+        <note>ID: SettingsProtection.PasswordNoticeWithSupportUrl</note>
+        <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNotice". Param 0: Factory password; Param 1: product name; Param 2: URL of support page</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox">
+        <source xml:lang="en">Require the factory password to get into settings.</source>
+        <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle">
+        <source xml:lang="en">Settings Protection</source>
+        <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
+      </trans-unit>
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle">
+        <source xml:lang="en">Release Notes</source>
+        <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
+      </trans-unit>
+      <trans-unit id="VoiceIdentifierView.betterLabel1">
+        <source xml:lang="en">In applications which support this option, fields with this input system will be able to play and record voice.</source>
+        <note>ID: VoiceIdentifierView.betterLabel1</note>
+        <note>Displayed if a user selects the voice special option in writing system setup</note>
+      </trans-unit>
+      <trans-unit id="WSFontControl.Font">
+        <source xml:lang="en">&amp;Font:</source>
+        <note>ID: WSFontControl.Font</note>
+      </trans-unit>
+      <trans-unit id="WSFontControl.FontNotAvailable">
+        <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
+        <note>ID: WSFontControl.FontNotAvailable</note>
+      </trans-unit>
+      <trans-unit id="WSFontControl.RightToLeftWS">
+        <source xml:lang="en">This is a &amp;right-to-left writing system.</source>
+        <note>ID: WSFontControl.RightToLeftWS</note>
+      </trans-unit>
+      <trans-unit id="WSFontControl.Size">
+        <source xml:lang="en">&amp;Size:</source>
+        <note>ID: WSFontControl.Size</note>
+      </trans-unit>
+      <trans-unit id="WSFontControl.TestArea">
+        <source xml:lang="en">&amp;Test Area:</source>
+        <note>ID: WSFontControl.TestArea</note>
+      </trans-unit>
+      <trans-unit id="WSIdentifierView.betterLabel4">
+        <source xml:lang="en">Abbreviation:</source>
+        <note>ID: WSIdentifierView.betterLabel4</note>
+        <note>In writing system setup general tab: label before abbreviation text box</note>
+      </trans-unit>
+      <trans-unit id="WSIdentifierView.betterLabel5">
+        <source xml:lang="en">Special:</source>
+        <note>ID: WSIdentifierView.betterLabel5</note>
+        <note>In writing system setup general tab:  Label before combo box with 'Special' choices</note>
+      </trans-unit>
+      <trans-unit id="WSIdentifiers.IpaIdentifierView.Default">
+        <source xml:lang="en">Default</source>
+        <note>ID: WSIdentifiers.IpaIdentifierView.Default</note>
+        <note>Choice for most users</note>
+      </trans-unit>
+      <trans-unit id="WSIdentifiers.IpaIdentifierView.Emic">
+        <source xml:lang="en">Emic (uses phonology of the language)</source>
+        <note>ID: WSIdentifiers.IpaIdentifierView.Emic</note>
+        <note>Only translate text inside of the parentheses ()</note>
+      </trans-unit>
+      <trans-unit id="WSIdentifiers.IpaIdentifierView.Etic">
+        <source xml:lang="en">Etic (raw phonetic transcription)</source>
+        <note>ID: WSIdentifiers.IpaIdentifierView.Etic</note>
+        <note>Only translate text inside of the parentheses ()</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed">
+        <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
+        <note>ID: WSKeyboardControl.KeyboardNotListed</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink">
+        <source xml:lang="en">Windows keyboard settings</source>
+        <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable">
+        <source xml:lang="en">Available keyboards</source>
+        <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed">
+        <source xml:lang="en">Previously used keyboards</source>
+        <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink">
+        <source xml:lang="en">Keyman Configuration</source>
+        <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled">
+        <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
+        <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel">
+        <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
+        <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.SetupKeyboards">
+        <source xml:lang="en">Set up keyboards</source>
+        <note>ID: WSKeyboardControl.SetupKeyboards</note>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.TestAreaCaption">
+        <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
+        <note>ID: WSKeyboardControl.TestAreaCaption</note>
+      </trans-unit>
+      <trans-unit id="Warning">
+        <source xml:lang="en">Warning</source>
+        <note>ID: Warning</note>
+      </trans-unit>
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption">
+        <source xml:lang="en">Unable to connect to SLDR</source>
+        <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
+      </trans-unit>
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText">
+        <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
+        <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>
+      </trans-unit>
+      <trans-unit id="XkbKeyboardAdaptor.MissingKeyboard">
+        <source xml:lang="en">[Missing] {0} ({1})</source>
+        <note>ID: XkbKeyboardAdaptor.MissingKeyboard</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/DistFiles/Palaso.es.xlf
+++ b/DistFiles/Palaso.es.xlf
@@ -1,0 +1,1064 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns:sil="http://sil.org/software/XLiff" xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" product-version="6.0.0" original="Palaso.dll" datatype="plaintext" target-language="es-ES">
+    <body>
+      <trans-unit id="AboutDialog.BuiltOnDate" approved="yes">
+        <source xml:lang="en">Built on {0}</source>
+        <note>ID: AboutDialog.BuiltOnDate</note>
+        <note>{0} is the date the application was built</note>
+        <target xml:lang="es-ES" state="final">Compilado en {0}</target>
+      </trans-unit>
+      <trans-unit id="AboutDialog.NoUpdates" approved="yes">
+        <source xml:lang="en">No Updates</source>
+        <note>ID: AboutDialog.NoUpdates</note>
+        <target xml:lang="es-ES" state="final">No hay actualizaciones</target>
+      </trans-unit>
+      <trans-unit id="AboutDialog.WindowTitle" approved="yes">
+        <source xml:lang="en">About {0}</source>
+        <note>ID: AboutDialog.WindowTitle</note>
+        <note>{0} is the application name</note>
+        <target xml:lang="es-ES" state="final">Acerca de {0}</target>
+      </trans-unit>
+      <trans-unit id="AboutDialog._checkForUpdates" approved="yes">
+        <source xml:lang="en">Check For Updates</source>
+        <note>ID: AboutDialog._checkForUpdates</note>
+        <target xml:lang="es-ES" state="final">Buscar actualizaciones</target>
+      </trans-unit>
+      <trans-unit id="AboutDialog._releaseNotesLabel" approved="yes">
+        <source xml:lang="en">Release Notes</source>
+        <note>ID: AboutDialog._releaseNotesLabel</note>
+        <target xml:lang="es-ES" state="final">Notas de la versión</target>
+      </trans-unit>
+      <trans-unit id="Application.AlreadyRunning.General" approved="yes">
+        <source xml:lang="en">Another copy of the application is already running. If you cannot find it, restart your computer.</source>
+        <note>ID: Application.AlreadyRunning.General</note>
+        <target xml:lang="es-ES" state="final">Ya se está ejecutando otra copia del programa. Si no la encuentra, reinicie su computadora.</target>
+      </trans-unit>
+      <trans-unit id="Application.AlreadyRunning.Specific" approved="yes">
+        <source xml:lang="en">Another copy of {0} is already running. If you cannot find that copy of {0}, restart your computer.</source>
+        <note>ID: Application.AlreadyRunning.Specific</note>
+        <note>{0} is the application name</note>
+        <target xml:lang="es-ES" state="final">Ya se está ejecutando otra copia de {0}. Si no la encuentra, reinicie su computadora.</target>
+      </trans-unit>
+      <trans-unit id="Application.ProblemStarting.General" approved="yes">
+        <source xml:lang="en">There was a problem starting the application which might require that you restart your computer.</source>
+        <note>ID: Application.ProblemStarting.General</note>
+        <target xml:lang="es-ES" state="final">Hubo un problema al iniciar el programa. Posiblemente tendrá que reiniciar su computadora.</target>
+      </trans-unit>
+      <trans-unit id="Application.ProblemStarting.Specific" approved="yes">
+        <source xml:lang="en">There was a problem starting {0} which might require that you restart your computer.</source>
+        <note>ID: Application.ProblemStarting.Specific</note>
+        <note>{0} is the application name</note>
+        <target xml:lang="es-ES" state="final">Hubo un problema al iniciar {0}. Posiblemente tendrá que reiniciar su computadora.</target>
+      </trans-unit>
+      <trans-unit id="Application.WaitingFinish.General" approved="yes">
+        <source xml:lang="en">Waiting for other application to finish...</source>
+        <note>ID: Application.WaitingFinish.General</note>
+        <target xml:lang="es-ES" state="final">Esperando que otra aplicación termine...</target>
+      </trans-unit>
+      <trans-unit id="Application.WaitingFinish.Specific" approved="yes">
+        <source xml:lang="en">Waiting for other {0} to finish...</source>
+        <note>ID: Application.WaitingFinish.Specific</note>
+        <note>{0} is the application name</note>
+        <target xml:lang="es-ES" state="final">Esperando que {0} termine...</target>
+      </trans-unit>
+      <trans-unit id="ArchivingDlg._chkMetadataOnly">
+        <source xml:lang="en">Metadata only</source>
+        <note>ID: ArchivingDlg._chkMetadataOnly</note>
+        <target xml:lang="es-ES" state="translated">Sólo metadatos</target>
+      </trans-unit>
+      <trans-unit id="ArchivingDlg._chkMetadataOnly_ToolTip_">
+        <source xml:lang="en">Select this to prevent copying actual data files into archive</source>
+        <note>ID: ArchivingDlg._chkMetadataOnly_ToolTip_</note>
+        <target xml:lang="es-ES" state="needs-translation">Select this to prevent copying actual data files into archive</target>
+      </trans-unit>
+      <trans-unit id="Common.AbortButton" approved="yes">
+        <source xml:lang="en">&amp;Abort</source>
+        <note>ID: Common.AbortButton</note>
+        <target xml:lang="es-ES" state="final">&amp;Cancelar</target>
+      </trans-unit>
+      <trans-unit id="Common.CancelButton" approved="yes">
+        <source xml:lang="en">&amp;Cancel</source>
+        <note>ID: Common.CancelButton</note>
+        <target xml:lang="es-ES" state="final">&amp;Cancelar</target>
+      </trans-unit>
+      <trans-unit id="Common.IgnoreButton" approved="yes">
+        <source xml:lang="en">&amp;Ignore</source>
+        <note>ID: Common.IgnoreButton</note>
+        <target xml:lang="es-ES" state="final">&amp;Ignorar</target>
+      </trans-unit>
+      <trans-unit id="Common.No">
+        <source xml:lang="en">No</source>
+        <note>ID: Common.No</note>
+        <target xml:lang="es-ES" state="translated">No</target>
+      </trans-unit>
+      <trans-unit id="Common.NoButton">
+        <source xml:lang="en">&amp;No</source>
+        <note>ID: Common.NoButton</note>
+        <target xml:lang="es-ES" state="translated">&amp;No</target>
+      </trans-unit>
+      <trans-unit id="Common.OKButton" approved="yes">
+        <source xml:lang="en">&amp;OK</source>
+        <note>ID: Common.OKButton</note>
+        <target xml:lang="es-ES" state="final">&amp;Aceptar</target>
+      </trans-unit>
+      <trans-unit id="Common.RetryButton" approved="yes">
+        <source xml:lang="en">&amp;Retry</source>
+        <note>ID: Common.RetryButton</note>
+        <target xml:lang="es-ES" state="final">&amp;Volver a intentar</target>
+      </trans-unit>
+      <trans-unit id="Common.Yes" approved="yes">
+        <source xml:lang="en">Yes</source>
+        <note>ID: Common.Yes</note>
+        <target xml:lang="es-ES" state="final">Si</target>
+      </trans-unit>
+      <trans-unit id="Common.YesButton" approved="yes">
+        <source xml:lang="en">&amp;Yes</source>
+        <note>ID: Common.YesButton</note>
+        <target xml:lang="es-ES" state="final">&amp;Sí</target>
+      </trans-unit>
+      <trans-unit id="CustomIdentifierView.betterLabel1" approved="yes">
+        <source xml:lang="en">RFC5646 code:</source>
+        <note>ID: CustomIdentifierView.betterLabel1</note>
+        <note>label describes the code for a custom identifier. Translate only 'code'</note>
+        <target xml:lang="es-ES" state="final">Código RFC5646:</target>
+      </trans-unit>
+      <trans-unit id="CustomIdentifierView.linkLabel1" approved="yes">
+        <source xml:lang="en">Read about language identifiers on the web</source>
+        <note>ID: CustomIdentifierView.linkLabel1</note>
+        <note>text used in the link to a webpage that describes the language identifiers</note>
+        <target xml:lang="es-ES" state="final">Lee acerca de los identificadores de idiomas en la web</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.AllFilesLabel">
+        <source xml:lang="en">All Files</source>
+        <note>ID: DialogBoxes.ArchivingDlg.AllFilesLabel</note>
+        <target xml:lang="es-ES" state="translated">Todos los archivos</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CancellingMsg">
+        <source xml:lang="en">Canceling...</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CancellingMsg</note>
+        <target xml:lang="es-ES" state="translated">Cancelando...</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CopyingFilesMsg">
+        <source xml:lang="en">Copying files</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CopyingFilesMsg</note>
+        <target xml:lang="es-ES" state="translated">Copiando archivos</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingArchiveErrorMsg">
+        <source xml:lang="en">There was an error attempting to create the RAMP file.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingArchiveErrorMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">There was an error attempting to create the RAMP file.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingIMDIPackageErrorMsg">
+        <source xml:lang="en">There was a problem starting process to create IMDI package.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingIMDIPackageErrorMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">There was a problem starting process to create IMDI package.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingInternalReapMetsFileErrorMsg">
+        <source xml:lang="en">There was an error attempting to create the RAMP/REAP mets file.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingInternalReapMetsFileErrorMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">There was an error attempting to create the RAMP/REAP mets file.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.CreatingZipFileErrorMsg">
+        <source xml:lang="en">There was a problem starting process to create zip file.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.CreatingZipFileErrorMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">There was a problem starting process to create zip file.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.FileExcludedFromPackage">
+        <source xml:lang="en">File excluded from {0} package: </source>
+        <note>ID: DialogBoxes.ArchivingDlg.FileExcludedFromPackage</note>
+        <note>Parameter is the type of archive (e.g., RAMP/IMDI)</note>
+        <target xml:lang="es-ES" state="translated">Archivo excluido del paquete {0}: </target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIActorsGroup">
+        <source xml:lang="en">Actors</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIActorsGroup</note>
+        <note>This is the heading displayed in the Archive Using IMDI dialog box for the files for the actors/participants</note>
+        <target xml:lang="es-ES" state="translated">Actores</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIArchiveType">
+        <source xml:lang="en">IMDI</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIArchiveType</note>
+        <note>This is the abbreviation for Isle Metadata Initiative (http://www.mpi.nl/imdi/). Typically this probably does not need to be localized.</note>
+        <target xml:lang="es-ES" state="needs-translation">IMDI</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIOverviewText">
+        <source xml:lang="en">{0} ({1}) is a metadata standard to describe multi-media and multi-modal language resources. The standard provides interoperability for browsable and searchable corpus structures and resource descriptions.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIOverviewText</note>
+        <note>Parameter 0  is 'Isle Metadata Initiative' (the first occurrence will be turned into a hyperlink); Parameter 1 is 'IMDI'</note>
+        <target xml:lang="es-ES" state="needs-translation">{0} ({1}) is a metadata standard to describe multi-media and multi-modal language resources. The standard provides interoperability for browsable and searchable corpus structures and resource descriptions.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IMDIProgramInfoText">
+        <source xml:lang="en">This tool will help you use {0} to archive your {1} data. When the {1} package has been created, you can launch {0} and enter any additional information before doing the actual submission.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IMDIProgramInfoText</note>
+        <note>Parameter 0 is the name of the program that will be launched to further prepare the IMDI data for submission; Parameter 1 is the name of the calling (host) program (SayMore, FLEx, etc.)</note>
+        <target xml:lang="es-ES" state="needs-translation">This tool will help you use {0} to archive your {1} data. When the {1} package has been created, you can launch {0} and enter any additional information before doing the actual submission.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ISO3CodeRequired">
+        <source xml:lang="en">ISO 639-3 3-letter language code required.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ISO3CodeRequired</note>
+        <note>Message displayed when an invalid language code is given.</note>
+        <target xml:lang="es-ES" state="needs-translation">ISO 639-3 3-letter language code required.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.InvalidLanguageCode">
+        <source xml:lang="en">Invalid ISO 639-3 code: {0}</source>
+        <note>ID: DialogBoxes.ArchivingDlg.InvalidLanguageCode</note>
+        <target xml:lang="es-ES" state="translated">Código ISO 639-3 no válido: {0}</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.IsleMetadataInitiative">
+        <source xml:lang="en">Isle Metadata Initiative</source>
+        <note>ID: DialogBoxes.ArchivingDlg.IsleMetadataInitiative</note>
+        <note>Typically this probably does not need to be localized.</note>
+        <target xml:lang="es-ES" state="needs-translation">Isle Metadata Initiative</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.NoIMDIProgramInfoText">
+        <source xml:lang="en">The {0} package will be created in {1}.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.NoIMDIProgramInfoText</note>
+        <note>Parameter 0 is 'IMDI'; Parameter 1 is the path where the package is created.</note>
+        <target xml:lang="es-ES" state="translated">El paquete {0} se creará en {1}.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.PathNotWritableMsg">
+        <source xml:lang="en">The path is not writable: {0}</source>
+        <note>ID: DialogBoxes.ArchivingDlg.PathNotWritableMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">The path is not writable: {0}</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.PrearchivingStatusMsg">
+        <source xml:lang="en">The following files will be added to the archive:</source>
+        <note>ID: DialogBoxes.ArchivingDlg.PrearchivingStatusMsg</note>
+        <target xml:lang="es-ES" state="translated">Los siguientes archivos se añadirán al almacén:</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.PreparingFilesMsg">
+        <source xml:lang="en">Analyzing component files</source>
+        <note>ID: DialogBoxes.ArchivingDlg.PreparingFilesMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">Analyzing component files</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ProgramsFileTypeLabel">
+        <source xml:lang="en">Programs</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ProgramsFileTypeLabel</note>
+        <target xml:lang="es-ES" state="translated">Programas</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.RAMPArchiveType">
+        <source xml:lang="en">RAMP (SIL Only)</source>
+        <note>ID: DialogBoxes.ArchivingDlg.RAMPArchiveType</note>
+        <target xml:lang="es-ES" state="translated">RAMP (sólo SIL)</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.RAMPOverviewText">
+        <source xml:lang="en">{0} is a utility for entering metadata and uploading submissions to SIL's internal archive, REAP. If you have access to this archive, this tool will help you use {0} to archive your {1} data. {2} When the {0} package has been created, you can  launch {0} and enter any additional information before doing the actual submission.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.RAMPOverviewText</note>
+        <note>Parameter 0  is the word 'RAMP' (the first one will be turned into a hyperlink); Parameter 1 is the name of the calling (host) program (SayMore, FLEx, etc.); Parameter 2 is additional app-specifc information.</note>
+        <target xml:lang="es-ES" state="needs-translation">{0} is a utility for entering metadata and uploading submissions to SIL's internal archive, REAP. If you have access to this archive, this tool will help you use {0} to archive your {1} data. {2} When the {0} package has been created, you can  launch {0} and enter any additional information before doing the actual submission.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.RampNotFoundMsg">
+        <source xml:lang="en">The RAMP program cannot be found!</source>
+        <note>ID: DialogBoxes.ArchivingDlg.RampNotFoundMsg</note>
+        <target xml:lang="es-ES" state="translated">¡El programa RAMP no se encuentra!</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ReadyToCallIMDIMsg">
+        <source xml:lang="en">Exported to {0}. This path is now on your clipboard. If you are using Arbil, go to File, Import, then paste this path in.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ReadyToCallIMDIMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">Exported to {0}. This path is now on your clipboard. If you are using Arbil, go to File, Import, then paste this path in.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.ReadyToCallRampMsg">
+        <source xml:lang="en">Ready to hand the package to RAMP</source>
+        <note>ID: DialogBoxes.ArchivingDlg.ReadyToCallRampMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">Ready to hand the package to RAMP</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.SavingFilesInPackageMsg">
+        <source xml:lang="en">Saving files in {0} package</source>
+        <note>ID: DialogBoxes.ArchivingDlg.SavingFilesInPackageMsg</note>
+        <note>Parameter is the type of archive (e.g., RAMP/IMDI)</note>
+        <target xml:lang="es-ES" state="translated">Guardando los archivos en el paquete {0}</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.SearchingForRampMsg">
+        <source xml:lang="en">Searching for the RAMP program...</source>
+        <note>ID: DialogBoxes.ArchivingDlg.SearchingForRampMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">Searching for the RAMP program...</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.StartingIMDIErrorMsg">
+        <source xml:lang="en">There was an error attempting to open the archive package in {0}.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.StartingIMDIErrorMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">There was an error attempting to open the archive package in {0}.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.StartingRampErrorMsg">
+        <source xml:lang="en">There was an error attempting to open the archive package in {0}.</source>
+        <note>ID: DialogBoxes.ArchivingDlg.StartingRampErrorMsg</note>
+        <target xml:lang="es-ES" state="needs-translation">There was an error attempting to open the archive package in {0}.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg.WindowTitle">
+        <source xml:lang="en">{0}: Archive using {1}</source>
+        <note>ID: DialogBoxes.ArchivingDlg.WindowTitle</note>
+        <note>Parameter is application name</note>
+        <target xml:lang="es-ES" state="translated">{0}: Almacenar con {1}</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg._buttonCancel">
+        <source xml:lang="en">Cancel</source>
+        <note>ID: DialogBoxes.ArchivingDlg._buttonCancel</note>
+        <target xml:lang="es-ES" state="translated">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg._buttonCreatePackage">
+        <source xml:lang="en">&amp;1) Create Package</source>
+        <note>ID: DialogBoxes.ArchivingDlg._buttonCreatePackage</note>
+        <target xml:lang="es-ES" state="needs-translation">&amp;1) Create Package</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ArchivingDlg._buttonLaunchRamp">
+        <source xml:lang="en">&amp;2) Launch {0}</source>
+        <note>ID: DialogBoxes.ArchivingDlg._buttonLaunchRamp</note>
+        <target xml:lang="es-ES" state="translated">&amp;2) Lanzar {0}</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems" approved="yes">
+        <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForMultipleItems</note>
+        <note>Param {0} is a description of the things being deleted (e.g., "The selected files")</note>
+        <target xml:lang="es-ES" state="final">{0} se moverá a la papelera de reciclaje.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem" approved="yes">
+        <source xml:lang="en">{0} will be moved to the Recycle Bin.</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.MessageForSingleItem</note>
+        <note>Param {0} is a file name</note>
+        <target xml:lang="es-ES" state="final">{0} se moverá a la papelera de reciclaje.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.WindowTitle" approved="yes">
+        <source xml:lang="en">Confirm Delete</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.WindowTitle</note>
+        <target xml:lang="es-ES" state="final">Confirmar eliminación</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.cancelBtn" approved="yes">
+        <source xml:lang="en">&amp;Cancel</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.cancelBtn</note>
+        <target xml:lang="es-ES" state="final">&amp;Cancelar</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.ConfirmRecycleDialog.deleteBtn" approved="yes">
+        <source xml:lang="en">&amp;Delete</source>
+        <note>ID: DialogBoxes.ConfirmRecycleDialog.deleteBtn</note>
+        <target xml:lang="es-ES" state="final">&amp;Eliminar</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.FileDlg.AllFilesLabel">
+        <source xml:lang="en">All Files</source>
+        <note>ID: DialogBoxes.FileDlg.AllFilesLabel</note>
+        <target xml:lang="es-ES" state="translated">Todos los archivos</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.ArchivingIMDILocationDescription">
+        <source xml:lang="en">Select a base folder where the IMDI directory structure should be created.</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.ArchivingIMDILocationDescription</note>
+        <target xml:lang="es-ES" state="needs-translation">Select a base folder where the IMDI directory structure should be created.</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.ChangeDestinationFolder">
+        <source xml:lang="en">Change Folder</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.ChangeDestinationFolder</note>
+        <target xml:lang="es-ES" state="translated">Cambiar carpeta de destino</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.ChangeProgramToLaunch">
+        <source xml:lang="en">Change Program to Launch</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.ChangeProgramToLaunch</note>
+        <target xml:lang="es-ES" state="needs-translation">Change Program to Launch</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.CloseButtonLabel">
+        <source xml:lang="en">Close</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.CloseButtonLabel</note>
+        <target xml:lang="es-ES" state="translated">Cerrar</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.CreatePackageButtonLabel">
+        <source xml:lang="en">Create Package</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.CreatePackageButtonLabel</note>
+        <target xml:lang="es-ES" state="translated">Crear paquete</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.IMDIArchivingDlg.SelectIMDIProgram">
+        <source xml:lang="en">Select the program to launch after IMDI package is created</source>
+        <note>ID: DialogBoxes.IMDIArchivingDlg.SelectIMDIProgram</note>
+        <target xml:lang="es-ES" state="needs-translation">Select the program to launch after IMDI package is created</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.SelectProjectDlg.ProjectFilesLabel">
+        <source xml:lang="en">{0} Project Files</source>
+        <note>ID: DialogBoxes.SelectProjectDlg.ProjectFilesLabel</note>
+        <note>{0} is the product name</note>
+        <target xml:lang="es-ES" state="translated">Archivos de proyecto de {0}</target>
+      </trans-unit>
+      <trans-unit id="DialogBoxes.SelectProjectDlg.ResourceBundleFileTypeLabel">
+        <source xml:lang="en">Text Resource Bundle files</source>
+        <note>ID: DialogBoxes.SelectProjectDlg.ResourceBundleFileTypeLabel</note>
+        <target xml:lang="es-ES" state="translated">Paquetes de descarga de texto</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ContinueButtonLabel">
+        <source xml:lang="en">Continue</source>
+        <note>ID: ExceptionReportingDialog.ContinueButtonLabel</note>
+        <target xml:lang="es-ES" state="translated">Continuar</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.EmailInstructions">
+        <source xml:lang="en">(Please e-mail this to)</source>
+        <note>ID: ExceptionReportingDialog.EmailInstructions</note>
+        <target xml:lang="es-ES" state="translated">(Por favor envíe esto por correo electrónico a)</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.NotificationTextLethal">
+        <source xml:lang="en">Well, this is embarrassing.</source>
+        <note>ID: ExceptionReportingDialog.NotificationTextLethal</note>
+        <note>For more formal cultures, something less cheeky might be better. In most cases, this will be replaced by a more useful message, but there are situations where a user could see this.</note>
+        <target xml:lang="es-ES" state="translated">Disculpenos por este error.</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.NotificationTextNonLethal">
+        <source xml:lang="en">No se preocupe. Problema no fatal.</source>
+        <note>ID: ExceptionReportingDialog.NotificationTextNonLethal</note>
+        <note>For more formal cultures, something less cheeky might be better. In most cases, this will be replaced by a more useful message, but there are situations where a user could see this.</note>
+        <target xml:lang="es-ES" state="translated"></target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para1">
+        <source xml:lang="en">If you don't care who reads your bug report, you can disregard this notice.</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para1</note>
+        <target xml:lang="es-ES" state="translated">Si no le preocupa quién lea su informe de error, puede ignorar este aviso.</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para2">
+        <source xml:lang="en">When you submit a crash report or other issue, it goes into our issue tracking system, "Jira", which is available via the web at https://jira.sil.org/issues.(This is a normal way to handle issues in an open-source project.)</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para2</note>
+        <target xml:lang="es-ES" state="translated">Los informes de fallas u otros problemas se ingresan a nuestro sistema de seguimiento de problemas, "Jira", que está disponible a través de la web en https://jira.sil.org/issues. (Esta es una forma normal de manejar problemas en un proyecto de código abierto.)</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para3">
+        <source xml:lang="en">Our issue-tracking system is not searchable by those without an account. Therefore, search engines (like Google) will not find your bug reports.</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para3</note>
+        <target xml:lang="es-ES" state="translated">Nuestro sistema de seguimiento de problemas no puede ser buscado por aquellos que no tienen una cuenta. Por lo tanto, los motores de búsqueda (como Google) no encontrarán sus informes de errores.</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.Privacy.Para4">
+        <source xml:lang="en">However, anyone can make an account and then read your report. So if you have something private to say, please send it to one of the developers privately with a note that you don't want the issue in our issue tracking system. If necessary, we can make a place-holder for your issue without the private information so the issue can still be tracked and not get lost.</source>
+        <note>ID: ExceptionReportingDialog.Privacy.Para4</note>
+        <target xml:lang="es-ES" state="translated">Sin embargo, cualquiera puede crear una cuenta y luego leer su informe. Entonces, si su informe contiene algo privado, envíelo mejor en privado directamente a uno de los desarrolladores con una nota de que no desea que el problema aparezca en nuestro sistema de seguimiento de problemas. Si es necesario, podemos crear un marcador de posición para su problema sin la información privada para que aún se pueda rastrear el problema y no perderse.</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.PrivacyNoticeCaption">
+        <source xml:lang="en">Privacy Notice</source>
+        <note>ID: ExceptionReportingDialog.PrivacyNoticeCaption</note>
+        <target xml:lang="es-ES" state="translated">Aviso de privacidad</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel">
+        <source xml:lang="en">&amp;Copy</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+        <target xml:lang="es-ES" state="translated">&amp;Copiar</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabelLethal">
+        <source xml:lang="en">&amp;Copy and Exit</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabelLethal</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+        <target xml:lang="es-ES" state="translated">&amp;Copiar y salir</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.CopyToClipboard">
+        <source xml:lang="en">Copy to clipboard</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.CopyToClipboard</note>
+        <target xml:lang="es-ES" state="translated">Copiar al portapapeles</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.Email">
+        <source xml:lang="en">Send using my email program</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.Email</note>
+        <target xml:lang="es-ES" state="translated">Enviar mensaje desde mi correo electrónico</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel">
+        <source xml:lang="en">&amp;Email</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+        <target xml:lang="es-ES" state="translated">&amp;Enviar mensaje</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabelLethal">
+        <source xml:lang="en">&amp;Email and Exit</source>
+        <note>ID: ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabelLethal</note>
+        <note>Ampersand is optional, to indicate accelerator key</note>
+        <target xml:lang="es-ES" state="translated">&amp;Enviar mensaje y salir</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog.WindowTitle">
+        <source xml:lang="en">Error</source>
+        <note>ID: ExceptionReportingDialog.WindowTitle</note>
+        <target xml:lang="es-ES" state="translated">Error</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._detailsForDevelopers">
+        <source xml:lang="en">Details for the developers:</source>
+        <note>ID: ExceptionReportingDialog._detailsForDevelopers</note>
+        <target xml:lang="es-ES" state="translated">Detalles para los desarrolladores:</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._lblPleaseHelp">
+        <source xml:lang="en">To help us fix the problem, we need to gather information on what went wrong.</source>
+        <note>ID: ExceptionReportingDialog._lblPleaseHelp</note>
+        <target xml:lang="es-ES" state="translated">Para ayudarnos a solucionar el problema, necesitamos recopilar información sobre lo que salió mal.</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._lblStepsToReproduce">
+        <source xml:lang="en">Can you list the steps to take to make this happen again, or tell us anything that might be helpful?</source>
+        <note>ID: ExceptionReportingDialog._lblStepsToReproduce</note>
+        <target xml:lang="es-ES" state="translated">¿Puede enumerar los pasos a seguir para que esto vuelva a suceder o indicar algo sobre el escenario que precedió a este problema?</target>
+      </trans-unit>
+      <trans-unit id="ExceptionReportingDialog._privacyNoticeButton">
+        <source xml:lang="en">Privacy Notice...</source>
+        <note>ID: ExceptionReportingDialog._privacyNoticeButton</note>
+        <target xml:lang="es-ES" state="translated">Aviso de privacidad...</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.AlmostMatchingImages" approved="yes">
+        <source xml:lang="en">Found {0} images with names close to “{1}”</source>
+        <note>ID: ImageToolbox.AlmostMatchingImages</note>
+        <note>The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.</note>
+        <target xml:lang="es-ES" state="final">Encontró {0} imágenes con nombres parecidos a {1}</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Camera" approved="yes">
+        <source xml:lang="en">Camera</source>
+        <note>ID: ImageToolbox.Camera</note>
+        <target xml:lang="es-ES" state="final">Cámara</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.CopyExemplarMetadata" approved="yes">
+        <source xml:lang="en">Use {0}</source>
+        <note>ID: ImageToolbox.CopyExemplarMetadata</note>
+        <note>Used to copy a previous metadata set to the current image. The  {0} will be replaced with the name of the exemplar image.</note>
+        <target xml:lang="es-ES" state="final">Utilizar {0}</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Crop" approved="yes">
+        <source xml:lang="en">Crop</source>
+        <note>ID: ImageToolbox.Crop</note>
+        <target xml:lang="es-ES" state="final">Recortar</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.DownloadArtOfReading" approved="yes">
+        <source xml:lang="en">Download Art Of Reading Installer</source>
+        <note>ID: ImageToolbox.DownloadArtOfReading</note>
+        <target xml:lang="es-ES" state="final">Descargar el instalador de Arte de la Lectura (Art of Reading)</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.EditMetadataLink" approved="yes">
+        <source xml:lang="en">Edit...</source>
+        <note>ID: ImageToolbox.EditMetadataLink</note>
+        <target xml:lang="es-ES" state="final">Editar...</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.EnterSearchTerms" approved="yes">
+        <source xml:lang="en">In the box above, type what you are searching for, then press ENTER.</source>
+        <note>ID: ImageToolbox.EnterSearchTerms</note>
+        <target xml:lang="es-ES" state="final">En el cuadro superior, escriba lo que está buscando. A continuación pulse ENTRAR.</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.FileButton" approved="yes">
+        <source xml:lang="en">File</source>
+        <note>ID: ImageToolbox.FileButton</note>
+        <target xml:lang="es-ES" state="final">Archivo</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.FileChooserTitle" approved="yes">
+        <source xml:lang="en">Choose Picture File</source>
+        <note>ID: ImageToolbox.FileChooserTitle</note>
+        <note>Title shown for a file chooser dialog brought up by the ImageToolbox</note>
+        <target xml:lang="es-ES" state="final">Elija archivo de imagen</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Galleries" approved="yes">
+        <source xml:lang="en">Galleries</source>
+        <note>ID: ImageToolbox.Galleries</note>
+        <target xml:lang="es-ES" state="final">Galerías</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.GenericGettingImageProblem" approved="yes">
+        <source xml:lang="en">Sorry, something went wrong while getting the image.</source>
+        <note>ID: ImageToolbox.GenericGettingImageProblem</note>
+        <target xml:lang="es-ES" state="final">Lo sentimos, algo falló al tratar de obtener la imagen.</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.GenericProblem" approved="yes">
+        <source xml:lang="en">Sorry, something went wrong with the ImageToolbox</source>
+        <note>ID: ImageToolbox.GenericProblem</note>
+        <target xml:lang="es-ES" state="final">Lo sentimos, algo falló con la Caja de Herramientas de Imágenes (ImageToolbox)</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.GetPicture" approved="yes">
+        <source xml:lang="en">Get Picture</source>
+        <note>ID: ImageToolbox.GetPicture</note>
+        <target xml:lang="es-ES" state="final">Obtener imagen</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.ImageGalleries" approved="yes">
+        <source xml:lang="en">Image Galleries</source>
+        <note>ID: ImageToolbox.ImageGalleries</note>
+        <target xml:lang="es-ES" state="final">Galerías de Imagenes</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.ImageToolboxWindowTitle" approved="yes">
+        <source xml:lang="en">Image Toolbox</source>
+        <note>ID: ImageToolbox.ImageToolboxWindowTitle</note>
+        <target xml:lang="es-ES" state="final">Caja de Herramientas de Imágenes (Image Toolbox)</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.InstallArtOfReading" approved="yes">
+        <source xml:lang="en">Install the Art Of Reading package (this may be very slow)</source>
+        <note>ID: ImageToolbox.InstallArtOfReading</note>
+        <target xml:lang="es-ES" state="final">Instalar el paquete de Arte de la Lectura (Art of Reading), (esto puede tardar)</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.MatchingImages" approved="yes">
+        <source xml:lang="en">Found {0} images</source>
+        <note>ID: ImageToolbox.MatchingImages</note>
+        <note>The {0} will be replaced by the number of matching images</note>
+        <target xml:lang="es-ES" state="final">Encontró {0} imágenes</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.NewMultilingual" approved="yes">
+        <source xml:lang="en">Did you know that there is a new version of this collection which lets you search in Arabic, Bengali, Chinese, English, French, Indonesian, Hindi, Portuguese, Spanish, Thai, or Swahili?  It is free and available for downloading.</source>
+        <note>ID: ImageToolbox.NewMultilingual</note>
+        <target xml:lang="es-ES" state="final">¿Sabía que hay una nueva versión de esta colección que le permite buscar en arábe, bengalí, chino, inglés, francés, indonesio, hindi, portugués, español, tailandés, o suajili? Es gratuita y está disponible para ser descargada.</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.NoGalleries" approved="yes">
+        <source xml:lang="en">This computer doesn't appear to have any galleries installed yet.</source>
+        <note>ID: ImageToolbox.NoGalleries</note>
+        <target xml:lang="es-ES" state="final">Parece que esta computadora todavía no tiene galerías instaladas.</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.NoMatchingImages" approved="yes">
+        <source xml:lang="en">Found no matching images</source>
+        <note>ID: ImageToolbox.NoMatchingImages</note>
+        <target xml:lang="es-ES" state="final">No se encontraron imágenes que coincidan</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.PictureFiles" approved="yes">
+        <source xml:lang="en">picture files</source>
+        <note>ID: ImageToolbox.PictureFiles</note>
+        <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
+        <target xml:lang="es-ES" state="final">archivos de imágenes</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.ProblemLoadingImage" approved="yes">
+        <source xml:lang="en">Sorry, there was a problem loading that image.</source>
+        <note>ID: ImageToolbox.ProblemLoadingImage</note>
+        <target xml:lang="es-ES" state="final">Lastimosamente, no se pudo cargar esa imagen.</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.PromptForMissingMetadata" approved="yes">
+        <source xml:lang="en">This image does not know:\n\nWho created it?\nWho can use it?</source>
+        <note>ID: ImageToolbox.PromptForMissingMetadata</note>
+        <target xml:lang="es-ES" state="final">Esta imagen no sabe:\n\n¿Quién la creó?\n¿Quién puede utilizarla?</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.Scanner" approved="yes">
+        <source xml:lang="en">Scanner</source>
+        <note>ID: ImageToolbox.Scanner</note>
+        <target xml:lang="es-ES" state="final">Escáner</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.SearchLanguage" approved="yes">
+        <source xml:lang="en">The search box is currently set to {0}</source>
+        <note>ID: ImageToolbox.SearchLanguage</note>
+        <target xml:lang="es-ES" state="final">Actualmente el cuadro de búsqueda está en {0}</target>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.SetUpMetadataLink" approved="yes">
+        <source xml:lang="en">Set up metadata...</source>
+        <note>ID: ImageToolbox.SetUpMetadataLink</note>
+        <target xml:lang="es-ES" state="final">Configurar metadatos...</target>
+      </trans-unit>
+      <trans-unit id="IpaIdentifierView.betterLabel1" approved="yes">
+        <source xml:lang="en">Purpose:</source>
+        <note>ID: IpaIdentifierView.betterLabel1</note>
+        <note>In writing system setup when IPA special option is selected: Label for the purpose combo box</note>
+        <target xml:lang="es-ES" state="final">Propósito:</target>
+      </trans-unit>
+      <trans-unit id="IpaIdentifierView.linkLabel1" approved="yes">
+        <source xml:lang="en">Read about IPA transcription on the web</source>
+        <note>ID: IpaIdentifierView.linkLabel1</note>
+        <note>In writing system setup when IPA special option is selected: text used in link to a webpage describing IPA transcription</note>
+        <target xml:lang="es-ES" state="final">Lee sobre la transcripción en AFI (Alfabeto Fonético Internacional) en la web</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2" approved="yes">
+        <source xml:lang="en">This list should include all the ISO-639 languages, including all the alternative names known to ethnologue.com.\n\nIf necessary, use the "Unlisted Language" option, which will be selected for you now.</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguage.LanguageLookup.CannotFindMyLanguageExplanation2</note>
+        <target xml:lang="es-ES" state="final">Esta lista debe incluir todos los idiomas de ISO-639, incluidos todos los nombres alternativos conocidos por ethnologue.com.\n\nSi es necesario, utilice la opción "Idioma no enlistado", esta opción será seleccionada ahora.</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToEthnologue">
+        <source xml:lang="en">Ethnologue.com</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToEthnologue</note>
+        <note>It's ok to change what this shows; the underlying destination will remain ethnologue.com</note>
+        <target xml:lang="es-ES" state="translated">Ethnologue.com</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes" approved="yes">
+        <source xml:lang="en">About Language 639-3 Codes &amp; How To Apply For New Ones</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguage.LinkToSILInformationAboutLanguageCodes</note>
+        <target xml:lang="es-ES" state="final">Acerca de Códigos de Idioma 639-3 y Cómo solicitar nuevos</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CannotFindMyLanguageWindowTitle" approved="yes">
+        <source xml:lang="en">About The ISO Language Registry</source>
+        <note>ID: LanguageLookup.CannotFindMyLanguageWindowTitle</note>
+        <target xml:lang="es-ES" state="final">Acerca del Registro ISO de Idiomas</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CodeHeader" approved="yes">
+        <source xml:lang="en">Code</source>
+        <note>ID: LanguageLookup.CodeHeader</note>
+        <target xml:lang="es-ES" state="final">Código</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CountryCount" approved="yes">
+        <source xml:lang="en">{0} Countries</source>
+        <note>ID: LanguageLookup.CountryCount</note>
+        <note>Shown when there are multiple countries and it is just confusing to list them all. {0} is a count of countries.</note>
+        <target xml:lang="es-ES" state="final">{0} países</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.CountryHeader" approved="yes">
+        <source xml:lang="en">Country</source>
+        <note>ID: LanguageLookup.CountryHeader</note>
+        <target xml:lang="es-ES" state="final">País</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.DesiredLanguageDisplayNameLabel" approved="yes">
+        <source xml:lang="en">You can change how the language name will be displayed here:</source>
+        <note>ID: LanguageLookup.DesiredLanguageDisplayNameLabel</note>
+        <target xml:lang="es-ES" state="final">Aquí puede cambiar cómo se mostrará el nombre del idioma:</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.LanguageLookupDialogWindowTitle" approved="yes">
+        <source xml:lang="en">Lookup Language Code...</source>
+        <note>ID: LanguageLookup.LanguageLookupDialogWindowTitle</note>
+        <target xml:lang="es-ES" state="final">Buscar el Código del Idioma...</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.PrimaryNameHeader" approved="yes">
+        <source xml:lang="en">Name</source>
+        <note>ID: LanguageLookup.PrimaryNameHeader</note>
+        <target xml:lang="es-ES" state="final">Nombre</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.ShowRegionalDialectsLabel" approved="yes">
+        <source xml:lang="en">Show regional dialects</source>
+        <note>ID: LanguageLookup.ShowRegionalDialectsLabel</note>
+        <target xml:lang="es-ES" state="final">Mostrar dialectos regionales</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup.UnlistedLanguage" approved="yes">
+        <source xml:lang="en">Unlisted Language</source>
+        <note>ID: LanguageLookup.UnlistedLanguage</note>
+        <target xml:lang="es-ES" state="final">Idioma no enlistado</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup._cannotFindLanguageLink" approved="yes">
+        <source xml:lang="en">Can't find your language?</source>
+        <note>ID: LanguageLookup._cannotFindLanguageLink</note>
+        <target xml:lang="es-ES" state="final">¿No encuentra su idioma?</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup._scriptsAndVariantsLabel" approved="yes">
+        <source xml:lang="en">my script variant label</source>
+        <note>ID: LanguageLookup._scriptsAndVariantsLabel</note>
+        <target xml:lang="es-ES" state="final">mi etiqueta variante de escritura</target>
+      </trans-unit>
+      <trans-unit id="LanguageLookup._scriptsAndVariantsLink" approved="yes">
+        <source xml:lang="en">Script and Variant</source>
+        <note>ID: LanguageLookup._scriptsAndVariantsLink</note>
+        <target xml:lang="es-ES" state="final">Escritura y variante</target>
+      </trans-unit>
+      <trans-unit id="MemoryWarning" approved="yes">
+        <source xml:lang="en">Unfortunately, {0} is starting to get short of memory, and may soon slow down or experience other problems. We recommend that you quit and restart it when convenient.</source>
+        <note>ID: MemoryWarning</note>
+        <target xml:lang="es-ES" state="final">Desafortunadamente, {0} no tiene memoria suficiente y podrá desacelerarse o experimentar otros problemas. Recomendamos que cierre y reinicie cuando sea conveniente.</target>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.Creator" approved="yes">
+        <source xml:lang="en">Creator: {0}</source>
+        <note>ID: MetadataDisplay.Creator</note>
+        <target xml:lang="es-ES" state="final">Creador: {0}</target>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.CreatorLabel" approved="yes">
+        <source xml:lang="en">Creator</source>
+        <note>ID: MetadataDisplay.CreatorLabel</note>
+        <target xml:lang="es-ES" state="final">Creador</target>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.LicenseInfo" approved="yes">
+        <source xml:lang="en">License Info</source>
+        <note>ID: MetadataDisplay.LicenseInfo</note>
+        <target xml:lang="es-ES" state="final">Información de la licencia</target>
+      </trans-unit>
+      <trans-unit id="MetadataDisplay.NoLicense" approved="yes">
+        <source xml:lang="en">No license specified</source>
+        <note>ID: MetadataDisplay.NoLicense</note>
+        <target xml:lang="es-ES" state="final">Ninguna licencia especificada</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.AllowCommercialUse" approved="yes">
+        <source xml:lang="en">Allow commercial uses of your work?</source>
+        <note>ID: MetadataEditor.AllowCommercialUse</note>
+        <target xml:lang="es-ES" state="final">¿Permite hacer uso comercial de su trabajo?</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.AllowDerivatives" approved="yes">
+        <source xml:lang="en">Allow modifications of your work?</source>
+        <note>ID: MetadataEditor.AllowDerivatives</note>
+        <target xml:lang="es-ES" state="final">¿Permite hacer modificaciones a su trabajo?</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CopyrightHolder" approved="yes">
+        <source xml:lang="en">Copyright Holder</source>
+        <note>ID: MetadataEditor.CopyrightHolder</note>
+        <target xml:lang="es-ES" state="final">Titular de los derechos de autor</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CopyrightYear" approved="yes">
+        <source xml:lang="en">Copyright Year</source>
+        <note>ID: MetadataEditor.CopyrightYear</note>
+        <target xml:lang="es-ES" state="final">Año de los derechos de autor</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CreativeCommons">
+        <source xml:lang="en">Creative Commons</source>
+        <note>ID: MetadataEditor.CreativeCommons</note>
+        <target xml:lang="es-ES" state="translated">Creative Commons</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CreativeCommons.Intergovernmental" approved="yes">
+        <source xml:lang="en">Intergovernmental Version</source>
+        <note>ID: MetadataEditor.CreativeCommons.Intergovernmental</note>
+        <target xml:lang="es-ES" state="final">Versión Intergubernamental</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CreatorLabel" approved="yes">
+        <source xml:lang="en">Creator</source>
+        <note>ID: MetadataEditor.CreatorLabel</note>
+        <target xml:lang="es-ES" state="final">Creador</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.CustomLicense" approved="yes">
+        <source xml:lang="en">Custom</source>
+        <note>ID: MetadataEditor.CustomLicense</note>
+        <target xml:lang="es-ES" state="final">Personalizado</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.License" approved="yes">
+        <source xml:lang="en">License</source>
+        <note>ID: MetadataEditor.License</note>
+        <target xml:lang="es-ES" state="final">Licencia</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.PublicDomain" approved="yes">
+        <source xml:lang="en">The copyright holder waives all rights</source>
+        <note>ID: MetadataEditor.PublicDomain</note>
+        <target xml:lang="es-ES" state="final">El títular de derchos de autor renuncia todos sus derechos</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.TitleNoCredit" approved="yes">
+        <source xml:lang="en">Copyright and License</source>
+        <note>ID: MetadataEditor.TitleNoCredit</note>
+        <target xml:lang="es-ES" state="final">Derechos de autor y licencia</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.TitleWithCredit" approved="yes">
+        <source xml:lang="en">Credit, Copyright, and License</source>
+        <note>ID: MetadataEditor.TitleWithCredit</note>
+        <target xml:lang="es-ES" state="final">Crédito, derechos de autor y licencia</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.UnknownLicense" approved="yes">
+        <source xml:lang="en">Contact the copyright holder for any permissions</source>
+        <note>ID: MetadataEditor.UnknownLicense</note>
+        <target xml:lang="es-ES" state="final">Comuníquese con el titular de los derechos de autor para solicitar permisos</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.YesShareAlike" approved="yes">
+        <source xml:lang="en">Yes, as long as others share alike</source>
+        <note>ID: MetadataEditor.YesShareAlike</note>
+        <target xml:lang="es-ES" state="final">Sí, mientras que otros compartan igualmente</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.additionalRequestsLabel" approved="yes">
+        <source xml:lang="en">Additional Requests</source>
+        <note>ID: MetadataEditor.additionalRequestsLabel</note>
+        <note>When you choose a Creative Commons License, this label shows over the text box at the bottom.</note>
+        <target xml:lang="es-ES" state="final">Solicitudes adicionales</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.betterLinkLabel1" approved="yes">
+        <source xml:lang="en">more info</source>
+        <note>ID: MetadataEditor.betterLinkLabel1</note>
+        <note>The meaning of  "non-commercial" is vague but important. This hyperlink takes you somewhere that defines it.</note>
+        <target xml:lang="es-ES" state="final">más información</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.linkToPublicDomainCC0" approved="yes">
+        <source xml:lang="en">about {0} Public Domain</source>
+        <note>ID: MetadataEditor.linkToPublicDomainCC0</note>
+        <note>{0} is replaced by an untranslatable abbreviation functioning as an adjective ("CC0")</note>
+        <target xml:lang="es-ES" state="final">acerca del dominio público {0}</target>
+      </trans-unit>
+      <trans-unit id="MetadataEditor.linkToWarningAboutRefiningCreativeCommons" approved="yes">
+        <source xml:lang="en">Not Enforceable</source>
+        <note>ID: MetadataEditor.linkToWarningAboutRefiningCreativeCommons</note>
+        <target xml:lang="es-ES" state="final">No aplicable</target>
+      </trans-unit>
+      <trans-unit id="ProblemNotificationDialog.Caption">
+        <source xml:lang="en">Problem</source>
+        <note>ID: ProblemNotificationDialog.Caption</note>
+		<target xml:lang="es-ES" state="translated">Problema</target>
+      </trans-unit>
+      <trans-unit id="Project.CannotRemove">
+        <source xml:lang="en">Cannot remove the selected project because it is currently open</source>
+        <note>ID: Project.CannotRemove</note>
+        <target xml:lang="es-ES" state="translated">No se puede eliminar el proyecto seleccionado porque está actualmente abierto.</target>
+      </trans-unit>
+      <trans-unit id="Project.CannotRemoveCaption">
+        <source xml:lang="en">Cannot Remove from List</source>
+        <note>ID: Project.CannotRemoveCaption</note>
+        <target xml:lang="es-ES" state="translated">No se puede eliminar de la lista.</target>
+      </trans-unit>
+      <trans-unit id="ProjectsList.Language">
+        <source xml:lang="en">Language</source>
+        <note>ID: ProjectsList.Language</note>
+        <target xml:lang="es-ES" state="translated">Idioma</target>
+      </trans-unit>
+      <trans-unit id="ProjectsList.RecordingProject">
+        <source xml:lang="en">Recording Project</source>
+        <note>ID: ProjectsList.RecordingProject</note>
+        <target xml:lang="es-ES" state="translated">Proyecto de grabación</target>
+      </trans-unit>
+      <trans-unit id="ScriptsAndVariants.ScriptsAndVariantsDialog._cancelButton" approved="yes">
+        <source xml:lang="en">Cancel</source>
+        <note>ID: ScriptsAndVariants.ScriptsAndVariantsDialog._cancelButton</note>
+        <target xml:lang="es-ES" state="final">Cancelar</target>
+      </trans-unit>
+      <trans-unit id="ScriptsAndVariants.ScriptsAndVariantsDialog._okButton" approved="yes">
+        <source xml:lang="en">OK</source>
+        <note>ID: ScriptsAndVariants.ScriptsAndVariantsDialog._okButton</note>
+        <target xml:lang="es-ES" state="final">Aceptar</target>
+      </trans-unit>
+      <trans-unit id="ScriptsAndVariantsDialog.ScriptsAndVariants" approved="yes">
+        <source xml:lang="en">Script and Variant</source>
+        <note>ID: ScriptsAndVariantsDialog.ScriptsAndVariants</note>
+        <target xml:lang="es-ES" state="final">Escritura y variante</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
+        <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
+        <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
+        <target xml:lang="es-ES" state="final">Esto también puede ocultar otros botones que no son necesarios para el usuario no avanzado.</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.CtrlShiftHint" approved="yes">
+        <source xml:lang="en">The button will show up when you hold down the Ctrl and Shift keys together.</source>
+        <note>ID: SettingsProtection.CtrlShiftHint</note>
+        <target xml:lang="es-ES" state="final">El botón se mostrará cuando se mantengan presionadas juntas las teclas Ctrl y Mayús.</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
+        <source xml:lang="en">Settings...</source>
+        <note>ID: SettingsProtection.LauncherButtonLabel</note>
+        <target xml:lang="es-ES" state="final">Protección de configuraciones...</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.NormallyHiddenCheckbox" approved="yes">
+        <source xml:lang="en">Hide the button that opens settings.</source>
+        <note>ID: SettingsProtection.NormallyHiddenCheckbox</note>
+        <target xml:lang="es-ES" state="final">Ocultar el botón que abre la configuración.</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.FactoryPassword" approved="yes">
+        <source xml:lang="en">Factory Password</source>
+        <note>ID: SettingsProtection.PasswordDialog.FactoryPassword</note>
+        <target xml:lang="es-ES" state="final">Contraseña de fábrica</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.Password.Explanation" approved="yes">
+        <source xml:lang="en">To prevent accidental changes which could cause this tool to stop working for you, these settings have been locked.</source>
+        <note>ID: SettingsProtection.PasswordDialog.Password.Explanation</note>
+        <target xml:lang="es-ES" state="final">Estas configuraciones han sido bloquedas para prevenir cambios accidentales que podrían impedir el funcionamiento de esta herramienta.</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle" approved="yes">
+        <source xml:lang="en">Settings Protection Password</source>
+        <note>ID: SettingsProtection.PasswordDialog.SettingsPasswordWindowTitle</note>
+        <target xml:lang="es-ES" state="final">Contraseña para proteger la configuración</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordDialog.ShowCharactersCheckbox" approved="yes">
+        <source xml:lang="en">Show Characters</source>
+        <note>ID: SettingsProtection.PasswordDialog.ShowCharactersCheckbox</note>
+        <target xml:lang="es-ES" state="final">Mostrar caracteres</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordNotice" approved="yes">
+        <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always visit the {1} support page.</source>
+        <note>ID: SettingsProtection.PasswordNotice</note>
+        <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNoticeWithSupportUrl". Param 0: Factory password; Param 1: product name</note>
+        <target xml:lang="es-ES" state="final">La contraseña de fábrica para estas configuraciones es "{0}". Si la olvida, siempre puede visitar la página de apoyo de {1}.</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.PasswordNoticeWithSupportUrl" approved="yes">
+        <source xml:lang="en">Factory password for these settings is "{0}". If you forget it, you can always visit the {1} support page: {2}</source>
+        <note>ID: SettingsProtection.PasswordNoticeWithSupportUrl</note>
+        <note>The localization for this should be kept in sync with "SettingsProtection.PasswordNotice". Param 0: Factory password; Param 1: product name; Param 2: URL of support page</note>
+        <target xml:lang="es-ES" state="final">La contraseña de fábrica para estas configuraciones es "{0}". Si la olvida, siempre puede visitar la página de apoyo {1} en: {2}</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.RequirePasswordCheckBox" approved="yes">
+        <source xml:lang="en">Require the factory password to get into settings.</source>
+        <note>ID: SettingsProtection.RequirePasswordCheckBox</note>
+        <target xml:lang="es-ES" state="final">Se requiere la contraseña de fábrica para entrar en la configuración.</target>
+      </trans-unit>
+      <trans-unit id="SettingsProtection.SettingProtectionDialogTitle" approved="yes">
+        <source xml:lang="en">Settings Protection</source>
+        <note>ID: SettingsProtection.SettingProtectionDialogTitle</note>
+        <target xml:lang="es-ES" state="final">Protección de configuración</target>
+      </trans-unit>
+      <trans-unit id="ShowReleaseNotesDialog.WindowTitle" approved="yes">
+        <source xml:lang="en">Release Notes</source>
+        <note>ID: ShowReleaseNotesDialog.WindowTitle</note>
+        <target xml:lang="es-ES" state="final">Notas de la versión</target>
+      </trans-unit>
+      <trans-unit id="VoiceIdentifierView.betterLabel1" approved="yes">
+        <source xml:lang="en">In applications which support this option, fields with this input system will be able to play and record voice.</source>
+        <note>ID: VoiceIdentifierView.betterLabel1</note>
+        <note>Displayed if a user selects the voice special option in writing system setup</note>
+        <target xml:lang="es-ES" state="final">En las aplicaciones que soportan esta opción, los campos con esta sistema de ingreso podrán grabar y reproducir la voz.</target>
+      </trans-unit>
+      <trans-unit id="WSFontControl.Font" approved="yes">
+        <source xml:lang="en">&amp;Font:</source>
+        <note>ID: WSFontControl.Font</note>
+        <target xml:lang="es-ES" state="final">&amp;Fuente:</target>
+      </trans-unit>
+      <trans-unit id="WSFontControl.FontNotAvailable" approved="yes">
+        <source xml:lang="en">(The selected font is not available on this machine. Using default.)</source>
+        <note>ID: WSFontControl.FontNotAvailable</note>
+        <target xml:lang="es-ES" state="final">(La fuente seleccionada no está disponible en esta computadora. Se usará la fuente predeterminada.)</target>
+      </trans-unit>
+      <trans-unit id="WSFontControl.RightToLeftWS" approved="yes">
+        <source xml:lang="en">This is a &amp;right to left writing system.</source>
+        <note>ID: WSFontControl.RightToLeftWS</note>
+        <target xml:lang="es-ES" state="final">Esto es una &amp;escritura de derecha a izquierda.</target>
+      </trans-unit>
+      <trans-unit id="WSFontControl.Size" approved="yes">
+        <source xml:lang="en">&amp;Size:</source>
+        <note>ID: WSFontControl.Size</note>
+        <target xml:lang="es-ES" state="final">&amp;Tamaño:</target>
+      </trans-unit>
+      <trans-unit id="WSFontControl.TestArea" approved="yes">
+        <source xml:lang="en">&amp;Test Area:</source>
+        <note>ID: WSFontControl.TestArea</note>
+        <target xml:lang="es-ES" state="final">&amp;Área de prueba:</target>
+      </trans-unit>
+      <trans-unit id="WSIdentifierView.betterLabel4" approved="yes">
+        <source xml:lang="en">Abbreviation:</source>
+        <note>ID: WSIdentifierView.betterLabel4</note>
+        <note>In writing system setup general tab: label before abbreviation text box</note>
+        <target xml:lang="es-ES" state="final">Abreviatura</target>
+      </trans-unit>
+      <trans-unit id="WSIdentifierView.betterLabel5" approved="yes">
+        <source xml:lang="en">Special:</source>
+        <note>ID: WSIdentifierView.betterLabel5</note>
+        <note>In writing system setup general tab:  Label before combo box with 'Special' choices</note>
+        <target xml:lang="es-ES" state="final">Especial:</target>
+      </trans-unit>
+      <trans-unit id="WSIdentifiers.IpaIdentifierView.Default" approved="yes">
+        <source xml:lang="en">Default</source>
+        <note>ID: WSIdentifiers.IpaIdentifierView.Default</note>
+        <note>Choice for most users</note>
+        <target xml:lang="es-ES" state="final">Predetermindado</target>
+      </trans-unit>
+      <trans-unit id="WSIdentifiers.IpaIdentifierView.Emic" approved="yes">
+        <source xml:lang="en">Emic (uses phonology of the language)</source>
+        <note>ID: WSIdentifiers.IpaIdentifierView.Emic</note>
+        <note>Only translate text inside of the parentheses ()</note>
+        <target xml:lang="es-ES" state="final">Emic (utiliza la fonología del idioma)</target>
+      </trans-unit>
+      <trans-unit id="WSIdentifiers.IpaIdentifierView.Etic" approved="yes">
+        <source xml:lang="en">Etic (raw phonetic transcription)</source>
+        <note>ID: WSIdentifiers.IpaIdentifierView.Etic</note>
+        <note>Only translate text inside of the parentheses ()</note>
+        <target xml:lang="es-ES" state="final">Etic (transcripción fonética automática)</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardNotListed" approved="yes">
+        <source xml:lang="en">If the keyboard you need is not listed, click the appropriate link below to set it up</source>
+        <note>ID: WSKeyboardControl.KeyboardNotListed</note>
+        <target xml:lang="es-ES" state="final">Si el teclado que necesita no está en la lista, haga clic en el enlace apropiado abajo para configurarlo</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardSettingsLink" approved="yes">
+        <source xml:lang="en">Windows keyboard settings</source>
+        <note>ID: WSKeyboardControl.KeyboardSettingsLink</note>
+        <target xml:lang="es-ES" state="final">Configuración del teclado de Windows</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardsAvailable" approved="yes">
+        <source xml:lang="en">Available keyboards</source>
+        <note>ID: WSKeyboardControl.KeyboardsAvailable</note>
+        <target xml:lang="es-ES" state="final">Teclados disponibles</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeyboardsPreviouslyUsed" approved="yes">
+        <source xml:lang="en">Previously used keyboards</source>
+        <note>ID: WSKeyboardControl.KeyboardsPreviouslyUsed</note>
+        <target xml:lang="es-ES" state="final">Teclados utilizados anteriormente</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeymanConfigurationLink" approved="yes">
+        <source xml:lang="en">Keyman Configuration</source>
+        <note>ID: WSKeyboardControl.KeymanConfigurationLink</note>
+        <target xml:lang="es-ES" state="final">Configuración de Keyman</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.KeymanNotInstalled" approved="yes">
+        <source xml:lang="en">Keyman 5.0 or later is not Installed.</source>
+        <note>ID: WSKeyboardControl.KeymanNotInstalled</note>
+        <target xml:lang="es-ES" state="final">Keyman 5.0 o más reciente no está instalado.</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.SelectKeyboardLabel" approved="yes">
+        <source xml:lang="en">Select the &amp;keyboard with which to type {0} text</source>
+        <note>ID: WSKeyboardControl.SelectKeyboardLabel</note>
+        <target xml:lang="es-ES" state="final">Seleccione el &amp;teclado con el cual desea ingresar texto {0}</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.SetupKeyboards" approved="yes">
+        <source xml:lang="en">Set up keyboards</source>
+        <note>ID: WSKeyboardControl.SetupKeyboards</note>
+        <target xml:lang="es-ES" state="final">Configurar teclados</target>
+      </trans-unit>
+      <trans-unit id="WSKeyboardControl.TestAreaCaption" approved="yes">
+        <source xml:lang="en">&amp;Test Area (Use this area to type something to test out your keyboard.)</source>
+        <note>ID: WSKeyboardControl.TestAreaCaption</note>
+        <target xml:lang="es-ES" state="final">&amp;Área de prueba (Utilice esta zona para escribir algo para probar el teclado.)</target>
+      </trans-unit>
+      <trans-unit id="Warning" approved="yes">
+        <source xml:lang="en">Warning</source>
+        <note>ID: Warning</note>
+        <target xml:lang="es-ES" state="final">Advertencia</target>
+      </trans-unit>
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrCaption" approved="yes">
+        <source xml:lang="en">Unable to connect to SLDR</source>
+        <note>ID: WritingSystemSetupView.UnableToConnectToSldrCaption</note>
+        <target xml:lang="es-ES" state="final">No se puede conectar al SLDR</target>
+      </trans-unit>
+      <trans-unit id="WritingSystemSetupView.UnableToConnectToSldrText" approved="yes">
+        <source xml:lang="en">The application is unable to connect to the SIL Locale Data Repository to retrieve the latest information about this language. If you create this writing system, the default settings might be incorrect or out of date. Are you sure you want to create a new writing system?</source>
+        <note>ID: WritingSystemSetupView.UnableToConnectToSldrText</note>
+        <target xml:lang="es-ES" state="final">La aplicación no puede conectarse con la base datos de SIL para obtener la información más reciente acerca de este idioma. Si usted crea este sistema escritura, la configuración predeterminada podría ser incorrecta u obsoleta. ¿Realmente desea crear un nuevo sistema de escritura?</target>
+      </trans-unit>
+      <trans-unit id="XkbKeyboardAdaptor.MissingKeyboard" approved="yes">
+        <source xml:lang="en">[Missing] {0} ({1})</source>
+        <note>ID: XkbKeyboardAdaptor.MissingKeyboard</note>
+        <target xml:lang="es-ES" state="final">[Faltante] {0} ({1})</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -14,6 +14,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bbbcccvvv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BBCCCVVV/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bidi/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=bldr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Clipboarding/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Deuterocanon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deuterocanonical/@EntryIndexedValue">True</s:Boolean>
@@ -25,11 +26,13 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ibus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IETF/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IMDI/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jira/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Keyman/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Klavier/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=LDML/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=libxklavier/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=modally/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=parsable/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Core/Extensions/StringExtensions.cs
+++ b/SIL.Core/Extensions/StringExtensions.cs
@@ -74,10 +74,7 @@ namespace SIL.Extensions
 		{
 			try
 			{
-				if (args.Length == 0)
-					return format;
-				else
-					return string.Format(format, args);
+				return args.Length == 0 ? format : string.Format(format, args);
 			}
 			catch (Exception e)
 			{

--- a/SIL.Windows.Forms/Extensions/TextBoxExtensions.cs
+++ b/SIL.Windows.Forms/Extensions/TextBoxExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+
+namespace SIL.Windows.Forms.Extensions
+{
+	internal static class TextBoxExtensions
+	{
+		public static void SetMultiLineText(this TextBox textBox, string text)
+		{
+			textBox.Multiline = true; // Normally this will already be set, but just to be sure.
+			textBox.Text = Regex.Replace(text, @"(?<!\r)\n", Environment.NewLine);
+		}
+	}
+}

--- a/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
@@ -60,7 +60,6 @@ namespace SIL.Windows.Forms.Reporting
 		private Label _emailAddress;
 		private static bool s_doIgnoreReport;
 		private TableLayoutPanel tableLayoutPanel1;
-		private L10NSharp.UI.L10NSharpExtender _l10NSharpExtender1;
 		private System.ComponentModel.IContainer components;
 
 		/// <summary>
@@ -168,9 +167,7 @@ namespace SIL.Windows.Forms.Reporting
 			this._privacyNoticeButton = new System.Windows.Forms.Button();
 			this._emailAddress = new System.Windows.Forms.Label();
 			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this._l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
 			this.tableLayoutPanel1.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this._l10NSharpExtender1)).BeginInit();
 			this.SuspendLayout();
 			// 
 			// m_reproduce
@@ -179,20 +176,12 @@ namespace SIL.Windows.Forms.Reporting
 			this._reproduce.AcceptsTab = true;
 			resources.ApplyResources(this._reproduce, "m_reproduce");
 			this.tableLayoutPanel1.SetColumnSpan(this._reproduce, 2);
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._reproduce, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._reproduce, null);
-			this._l10NSharpExtender1.SetLocalizationPriority(this._reproduce, L10NSharp.LocalizationPriority.NotLocalizable);
-			this._l10NSharpExtender1.SetLocalizingId(this._reproduce, "ExceptionReportingDialog._reproduce");
 			this._reproduce.Name = "m_reproduce";
 			// 
 			// _detailsForDevelopers
 			// 
 			resources.ApplyResources(this._detailsForDevelopers, "_detailsForDevelopers");
 			this.tableLayoutPanel1.SetColumnSpan(this._detailsForDevelopers, 2);
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._detailsForDevelopers, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._detailsForDevelopers, null);
-			this._l10NSharpExtender1.SetLocalizationPriority(this._detailsForDevelopers, L10NSharp.LocalizationPriority.NotLocalizable);
-			this._l10NSharpExtender1.SetLocalizingId(this._detailsForDevelopers, "ExceptionReportingDialog._detailsForDevelopers");
 			this._detailsForDevelopers.Name = "_detailsForDevelopers";
 			// 
 			// _details
@@ -200,9 +189,6 @@ namespace SIL.Windows.Forms.Reporting
 			resources.ApplyResources(this._details, "_details");
 			this._details.BackColor = System.Drawing.SystemColors.ControlLightLight;
 			this.tableLayoutPanel1.SetColumnSpan(this._details, 2);
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._details, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._details, null);
-			this._l10NSharpExtender1.SetLocalizingId(this._details, "ExceptionReportingDialog._details");
 			this._details.Name = "_details";
 			this._details.ReadOnly = true;
 			// 
@@ -210,9 +196,6 @@ namespace SIL.Windows.Forms.Reporting
 			// 
 			resources.ApplyResources(this._sendAndCloseButton, "_sendAndCloseButton");
 			this._sendAndCloseButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._sendAndCloseButton, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._sendAndCloseButton, null);
-			this._l10NSharpExtender1.SetLocalizingId(this._sendAndCloseButton, "ExceptionReportingDialog._sendAndCloseButton");
 			this._sendAndCloseButton.Name = "_sendAndCloseButton";
 			this._sendAndCloseButton.Click += new System.EventHandler(this.btnClose_Click);
 			// 
@@ -222,10 +205,6 @@ namespace SIL.Windows.Forms.Reporting
 			this._lblPleaseHelp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
 			this.tableLayoutPanel1.SetColumnSpan(this._lblPleaseHelp, 2);
 			this._lblPleaseHelp.ForeColor = System.Drawing.Color.Black;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._lblPleaseHelp, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._lblPleaseHelp, null);
-			this._l10NSharpExtender1.SetLocalizationPriority(this._lblPleaseHelp, L10NSharp.LocalizationPriority.NotLocalizable);
-			this._l10NSharpExtender1.SetLocalizingId(this._lblPleaseHelp, "ExceptionReportingDialog._lblPleaseHelp");
 			this._lblPleaseHelp.Name = "_lblPleaseHelp";
 			// 
 			// _notificationText
@@ -234,9 +213,6 @@ namespace SIL.Windows.Forms.Reporting
 			this._notificationText.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
 			this.tableLayoutPanel1.SetColumnSpan(this._notificationText, 2);
 			this._notificationText.ForeColor = System.Drawing.Color.Black;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._notificationText, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._notificationText, null);
-			this._l10NSharpExtender1.SetLocalizingId(this._notificationText, "ExceptionReportingDialog._notificationText");
 			this._notificationText.Name = "_notificationText";
 			// 
 			// _lblStepsToReproduce
@@ -245,10 +221,6 @@ namespace SIL.Windows.Forms.Reporting
 			this._lblStepsToReproduce.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
 			this.tableLayoutPanel1.SetColumnSpan(this._lblStepsToReproduce, 2);
 			this._lblStepsToReproduce.ForeColor = System.Drawing.Color.Black;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._lblStepsToReproduce, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._lblStepsToReproduce, null);
-			this._l10NSharpExtender1.SetLocalizationPriority(this._lblStepsToReproduce, L10NSharp.LocalizationPriority.NotLocalizable);
-			this._l10NSharpExtender1.SetLocalizingId(this._lblStepsToReproduce, "ExceptionReportingDialog._lblStepsToReproduce");
 			this._lblStepsToReproduce.Name = "_lblStepsToReproduce";
 			// 
 			// _methodCombo
@@ -256,9 +228,6 @@ namespace SIL.Windows.Forms.Reporting
 			resources.ApplyResources(this._methodCombo, "_methodCombo");
 			this._methodCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._methodCombo.FormattingEnabled = true;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._methodCombo, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._methodCombo, null);
-			this._l10NSharpExtender1.SetLocalizingId(this._methodCombo, "ExceptionReportingDialog._methodCombo");
 			this._methodCombo.Name = "_methodCombo";
 			this._methodCombo.SelectedIndexChanged += new System.EventHandler(this._methodCombo_SelectedIndexChanged);
 			// 
@@ -266,9 +235,6 @@ namespace SIL.Windows.Forms.Reporting
 			// 
 			resources.ApplyResources(this._privacyNoticeButton, "_privacyNoticeButton");
 			this._privacyNoticeButton.Image = global::SIL.Windows.Forms.Properties.Resources.spy16x16;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._privacyNoticeButton, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._privacyNoticeButton, null);
-			this._l10NSharpExtender1.SetLocalizingId(this._privacyNoticeButton, "ExceptionReportingDialog._privacyNoticeButton");
 			this._privacyNoticeButton.Name = "_privacyNoticeButton";
 			this._privacyNoticeButton.UseVisualStyleBackColor = true;
 			this._privacyNoticeButton.Click += new System.EventHandler(this._privacyNoticeButton_Click);
@@ -277,9 +243,6 @@ namespace SIL.Windows.Forms.Reporting
 			// 
 			this._emailAddress.ForeColor = System.Drawing.Color.DimGray;
 			resources.ApplyResources(this._emailAddress, "_emailAddress");
-			this._l10NSharpExtender1.SetLocalizableToolTip(this._emailAddress, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this._emailAddress, null);
-			this._l10NSharpExtender1.SetLocalizingId(this._emailAddress, "ExceptionReportingDialog._emailAddress");
 			this._emailAddress.Name = "_emailAddress";
 			// 
 			// tableLayoutPanel1
@@ -297,11 +260,6 @@ namespace SIL.Windows.Forms.Reporting
 			this.tableLayoutPanel1.Controls.Add(this._detailsForDevelopers, 0, 4);
 			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
 			// 
-			// l10NSharpExtender1
-			// 
-			this._l10NSharpExtender1.LocalizationManagerId = null;
-			this._l10NSharpExtender1.PrefixForNewItems = null;
-			// 
 			// ExceptionReportingDialog
 			// 
 			this.AcceptButton = this._sendAndCloseButton;
@@ -310,9 +268,6 @@ namespace SIL.Windows.Forms.Reporting
 			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
 			this.Controls.Add(this.tableLayoutPanel1);
 			this.KeyPreview = true;
-			this._l10NSharpExtender1.SetLocalizableToolTip(this, null);
-			this._l10NSharpExtender1.SetLocalizationComment(this, null);
-			this._l10NSharpExtender1.SetLocalizingId(this, "ExceptionReportingDialog.WindowTitle");
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.Name = "ExceptionReportingDialog";
@@ -322,7 +277,6 @@ namespace SIL.Windows.Forms.Reporting
 			this.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ExceptionReportingDialog_KeyPress);
 			this.tableLayoutPanel1.ResumeLayout(false);
 			this.tableLayoutPanel1.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this._l10NSharpExtender1)).EndInit();
 			this.ResumeLayout(false);
 
 		}
@@ -330,27 +284,96 @@ namespace SIL.Windows.Forms.Reporting
 		private void SetupMethodCombo()
 		{
 			_methodCombo.Items.Clear();
+			string reportingMethod, closeButtonLabelLethal, closeButtonLabelNonLethal;
+			try
+			{
+				reportingMethod = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ReportingMethod.Email",
+					"Send using my email program");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				reportingMethod = "Send using my email program";
+			}
+			try
+			{
+				closeButtonLabelLethal = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabelLethal",
+					"&Email and Exit", "Ampersand is optional, to indicate accelerator key");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				closeButtonLabelLethal = "&Email and Exit";
+			}
+			try
+			{
+				closeButtonLabelNonLethal = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel",
+					"&Email", "Ampersand is optional, to indicate accelerator key");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				closeButtonLabelNonLethal = "&Email";
+			}
 			_methodCombo.Items.Add(new ReportingMethod(
-				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.Email", "Send using my email program"),
-				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel", "&Email"),
+				reportingMethod, closeButtonLabelLethal, closeButtonLabelNonLethal,
 				"mapiWithPopup", SendViaEmail));
+			
+			try
+			{
+				reportingMethod = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ReportingMethod.CopyToClipboard",
+					"Copy to clipboard");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				reportingMethod = "Copy to clipboard";
+			}
+			try
+			{
+				closeButtonLabelLethal = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabelLethal",
+					"&Copy and Exit", "Ampersand is optional, to indicate accelerator key");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				closeButtonLabelLethal = "&Copy and Exit";
+			}
+			try
+			{
+				closeButtonLabelNonLethal = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel",
+					"&Copy", "Ampersand is optional, to indicate accelerator key");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				closeButtonLabelNonLethal = "&Copy";
+			}
 			_methodCombo.Items.Add(new ReportingMethod(
-				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.CopyToClipboard", "Copy to clipboard"),
-				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel", "&Copy"),
+				reportingMethod, closeButtonLabelLethal, closeButtonLabelNonLethal,
 				"clipboard", PutOnClipboard));
 		}
 
-		class ReportingMethod
+		private class ReportingMethod
 		{
 			private readonly string _label;
-			public readonly string CloseButtonLabel;
+			public readonly string CloseButtonLabelLethal;
+			public readonly string CloseButtonLabelNonLethal;
 			public readonly string Id;
 			public readonly Func<bool> Method;
 
-			public ReportingMethod(string label, string closeButtonLabel, string id, Func<bool> method)
+			public ReportingMethod(string label, string closeButtonLabelLethal,
+				string closeButtonLabelNonLethal, string id, Func<bool> method)
 			{
 				_label = label;
-				CloseButtonLabel = closeButtonLabel;
+				CloseButtonLabelLethal = closeButtonLabelLethal;
+				CloseButtonLabelNonLethal = closeButtonLabelNonLethal;
 				Id = id;
 				Method = method;
 			}
@@ -548,7 +571,7 @@ namespace SIL.Windows.Forms.Reporting
 				}
 				catch (Exception err)
 				{
-					//We have more than one report of dieing while logging an exception.
+					//We have more than one report of dying while logging an exception.
 					_details.Text += "****Could not write to log (" + err.Message + ")" + Environment.NewLine;
 				}
 			}
@@ -689,18 +712,28 @@ namespace SIL.Windows.Forms.Reporting
 			if (!_isLethal)
 			{
 				BackColor = Color.FromArgb(255, 255, 192); //yellow
-				_notificationText.Text = LocalizationManager.GetString(
-					"ExceptionReportingDialog.NonLethalNotification",
-					"Take Courage. It'll work out.",
-					"For more formal cultures, something less cheeky might be better. In most " +
-					"cases, this will be replaced by a more useful message, but there are " +
-					"situations where a user could see this.");
+				try
+				{
+					_notificationText.Text = LocalizationManager.GetString(
+						"ExceptionReportingDialog.NotificationTextNonLethal",
+						"Take Courage. It'll work out.",
+						"For more formal cultures, something less cheeky might be better. In most " +
+						"cases, this will be replaced by a more useful message, but there are " +
+						"situations where a user could see this.");
+				}
+				catch (Exception e)
+				{
+					try { Logger.WriteError(e); } catch { /* We tried. */ }
+				}
+
 				_notificationText.BackColor = BackColor;
 				_lblPleaseHelp.BackColor = BackColor;
 				_lblStepsToReproduce.BackColor = BackColor;
 			}
 
 			SetupCloseButtonText();
+
+			SetLocalizedText();
 		}
 
 		private void ShowReportDialogIfAppropriate(Form owningForm)
@@ -718,8 +751,7 @@ namespace SIL.Windows.Forms.Reporting
 
 
 		}
-
-
+		
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		///
@@ -755,9 +787,23 @@ namespace SIL.Windows.Forms.Reporting
 		{
 			if (ErrorReport.EmailAddress != null)
 			{
-				// REVIEW: Should this be localized? If so, does it *also* need to be kept in
-				// English for support purposes?
-				_details.Text = Format("Please e-mail this to {0} {1}", ErrorReport.EmailAddress, _details.Text);
+				string localizedEmailInstructions = null;
+				try
+				{
+					if (LocalizationManager.UILanguageId != "en")
+					{
+						localizedEmailInstructions = LocalizationManager.GetString(
+							"ExceptionReportingDialog.EmailInstructions",
+							"(Please e-mail this to)");
+						if (localizedEmailInstructions == "(Please e-mail this to)")
+							localizedEmailInstructions = null;
+					}
+				}
+				catch (Exception e)
+				{
+					try { Logger.WriteError(e); } catch { /* We tried. */ }
+				}
+				_details.Text = $"Please e-mail this to {localizedEmailInstructions} {ErrorReport.EmailAddress} {_details.Text}";
 			}
 			try
 			{
@@ -863,8 +909,15 @@ namespace SIL.Windows.Forms.Reporting
 		{
 			if (e.KeyCode == Keys.ShiftKey && Visible)
 			{
-				_sendAndCloseButton.Text = LocalizationManager.GetString(
-					"ExceptionReportingDialog.ContinueButtonLabel", "Continue");
+				try
+				{
+					_sendAndCloseButton.Text = LocalizationManager.GetString(
+						"ExceptionReportingDialog.ContinueButtonLabel", "Continue");
+				}
+				catch (Exception ex)
+				{
+					try { Logger.WriteError(ex); } catch { /* We tried. */ }
+				}
 			}
 			base.OnKeyDown(e);
 		}
@@ -889,21 +942,99 @@ namespace SIL.Windows.Forms.Reporting
 			SetupCloseButtonText();
 		}
 
-		private void SetupCloseButtonText()
+		private void SetupCloseButtonText() =>
+			_sendAndCloseButton.Text = _isLethal ? SelectedMethod.CloseButtonLabelLethal :
+				SelectedMethod.CloseButtonLabelNonLethal;
+
+		private void SetLocalizedText()
 		{
-			_sendAndCloseButton.Text = SelectedMethod.CloseButtonLabel;
+			try
+			{
+				if (LocalizationManager.UILanguageId == "en")
+					return;
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				// If we couldn't get the current UILanguageId without crashing, we don't have much
+				// hope of retrieving localized strings. Just use what Designer resources supplied.
+				return;
+			}
+
+			// All of these strings should be kept in sync with the ones in the Designer-generated
+			// We opted to do it this way instead of using the LocalizationExtender so we could
+			// ensure that applying localizations to the error reporting form would not itself
+			// result in a fatal error.
+			try
+			{
+				Text = LocalizationManager.GetString("ExceptionReportingDialog.WindowTitle",
+					"Error");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+			}
+
+			try
+			{
+				_detailsForDevelopers.Text = LocalizationManager.GetString(
+					"ExceptionReportingDialog._detailsForDevelopers",
+					"Details for the developers:");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+			}
+
+			try
+			{
+				_lblPleaseHelp.Text = LocalizationManager.GetString(
+					"ExceptionReportingDialog._lblPleaseHelp",
+					"To help us fix the problem, we need to gather information on what went wrong.");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+			}
+
 			if (_isLethal)
 			{
-				_sendAndCloseButton.Text = Format(LocalizationManager.GetString(
-						"ExceptionReportingDialog.CloseButtonLethal", "{0} and Exit",
-						"Used together with the normal Close button label (Param 0) to indicate " +
-						"that the the program will have to exit after the error report is sent."),
-					_sendAndCloseButton.Text);
+				try
+				{
+					_notificationText.Text = LocalizationManager.GetString(
+						"ExceptionReportingDialog.NotificationTextLethal",
+						"Well, this is embarrassing.",
+						"For more formal cultures, something less cheeky might be better. In most " +
+						"cases, this will be replaced by a more useful message, but there are " +
+						"situations where a user could see this.");
+				}
+				catch (Exception e)
+				{
+					try { Logger.WriteError(e); } catch { /* We tried. */ }
+				}
 			}
-			//else
-			//{
-			//	_dontSendEmailLink.Text = "Don't Send Email";
-			//}
+
+			try
+			{
+				_lblStepsToReproduce.Text = LocalizationManager.GetString(
+					"ExceptionReportingDialog._lblStepsToReproduce",
+					"Can you list the steps to take to make this happen again, or tell us anything that might be helpful?");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+			}
+
+			try
+			{
+				_privacyNoticeButton.Text = LocalizationManager.GetString(
+					"ExceptionReportingDialog._privacyNoticeButton",
+					"Privacy Notice...");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+			}
 		}
 
 		private ReportingMethod SelectedMethod
@@ -914,8 +1045,8 @@ namespace SIL.Windows.Forms.Reporting
 
 		/// <summary>
 		/// Although this is public and can be set externally for an application that has a custom
-		/// policy (e.e., does not use Jira), be aware that if you want it to localized, you will
-		/// need to reset it if the UI locale changes.
+		/// policy (i.e., does not use Jira), be aware that if you want it to be localized, you
+		/// will need to reset it if the UI locale changes.
 		/// </summary>
 		public static string PrivacyNotice;
 
@@ -924,36 +1055,101 @@ namespace SIL.Windows.Forms.Reporting
 		private static string GetDefaultPrivacyNotice()
 		{
 			var bldr = new StringBuilder();
-			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para1",
-				"If you don't care who reads your bug report, you can disregard this notice."));
+			string nextPara;
+			try
+			{
+				nextPara = LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para1",
+					"If you don't care who reads your bug report, you can disregard this notice.");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+
+				nextPara = "If you don't care who reads your bug report, you can disregard this " +
+					"notice.";
+			}
+			bldr.Append(nextPara);
 			bldr.Append(Environment.NewLine);
 			bldr.Append(Environment.NewLine);
+
 			// REVIEW: Is the last line (which I have put in parentheses) true and/or helpful?
-			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para2",
-				"When you submit a crash report or other issue, it goes into our issue tracking " +
-				"system, \"Jira\", which is available via the web at https://jira.sil.org/issues." +
-				"(This is a normal way to handle issues in an open-source project.)"));
+			try
+			{
+				nextPara = LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para2",
+					"When you submit a crash report or other issue, it goes into our issue " +
+					"tracking system, \"Jira\", which is available via the web at " +
+					"https://jira.sil.org/issues." +
+					"(This is a normal way to handle issues in an open-source project.)");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+
+				nextPara = "When you submit a crash report or other issue, it goes into our issue " +
+					"tracking system, \"Jira\", which is available via the web at " +
+					"https://jira.sil.org/issues." +
+					"(This is a normal way to handle issues in an open-source project.)";
+			}
+			bldr.Append(nextPara);
 			bldr.Append(Environment.NewLine);
 			bldr.Append(Environment.NewLine);
-			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para3",
-				"Our issue-tracking system is not searchable by those without an account. " +
-				"Therefore, search engines (like Google) will not find your bug reports."));
+
+			try
+			{
+				nextPara = LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para3",
+					"Our issue-tracking system is not searchable by those without an account. " +
+					"Therefore, search engines (like Google) will not find your bug reports.");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+
+				nextPara = "Our issue-tracking system is not searchable by those without an " +
+					"account. Therefore, search engines (like Google) will not find your bug " +
+					"reports.";
+			}
+			bldr.Append(nextPara);
 			bldr.Append(Environment.NewLine);
 			bldr.Append(Environment.NewLine);
-			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para4",
-				"However, anyone can make an account and then read your report. So if you have " +
-				"something private to say, please send it to one of the developers privately " +
-				"with a note that you don't want the issue in our issue tracking system. If " +
-				"necessary, we can make a place-holder for your issue without the private " +
-				"information so the issue can still be tracked and not get lost."));
+			
+			try
+			{
+				nextPara = LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para4",
+					"However, anyone can make an account and then read your report. So if you " +
+					"have something private to say, please send it to one of the developers " +
+					"privately with a note that you don't want the issue in our issue tracking " +
+					"system. If necessary, we can make a place-holder for your issue without " +
+					"the private information so the issue can still be tracked and not get lost.");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+
+				nextPara = "However, anyone can make an account and then read your report. So if" +
+					" you have something private to say, please send it to one of the developers" +
+					" privately with a note that you don't want the issue in our issue tracking " +
+					"system. If necessary, we can make a place-holder for your issue without " +
+					"the private information so the issue can still be tracked and not get lost.";
+			}
+			bldr.Append(nextPara);
 
 			return bldr.ToString();
 		}
 
 		private void _privacyNoticeButton_Click(object sender, EventArgs e)
 		{
-			MessageBox.Show(LocalizedPrivacyNotice, LocalizationManager.GetString(
-				"ExceptionReportingDialog.PrivacyNoticeCaption", "Privacy Notice"));
+			string caption;
+			try
+			{
+				caption = LocalizationManager.GetString(
+					"ExceptionReportingDialog.PrivacyNoticeCaption", "Privacy Notice");
+			}
+			catch (Exception ex)
+			{
+				try { Logger.WriteError(ex); } catch { /* We tried. */ }
+				caption = "Privacy Notice";
+			}
+			MessageBox.Show(LocalizedPrivacyNotice, caption);
 		}
 
 		private void ExceptionReportingDialog_KeyPress(object sender, KeyPressEventArgs e)

--- a/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
@@ -5,11 +5,11 @@ using System.Drawing;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
+using L10NSharp;
 using SIL.Email;
 using SIL.Reporting;
-using System.Runtime.InteropServices;
-using SIL.PlatformUtilities;
 using SIL.Windows.Forms.Miscellaneous;
+using static System.String;
 
 namespace SIL.Windows.Forms.Reporting
 {
@@ -34,31 +34,35 @@ namespace SIL.Windows.Forms.Reporting
 				ThreadId = threadId;
 			}
 
-			public string Message;
-			public string MessageBeforeStack;
-			public Exception Error;
-			public Form OwningForm;
-			public StackTrace StackTrace;
-			public int ThreadId;
+			public readonly string Message;
+			public readonly string MessageBeforeStack;
+			public readonly Exception Error;
+			public readonly Form OwningForm;
+			public readonly StackTrace StackTrace;
+			public readonly int ThreadId;
 		}
 		#endregion
 
 		#region Member variables
 
-		private Label label3;
+		private Label _detailsForDevelopers;
 		private TextBox _details;
-		private TextBox _pleaseHelpText;
-		private TextBox m_reproduce;
+		private Label _lblPleaseHelp;
+		private TextBox _reproduce;
 
-		private bool _isLethal;
+		private readonly bool _isLethal;
 
 		private Button _sendAndCloseButton;
-		private TextBox _notificationText;
-		private TextBox textBox1;
+		private Label _notificationText;
+		private Label _lblStepsToReproduce;
 		private ComboBox _methodCombo;
 		private Button _privacyNoticeButton;
 		private Label _emailAddress;
 		private static bool s_doIgnoreReport;
+		private TableLayoutPanel tableLayoutPanel1;
+		private L10NSharp.UI.L10NSharpExtender _l10NSharpExtender1;
+		private System.ComponentModel.IContainer components;
+
 		/// <summary>
 		/// Stack with exception data.
 		/// </summary>
@@ -75,7 +79,8 @@ namespace SIL.Windows.Forms.Reporting
 		/// the exception (similar to the behavior we already have when we get an exception on
 		/// the UI thread while displaying the exception dialog). Otherwise we display the
 		/// exception dialog, appending the messages from the exception data stack.</remarks>
-		private static Stack<ExceptionReportingData> s_reportDataStack = new Stack<ExceptionReportingData>();
+		private static readonly Stack<ExceptionReportingData> s_reportDataStack =
+			new Stack<ExceptionReportingData>();
 
 		#endregion
 
@@ -95,7 +100,8 @@ namespace SIL.Windows.Forms.Reporting
 		{
 			if (IsDisposed)
 			{
-				throw new ObjectDisposedException(String.Format("'{0}' in use after being disposed.", GetType().Name));
+				throw new ObjectDisposedException(
+					$"'{GetType().Name}' in use after being disposed.");
 			}
 		}
 
@@ -149,128 +155,189 @@ namespace SIL.Windows.Forms.Reporting
 		/// </summary>
 		private void InitializeComponent()
 		{
+			this.components = new System.ComponentModel.Container();
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ExceptionReportingDialog));
-			this.m_reproduce = new System.Windows.Forms.TextBox();
-			this.label3 = new System.Windows.Forms.Label();
+			this._reproduce = new System.Windows.Forms.TextBox();
+			this._detailsForDevelopers = new System.Windows.Forms.Label();
 			this._details = new System.Windows.Forms.TextBox();
 			this._sendAndCloseButton = new System.Windows.Forms.Button();
-			this._pleaseHelpText = new System.Windows.Forms.TextBox();
-			this._notificationText = new System.Windows.Forms.TextBox();
-			this.textBox1 = new System.Windows.Forms.TextBox();
+			this._lblPleaseHelp = new System.Windows.Forms.Label();
+			this._notificationText = new System.Windows.Forms.Label();
+			this._lblStepsToReproduce = new System.Windows.Forms.Label();
 			this._methodCombo = new System.Windows.Forms.ComboBox();
 			this._privacyNoticeButton = new System.Windows.Forms.Button();
 			this._emailAddress = new System.Windows.Forms.Label();
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this._l10NSharpExtender1 = new L10NSharp.UI.L10NSharpExtender(this.components);
+			this.tableLayoutPanel1.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this._l10NSharpExtender1)).BeginInit();
 			this.SuspendLayout();
-			//
+			// 
 			// m_reproduce
-			//
-			this.m_reproduce.AcceptsReturn = true;
-			this.m_reproduce.AcceptsTab = true;
-			resources.ApplyResources(this.m_reproduce, "m_reproduce");
-			this.m_reproduce.Name = "m_reproduce";
-			//
-			// label3
-			//
-			resources.ApplyResources(this.label3, "label3");
-			this.label3.Name = "label3";
-			//
+			// 
+			this._reproduce.AcceptsReturn = true;
+			this._reproduce.AcceptsTab = true;
+			resources.ApplyResources(this._reproduce, "m_reproduce");
+			this.tableLayoutPanel1.SetColumnSpan(this._reproduce, 2);
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._reproduce, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._reproduce, null);
+			this._l10NSharpExtender1.SetLocalizationPriority(this._reproduce, L10NSharp.LocalizationPriority.NotLocalizable);
+			this._l10NSharpExtender1.SetLocalizingId(this._reproduce, "ExceptionReportingDialog._reproduce");
+			this._reproduce.Name = "m_reproduce";
+			// 
+			// _detailsForDevelopers
+			// 
+			resources.ApplyResources(this._detailsForDevelopers, "_detailsForDevelopers");
+			this.tableLayoutPanel1.SetColumnSpan(this._detailsForDevelopers, 2);
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._detailsForDevelopers, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._detailsForDevelopers, null);
+			this._l10NSharpExtender1.SetLocalizationPriority(this._detailsForDevelopers, L10NSharp.LocalizationPriority.NotLocalizable);
+			this._l10NSharpExtender1.SetLocalizingId(this._detailsForDevelopers, "ExceptionReportingDialog._detailsForDevelopers");
+			this._detailsForDevelopers.Name = "_detailsForDevelopers";
+			// 
 			// _details
-			//
+			// 
 			resources.ApplyResources(this._details, "_details");
 			this._details.BackColor = System.Drawing.SystemColors.ControlLightLight;
+			this.tableLayoutPanel1.SetColumnSpan(this._details, 2);
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._details, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._details, null);
+			this._l10NSharpExtender1.SetLocalizingId(this._details, "ExceptionReportingDialog._details");
 			this._details.Name = "_details";
 			this._details.ReadOnly = true;
-			//
+			// 
 			// _sendAndCloseButton
-			//
+			// 
 			resources.ApplyResources(this._sendAndCloseButton, "_sendAndCloseButton");
 			this._sendAndCloseButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._sendAndCloseButton, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._sendAndCloseButton, null);
+			this._l10NSharpExtender1.SetLocalizingId(this._sendAndCloseButton, "ExceptionReportingDialog._sendAndCloseButton");
 			this._sendAndCloseButton.Name = "_sendAndCloseButton";
 			this._sendAndCloseButton.Click += new System.EventHandler(this.btnClose_Click);
-			//
-			// _pleaseHelpText
-			//
-			resources.ApplyResources(this._pleaseHelpText, "_pleaseHelpText");
-			this._pleaseHelpText.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
-			this._pleaseHelpText.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this._pleaseHelpText.ForeColor = System.Drawing.Color.Black;
-			this._pleaseHelpText.Name = "_pleaseHelpText";
-			this._pleaseHelpText.ReadOnly = true;
-			//
+			// 
+			// _lblPleaseHelp
+			// 
+			resources.ApplyResources(this._lblPleaseHelp, "_lblPleaseHelp");
+			this._lblPleaseHelp.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
+			this.tableLayoutPanel1.SetColumnSpan(this._lblPleaseHelp, 2);
+			this._lblPleaseHelp.ForeColor = System.Drawing.Color.Black;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._lblPleaseHelp, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._lblPleaseHelp, null);
+			this._l10NSharpExtender1.SetLocalizationPriority(this._lblPleaseHelp, L10NSharp.LocalizationPriority.NotLocalizable);
+			this._l10NSharpExtender1.SetLocalizingId(this._lblPleaseHelp, "ExceptionReportingDialog._lblPleaseHelp");
+			this._lblPleaseHelp.Name = "_lblPleaseHelp";
+			// 
 			// _notificationText
-			//
+			// 
 			resources.ApplyResources(this._notificationText, "_notificationText");
 			this._notificationText.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
-			this._notificationText.BorderStyle = System.Windows.Forms.BorderStyle.None;
+			this.tableLayoutPanel1.SetColumnSpan(this._notificationText, 2);
 			this._notificationText.ForeColor = System.Drawing.Color.Black;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._notificationText, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._notificationText, null);
+			this._l10NSharpExtender1.SetLocalizingId(this._notificationText, "ExceptionReportingDialog._notificationText");
 			this._notificationText.Name = "_notificationText";
-			this._notificationText.ReadOnly = true;
-			//
-			// textBox1
-			//
-			resources.ApplyResources(this.textBox1, "textBox1");
-			this.textBox1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
-			this.textBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.textBox1.ForeColor = System.Drawing.Color.Black;
-			this.textBox1.Name = "textBox1";
-			this.textBox1.ReadOnly = true;
-			//
+			// 
+			// _lblStepsToReproduce
+			// 
+			resources.ApplyResources(this._lblStepsToReproduce, "_lblStepsToReproduce");
+			this._lblStepsToReproduce.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
+			this.tableLayoutPanel1.SetColumnSpan(this._lblStepsToReproduce, 2);
+			this._lblStepsToReproduce.ForeColor = System.Drawing.Color.Black;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._lblStepsToReproduce, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._lblStepsToReproduce, null);
+			this._l10NSharpExtender1.SetLocalizationPriority(this._lblStepsToReproduce, L10NSharp.LocalizationPriority.NotLocalizable);
+			this._l10NSharpExtender1.SetLocalizingId(this._lblStepsToReproduce, "ExceptionReportingDialog._lblStepsToReproduce");
+			this._lblStepsToReproduce.Name = "_lblStepsToReproduce";
+			// 
 			// _methodCombo
-			//
+			// 
 			resources.ApplyResources(this._methodCombo, "_methodCombo");
 			this._methodCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._methodCombo.FormattingEnabled = true;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._methodCombo, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._methodCombo, null);
+			this._l10NSharpExtender1.SetLocalizingId(this._methodCombo, "ExceptionReportingDialog._methodCombo");
 			this._methodCombo.Name = "_methodCombo";
 			this._methodCombo.SelectedIndexChanged += new System.EventHandler(this._methodCombo_SelectedIndexChanged);
-			//
+			// 
 			// _privacyNoticeButton
-			//
+			// 
 			resources.ApplyResources(this._privacyNoticeButton, "_privacyNoticeButton");
 			this._privacyNoticeButton.Image = global::SIL.Windows.Forms.Properties.Resources.spy16x16;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._privacyNoticeButton, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._privacyNoticeButton, null);
+			this._l10NSharpExtender1.SetLocalizingId(this._privacyNoticeButton, "ExceptionReportingDialog._privacyNoticeButton");
 			this._privacyNoticeButton.Name = "_privacyNoticeButton";
 			this._privacyNoticeButton.UseVisualStyleBackColor = true;
 			this._privacyNoticeButton.Click += new System.EventHandler(this._privacyNoticeButton_Click);
-			//
+			// 
 			// _emailAddress
-			//
-			resources.ApplyResources(this._emailAddress, "_emailAddress");
+			// 
 			this._emailAddress.ForeColor = System.Drawing.Color.DimGray;
+			resources.ApplyResources(this._emailAddress, "_emailAddress");
+			this._l10NSharpExtender1.SetLocalizableToolTip(this._emailAddress, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this._emailAddress, null);
+			this._l10NSharpExtender1.SetLocalizingId(this._emailAddress, "ExceptionReportingDialog._emailAddress");
 			this._emailAddress.Name = "_emailAddress";
-			//
+			// 
+			// tableLayoutPanel1
+			// 
+			resources.ApplyResources(this.tableLayoutPanel1, "tableLayoutPanel1");
+			this.tableLayoutPanel1.Controls.Add(this._notificationText, 0, 0);
+			this.tableLayoutPanel1.Controls.Add(this._sendAndCloseButton, 1, 7);
+			this.tableLayoutPanel1.Controls.Add(this._privacyNoticeButton, 0, 7);
+			this.tableLayoutPanel1.Controls.Add(this._emailAddress, 0, 6);
+			this.tableLayoutPanel1.Controls.Add(this._methodCombo, 1, 6);
+			this.tableLayoutPanel1.Controls.Add(this._lblPleaseHelp, 0, 1);
+			this.tableLayoutPanel1.Controls.Add(this._lblStepsToReproduce, 0, 2);
+			this.tableLayoutPanel1.Controls.Add(this._reproduce, 0, 3);
+			this.tableLayoutPanel1.Controls.Add(this._details, 0, 5);
+			this.tableLayoutPanel1.Controls.Add(this._detailsForDevelopers, 0, 4);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			// 
+			// l10NSharpExtender1
+			// 
+			this._l10NSharpExtender1.LocalizationManagerId = null;
+			this._l10NSharpExtender1.PrefixForNewItems = null;
+			// 
 			// ExceptionReportingDialog
-			//
+			// 
 			this.AcceptButton = this._sendAndCloseButton;
 			resources.ApplyResources(this, "$this");
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
-			this.Controls.Add(this._emailAddress);
-			this.Controls.Add(this._privacyNoticeButton);
-			this.Controls.Add(this._methodCombo);
-			this.Controls.Add(this.textBox1);
-			this.Controls.Add(this.m_reproduce);
-			this.Controls.Add(this._notificationText);
-			this.Controls.Add(this._pleaseHelpText);
-			this.Controls.Add(this._details);
-			this.Controls.Add(this.label3);
-			this.Controls.Add(this._sendAndCloseButton);
+			this.Controls.Add(this.tableLayoutPanel1);
 			this.KeyPreview = true;
+			this._l10NSharpExtender1.SetLocalizableToolTip(this, null);
+			this._l10NSharpExtender1.SetLocalizationComment(this, null);
+			this._l10NSharpExtender1.SetLocalizingId(this, "ExceptionReportingDialog.WindowTitle");
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.Name = "ExceptionReportingDialog";
-			this.ControlBox = true;
-			this.ShowIcon = false; // Showing the Control box ("X") also shows a default icon.
+			this.ShowIcon = false;
+			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
 			this.TopMost = true;
 			this.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.ExceptionReportingDialog_KeyPress);
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.tableLayoutPanel1.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this._l10NSharpExtender1)).EndInit();
 			this.ResumeLayout(false);
-			this.PerformLayout();
 
 		}
 
 		private void SetupMethodCombo()
 		{
 			_methodCombo.Items.Clear();
-			_methodCombo.Items.Add(new ReportingMethod("Send using my email program", "&Email", "mapiWithPopup", SendViaEmail));
-			_methodCombo.Items.Add(new ReportingMethod("Copy to clipboard", "&Copy", "clipboard", PutOnClipboard));
+			_methodCombo.Items.Add(new ReportingMethod(
+				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.Email", "Send using my email program"),
+				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.EmailCloseButtonLabel", "&Email"),
+				"mapiWithPopup", SendViaEmail));
+			_methodCombo.Items.Add(new ReportingMethod(
+				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.CopyToClipboard", "Copy to clipboard"),
+				LocalizationManager.GetString("ExceptionReportingDialog.ReportingMethod.CopyCloseButtonLabel", "&Copy"),
+				"clipboard", PutOnClipboard));
 		}
 
 		class ReportingMethod
@@ -333,13 +400,11 @@ namespace SIL.Windows.Forms.Reporting
 					s_reportDataStack.Push(new ExceptionReportingData(null, null, error,
 						null, parent, Thread.CurrentThread.ManagedThreadId));
 				}
-				return;            // ignore message if we are showing from a previous error
+				return; // ignore message if we are showing from a previous error
 			}
 
 			using (ExceptionReportingDialog dlg = new ExceptionReportingDialog(isLethal))
-			{
 				dlg.Report(error, parent);
-			}
 		}
 
 		internal static void ReportMessage(string message, StackTrace stack, bool isLethal)
@@ -351,13 +416,11 @@ namespace SIL.Windows.Forms.Reporting
 					s_reportDataStack.Push(new ExceptionReportingData(message, null, null,
 						stack, null, Thread.CurrentThread.ManagedThreadId));
 				}
-				return;            // ignore message if we are showing from a previous error
+				return; // ignore message if we are showing from a previous error
 			}
 
 			using (ExceptionReportingDialog dlg = new ExceptionReportingDialog(isLethal))
-			{
-				dlg.Report(message, string.Empty, stack, null);
-			}
+				dlg.Report(message, Empty, stack, null);
 		}
 
 		internal static void ReportMessage(string message, Exception error, bool isLethal)
@@ -369,7 +432,7 @@ namespace SIL.Windows.Forms.Reporting
 					s_reportDataStack.Push(new ExceptionReportingData(message, null, error,
 						null, null, Thread.CurrentThread.ManagedThreadId));
 				}
-				return;            // ignore message if we are showing from a previous error
+				return; // ignore message if we are showing from a previous error
 			}
 
 			using (ExceptionReportingDialog dlg = new ExceptionReportingDialog(isLethal))
@@ -380,7 +443,7 @@ namespace SIL.Windows.Forms.Reporting
 
 		protected void GatherData()
 		{
-			_details.Text += Environment.NewLine + "To Reproduce: " + m_reproduce.Text + Environment.NewLine;
+			_details.Text += Environment.NewLine + "To Reproduce: " + _reproduce.Text + Environment.NewLine;
 		}
 
 		public void Report(Exception error, Form owningForm)
@@ -447,7 +510,7 @@ namespace SIL.Windows.Forms.Reporting
 
 			PrepareDialog();
 
-			if(!string.IsNullOrEmpty(reportingData.Message))
+			if (!IsNullOrEmpty(reportingData.Message))
 				_notificationText.Text = reportingData.Message;
 
 			var bldr = new StringBuilder();
@@ -470,7 +533,7 @@ namespace SIL.Windows.Forms.Reporting
 				}
 				catch (Exception err)
 				{
-					//We have more than one report of dieing while logging an exception.
+					//We have more than one report of dying while logging an exception.
 					_details.Text += "****Could not write to log (" + err.Message + ")" + Environment.NewLine;
 					_details.Text += "Was trying to log the exception: " + error.Message + Environment.NewLine;
 					_details.Text += "Recent events:" + Environment.NewLine;
@@ -497,7 +560,7 @@ namespace SIL.Windows.Forms.Reporting
 		{
 			try
 			{
-				if (!string.IsNullOrEmpty(reportingData.Message))
+				if (!IsNullOrEmpty(reportingData.Message))
 					UsageReporter.ReportExceptionString(reportingData.Message);
 				else if (reportingData.Error != null)
 					UsageReporter.ReportException(reportingData.Error);
@@ -539,13 +602,13 @@ namespace SIL.Windows.Forms.Reporting
 
 		private static Exception FormatMessage(StringBuilder bldr, ExceptionReportingData data)
 		{
-			if (!string.IsNullOrEmpty(data.Message))
+			if (!IsNullOrEmpty(data.Message))
 			{
 				bldr.Append("Message (not an exception): ");
 				bldr.AppendLine(data.Message);
 				bldr.AppendLine();
 			}
-			if (!string.IsNullOrEmpty(data.MessageBeforeStack))
+			if (!IsNullOrEmpty(data.MessageBeforeStack))
 			{
 				bldr.AppendLine(data.MessageBeforeStack);
 			}
@@ -554,8 +617,8 @@ namespace SIL.Windows.Forms.Reporting
 			{
 				Exception innerMostException = null;
 				bldr.Append(ErrorReport.GetHiearchicalExceptionInfo(data.Error, ref innerMostException));
-				//if the exception had inner exceptions, show the inner-most exception first, since that is usually the one
-				//we want the developer to read.
+				// If the exception had inner exceptions, show the inner-most exception first,
+				// since that is likely to be the one most useful for the developer to read first.
 				if (innerMostException != null)
 				{
 					var oldText = bldr.ToString();
@@ -626,10 +689,15 @@ namespace SIL.Windows.Forms.Reporting
 			if (!_isLethal)
 			{
 				BackColor = Color.FromArgb(255, 255, 192); //yellow
-				_notificationText.Text = "Take Courage. It'll work out.";
+				_notificationText.Text = LocalizationManager.GetString(
+					"ExceptionReportingDialog.NonLethalNotification",
+					"Take Courage. It'll work out.",
+					"For more formal cultures, something less cheeky might be better. In most " +
+					"cases, this will be replaced by a more useful message, but there are " +
+					"situations where a user could see this.");
 				_notificationText.BackColor = BackColor;
-				_pleaseHelpText.BackColor = BackColor;
-				textBox1.BackColor = BackColor;
+				_lblPleaseHelp.BackColor = BackColor;
+				_lblStepsToReproduce.BackColor = BackColor;
 			}
 
 			SetupCloseButtonText();
@@ -687,7 +755,9 @@ namespace SIL.Windows.Forms.Reporting
 		{
 			if (ErrorReport.EmailAddress != null)
 			{
-				_details.Text = String.Format("Please e-mail this to {0} {1}", ErrorReport.EmailAddress, _details.Text);
+				// REVIEW: Should this be localized? If so, does it *also* need to be kept in
+				// English for support purposes?
+				_details.Text = Format("Please e-mail this to {0} {1}", ErrorReport.EmailAddress, _details.Text);
 			}
 			try
 			{
@@ -793,7 +863,8 @@ namespace SIL.Windows.Forms.Reporting
 		{
 			if (e.KeyCode == Keys.ShiftKey && Visible)
 			{
-				_sendAndCloseButton.Text = "Continue";
+				_sendAndCloseButton.Text = LocalizationManager.GetString(
+					"ExceptionReportingDialog.ContinueButtonLabel", "Continue");
 			}
 			base.OnKeyDown(e);
 		}
@@ -813,11 +884,6 @@ namespace SIL.Windows.Forms.Reporting
 			base.OnKeyUp(e);
 		}
 
-		private void OnJustExit_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-		{
-			CloseUp();
-		}
-
 		private void _methodCombo_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			SetupCloseButtonText();
@@ -826,42 +892,74 @@ namespace SIL.Windows.Forms.Reporting
 		private void SetupCloseButtonText()
 		{
 			_sendAndCloseButton.Text = SelectedMethod.CloseButtonLabel;
-			if (!_isLethal)
+			if (_isLethal)
 			{
-				// _dontSendEmailLink.Text = "Don't Send Email";
+				_sendAndCloseButton.Text = Format(LocalizationManager.GetString(
+						"ExceptionReportingDialog.CloseButtonLethal", "{0} and Exit",
+						"Used together with the normal Close button label (Param 0) to indicate " +
+						"that the the program will have to exit after the error report is sent."),
+					_sendAndCloseButton.Text);
 			}
-			else
-			{
-				_sendAndCloseButton.Text += " and Exit";
-			}
+			//else
+			//{
+			//	_dontSendEmailLink.Text = "Don't Send Email";
+			//}
 		}
 
 		private ReportingMethod SelectedMethod
 		{
-			get { return ((ReportingMethod) _methodCombo.SelectedItem); }
-			set { _methodCombo.SelectedItem = value; }
+			get => ((ReportingMethod) _methodCombo.SelectedItem);
+			set => _methodCombo.SelectedItem = value;
 		}
 
-		public static string PrivacyNotice = @"If you don't care who reads your bug report, you can skip this notice.
+		/// <summary>
+		/// Although this is public and can be set externally for an application that has a custom
+		/// policy (e.e., does not use Jira), be aware that if you want it to localized, you will
+		/// need to reset it if the UI locale changes.
+		/// </summary>
+		public static string PrivacyNotice;
 
-When you submit a crash report or other issue, the contents of your email go in our issue tracking system, ""jira"", which is available via the web at https://jira.sil.org/issues. This is the normal way to handle issues in an open-source project.
+		private static string LocalizedPrivacyNotice => PrivacyNotice ?? GetDefaultPrivacyNotice();
 
-Our issue-tracking system is not searchable by those without an account. Therefore, someone searching via Google will not find your bug reports.
+		private static string GetDefaultPrivacyNotice()
+		{
+			var bldr = new StringBuilder();
+			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para1",
+				"If you don't care who reads your bug report, you can disregard this notice."));
+			bldr.Append(Environment.NewLine);
+			bldr.Append(Environment.NewLine);
+			// REVIEW: Is the last line (which I have put in parentheses) true and/or helpful?
+			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para2",
+				"When you submit a crash report or other issue, it goes into our issue tracking " +
+				"system, \"Jira\", which is available via the web at https://jira.sil.org/issues." +
+				"(This is a normal way to handle issues in an open-source project.)"));
+			bldr.Append(Environment.NewLine);
+			bldr.Append(Environment.NewLine);
+			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para3",
+				"Our issue-tracking system is not searchable by those without an account. " +
+				"Therefore, search engines (like Google) will not find your bug reports."));
+			bldr.Append(Environment.NewLine);
+			bldr.Append(Environment.NewLine);
+			bldr.Append(LocalizationManager.GetString("ExceptionReportingDialog.Privacy.Para4",
+				"However, anyone can make an account and then read your report. So if you have " +
+				"something private to say, please send it to one of the developers privately " +
+				"with a note that you don't want the issue in our issue tracking system. If " +
+				"necessary, we can make a place-holder for your issue without the private " +
+				"information so the issue can still be tracked and not get lost."));
 
-However, anyone can make an account and then read what you sent us. So if you have something private to say, please send it to one of the developers privately with a note that you don't want the issue in our issue tracking system. If need be, we'll make some kind of sanitized place-holder for your issue so that we don't lose it.
-";
+			return bldr.ToString();
+		}
 
 		private void _privacyNoticeButton_Click(object sender, EventArgs e)
 		{
-			MessageBox.Show(PrivacyNotice, "Privacy Notice");
+			MessageBox.Show(LocalizedPrivacyNotice, LocalizationManager.GetString(
+				"ExceptionReportingDialog.PrivacyNoticeCaption", "Privacy Notice"));
 		}
 
 		private void ExceptionReportingDialog_KeyPress(object sender, KeyPressEventArgs e)
 		{
-			if(e.KeyChar== 27)//ESCAPE
-			{
+			if (e.KeyChar== 27)//ESCAPE
 				CloseUp();
-			}
 		}
 	}
 }

--- a/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.cs
@@ -803,7 +803,8 @@ namespace SIL.Windows.Forms.Reporting
 				{
 					try { Logger.WriteError(e); } catch { /* We tried. */ }
 				}
-				_details.Text = $"Please e-mail this to {localizedEmailInstructions} {ErrorReport.EmailAddress} {_details.Text}";
+				_details.Text = $"Please e-mail this to {localizedEmailInstructions} {ErrorReport.EmailAddress}" +
+					$"{Environment.NewLine}{_details.Text}";
 			}
 			try
 			{

--- a/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.resx
+++ b/SIL.Windows.Forms/Reporting/ExceptionReportingDialog.resx
@@ -1,468 +1,537 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-	Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-	Version 2.0
-
-	The primary goals of this format is to allow a simple XML format
-	that is mostly human readable. The generation and parsing of the
-	various data types are done through the TypeConverter classes
-	associated with the data types.
-
-	Example:
-
-	... ado.net/XML headers & schema ...
-	<resheader name="resmimetype">text/microsoft-resx</resheader>
-	<resheader name="version">2.0</resheader>
-	<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-	<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-	<data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-	<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-	<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-		<value>[base64 mime encoded serialized .NET Framework object]</value>
-	</data>
-	<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-		<value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-		<comment>This is a comment</comment>
-	</data>
-
-	There are any number of "resheader" rows that contain simple
-	name/value pairs.
-
-	Each data row contains a name, and value. The row also contains a
-	type or mimetype. Type corresponds to a .NET class that support
-	text/value conversion through the TypeConverter architecture.
-	Classes that don't support this are serialized and stored with the
-	mimetype set.
-
-	The mimetype is used for serialized objects, and tells the
-	ResXResourceReader how to depersist the object. This is currently not
-	extensible. For a given mimetype the value must be set accordingly:
-
-	Note - application/x-microsoft.net.object.binary.base64 is the format
-	that the ResXResourceWriter will generate, however the reader can
-	read any of the formats listed below.
-
-	mimetype: application/x-microsoft.net.object.binary.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.soap.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.bytearray.base64
-	value   : The object must be serialized into a byte array
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-	<xsd:element name="root" msdata:IsDataSet="true">
-	  <xsd:complexType>
-		<xsd:choice maxOccurs="unbounded">
-		  <xsd:element name="metadata">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" use="required" type="xsd:string" />
-			  <xsd:attribute name="type" type="xsd:string" />
-			  <xsd:attribute name="mimetype" type="xsd:string" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="assembly">
-			<xsd:complexType>
-			  <xsd:attribute name="alias" type="xsd:string" />
-			  <xsd:attribute name="name" type="xsd:string" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="data">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-				<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-			  <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-			  <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="resheader">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" />
-			</xsd:complexType>
-		  </xsd:element>
-		</xsd:choice>
-	  </xsd:complexType>
-	</xsd:element>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
   </xsd:schema>
   <resheader name="resmimetype">
-	<value>text/microsoft-resx</value>
+    <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-	<value>2.0</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-	<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-	<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="m_reproduce.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="m_reproduce.Location" type="System.Drawing.Point, System.Drawing">
-	<value>24, 161</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="m_reproduce.Multiline" type="System.Boolean, mscorlib">
-	<value>True</value>
-  </data>
-  <data name="m_reproduce.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-	<value>Vertical</value>
-  </data>
-  <data name="m_reproduce.Size" type="System.Drawing.Size, System.Drawing">
-	<value>509, 87</value>
-  </data>
-  <data name="m_reproduce.TabIndex" type="System.Int32, mscorlib">
-	<value>0</value>
-  </data>
-  <data name="&gt;&gt;m_reproduce.Name" xml:space="preserve">
-	<value>m_reproduce</value>
-  </data>
-  <data name="&gt;&gt;m_reproduce.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;m_reproduce.Parent" xml:space="preserve">
-	<value>$this</value>
-  </data>
-  <data name="&gt;&gt;m_reproduce.ZOrder" xml:space="preserve">
-	<value>4</value>
-  </data>
-  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Bottom, Left</value>
-  </data>
-  <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
-  </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-	<value>24, 263</value>
-  </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-	<value>509, 56</value>
-  </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
-	<value>17</value>
-  </data>
-  <data name="label3.Text" xml:space="preserve">
-	<value>Details for the developers:</value>
-  </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-	<value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-	<value>$this</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-	<value>8</value>
-  </data>
-  <data name="_details.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="_details.Location" type="System.Drawing.Point, System.Drawing">
-	<value>24, 280</value>
-  </data>
-  <data name="_details.Multiline" type="System.Boolean, mscorlib">
-	<value>True</value>
-  </data>
-  <data name="_details.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-	<value>Both</value>
-  </data>
-  <data name="_details.Size" type="System.Drawing.Size, System.Drawing">
-	<value>509, 138</value>
-  </data>
-  <data name="_details.TabIndex" type="System.Int32, mscorlib">
-	<value>4</value>
-  </data>
-  <data name="&gt;&gt;_details.Name" xml:space="preserve">
-	<value>_details</value>
-  </data>
-  <data name="&gt;&gt;_details.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_details.Parent" xml:space="preserve">
-	<value>$this</value>
-  </data>
-  <data name="&gt;&gt;_details.ZOrder" xml:space="preserve">
-	<value>7</value>
-  </data>
-  <data name="_sendAndCloseButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Bottom, Right</value>
-  </data>
-  <data name="_sendAndCloseButton.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
-	<value>System</value>
-  </data>
-  <data name="_sendAndCloseButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
-  </data>
-  <data name="_sendAndCloseButton.Location" type="System.Drawing.Point, System.Drawing">
-	<value>413, 473</value>
-  </data>
-  <data name="_sendAndCloseButton.Size" type="System.Drawing.Size, System.Drawing">
-	<value>120, 23</value>
-  </data>
-  <data name="_sendAndCloseButton.TabIndex" type="System.Int32, mscorlib">
-	<value>3</value>
-  </data>
-  <data name="_sendAndCloseButton.Text" xml:space="preserve">
-	<value>Email and E&amp;xit</value>
-  </data>
-  <data name="&gt;&gt;_sendAndCloseButton.Name" xml:space="preserve">
-	<value>_sendAndCloseButton</value>
-  </data>
-  <data name="&gt;&gt;_sendAndCloseButton.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_sendAndCloseButton.Parent" xml:space="preserve">
-	<value>$this</value>
-  </data>
-  <data name="&gt;&gt;_sendAndCloseButton.ZOrder" xml:space="preserve">
-	<value>9</value>
-  </data>
-  <data name="_pleaseHelpText.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Left, Right</value>
-  </data>
-  <data name="_pleaseHelpText.Font" type="System.Drawing.Font, System.Drawing">
-	<value>Arial, 9.75pt</value>
-  </data>
-  <data name="_pleaseHelpText.Location" type="System.Drawing.Point, System.Drawing">
-	<value>24, 54</value>
-  </data>
-  <data name="_pleaseHelpText.Multiline" type="System.Boolean, mscorlib">
-	<value>True</value>
-  </data>
-  <data name="_pleaseHelpText.Size" type="System.Drawing.Size, System.Drawing">
-	<value>509, 54</value>
-  </data>
-  <data name="_pleaseHelpText.TabIndex" type="System.Int32, mscorlib">
-	<value>22</value>
-  </data>
-  <data name="_pleaseHelpText.Text" xml:space="preserve">
-	<value>To help us fix the problem, we need to gather information on what went wrong.</value>
-  </data>
-  <data name="&gt;&gt;_pleaseHelpText.Name" xml:space="preserve">
-	<value>_pleaseHelpText</value>
-  </data>
-  <data name="&gt;&gt;_pleaseHelpText.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_pleaseHelpText.Parent" xml:space="preserve">
-	<value>$this</value>
-  </data>
-  <data name="&gt;&gt;_pleaseHelpText.ZOrder" xml:space="preserve">
-	<value>6</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
   <data name="_notificationText.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Left, Right</value>
+    <value>Top, Left, Right</value>
   </data>
+  <data name="_notificationText.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="_notificationText.Font" type="System.Drawing.Font, System.Drawing">
-	<value>Arial, 9.75pt, style=Bold</value>
+    <value>Arial, 9.75pt, style=Bold</value>
   </data>
+  <metadata name="_l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="_notificationText.Location" type="System.Drawing.Point, System.Drawing">
-	<value>25, 12</value>
+    <value>3, 0</value>
   </data>
-  <data name="_notificationText.Multiline" type="System.Boolean, mscorlib">
-	<value>True</value>
+  <data name="_notificationText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 10</value>
   </data>
   <data name="_notificationText.Size" type="System.Drawing.Size, System.Drawing">
-	<value>512, 44</value>
+    <value>498, 16</value>
   </data>
   <data name="_notificationText.TabIndex" type="System.Int32, mscorlib">
-	<value>22</value>
+    <value>22</value>
   </data>
   <data name="_notificationText.Text" xml:space="preserve">
-	<value>Well, this is embarrassing.</value>
+    <value>Well, this is embarrassing.</value>
   </data>
   <data name="&gt;&gt;_notificationText.Name" xml:space="preserve">
-	<value>_notificationText</value>
+    <value>_notificationText</value>
   </data>
   <data name="&gt;&gt;_notificationText.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;_notificationText.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_notificationText.ZOrder" xml:space="preserve">
-	<value>5</value>
+    <value>0</value>
   </data>
-  <data name="textBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Top, Left, Right</value>
+  <data name="_sendAndCloseButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
   </data>
-  <data name="textBox1.Font" type="System.Drawing.Font, System.Drawing">
-	<value>Arial, 9pt</value>
+  <data name="_sendAndCloseButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="textBox1.Location" type="System.Drawing.Point, System.Drawing">
-	<value>24, 103</value>
+  <data name="_sendAndCloseButton.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
   </data>
-  <data name="textBox1.Multiline" type="System.Boolean, mscorlib">
-	<value>True</value>
+  <data name="_sendAndCloseButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="textBox1.Size" type="System.Drawing.Size, System.Drawing">
-	<value>505, 52</value>
+  <data name="_sendAndCloseButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>382, 462</value>
   </data>
-  <data name="textBox1.TabIndex" type="System.Int32, mscorlib">
-	<value>25</value>
+  <data name="_sendAndCloseButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 2, 0</value>
   </data>
-  <data name="textBox1.Text" xml:space="preserve">
-	<value>Can you list the steps to take to make this happen again, or tell us anything that might be helpful?</value>
+  <data name="_sendAndCloseButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 22</value>
   </data>
-  <data name="&gt;&gt;textBox1.Name" xml:space="preserve">
-	<value>textBox1</value>
+  <data name="_sendAndCloseButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="&gt;&gt;textBox1.Type" xml:space="preserve">
-	<value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="_sendAndCloseButton.Text" xml:space="preserve">
+    <value>Email and E&amp;xit</value>
   </data>
-  <data name="&gt;&gt;textBox1.Parent" xml:space="preserve">
-	<value>$this</value>
+  <data name="&gt;&gt;_sendAndCloseButton.Name" xml:space="preserve">
+    <value>_sendAndCloseButton</value>
   </data>
-  <data name="&gt;&gt;textBox1.ZOrder" xml:space="preserve">
-	<value>3</value>
+  <data name="&gt;&gt;_sendAndCloseButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="_methodCombo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Bottom, Right</value>
+  <data name="&gt;&gt;_sendAndCloseButton.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
   </data>
-  <data name="_methodCombo.Location" type="System.Drawing.Point, System.Drawing">
-	<value>327, 434</value>
-  </data>
-  <data name="_methodCombo.Size" type="System.Drawing.Size, System.Drawing">
-	<value>204, 21</value>
-  </data>
-  <data name="_methodCombo.TabIndex" type="System.Int32, mscorlib">
-	<value>26</value>
-  </data>
-  <data name="&gt;&gt;_methodCombo.Name" xml:space="preserve">
-	<value>_methodCombo</value>
-  </data>
-  <data name="&gt;&gt;_methodCombo.Type" xml:space="preserve">
-	<value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;_methodCombo.Parent" xml:space="preserve">
-	<value>$this</value>
-  </data>
-  <data name="&gt;&gt;_methodCombo.ZOrder" xml:space="preserve">
-	<value>2</value>
+  <data name="&gt;&gt;_sendAndCloseButton.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="_privacyNoticeButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Bottom, Left</value>
+    <value>Bottom, Left</value>
   </data>
   <data name="_privacyNoticeButton.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
+    <value>True</value>
   </data>
   <data name="_privacyNoticeButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="_privacyNoticeButton.Location" type="System.Drawing.Point, System.Drawing">
-	<value>27, 473</value>
+    <value>2, 461</value>
+  </data>
+  <data name="_privacyNoticeButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 3, 3, 0</value>
   </data>
   <data name="_privacyNoticeButton.Size" type="System.Drawing.Size, System.Drawing">
-	<value>115, 23</value>
+    <value>115, 23</value>
   </data>
   <data name="_privacyNoticeButton.TabIndex" type="System.Int32, mscorlib">
-	<value>27</value>
+    <value>27</value>
   </data>
   <data name="_privacyNoticeButton.Text" xml:space="preserve">
-	<value>Privacy Notice...</value>
+    <value>Privacy Notice...</value>
   </data>
   <data name="_privacyNoticeButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
-	<value>ImageBeforeText</value>
+    <value>ImageBeforeText</value>
   </data>
   <data name="&gt;&gt;_privacyNoticeButton.Name" xml:space="preserve">
-	<value>_privacyNoticeButton</value>
+    <value>_privacyNoticeButton</value>
   </data>
   <data name="&gt;&gt;_privacyNoticeButton.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;_privacyNoticeButton.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_privacyNoticeButton.ZOrder" xml:space="preserve">
-	<value>1</value>
-  </data>
-  <data name="_emailAddress.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-	<value>Bottom, Left</value>
+    <value>2</value>
   </data>
   <data name="_emailAddress.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-	<value>NoControl</value>
+    <value>NoControl</value>
   </data>
   <data name="_emailAddress.Location" type="System.Drawing.Point, System.Drawing">
-	<value>25, 434</value>
+    <value>3, 418</value>
   </data>
   <data name="_emailAddress.Size" type="System.Drawing.Size, System.Drawing">
-	<value>296, 23</value>
+    <value>288, 23</value>
   </data>
   <data name="_emailAddress.TabIndex" type="System.Int32, mscorlib">
-	<value>29</value>
+    <value>29</value>
   </data>
   <data name="_emailAddress.Text" xml:space="preserve">
-	<value>email address</value>
+    <value>email address</value>
   </data>
   <data name="_emailAddress.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-	<value>MiddleLeft</value>
+    <value>MiddleLeft</value>
   </data>
   <data name="&gt;&gt;_emailAddress.Name" xml:space="preserve">
-	<value>_emailAddress</value>
+    <value>_emailAddress</value>
   </data>
   <data name="&gt;&gt;_emailAddress.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;_emailAddress.Parent" xml:space="preserve">
-	<value>$this</value>
+    <value>tableLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;_emailAddress.ZOrder" xml:space="preserve">
-	<value>0</value>
+    <value>3</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-	<value>True</value>
+  <data name="_methodCombo.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="_methodCombo.Location" type="System.Drawing.Point, System.Drawing">
+    <value>297, 421</value>
+  </data>
+  <data name="_methodCombo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 16</value>
+  </data>
+  <data name="_methodCombo.Size" type="System.Drawing.Size, System.Drawing">
+    <value>204, 21</value>
+  </data>
+  <data name="_methodCombo.TabIndex" type="System.Int32, mscorlib">
+    <value>26</value>
+  </data>
+  <data name="&gt;&gt;_methodCombo.Name" xml:space="preserve">
+    <value>_methodCombo</value>
+  </data>
+  <data name="&gt;&gt;_methodCombo.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_methodCombo.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_methodCombo.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="_lblPleaseHelp.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_lblPleaseHelp.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_lblPleaseHelp.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Arial, 9.75pt</value>
+  </data>
+  <data name="_lblPleaseHelp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 26</value>
+  </data>
+  <data name="_lblPleaseHelp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 10</value>
+  </data>
+  <data name="_lblPleaseHelp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>498, 16</value>
+  </data>
+  <data name="_lblPleaseHelp.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="_lblPleaseHelp.Text" xml:space="preserve">
+    <value>To help us fix the problem, we need to gather information on what went wrong.</value>
+  </data>
+  <data name="&gt;&gt;_lblPleaseHelp.Name" xml:space="preserve">
+    <value>_lblPleaseHelp</value>
+  </data>
+  <data name="&gt;&gt;_lblPleaseHelp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_lblPleaseHelp.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_lblPleaseHelp.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="_lblStepsToReproduce.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="_lblStepsToReproduce.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_lblStepsToReproduce.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Arial, 9pt</value>
+  </data>
+  <data name="_lblStepsToReproduce.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 52</value>
+  </data>
+  <data name="_lblStepsToReproduce.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 10</value>
+  </data>
+  <data name="_lblStepsToReproduce.Size" type="System.Drawing.Size, System.Drawing">
+    <value>498, 30</value>
+  </data>
+  <data name="_lblStepsToReproduce.TabIndex" type="System.Int32, mscorlib">
+    <value>25</value>
+  </data>
+  <data name="_lblStepsToReproduce.Text" xml:space="preserve">
+    <value>Can you list the steps to take to make this happen again, or tell us anything that might be helpful?</value>
+  </data>
+  <data name="&gt;&gt;_lblStepsToReproduce.Name" xml:space="preserve">
+    <value>_lblStepsToReproduce</value>
+  </data>
+  <data name="&gt;&gt;_lblStepsToReproduce.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_lblStepsToReproduce.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_lblStepsToReproduce.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="_details.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="_details.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 208</value>
+  </data>
+  <data name="_details.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 16</value>
+  </data>
+  <data name="_details.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_details.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Both</value>
+  </data>
+  <data name="_details.Size" type="System.Drawing.Size, System.Drawing">
+    <value>498, 194</value>
+  </data>
+  <data name="_details.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;_details.Name" xml:space="preserve">
+    <value>_details</value>
+  </data>
+  <data name="&gt;&gt;_details.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_details.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_details.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="_detailsForDevelopers.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="_detailsForDevelopers.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="_detailsForDevelopers.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="_detailsForDevelopers.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 185</value>
+  </data>
+  <data name="_detailsForDevelopers.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 0, 3, 4</value>
+  </data>
+  <data name="_detailsForDevelopers.Size" type="System.Drawing.Size, System.Drawing">
+    <value>130, 16</value>
+  </data>
+  <data name="_detailsForDevelopers.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="_detailsForDevelopers.Text" xml:space="preserve">
+    <value>Details for the developers:</value>
+  </data>
+  <data name="&gt;&gt;_detailsForDevelopers.Name" xml:space="preserve">
+    <value>_detailsForDevelopers</value>
+  </data>
+  <data name="&gt;&gt;_detailsForDevelopers.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;_detailsForDevelopers.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;_detailsForDevelopers.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="tableLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tableLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>24, 12</value>
+  </data>
+  <data name="tableLayoutPanel1.RowCount" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="tableLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>504, 484</value>
+  </data>
+  <data name="tableLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>30</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Name" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tableLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="tableLayoutPanel1.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="_notificationText" Row="0" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_sendAndCloseButton" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_privacyNoticeButton" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_emailAddress" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="_methodCombo" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="_lblPleaseHelp" Row="1" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_lblStepsToReproduce" Row="2" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="m_reproduce" Row="3" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_details" Row="5" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="_detailsForDevelopers" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20,Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="m_reproduce.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 95</value>
+  </data>
+  <data name="m_reproduce.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="m_reproduce.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Vertical</value>
+  </data>
+  <data name="m_reproduce.Size" type="System.Drawing.Size, System.Drawing">
+    <value>498, 87</value>
+  </data>
+  <data name="m_reproduce.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;m_reproduce.Name" xml:space="preserve">
+    <value>m_reproduce</value>
+  </data>
+  <data name="&gt;&gt;m_reproduce.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;m_reproduce.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;m_reproduce.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-	<value>96, 96</value>
+    <value>96, 96</value>
   </data>
   <data name="$this.AutoSize" type="System.Boolean, mscorlib">
-	<value>True</value>
-  </data>
-  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-	<value>GrowAndShrink</value>
+    <value>True</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-	<value>552, 516</value>
+    <value>552, 516</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-	<value>465, 480</value>
+    <value>465, 480</value>
+  </data>
+  <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>24, 12, 24, 20</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-	<value>CenterScreen</value>
+    <value>CenterScreen</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-	<value>Error</value>
+    <value>Error</value>
+  </data>
+  <data name="&gt;&gt;_l10NSharpExtender1.Name" xml:space="preserve">
+    <value>_l10NSharpExtender1</value>
+  </data>
+  <data name="&gt;&gt;_l10NSharpExtender1.Type" xml:space="preserve">
+    <value>L10NSharp.UI.L10NSharpExtender, L10NSharp, Version=5.0.0.0, Culture=neutral, PublicKeyToken=fd0b3e309a5b7c28</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
-	<value>ExceptionReportingDialog</value>
+    <value>ExceptionReportingDialog</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-	<value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/SIL.Windows.Forms/Reporting/ProblemNotificationDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ProblemNotificationDialog.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Windows.Forms;
 using L10NSharp;
+using SIL.Reporting;
 using SIL.Windows.Forms.Extensions;
 using SIL.Windows.Forms.Miscellaneous;
 
@@ -42,8 +43,18 @@ namespace SIL.Windows.Forms.Reporting
 
 		public static void Show(string message)
 		{
-			using (var d = new ProblemNotificationDialog(message,
-				LocalizationManager.GetString("ProblemNotificationDialog.Caption", "Problem")))
+			string caption;
+			try
+			{
+				caption = LocalizationManager.GetString("ProblemNotificationDialog.Caption",
+					"Problem");
+			}
+			catch (Exception e)
+			{
+				try { Logger.WriteError(e); } catch { /* We tried. */ }
+				caption = "Problem";
+			}
+			using (var d = new ProblemNotificationDialog(message, caption))
 			{
 				d.ShowDialog();
 			}

--- a/SIL.Windows.Forms/Reporting/ProblemNotificationDialog.cs
+++ b/SIL.Windows.Forms/Reporting/ProblemNotificationDialog.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Drawing;
 using System.Windows.Forms;
+using L10NSharp;
+using SIL.Windows.Forms.Extensions;
 using SIL.Windows.Forms.Miscellaneous;
 
 namespace SIL.Windows.Forms.Reporting
@@ -40,8 +42,11 @@ namespace SIL.Windows.Forms.Reporting
 
 		public static void Show(string message)
 		{
-			using (var d = new ProblemNotificationDialog(message, "Problem"))
+			using (var d = new ProblemNotificationDialog(message,
+				LocalizationManager.GetString("ProblemNotificationDialog.Caption", "Problem")))
+			{
 				d.ShowDialog();
+			}
 		}
 
 		private ProblemNotificationDialog()
@@ -73,7 +78,7 @@ namespace SIL.Windows.Forms.Reporting
 				_icon.Image = icon;
 
 			Text = dialogTitle;
-			_message.Text = message;
+			_message.SetMultiLineText(message);
 		}
 
 		private void _acceptButton_Click(object sender, EventArgs e)

--- a/TestApps/SIL.Windows.Forms.TestApp/Program.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Program.cs
@@ -4,7 +4,10 @@ using System.Threading;
 using System.Windows.Forms;
 using L10NSharp;
 using SIL.IO;
+using SIL.Reporting;
+using SIL.Windows.Forms.Reporting;
 using SIL.WritingSystems;
+using static System.StringComparison;
 
 namespace SIL.Windows.Forms.TestApp
 {
@@ -18,12 +21,37 @@ namespace SIL.Windows.Forms.TestApp
 		{
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
+
+			SetUpErrorHandling();
+
 			Sldr.Initialize();
 			Icu.Wrapper.Init();
-			var localizationFolder = Path.GetDirectoryName(FileLocationUtilities.GetFileDistributedWithApplication("Palaso.en.tmx"));
-			LocalizationManager.Create(TranslationMemory.Tmx, "fr", "Palaso", "Palaso", "1.0.0", localizationFolder, "SIL/Palaso",
-				null, "");
-			if(args.Length>0) //for testing commandlinerunner
+
+			var testCommandLineRunner = false;
+			var distFilesEnglishStrings = "Palaso.en.tmx";
+			var localizationType = TranslationMemory.Tmx;
+			var preferredUILocale = "fr";
+			if (args.Length > 0)
+			{
+				if (args[0].Equals(TranslationMemory.XLiff.ToString(), OrdinalIgnoreCase))
+				{
+					distFilesEnglishStrings =
+						Path.ChangeExtension(distFilesEnglishStrings, "xlf");
+					localizationType = TranslationMemory.XLiff;
+					preferredUILocale = "es";
+				}
+				else
+				{
+					testCommandLineRunner = true;
+				}
+			}
+
+			var localizationFolder = Path.GetDirectoryName(
+				FileLocationUtilities.GetFileDistributedWithApplication(distFilesEnglishStrings));
+			LocalizationManager.Create(localizationType, preferredUILocale, "Palaso", "Palaso",
+				"1.0.0", localizationFolder, "SIL/Palaso", null, "");
+
+			if (testCommandLineRunner)
 			{
 				for (int i = 0; i < 10; i++)
 				{
@@ -38,5 +66,12 @@ namespace SIL.Windows.Forms.TestApp
 			Sldr.Cleanup();
 		}
 
+		/// ------------------------------------------------------------------------------------
+		private static void SetUpErrorHandling()
+		{
+			ErrorReport.EmailAddress = "bogus_test_app_email_addr@sil.org";
+			ErrorReport.AddStandardProperties();
+			ExceptionHandler.Init(new WinFormsExceptionHandler());
+		}
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
@@ -1,9 +1,9 @@
-﻿// ---------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------
 using SIL.Windows.Forms.Keyboarding;
 
-#region // Copyright (c) 2013, SIL International. All Rights Reserved.
-// <copyright from='2013' to='2013' company='SIL International'>
-//		Copyright (c) 2013, SIL International. All Rights Reserved.
+#region // Copyright (c) 2022, SIL International. All Rights Reserved.
+// <copyright from='2013' to='2022' company='SIL International'>
+//		Copyright (c) 2022, SIL International. All Rights Reserved.
 //
 //		Distributable under the terms of either the Common Public License or the
 //		GNU Lesser General Public License, as specified in the LICENSING.txt file.
@@ -64,6 +64,7 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSilAboutBox = new System.Windows.Forms.Button();
 			this.btnShowReleaseNotes = new System.Windows.Forms.Button();
 			this.superToolTip1 = new SIL.Windows.Forms.SuperToolTip.SuperToolTip(this.components);
+			this.btnThrowException = new System.Windows.Forms.Button();
 			this.label1 = new System.Windows.Forms.Label();
 			this.btnMetaDataEditor = new System.Windows.Forms.Button();
 			this.btnSelectFile = new System.Windows.Forms.Button();
@@ -84,6 +85,16 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnFolderBrowserControl.Text = "FolderBrowserControl";
 			this.btnFolderBrowserControl.UseVisualStyleBackColor = true;
 			this.btnFolderBrowserControl.Click += new System.EventHandler(this.OnFolderBrowserControlClicked);
+			// 
+			// btnThrowException
+			// 
+			this.btnThrowException.Location = new System.Drawing.Point(12, 418);
+			this.btnThrowException.Name = "btnThrowException";
+			this.btnThrowException.Size = new System.Drawing.Size(157, 23);
+			this.btnThrowException.TabIndex = 8;
+			this.btnThrowException.Text = "Throw Unhandled Exception";
+			this.btnThrowException.UseVisualStyleBackColor = true;
+			this.btnThrowException.Click += new System.EventHandler(this.btnThrowException_Click);
 			// 
 			// btnLookupISOCodeDialog
 			// 
@@ -248,7 +259,8 @@ namespace SIL.Windows.Forms.TestApp
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(187, 453);
+			this.ClientSize = new System.Drawing.Size(187, 489);
+			this.Controls.Add(this.btnThrowException);
 			this.Controls.Add(this.btnShowFormWithModalChild);
 			this.Controls.Add(this.btnTestContributorsList);
 			this.Controls.Add(this.recordPlayButton);
@@ -289,5 +301,6 @@ namespace SIL.Windows.Forms.TestApp
 		private System.Windows.Forms.Button recordPlayButton;
 		private System.Windows.Forms.Button btnTestContributorsList;
 		private System.Windows.Forms.Button btnShowFormWithModalChild;
+		private System.Windows.Forms.Button btnThrowException;
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 SIL International
+// Copyright (c) 2013-2022 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -349,6 +349,11 @@ and displays it as HTML.
 		{
 			var parent = new ParentOfModalChild();
 			parent.Show();
+		}
+
+		private void btnThrowException_Click(object sender, EventArgs e)
+		{
+			throw new Exception("This is a test of the error reporting window!");
 		}
 	}
 }


### PR DESCRIPTION
Internationalized the ExceptionReportingDialog
Also used LocalizationManager for the caption for the ProblemNotificationDialog.
Fixed layout issues in ExceptionReportingDialog to prevent overlapping text.
Fixed handling of \n in message text so that it lays out correctly in the ProblemNotificationDialog (because strings returned from L10NSharp typically don't have the \r)
[WIP] Could not figure out how to re-extract the strings to update the XLF files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1148)
<!-- Reviewable:end -->
