### PR TITLE
Improvements for UI locale menu strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added override of SerializeToFileWithWriteThrough to simplify error handling.
 - [SIL.Windows.Forms] Added a CheckedComboBox control
 - [SIL.WritingSystems] Added several methods to IetfLanguageTag class to support getting language names.
-- [SIL.Windows.Forms.WritingSystems] Added common UI string MoreLanguagesMenuText
+- [SIL.Windows.Forms.WritingSystems] Added extension method InitializeWithAvailableUILocales
 - [SIL.WritingSystems] Added WellKnownSubtag zh-TW.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added override of SerializeToFileWithWriteThrough to simplify error handling.
 - [SIL.Windows.Forms] Added a CheckedComboBox control
 - [SIL.WritingSystems] Added several methods to IetfLanguageTag class to support getting language names.
+- [SIL.Windows.Forms.WritingSystems] Added common UI string MoreLanguagesMenuText
+- [SIL.WritingSystems] Added WellKnownSubtag zh-TW.
 
 ### Changed
 
@@ -68,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Corrected typo in the name of AcquireImageControl.SetInitialSearchString
 - [SIL.Core] ConsoleErrorReporter logs exception if available
 - [SIL.Core, SIL.Windows.Forms] If WinFormsErrorReporter is set as the ErrorReporter, and ErrorReporter.NotifyUserOfProblem(IRepeatNoticePolicy, Exception, String, params object[]) is passed null for the exception, the "Details" button will no longer appear, making this consistent with the no-Exception overload of this method
+- [SIL.WritingSystems] Changed behavior of IetfLanguageTag to better handle zh-TW.
 
 ### Fixed
 

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -5,6 +5,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GUID/@EntryIndexedValue">GUID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IMDI/@EntryIndexedValue">IMDI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LIFT/@EntryIndexedValue">LIFT</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue">/opt/mono5-sil/lib/mono/msbuild/15.0/bin/MSBuild.dll</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MonoExePath/@EntryValue">/opt/mono5-sil/bin/mono-sil.sh</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=acknowledgements/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Windows.Forms.WritingSystems/Extensions.cs
+++ b/SIL.Windows.Forms.WritingSystems/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
@@ -78,5 +78,8 @@ namespace SIL.Windows.Forms.WritingSystems
 
 			return ws;
 		}
+
+		public static string MoreLanguagesMenuText => LocalizationManager.GetString("Common.MoreMenuItem",
+			"&More...", "Last item in menu of UI languages, used to open localization dialog box");
 	}
 }

--- a/SIL.Windows.Forms.WritingSystems/Extensions.cs
+++ b/SIL.Windows.Forms.WritingSystems/Extensions.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using JetBrains.Annotations;
 using L10NSharp;
 using SIL.Windows.Forms.Miscellaneous;
 using SIL.WritingSystems;
+using static SIL.WritingSystems.IetfLanguageTag;
 
 namespace SIL.Windows.Forms.WritingSystems
 {
@@ -79,7 +82,109 @@ namespace SIL.Windows.Forms.WritingSystems
 			return ws;
 		}
 
