### PR TITLE
Another attempt to fix l10n.proj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.ClearShare.WinFormsUI] Default to CC-BY for new CC licenses
 - [SIL.Media] Allow RecordingDeviceIndicator to find new sound input device when there was no selected device (state == NotYetStarted)
 - [SIL.Windows.Forms] Internationalized the ExceptionReportingDialog.
+- [SIL.Windows.Forms] Corrected typo in the name of AcquireImageControl.SetInitialSearchString
 
 ### Fixed
 

--- a/DistFiles/Palaso.en.xlf
+++ b/DistFiles/Palaso.en.xlf
@@ -518,6 +518,10 @@
         <note>ID: ImageToolbox.PictureFiles</note>
         <note>Shown in the file-picking dialog to describe what kind of files the dialog is filtering for</note>
       </trans-unit>
+      <trans-unit id="ImageToolbox.ProblemGettingImageFromDevice">
+        <source xml:lang="en">Problem Getting Image</source>
+        <note>ID: ImageToolbox.ProblemGettingImageFromDevice</note>
+      </trans-unit>
       <trans-unit id="ImageToolbox.ProblemLoadingImage">
         <source xml:lang="en">Sorry, there was a problem loading that image.</source>
         <note>ID: ImageToolbox.ProblemLoadingImage</note>
@@ -537,6 +541,14 @@
       <trans-unit id="ImageToolbox.SetUpMetadataLink">
         <source xml:lang="en">Set up metadata...</source>
         <note>ID: ImageToolbox.SetUpMetadataLink</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.TwainDriverNotSupported">
+        <source xml:lang="en">'TWAIN' driver</source>
+        <note>ID: ImageToolbox.TwainDriverNotSupported</note>
+      </trans-unit>
+      <trans-unit id="ImageToolbox.WindowsXpMissingWiaV2Dll">
+        <source xml:lang="en">http://vbnet.mvps.org/files/updates/wiaautsdk.zip</source>
+        <note>ID: ImageToolbox.WindowsXpMissingWiaV2Dll</note>
       </trans-unit>
       <trans-unit id="IpaIdentifierView.betterLabel1">
         <source xml:lang="en">Purpose:</source>

--- a/SIL.Media/WindowsAudioSession.cs
+++ b/SIL.Media/WindowsAudioSession.cs
@@ -62,7 +62,7 @@ namespace SIL.Media
 		public void StopRecordingAndSaveAsWav()
 		{
 			if (!_thinkWeAreRecording)
-				throw new ApplicationException("Stop Recording called when we weren't recording.  Use IsRecording to check first.");
+				throw new ApplicationException("Stop Recording called when we weren't recording. Use IsRecording to check first.");
 
 			_thinkWeAreRecording = false;
 			_recorder.StopRecordingAudio();

--- a/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
@@ -246,25 +246,47 @@ namespace SIL.Windows.Forms.ImageToolbox
 			catch (ImageDeviceNotFoundException error)
 			{
 				_messageLabel.Text = error.Message + Environment.NewLine + Environment.NewLine +
-									 "Note: this program works with devices that have a 'WIA' driver, not the old-style 'TWAIN' driver";
+					TwainDriverNotSupportedMessage;
 				_messageLabel.Visible = true;
 			}
 			catch (WIA_Version2_MissingException)
 			{
-				_messageLabel.Text = "Windows XP does not come with a crucial DLL that lets you use a WIA scanner with this program. Get a technical person to download and follow the directions at http://vbnet.mvps.org/files/updates/wiaautsdk.zip";
+				_messageLabel.Text = WIAVersion2MissingMessage;
 				_messageLabel.Visible = true;
 			}
 			catch (Exception error)
 			{
-				ErrorReport.NotifyUserOfProblem(error, "Problem Getting Image".Localize("ImageToolbox.ProblemGettingImageFromDevice"));
+				ErrorReport.NotifyUserOfProblem(error, ProblemGettingImageFromDeviceMessage);
 			}
 		}
+
+		// This is a separate property because L10nSharp's extraction code cannot properly load
+		// Interop.WIA by reflection, so any strings contained in methods that depend on WIA
+		// calls are omitted.
+		private string TwainDriverNotSupportedMessage =>
+			"Note: this program works with devices that have a 'WIA' driver, not the old-style " +
+			"'TWAIN' driver".Localize("ImageToolbox.TwainDriverNotSupported");
+
+		// This is a separate property because L10nSharp's extraction code cannot properly load
+		// Interop.WIA by reflection, so any strings contained in methods that depend on WIA
+		// calls are omitted.
+		private string WIAVersion2MissingMessage =>
+			"Windows XP does not come with a crucial DLL that lets you use a WIA scanner with " +
+			"this program. Get a technical person to download and follow the directions at " +
+			"http://vbnet.mvps.org/files/updates/wiaautsdk.zip".Localize(
+				"ImageToolbox.WindowsXpMissingWiaV2Dll");
+
+		// This is a separate property because L10nSharp's extraction code cannot properly load
+		// Interop.WIA by reflection, so any strings contained in methods that depend on WIA
+		// calls are omitted.
+		private string ProblemGettingImageFromDeviceMessage =>
+			"Problem Getting Image".Localize("ImageToolbox.ProblemGettingImageFromDevice");
 
 		/// <summary>
 		/// use if the calling app already has some notion of what the user might be looking for (e.g. the definition in a dictionary program)
 		/// </summary>
 		/// <param name="searchTerm"></param>
