### PR TITLE
Allowed for alternate way of getting Unicode character categories in  IsLikelyWordForming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] ErrorReport now has a GetErrorReporter() getter function.
 - [SIL.Core] ErrorReport exposes a NotifyUserOfProblemWrapper() protected function, which is designed to make it easier for subclasses to add additional NotifyUserOfProblem options
 - [SIL.Core] Added AltImplGetUnicodeCategory function to StringExtensions
+- [SIL.WritingSystems] Added static class IcuUCharCategoryExtensions with a method ToUnicodeCategory to translate from Character.UCharCategory to System.Globalization.UnicodeCategory.
 
 ### Changed
 - [SIL.Windows.Forms.WritingSystems] Moved (internal) extension method InitializeWithAvailableUILocales to SIL.Windows.Forms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Added property SummaryDisplayMember to CheckedComboBox.
 - [SIL.Core] ErrorReport now has a GetErrorReporter() getter function.
 - [SIL.Core] ErrorReport exposes a NotifyUserOfProblemWrapper() protected function, which is designed to make it easier for subclasses to add additional NotifyUserOfProblem options
+- [SIL.Core] Added AltImplGetUnicodeCategory function to StringExtensions
 
 ### Changed
 - [SIL.Windows.Forms.WritingSystems] Moved (internal) extension method InitializeWithAvailableUILocales to SIL.Windows.Forms.

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -45,6 +45,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=macrolanguage/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=modally/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=optimizable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Palaso/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=parsable/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Core/Extensions/StringExtensions.cs
+++ b/SIL.Core/Extensions/StringExtensions.cs
@@ -578,6 +578,15 @@ namespace SIL.Extensions
 			return bestMatch;
 		}
 
+		/// <summary>
+		/// Alternate implementation of the method to get the Unicode character category of a
+		/// character in a string. The default implementation is based on the Unicode support in
+		/// System.Globalization because SIL.Core does not reference Icu.net, but if a product is
+		/// using a version of ICU that has more up-to-date information, that is the preferred
+		/// source. Although this function has a public setter, clients that initialize the Sldr
+		/// (in SIL.WritingSystems) will not normally need to set this directly, since that
+		/// initialization automatically hooks up an ICU-based implementation.
+		/// </summary>
 		public static Func<string, int, UnicodeCategory> AltImplGetUnicodeCategory { get; set; }
 
 		/// <summary>
@@ -627,6 +636,7 @@ namespace SIL.Extensions
 				case SpacingCombiningMark:
 				case TitlecaseLetter:
 				case UppercaseLetter:
+				case OtherNotAssigned: // Most likely a word-forming character added in a later version of Unicode.
 					return true;
 			}
 

--- a/SIL.Core/Extensions/StringExtensions.cs
+++ b/SIL.Core/Extensions/StringExtensions.cs
@@ -578,6 +578,8 @@ namespace SIL.Extensions
 			return bestMatch;
 		}
 
+		public static Func<string, int, UnicodeCategory> AltImplGetUnicodeCategory { get; set; }
+
 		/// <summary>
 		/// Gets a value indicating whether the (Unicode) character at the indicated index position
 		/// in the string is likely to be used in a word (as opposed to being a word-breaking
@@ -596,14 +598,19 @@ namespace SIL.Extensions
 		/// in the given string. See <paramref name="returnFalseAtEndOfString"/> for more
 		/// information.</exception>
 		/// <exception cref="ArgumentNullException"><paramref name="s"/> is null.</exception>