-		public static string MoreLanguagesMenuText => LocalizationManager.GetString("Common.MoreMenuItem",
-			"&More...", "Last item in menu of UI languages, used to open localization dialog box");
+		/// <summary>
+		/// Adds one entry to this menu for each UI language known to the loaded L10NSharp
+		/// LocalizationManagers, plus any additional named locales passed in. The items are added
+		/// in order by language name using the current culture's sort order. Unless the
+		/// application-specific function returns <c>false</c>, the Click event for each of these
+		/// menu items is set up to make that language the default used for retrieving localized
+		/// strings. If this menu is a <see cref="ToolStripDropDownButton"/>, it also has its text
+		/// set to the name of the selected language.
+		/// Finally, if a primary <see cref="ILocalizationManager"/> is provided, a separate "More"
+		/// item is added at the bottom of the menu.
+		/// </summary>
+		/// <param name="menu">The menu whose <see cref="ToolStripDropDownItem.DropDownItems"/>
+		/// collection is to be initialized.</param>
+		/// <param name="localeSelectedAction">Application-specific function to call when a
+		/// different language is selected. This function should normally return <c>true</c> but
+		/// may return <c>false</c> to indicate that the default behavior should be suppressed.
+		/// </param>
+		/// <param name="lm">The primary  <see cref="ILocalizationManager"/> for the application
+		/// (used to determine which node in the tree should be selected when displaying the
+		/// localization dialog box in response to the user clicking More. If an application does
+		/// not support field-based localization, this can be omitted and the More menu item will
+		/// not be added.</param>
+		/// <param name="moreSelected">Application-specific function to call when the More menu
+		/// item is selected. This function should normally return <c>true</c> but may return
+		/// <c>false</c> to indicate that the default behavior should be suppressed.
+		/// </param>
+		/// <param name="additionalNamedLocales">Dictionary of display-name to IetfTag for any
+		/// additional locales an application wishes to display (besides those known to the
+		/// LocalizationManager). The primary purpose of this is to allow the user to choose a
+		/// country- or script-specific variant of a language. Duplicate language codes are
+		/// discarded, so it is not possible to have multiple menu items which correspond to the
+		/// same code. In addition, to avoid confusion, if the localization manager has entries
+		/// for a (general) language which is the same as one or more entries in this collection,
+		/// the general language entry will be omitted in favor of the more specific one named in
+		/// this collection.</param>
+		/// <remarks>REVIEW: It is not entirely clear whether this method belongs here. L10NSharp
+		/// currently has a UILanguageComboBox which attempts to present a similar list of language
+		/// choices. However, that logic does not have access to
+		/// <see cref="GetNativeLanguageNameWithEnglishSubtitle"/>, which is what we really want to
+		/// use for determining the name of the language to display. If/when L10nSharp is split
+		/// into two DLLs (WinForms and non-WinForms), we may be able to refactor things such that
+		/// the WinForms DLL will be able to have access to SIL.WritingSystems, and then this method
+		/// could be moved into L10nSharp.Windows.Forms.</remarks>
+		[PublicAPI]
+		public static void InitializeWithAvailableUILocales(this ToolStripDropDownItem menu,
+			Func<string, bool> localeSelectedAction = null, ILocalizationManager lm = null,
+			Func<bool> moreSelected = null, Dictionary<string, string> additionalNamedLocales = null)
+		{
+			menu.DropDownItems.Clear();
+
+			var namedLocales = new SortedDictionary<string, string>(StringComparer.CurrentCulture);
+
+			if (additionalNamedLocales != null)
+			{
+				foreach (var additionalLocale in additionalNamedLocales)
+					if (!namedLocales.ContainsValue(additionalLocale.Value))
+						namedLocales[additionalLocale.Key] = additionalLocale.Value;
+			}
+
+			foreach (var lang in LocalizationManager.GetUILanguages(true))
+			{
+				string languageId = lang.IetfLanguageTag;
+				if (!namedLocales.Values.Any(t => t == languageId || GetGeneralCode(t) == languageId))
+					namedLocales[GetNativeLanguageNameWithEnglishSubtitle(languageId)] = languageId;
+			}
+
+			foreach (var locale in namedLocales)
+			{
+				var item = menu.DropDownItems.Add(locale.Key);
+				var languageId = locale.Value;
+				item.Tag = languageId;
+				item.Click += (a, b) =>
+				{
+					if (LocalizationManager.UILanguageId == languageId ||
+					    (localeSelectedAction != null && !localeSelectedAction.Invoke(languageId)))
+						return;
+					
+					LocalizationManager.SetUILanguage(languageId, true);
+					item.Select(); // This doesn't actually do anything noticeable.
+					if (menu is ToolStripDropDownButton btn)
+						btn.Text = item.Text;
+				};
+				if (languageId == LocalizationManager.UILanguageId)
+				{
+					if (menu is ToolStripDropDownButton btn)
+						btn.Text = item.Text;
+				}
+			}
+
+			if (lm != null)
+			{
+				menu.DropDownItems.Add(new ToolStripSeparator());
+				var moreMenu = menu.DropDownItems.Add(LocalizationManager.GetString("Common.MoreMenuItem",
+					"&More...", "Last item in menu of UI languages, used to open localization dialog box"));
+				moreMenu.Click += (a, b) =>
+				{
+					if (moreSelected != null && !moreSelected.Invoke())
+						return;
+					lm.ShowLocalizationDialogBox(false);
+					menu.InitializeWithAvailableUILocales(localeSelectedAction, lm,
+						moreSelected, additionalNamedLocales);
+				};
+			}
+		}
 	}
 }

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -996,6 +996,7 @@ namespace SIL.WritingSystems.Tests
 		[TestCase("en-x-etic", ExpectedResult = "English")]
 		[TestCase("en-Ethi", ExpectedResult = "English")]
 		[TestCase("en-US", ExpectedResult = "English")]
