### PR TITLE
Fix changelog entries merged into wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Added extension method InitializeWithAvailableUILocales.
 - [SIL.Windows.Forms] Added LocalizationIncompleteDlg and LocalizationIncompleteViewModel classes
 - [SIL.Windows.Forms] Added property SummaryDisplayMember to CheckedComboBox.
+- [SIL.Core] ErrorReport now has a GetErrorReporter() getter function.
+- [SIL.Core] ErrorReport exposes a NotifyUserOfProblemWrapper() protected function, which is designed to make it easier for subclasses to add additional NotifyUserOfProblem options
 
 ### Changed
 - [SIL.Windows.Forms.WritingSystems] Moved (internal) extension method InitializeWithAvailableUILocales to SIL.Windows.Forms.
 - [SIL.Windows.Forms.WritingSystems] Added additional optional localizationIncompleteViewModel parameter to ToolStripExtensions.InitializeWithAvailableUILocales.
+- [SIL.Core] If NotifyUserOfProblem is called with a null exception, it will no longer call UsageReporter.ReportException
 - Replace deprecated `Mono.Posix` dependency with `Mono.Unix` (#1186)
 
 ### Removed
@@ -60,8 +63,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.WritingSystems] Added several methods to IetfLanguageTag class to support getting language names.
 - [SIL.Windows.Forms.WritingSystems] Added extension method InitializeWithAvailableUILocales
 - [SIL.WritingSystems] Added WellKnownSubtag zh-TW.
-- [SIL.Core] ErrorReport now has a GetErrorReporter() getter function.
-- [SIL.Core] ErrorReport exposes a NotifyUserOfProblemWrapper() protected function, which is designed to make it easier for subclasses to add additional NotifyUserOfProblem options
 
 ### Changed
 
@@ -88,7 +89,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] ConsoleErrorReporter logs exception if available
 - [SIL.Core, SIL.Windows.Forms] If WinFormsErrorReporter is set as the ErrorReporter, and ErrorReporter.NotifyUserOfProblem(IRepeatNoticePolicy, Exception, String, params object[]) is passed null for the exception, the "Details" button will no longer appear, making this consistent with the no-Exception overload of this method
 - [SIL.WritingSystems] Changed behavior of IetfLanguageTag to better handle zh-TW.
-- [SIL.Core] If NotifyUserOfProblem is called with a null exception, it will no longer call UsageReporter.ReportException
 
 ### Fixed
 


### PR DESCRIPTION
The changelog entries were merged in under the 9.* section, but should've been in the post-9.* section. I thought I had manually fixed this, but apparently that didn't make it into the final version :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1200)
<!-- Reviewable:end -->
