### PR TITLE
LT-21002: Prevent crash by filtering the sort list

### DIFF
--- a/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemSetupModel.cs
@@ -545,6 +545,11 @@ namespace SIL.Windows.Forms.WritingSystems
 				{
 					if (prohibitedList.Contains(cultureInfo.Name, StringComparison.OrdinalIgnoreCase))
 						continue;
+
+					// Do not add languages that are not installed.
+					if (!SystemCollator.ValidateLanguageTag(cultureInfo.Name, out _))
+						continue;
+
 					yield return new KeyValuePair<string, string>(cultureInfo.Name, cultureInfo.DisplayName);
 				}
 			}


### PR DESCRIPTION
Filter the sort language list so that it only contains languages
that are installed on the machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1154)
<!-- Reviewable:end -->