+		[TestCase("en-GB", ExpectedResult = "English")]
 		[TestCase("en-x-etic", ExpectedResult = "English")]
 		[TestCase("fr", ExpectedResult = "français")]
 		[TestCase("es", ExpectedResult = "español")]
@@ -1013,15 +1014,17 @@ namespace SIL.WritingSystems.Tests
 			return IetfLanguageTag.GetNativeLanguageNameWithEnglishSubtitle(tag);
 		}
 
-		[Test]
-		public void GetNativeLanguageNameWithEnglishSubtitle_China_GetsNativeNamePlusEnglishAsNeeded()
+		[TestCase("zh-CN", "中文(中华人民共和国) (Chinese (Simplified))", "中文 (中国) (Chinese (Simplified))", ExpectedResult = "中文(中国) (Chinese (Simplified))")]
+		[TestCase("zh-TW", "中文(中华人民共和国) (Chinese (Traditional))", "中文 (台灣) (Chinese (Traditional))", ExpectedResult = "中文(台灣) (Chinese (Traditional))")]
+		public string GetNativeLanguageNameWithEnglishSubtitle_China_GetsNativeNamePlusEnglishAsNeeded(
+			string tag, string acceptableResultPreWindows10, string acceptableResultLinux)
 		{
-			var result = IetfLanguageTag.GetNativeLanguageNameWithEnglishSubtitle("zh-CN");
-			if (result == "中文(中华人民共和国) (Chinese (Simplified))" && PlatformUtilities.Platform.IsPreWindows10)
+			var result = IetfLanguageTag.GetNativeLanguageNameWithEnglishSubtitle(tag);
+			if (result == acceptableResultPreWindows10 && PlatformUtilities.Platform.IsPreWindows10)
 				Assert.Pass("Acceptable on older versions of the OS");
-			if (result == "中文 (中国) (Chinese (Simplified))" && PlatformUtilities.Platform.IsLinux)
+			if (result == acceptableResultLinux && PlatformUtilities.Platform.IsLinux)
 				Assert.Pass("Extra space is acceptable");
-			Assert.That(result, Is.EqualTo("中文(中国) (Chinese (Simplified))"));
+			return result;
 		}
 		#endregion
 

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -1015,7 +1015,7 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[TestCase("zh-CN", "中文(中华人民共和国) (Chinese (Simplified))", "中文 (中国) (Chinese (Simplified))", ExpectedResult = "中文(中国) (Chinese (Simplified))")]
-		[TestCase("zh-TW", "中文(中华人民共和国) (Chinese (Traditional))", "中文 (台灣) (Chinese (Traditional))", ExpectedResult = "中文(台灣) (Chinese (Traditional))")]
+		[TestCase("zh-TW", "中文(中华人民共和国) (Chinese (Traditional))", "中文 (台湾) (Chinese (Traditional))", ExpectedResult = "中文(台灣) (Chinese (Traditional))")]
 		public string GetNativeLanguageNameWithEnglishSubtitle_China_GetsNativeNamePlusEnglishAsNeeded(
 			string tag, string acceptableResultPreWindows10, string acceptableResultLinux)
 		{

--- a/SIL.WritingSystems/IetfLanguageTag.cs
+++ b/SIL.WritingSystems/IetfLanguageTag.cs
@@ -1245,7 +1245,7 @@ namespace SIL.WritingSystems
 			name = isoCode; // At this point, the best name we can come up with is the isoCode itself.
 			return false;
 		}
