### PR TITLE
Replace and/or update Mono.Posix library

### DIFF
--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -10,12 +10,12 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" PrivateAssets="All" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" PrivateAssets="All" Condition="'$(OS)' == 'Windows_NT'" />
     <Reference Include="Mono.Posix" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
 

--- a/SIL.Linux.Logging/SIL.Linux.Logging.csproj
+++ b/SIL.Linux.Logging/SIL.Linux.Logging.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" PrivateAssets="All" Condition="'$(OS)' == 'Windows_NT'" />
     <Reference Include="Mono.Posix" Condition="'$(OS)' != 'Windows_NT'" />
   </ItemGroup>
 

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="icu.net" Version="2.7.1" />
     <PackageReference Include="L10NSharp" Version="5.0.0-beta0059" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
+    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.3.4-*" PrivateAssets="All" />
   </ItemGroup>
 

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup Condition="'$(OS)'=='Windows_NT'">
     <!--These references are required to compile on Windows -->
-    <PackageReference Include="Mono.Posix" Version="5.4.0.201" PrivateAssets="All" />
+    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)'!='Windows_NT'">


### PR DESCRIPTION
Fixes #1186.

This is currently a first-pass attempt, only replacing Mono.Posix with Mono.Unix in the .NET Standard builds, while keeping Mono.Posix in the net461 builds (though updating it to the most recent release of Mono.Posix). If this builds and passes tests, we'll then try replacing Mono.Posix with Mono.Unix everywhere and see what that does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1187)
<!-- Reviewable:end -->