-		public void SetIntialSearchString(string searchTerm)
+		public void SetInitialSearchString(string searchTerm)
 		{
 			_galleryControl.SetIntialSearchTerm(searchTerm);
 		}
@@ -274,8 +296,8 @@ namespace SIL.Windows.Forms.ImageToolbox
 		/// </summary>
 		public string SearchLanguage
 		{
-			get { return _galleryControl.SearchLanguage; }
-			set { _galleryControl.SearchLanguage = value; }
+			get => _galleryControl.SearchLanguage;
+			set => _galleryControl.SearchLanguage = value;
 		}
 
 		/*

--- a/SIL.Windows.Forms/ImageToolbox/ImageAcquisitionService.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageAcquisitionService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -24,10 +24,6 @@ namespace SIL.Windows.Forms.ImageToolbox
 	}
 	   public class WIA_Version2_MissingException : ApplicationException
 	{
-		public WIA_Version2_MissingException()
-			: base()
-		{ }
-
 	}
 
 
@@ -53,8 +49,6 @@ namespace SIL.Windows.Forms.ImageToolbox
 		[CLSCompliant(false)]
 		public ImageFile Acquire()
 		{
-			ImageFile image;
-
 			try
 			{
 				CommonDialog dialog = new CommonDialog();
@@ -77,22 +71,22 @@ namespace SIL.Windows.Forms.ImageToolbox
 					}
 				}
 
-				//this gives the UI we want (can select profiles), but there's no way for an application to get the
-				//results of the scan!!!! It just asks the user where to save the image. GRRRRRRR.
-				//object x = dialog.ShowAcquisitionWizard(device);
+				// This gives the UI we want (can select profiles), but there's no way for an application to get the
+				// results of the scan!!!! It just asks the user where to save the image. GRRRRRRR.
+				// object x = dialog.ShowAcquisitionWizard(device);
 
 
 				//With the low-end canoscan I'm using, it just ignores these settings, so we just get a bitmap of whatever
 				//b&w / color the user requested
 
-				  image = dialog.ShowAcquireImage(
-						type,
-						WiaImageIntent.GrayscaleIntent,
-						WiaImageBias.MaximizeQuality,
-						WIA.FormatID.wiaFormatBMP, //We'll automatically choose the format later depending on what we see
-					   false,
-					   true,
-						false);
+				  var image = dialog.ShowAcquireImage(
+					  type,
+					  WiaImageIntent.GrayscaleIntent,
+					  WiaImageBias.MaximizeQuality,
+					  WIA.FormatID.wiaFormatBMP, //We'll automatically choose the format later depending on what we see
+					  false,
+					  true,
+					  false);
 				UsageReporter.SendNavigationNotice("AcquiredImage/" + (_deviceKind == DeviceKind.Camera?"Camera": "Scanner"));
 
 				return image;
@@ -103,22 +97,18 @@ namespace SIL.Windows.Forms.ImageToolbox
 				{
 					throw new ImageDeviceNotFoundException();
 				}
-				else
+
+				//NB: I spend some hours working on adding this wiaaut.dll via the installer, using wix heat, but it was one problem after another.
+				//Decided eventually that it wasn't worth it at this point; it's easy enough to install by hand.
+				if (ErrorReport.GetOperatingSystemLabel().Contains("XP"))
 				{
-					//NB: I spend some hours working on adding this wiaaut.dll via the installer, using wix heat, but it was one problem after another.
-					//Decided eventually that it wasn't worth it at this point; it's easy enough to install by hand.
-					if (ErrorReport.GetOperatingSystemLabel().Contains("XP"))
-					{
-						var comErrorCode = new Win32Exception(((COMException) ex).ErrorCode).ErrorCode;
+					var comErrorCode = new Win32Exception(ex.ErrorCode).ErrorCode;
 
-						if (comErrorCode == 80040154)
-						{
-							throw new WIA_Version2_MissingException();
-						}
-					}
-
-					throw new ImageDeviceException("COM Exception", ex);
+					if (comErrorCode == 80040154)
+						throw new WIA_Version2_MissingException();
 				}
+
+				throw new ImageDeviceException("COM Exception", ex);
 			}
 		}
 

--- a/SIL.Windows.Forms/ImageToolbox/ImageToolboxControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageToolboxControl.cs
@@ -404,7 +404,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 				_acquireImageControl = new AcquireImageControl();
 				_acquireImageControl.ImageLoadingExceptionReporter =
 					ImageLoadingExceptionReporter;
-				_acquireImageControl.SetIntialSearchString(InitialSearchString);
+				_acquireImageControl.SetInitialSearchString(InitialSearchString);
 				_acquireImageControl.SearchLanguage = _incomingSearchLanguage;
 				return _acquireImageControl;
 			});

--- a/l10n/l10n.proj
+++ b/l10n/l10n.proj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks/>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SIL.libpalaso.l10ns</PackageId>
     <Version>$(GitVersion_NuGetVersion)</Version>
     <Authors>Jason Naylor</Authors>

--- a/l10n/l10n.proj
+++ b/l10n/l10n.proj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="GitVersion.MsBuild" Version="5.9.0" GeneratePathProperty="true" />
-	<PackageReference Include="L10NSharp.ExtractXliff" Version="4.1.0-beta0036" GeneratePathProperty="true" />
-    <PackageReference Include="NuGet.CommandLine" Version="5.4.0" GeneratePathProperty="true" />
+	<PackageReference Include="L10NSharp.ExtractXliff" Version="5.0.0-beta0080" GeneratePathProperty="true" />
+    <PackageReference Include="NuGet.CommandLine" Version="6.1.0" GeneratePathProperty="true" />
     <PackageReference Include="SIL.BuildTasks" Version="2.3.0-beta.14" GeneratePathProperty="true" />
   </ItemGroup>
   <UsingTask TaskName="NormalizeLocales" AssemblyFile="$(PkgSIL_BuildTasks)\tools\SIL.BuildTasks.dll" />

--- a/l10n/l10n.proj
+++ b/l10n/l10n.proj
@@ -6,19 +6,36 @@
     <Version>$(GitVersion_NuGetVersion)</Version>
     <Authors>Jason Naylor</Authors>
     <Company>SIL International</Company>
+	<RestartBuild Condition="'$(PkgL10NSharp_ExtractXliff)' == ''">true</RestartBuild>
+	<RestartBuild Condition="'$(PkgL10NSharp_ExtractXliff)' != ''">false</RestartBuild>
   </PropertyGroup>
+  
   <ItemGroup>
 	<PackageReference Include="GitVersion.MsBuild" Version="5.9.0" GeneratePathProperty="true" />
 	<PackageReference Include="L10NSharp.ExtractXliff" Version="5.0.0-beta0080" GeneratePathProperty="true" />
     <PackageReference Include="NuGet.CommandLine" Version="6.1.0" GeneratePathProperty="true" />
     <PackageReference Include="SIL.BuildTasks" Version="2.3.0-beta.14" GeneratePathProperty="true" />
   </ItemGroup>
+  
   <UsingTask TaskName="NormalizeLocales" AssemblyFile="$(PkgSIL_BuildTasks)\tools\SIL.BuildTasks.dll" />
-  <Target Name="UpdateCrowdin" DependsOnTargets="restore;GetVersion">
+  
+  <Target Name="UpdateCrowdin">
+	<Message Text="RestartBuild=$(RestartBuild)"/>
+	<CallTarget Targets="RestoreBuildDependencies"/>
+	<CallTarget Targets="UpdateCrowdinInternal" Condition="!$(RestartBuild)" />
+  </Target>
+  
+  <Target Name="RestoreBuildDependencies" DependsOnTargets="restore">
+	<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="UpdateCrowdinInternal" Properties="Configuration=$(Configuration)" Condition="$(RestartBuild)" />
+  </Target>
+	
+  <Target Name="UpdateCrowdinInternal" DependsOnTargets="GetVersion">
 	<MSBuild Projects="..\build\Palaso.proj" Targets="Build" Properties="Configuration=Release" />
 	<Exec Command="&quot;$(PkgL10NSharp_ExtractXliff)\tools\ExtractXliff.exe&quot; -n SIL -o Palaso.dll -x Palaso.en.xlf -p $(GitVersion_NuGetVersion) -m SIL.Localizer.GetString -m SIL.Localizer.Localize -g ../Output/Release/net461/SIL.*.dll" />
 	<!-- <Exec Command="overcrowdin updatefiles" /> -->
   </Target>
+  
+  <!-- REVIEW: This probably needs to make use of the RestartBuild logic also.  -->
   <Target Name="PackageL10ns" DependsOnTargets="restore;GetVersion">
 	<RemoveDir Directories="CommonLibsL10ns" />
 	<Exec Command="overcrowdin download -e -f CommonLibsL10ns.zip" />


### PR DESCRIPTION
During a regular build (of a .csproj) the build system sets `TargetFramework` for each framework in `TargetFrameworks`. This causes the `PkgL10NSharp_ExtractXliff` to get defined (in `obj\l10n.proj.nuget.g.props`). However, if `TargetFrameworks` is set,
the definition of the property gets an additional condition on `TargetFramework` so that the property isn't set when `UpdateCrowdin` runs.

This change sets `TargetFramework` (and sets `TargetFrameworks` to the empty string) to work around this problem.

See also https://github.com/NuGet/Home/issues/11721 and https://github.com/NuGet/Home/issues/11725

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1155)
<!-- Reviewable:end -->