-		/// <remarks>This correctly handles surrogate pairs.</remarks>
+		/// <remarks>This correctly handles surrogate pairs.
+		/// Note that the normal implementation of this does not use ICU to get the character
+		/// category. An application that uses ICU can substitute an ICU-based implementation by
+		/// setting <see cref="AltImplGetUnicodeCategory"/>.</remarks>
 		public static bool IsLikelyWordForming(this string s, int index,
 			bool returnFalseAtEndOfString = true)
 		{
 			if (index == s.Length && returnFalseAtEndOfString)
 				return false;
 
-			switch (CharUnicodeInfo.GetUnicodeCategory(s, index))
+			var cat = AltImplGetUnicodeCategory?.Invoke(s, index) ?? UnicodeInfo.GetUnicodeCategory(s, index);
+
+			switch (cat)
 			{
 				// REVIEW: Enclosing marks are seldom (if ever) used in normal (e.g., Scripture)
 				// text. Probably best not to treat them as word-forming here.

--- a/SIL.WritingSystems.Tests/SldrTests.cs
+++ b/SIL.WritingSystems.Tests/SldrTests.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Xml;
 using NUnit.Framework;
-using SIL.ObjectModel;
 using SIL.TestUtilities;
 using Is = SIL.TestUtilities.NUnitExtensions.Is;
 

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using System.Text;
 using SIL.IO;
 using SIL.PlatformUtilities;
 using SIL.Threading;
@@ -20,8 +19,8 @@ namespace SIL.WritingSystems
 	public class GlobalWritingSystemRepository : GlobalWritingSystemRepository<WritingSystemDefinition>
 	{
 		///<summary>
-		/// Initializes the global writing system repository.  Migrates any ldml files if required,
-		/// notifying of any changes of writing system id that occured during migration.
+		/// Initializes the global writing system repository. Migrates any ldml files if required,
+		/// notifying of any changes of writing system id that occurred during migration.
 		///</summary>
 		public static GlobalWritingSystemRepository Initialize(Action<int, IEnumerable<LdmlMigrationInfo>> migrationHandler = null)
 		{

--- a/SIL.WritingSystems/IcuUCharCategoryExtensions.cs
+++ b/SIL.WritingSystems/IcuUCharCategoryExtensions.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+using Icu;
+
+namespace SIL.WritingSystems
+{
+	public static class IcuUCharCategoryExtensions
+	{
+		public static UnicodeCategory ToUnicodeCategory(this Character.UCharCategory category)
+		{
+			switch (category)
+			{
+				case Character.UCharCategory.UNASSIGNED:
+					return UnicodeCategory.OtherNotAssigned;
+				case Character.UCharCategory.UPPERCASE_LETTER:
+					return UnicodeCategory.UppercaseLetter;
+				case Character.UCharCategory.LOWERCASE_LETTER:
+					return UnicodeCategory.LowercaseLetter;
+				case Character.UCharCategory.TITLECASE_LETTER:
+					return UnicodeCategory.TitlecaseLetter;
+				case Character.UCharCategory.MODIFIER_LETTER:
+					return UnicodeCategory.ModifierLetter;
+				case Character.UCharCategory.OTHER_LETTER:
+					return UnicodeCategory.OtherLetter;
+				case Character.UCharCategory.NON_SPACING_MARK:
+					return UnicodeCategory.NonSpacingMark;
+				case Character.UCharCategory.ENCLOSING_MARK:
+					return UnicodeCategory.EnclosingMark;
+				case Character.UCharCategory.COMBINING_SPACING_MARK:
+					return UnicodeCategory.SpacingCombiningMark;
+				case Character.UCharCategory.DECIMAL_DIGIT_NUMBER:
+					return UnicodeCategory.DecimalDigitNumber;
+				case Character.UCharCategory.LETTER_NUMBER:
+					return UnicodeCategory.LetterNumber;
+				case Character.UCharCategory.OTHER_NUMBER:
+					return UnicodeCategory.OtherNumber;
+				case Character.UCharCategory.SPACE_SEPARATOR:
+					return UnicodeCategory.SpaceSeparator;
+				case Character.UCharCategory.LINE_SEPARATOR:
+					return UnicodeCategory.LineSeparator;
+				case Character.UCharCategory.PARAGRAPH_SEPARATOR:
+					return UnicodeCategory.ParagraphSeparator;
+				case Character.UCharCategory.CONTROL_CHAR:
+					return UnicodeCategory.Control;
+				case Character.UCharCategory.FORMAT_CHAR:
+					return UnicodeCategory.Format;
+				case Character.UCharCategory.PRIVATE_USE_CHAR:
+					return UnicodeCategory.PrivateUse;
+				case Character.UCharCategory.SURROGATE:
+					return UnicodeCategory.Surrogate;
+				case Character.UCharCategory.DASH_PUNCTUATION:
+					return UnicodeCategory.DashPunctuation;
+				case Character.UCharCategory.START_PUNCTUATION:
+					return UnicodeCategory.OpenPunctuation;
+				case Character.UCharCategory.END_PUNCTUATION:
+					return UnicodeCategory.ClosePunctuation;
+				case Character.UCharCategory.CONNECTOR_PUNCTUATION:
+					return UnicodeCategory.ConnectorPunctuation;
+				case Character.UCharCategory.OTHER_PUNCTUATION:
+					return UnicodeCategory.OtherPunctuation;
+				case Character.UCharCategory.MATH_SYMBOL:
+					return UnicodeCategory.MathSymbol;
+				case Character.UCharCategory.CURRENCY_SYMBOL:
+					return UnicodeCategory.CurrencySymbol;
+				case Character.UCharCategory.MODIFIER_SYMBOL:
+					return UnicodeCategory.ModifierSymbol;
+				case Character.UCharCategory.OTHER_SYMBOL:
+					return UnicodeCategory.OtherSymbol;
+				case Character.UCharCategory.INITIAL_PUNCTUATION:
+					return UnicodeCategory.InitialQuotePunctuation;
+				case Character.UCharCategory.FINAL_PUNCTUATION:
+					return UnicodeCategory.FinalQuotePunctuation;
+				default:
+					return UnicodeCategory.OtherNotAssigned;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Also added unit tests for this method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1202)
<!-- Reviewable:end -->
