### PR TITLE
Update IErrorReporter interface

### DIFF
--- a/SIL.Core/Reporting/ConsoleErrorReporter.cs
+++ b/SIL.Core/Reporting/ConsoleErrorReporter.cs
@@ -16,22 +16,37 @@ namespace SIL.Reporting
 			WriteExceptionToConsole(error, null, Severity.Fatal);
 		}
 
-		public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label,
-			ErrorResult resultIfAlternateButtonPressed, string message)
+		/// <summary>
+		/// Notifies the user of problem by writing to console
+		/// </summary>
+		/// <param name="policy">The policy used to check if the message should be shown</param>
+		/// <param name="error">N/A. You may pass null. This parameter will be ignored.</param>
+		/// <param name="message">The message to print to console, if the policy allows</param>
+		/// <exception cref="ErrorReport.ProblemNotificationSentToUserException"></exception>
+		public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception error, string message)
 		{
 			if (!policy.ShouldShowMessage(message))
 			{
-				return ErrorResult.OK;
+				return;
 			}
 
 			if (ErrorReport.IsOkToInteractWithUser)
 			{
 				Console.WriteLine(message);
 				Console.WriteLine(policy.ReoccurenceMessage);
-				return ErrorResult.OK;
+				return;
 			}
 
 			throw new ErrorReport.ProblemNotificationSentToUserException(message);
+		}
+
+		/// <param name="alternateButton1Label">N/A. You may pass null. This parameter will be ignored.</param>
+		/// <param name="resultIfAlternateButtonPressed">N/A. This parameter will be ignored.</param>
+		public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string alternateButton1Label,
+			ErrorResult resultIfAlternateButtonPressed, string message)
+		{
+			NotifyUserOfProblem(policy, null, message);
+			return ErrorResult.OK;
 		}
 
 		public void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy)

--- a/SIL.Core/Reporting/ErrorReport.cs
+++ b/SIL.Core/Reporting/ErrorReport.cs
@@ -17,10 +17,26 @@ namespace SIL.Reporting
 	public interface IErrorReporter
 	{
 		void ReportFatalException(Exception e);
+
+		/// <summary>
+		/// Notify the user of the {exception} and {message}, if {policy} permits, using the IErrorReporter's default options 
+		/// </summary>
+		/// <remarks>It is not required for the implementation to block (if the caller is not on the UI thread)
+		/// I would suggest that it should not block (if the caller is not on the UI thread)
+		/// By not blocking, you reduce headache and worry about the application deadlocking.
+		/// This will allow the caller to do an easy "fire and forget" of the problem notification mechanism</remarks>
+		void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message);
+
+		/// <summary>
+		/// Notify the user of the {message}, if {policy} permits. Customize the {alternate button} label. 
+		/// </summary>
+		/// <remarks>The method should block and wait for the user to press the required button</remarks>
+		/// <returns>The method should return {resultIfAlternateButtonPressed} if the alternate button is clicked, ErrorResult.OK otherwise</returns>
 		ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy,
 										string alternateButton1Label,
 										ErrorResult resultIfAlternateButtonPressed,
 										string message);
+
 		void ReportNonFatalException(Exception exception, IRepeatNoticePolicy policy);
 		void ReportNonFatalExceptionWithMessage(Exception error, string message, params object[] args);
 		void ReportNonFatalMessageWithStackTrace(string message, params object[] args);
@@ -473,23 +489,27 @@ namespace SIL.Reporting
 
 		public static ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy, string messageFmt, params object[] args)
 		{
-			return NotifyUserOfProblem(policy, null, default(ErrorResult), messageFmt, args);
+			NotifyUserOfProblem(policy, null, messageFmt, args);
+			return ErrorResult.OK;
 		}
 
-		public static void NotifyUserOfProblem(Exception error, string messageFmt, params object[] args)
+		public static void NotifyUserOfProblem(Exception exception, string messageFmt, params object[] args)
 		{
-			NotifyUserOfProblem(new ShowAlwaysPolicy(), error, messageFmt, args);
+			NotifyUserOfProblem(new ShowAlwaysPolicy(), exception, messageFmt, args);
 		}
-
-		public static void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception error, string messageFmt, params object[] args)
+				
+		public static void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string messageFmt, params object[] args)
 		{
-			var result = NotifyUserOfProblem(policy, "Details", ErrorResult.Yes, messageFmt, args);
-			if (result == ErrorResult.Yes)
+			var message = string.Format(messageFmt, args);
+			if (s_justRecordNonFatalMessagesForTesting)
 			{
-				OnShowDetails(error, string.Format(messageFmt, args));
+				s_previousNonFatalMessage = message;
+				return;
 			}
 
-			UsageReporter.ReportException(false, null, error, String.Format(messageFmt, args));
+			_errorReporter.NotifyUserOfProblem(policy, exception, message);
+
+			UsageReporter.ReportException(false, null, exception, String.Format(messageFmt, args));
 		}
 
 		public static ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy,

--- a/SIL.Windows.Forms/Reporting/WinFormsErrorReporter.cs
+++ b/SIL.Windows.Forms/Reporting/WinFormsErrorReporter.cs
@@ -13,6 +13,32 @@ namespace SIL.Windows.Forms.Reporting
 			ExceptionReportingDialog.ReportException(e, null);
 		}
 
+		/// <summary>
+		// Notifies the user of {message}, if {policy} permits.
+		// If {exception} is non-null, then a "Details" button will appear, which if pressed, will invoke {ErrorReport.OnShowDetails(exception, message)}
+		/// </summary>
+		public void NotifyUserOfProblem(IRepeatNoticePolicy policy, Exception exception, string message)
+		{
+			string alternateButton1Label;
+			ErrorResult resultIfAlternateButtonPressed;
+			if (exception == null)
+			{
+				alternateButton1Label = null;
+				resultIfAlternateButtonPressed = default(ErrorResult);
+			}
+			else
+			{
+				alternateButton1Label = "Details";
+				resultIfAlternateButtonPressed = ErrorResult.Yes;
+			}
+			var result = NotifyUserOfProblem(policy, alternateButton1Label, resultIfAlternateButtonPressed, message);
+
+			if (result == ErrorResult.Yes)
+			{
+				ErrorReport.OnShowDetails(exception, message);
+			}
+		}
+
 		public ErrorResult NotifyUserOfProblem(IRepeatNoticePolicy policy,
 									string alternateButton1Label,
 									ErrorResult resultIfAlternateButtonPressed,


### PR DESCRIPTION
Normally goes through a simpler method which gives the IErrorReporter more control over the flow. The {resultIfAlternateButtonPressed} flow is only used if explicitly requested.