### PR TITLE
archiving: don't throw when no languages.yaml in Linux

### DIFF
--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -1806,7 +1806,8 @@ namespace SIL.Archiving
 		#region Language functions
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Get the path and file name of the RAMP Languages file
+		/// Get the path and file name of the RAMP Languages file.
+		/// Note that RAMP 3 does not ship the languages file.
 		/// </summary>
 		/// <returns>The full name of the RAMP languages file</returns>
 		/// ------------------------------------------------------------------------------------
@@ -1820,16 +1821,16 @@ namespace SIL.Archiving
 			if (dir == null)
 				throw new DirectoryNotFoundException("The RAMP directory was not found.");
 
+			// RAMP 3.0 doesn't have languages.yaml, so just return string.Empty if it is not found.
 
 			if (Platform.IsWindows)
 			{
-				//Ramp 3.0 Package doesn't have languages.yaml
 				if (!Directory.Exists(Path.Combine(dir, "data")))
 				{
 					return string.Empty;
 				}
 			}
-			// on Linux the exe and data directory are not in the same directory
+			// On Linux the exe and data directory are not in the same directory
 			if (!Directory.Exists(Path.Combine(dir, "data")))
 			{
 				dir = Directory.GetParent(dir).FullName;
@@ -1837,20 +1838,20 @@ namespace SIL.Archiving
 					dir = Path.Combine(dir, "share");
 			}
 
-			// get the data directory
+			// Get the data directory
 			dir = Path.Combine(dir, "data");
 			if (!Directory.Exists(dir))
-				throw new DirectoryNotFoundException(string.Format("The path {0} is not valid.", dir));
+				return string.Empty;
 
-			// get the options directory
+			// Get the options directory
 			dir = Path.Combine(dir, "options");
 			if (!Directory.Exists(dir))
-				throw new DirectoryNotFoundException(string.Format("The path {0} is not valid.", dir));
+				return string.Empty;
 
-			// get the languages.yaml file
+			// Get the languages.yaml file
 			var langFile = Path.Combine(dir, "languages.yaml");
 			if (!File.Exists(langFile))
-				throw new FileNotFoundException(string.Format("The file {0} was not found.", langFile));
+				return string.Empty;
 
 			return langFile;
 		}


### PR DESCRIPTION
- This was already done for Windows in LT-19077.
- This change returns string.Empty in Linux as well, when
languages.yaml is not found.
- This is to fix the problem reported in LT-20968.

---

**Stack**:
- #1157
- #1152 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1152)
<!-- Reviewable:end -->
