### PR TITLE
Added explicit dependency on Newtonsoft.Json to SIL.WritingSystems

### DIFF
--- a/SIL.WritingSystems/SIL.WritingSystems.csproj
+++ b/SIL.WritingSystems/SIL.WritingSystems.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="icu.net" Version="2.8.1" />
     <PackageReference Include="Spart" Version="1.0.0" />


### PR DESCRIPTION
This is an attempt to try to prevent runtime version conflict in the LanguageLookup constructor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1206)
<!-- Reviewable:end -->
