### PR TITLE
Made ICU-based implementation of method to get Unicode category of a character more robust

### DIFF
--- a/SIL.Core/Extensions/StringExtensions.cs
+++ b/SIL.Core/Extensions/StringExtensions.cs
@@ -596,8 +596,9 @@ namespace SIL.Extensions
 		/// </summary>
 		/// <param name="s">The string containing the character to check.</param>
 		/// <param name="index">The index of the character to check. (For surrogate pairs
-		/// this should refer to the position of the high-order byte, though it seems to
-		/// tolerate referring to the position between the two bytes.)</param>
+		/// this should refer to the position of the high-order byte. The implementation
+		/// might tolerate referring to the position between the two bytes, but it is best
+		/// not to rely on this.)</param>
 		/// <param name="returnFalseAtEndOfString">Allows special treatment of the character
 		/// position at the end of the string (i.e., <paramref name="index"/> ==
 		/// <paramref name="s"/>.<see cref="string.Length"/>) as a convenience so the caller

--- a/SIL.WritingSystems.Tests/SldrTests.cs
+++ b/SIL.WritingSystems.Tests/SldrTests.cs
@@ -444,5 +444,31 @@ namespace SIL.WritingSystems.Tests
 				Assert.That(File.Exists(langTagsPath), Is.False);
 			}
 		}
+
+		[Test]
+		public void GetUnicodeCategoryBasedOnICU_HighSurrogate_GetsCorrectCategory()
+		{
+			Assert.That(Sldr.GetUnicodeCategoryBasedOnICU("\U00020056\U000200D9", 0),
+				Is.EqualTo(UnicodeCategory.OtherLetter));
+			Assert.That(Sldr.GetUnicodeCategoryBasedOnICU("\U00020056\U000200D9", 2),
+				Is.EqualTo(UnicodeCategory.OtherLetter));
+		}
+
+		[Test]
+		public void GetUnicodeCategoryBasedOnICU_LowSurrogate_GetsCorrectCategory()
+		{
+			Assert.That(Sldr.GetUnicodeCategoryBasedOnICU("\U00020056\U000200D9", 1),
+				Is.EqualTo(UnicodeCategory.OtherLetter));
+			Assert.That(Sldr.GetUnicodeCategoryBasedOnICU("\U00020056\U000200D9", 3),
+				Is.EqualTo(UnicodeCategory.OtherLetter));
+		}
+
+		[Test]
+		public void GetUnicodeCategoryBasedOnICU_LowSurrogateAtStartOfString_ThrowsArgumentException()
+		{
+			var bogusString = "\U00020056\U000200D9".Substring(1);
+			Assert.That(() => Sldr.GetUnicodeCategoryBasedOnICU(bogusString, 0),
+				Throws.ArgumentException);
+		}
 	}
 }


### PR DESCRIPTION
Made the method testable and made it handle the case where the index passed in to IsLikelyWordForming is the character between the high and low surrogates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1203)
<!-- Reviewable:end -->