-		
+
 		private static readonly Dictionary<Tuple<string, string>, string> MapIsoCodesToLanguageName =
 			new Dictionary<Tuple<string, string>, string>();
 
@@ -1384,16 +1384,17 @@ namespace SIL.WritingSystems
 			{
 				// englishNameSuffix is always an empty string if we don't need it.
 				string englishNameSuffix = Empty;
-				var ci = CultureInfo.GetCultureInfo(generalCode);	// this may throw or produce worthless empty object
+				var ci = CultureInfo.GetCultureInfo(generalCode); // this may throw or produce worthless empty object
 				if (NeedEnglishSuffixForLanguageName(ci))
 					englishNameSuffix = $" ({GetManuallyOverriddenEnglishNameIfNeeded(code, ()=>ci.EnglishName)})";
 
 				nativeName = FixBotchedNativeName(ci.NativeName);
 				if (IsNullOrWhiteSpace(nativeName))
 					nativeName = code;
-				// Remove any country (or script?) names apart from Chinese (Simplified)
-				if (ci.Name != ChineseSimplifiedTag)
+
+				if (ci.Name != ChineseSimplifiedTag && ci.Name != ChineseTraditionalTag)
 				{
+					// Remove any country (or script?) names.
 					var idxCountry = englishNameSuffix.LastIndexOf(" (", StringComparison.Ordinal);
 					if (englishNameSuffix.Length > 0 && idxCountry > 0)
 						englishNameSuffix = englishNameSuffix.Substring(0, idxCountry) + ")";
@@ -1401,7 +1402,7 @@ namespace SIL.WritingSystems
 					if (idxCountry > 0)
 						nativeName = nativeName.Substring(0, idxCountry);
 				}
-				else
+				else if (englishNameSuffix.Length > 0)
 				{
 					// I have seen more cruft after the country name a few times, so remove that
 					// as well. The parenthetical expansion always seems to start "(Simplified",
@@ -1410,7 +1411,7 @@ namespace SIL.WritingSystems
 					// "Simplified" (which precedes ", China" or ", PRC"). Also, we don't worry
 					// about the parenthetical content of the native Chinese name.
 					var idxCountry = englishNameSuffix.IndexOf(", ", StringComparison.Ordinal);
-					if (englishNameSuffix.Length > 0 && idxCountry > 0)
+					if (idxCountry > 0)
 						englishNameSuffix = englishNameSuffix.Substring(0, idxCountry) + "))";
 				}
 				langName = nativeName + englishNameSuffix;
@@ -1476,7 +1477,7 @@ namespace SIL.WritingSystems
 		}
 
 		/// <summary>
-		/// Gte the language part of the given tag, except leave zh-CN alone.
+		/// Get the language part of the given tag.
 		/// </summary>
 		public static string GetGeneralCode(string code)
 		{
@@ -1484,7 +1485,7 @@ namespace SIL.WritingSystems
 			// methods works with three-letter codes even if there is a valid 2-letter code that
 			// should be used instead.
 			var idxCountry = code.IndexOf("-");
-			if (idxCountry == -1 || code == ChineseSimplifiedTag)
+			if (idxCountry == -1 || code == ChineseSimplifiedTag || code == ChineseTraditionalTag)
 				return code;
 			return code.Substring(0, idxCountry);
 		}

--- a/SIL.WritingSystems/WellKnownSubtags.cs
+++ b/SIL.WritingSystems/WellKnownSubtags.cs
@@ -52,6 +52,14 @@ namespace SIL.WritingSystems
 		/// </summary>
 		public const string PinyinVariant = "pinyin";
 
+		/// <summary>
+		/// Simplified (as opposed to traditional) Chinese
+		/// </summary>
 		public const string ChineseSimplifiedTag = "zh-CN";
+
+		/// <summary>
+		/// Traditional (as opposed to simplified) Chinese
+		/// </summary>
+		public const string ChineseTraditionalTag = "zh-TW";
 	}
 }


### PR DESCRIPTION
Added common UI string for More menu.
Improved logic in IetfLanguageTag to get better results for zh-TW

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1171)
<!-- Reviewable:end -->
