### PR TITLE
PTX-21397 add ability to paste scripture ref in VerseControl

### DIFF
--- a/SIL.Scripture/MultilingScrBooks.cs
+++ b/SIL.Scripture/MultilingScrBooks.cs
@@ -112,6 +112,8 @@ namespace SIL.Scripture
         #region Data members
         /// <summary>The maximum number of Scripture books that may be returned to the caller.</summary>
         public const int LastBook = 66;
+        /// <summary>Regular expression used to parse verse reference strings.</summary>
+		public const string VerseRefRegex = @"(?<book>\w?.*[a-zA-Z])\s?((?<chapter>\d+)(\D+(?<verse>\d+))?)?";
 
 		/// <summary>// Indicates whether to process deutero-canonical book names.</summary>
 		protected bool m_fProcessDeuteroCanonical = false;
@@ -478,7 +480,7 @@ namespace SIL.Scripture
 		/// ------------------------------------------------------------------------------------
 		public virtual BCVRef ParseRefString(string sTextToBeParsed, int startingBook)
 		{
-			Regex regex = new Regex(@"(?<book>\w?.*[a-zA-Z])\s?((?<chapter>\d+)(\D+(?<verse>\d+))?)?");
+			Regex regex = new Regex(VerseRefRegex);
 			Match match = regex.Match(sTextToBeParsed.TrimStart());
 			if (match.Success)
 			{

--- a/SIL.Windows.Forms.Scripture.Tests/VerseControlTests.cs
+++ b/SIL.Windows.Forms.Scripture.Tests/VerseControlTests.cs
@@ -70,6 +70,7 @@ namespace SIL.Windows.Forms.Scripture.Tests
 		[TestCase("2CO 3:18", "2CO 3:18", true)]
 		[TestCase("2CO3:18", "2CO 3:18", true)]
 		[TestCase("2CO 3.18", "2CO 3:18", true)]
+		[TestCase("2CO 3", "2CO 3:1", true)]
 		public void PastedTextGetsExpectedResult(string text, string expectedResult, bool isValid)
 		{
 			m_verseCtrl.VerseRef = new VerseRef("MAT", "1", "1", ScrVers.English);

--- a/SIL.Windows.Forms.Scripture.Tests/VerseControlTests.cs
+++ b/SIL.Windows.Forms.Scripture.Tests/VerseControlTests.cs
@@ -1,0 +1,99 @@
+using System.Threading;
+using System.Windows.Forms;
+using NUnit.Framework;
+using SIL.PlatformUtilities;
+using SIL.Reflection;
+using SIL.Scripture;
+using SIL.Windows.Forms.Miscellaneous;
+
+namespace SIL.Windows.Forms.Scripture.Tests
+{
+	[TestFixture]
+	[Apartment(ApartmentState.STA)]
+	public class VerseControlTests
+	{
+		private Form m_ctrlOwner;
+		private VerseControl m_verseCtrl;
+
+		#region Setup methods
+		/// ------------------------------------------------------------------------------------
+		[SetUp]
+		public void TestSetup()
+		{
+			m_ctrlOwner = new Form();
+			m_verseCtrl = new VerseControl();
+			m_ctrlOwner.Controls.Add(m_verseCtrl);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// End of a test
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[TearDown]
+		public void TestTearDown()
+		{
+			if (Platform.IsWindows)
+			{
+				// m_dbScp.SimulateDropDownButtonClick(); can cause this form to hang on close on mono.
+				m_ctrlOwner.Close();
+			}
+			m_ctrlOwner.Dispose();
+		}
+		#endregion
+
+		[TestCase("uiBook_KeyDown")]
+		[TestCase("uiChapter_KeyDown")]
+		[TestCase("uiVerse_KeyDown")]
+		public void PastedStandardReferenceInTextField(string methodName)
+		{
+			PortableClipboard.SetText("JER 31:32");
+			m_verseCtrl.GotoBookField();
+			var keyEvent = new KeyEventArgs(Keys.V | Keys.Control);
+			m_verseCtrl.CallKeyDown(methodName, keyEvent);
+			Assert.AreEqual("JER", m_verseCtrl.VerseRef.Book);
+			Assert.AreEqual(31, m_verseCtrl.VerseRef.ChapterNum);
+			Assert.AreEqual(32, m_verseCtrl.VerseRef.VerseNum);
+			Assert.IsTrue(keyEvent.SuppressKeyPress);
+		}
+
+		[TestCase("2 Corinthians 3:18", "2CO 3:18", true)]
+		[TestCase("2 Corinthians3:18", "2CO 3:18", true)]
+		[TestCase("2 Corinthians3*18", "2CO 3:18", true)]
+		[TestCase("PSA 119:176", "PSA 119:176", true)]
+		[TestCase("MRK 1:0", "MRK 1:0", true)]
+		[TestCase("LUK 2.3", "LUK 2:3", true)]
+		[TestCase("jhn 4:5", "JHN 4:5", true)]
+		[TestCase("ACT 99:888", "ACT 28:31", true)]
+		[TestCase("2 Cor 3:18", "2CO 3:18", true)]
+		[TestCase("2 C 3:18", "MAT 1:1", false)]
+		[TestCase("2CO 3:18", "2CO 3:18", true)]
+		[TestCase("2CO3:18", "2CO 3:18", true)]
+		[TestCase("2CO 3.18", "2CO 3:18", true)]
+		public void PastedTextGetsExpectedResult(string text, string expectedResult, bool isValid)
+		{
+			m_verseCtrl.VerseRef = new VerseRef("MAT", "1", "1", ScrVers.English);
+			PortableClipboard.SetText(text);
+			m_verseCtrl.GotoBookField();
+			var keyEvent = new KeyEventArgs(Keys.V | Keys.Control);
+			m_verseCtrl.CallKeyDown("uiBook_KeyDown", keyEvent);
+			Assert.AreEqual(isValid, keyEvent.SuppressKeyPress);
+			Assert.AreEqual(expectedResult, m_verseCtrl.VerseRef.ToString());
+		}
+
+		[Test]
+		[Explicit("Test is just intended to be an easy way to see the verse control and test it manually")]
+		public void ShowVerseControl()
+		{
+			m_ctrlOwner.ShowDialog();
+		}
+	}
+
+	internal static class VerseControlTestHelperExt
+	{
+		internal static void CallKeyDown(this VerseControl verseControl, string methodName, KeyEventArgs eventArgs)
+		{
+			ReflectionHelper.CallMethod(verseControl, methodName, null, eventArgs);
+		}
+	}
+}


### PR DESCRIPTION
Implementing a Paratext feature request to be able to paste a scripture reference into the verse control.

The reference can either be the short form: GEN 1:27

or a longer form that uses the localized book names: 2 Corinthians 3:18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1153)
<!-- Reviewable:end -->
