### PR TITLE
Test for normalised DateTimes

### DIFF
--- a/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
+++ b/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
@@ -10,6 +10,7 @@ using L10NSharp;
 using SIL.Archiving.Generic;
 using SIL.Archiving.IMDI.Schema;
 using System.Windows.Forms;
+using SIL.Extensions;
 
 namespace SIL.Archiving.IMDI
 {
@@ -476,7 +477,7 @@ namespace SIL.Archiving.IMDI
 				
 				if (string.IsNullOrEmpty(_corpusDirectoryName))
 				{
-					var baseName = NormalizeDirectoryName(_titles[_id] + " " + DateTime.Today.ToString("yyyy-MM-dd"));
+					var baseName = NormalizeDirectoryName(_titles[_id] + " " + DateTime.Today.ToISO8601TimeFormatDateOnlyString());
 					var test = baseName;
 					var i = 1;
 

--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -14,6 +14,7 @@ using Ionic.Zip;
 using L10NSharp;
 using SIL.Archiving.Generic;
 using SIL.Archiving.Properties;
+using SIL.Extensions;
 using SIL.IO;
 using SIL.PlatformUtilities;
 using SIL.Windows.Forms.ClearShare;
@@ -949,7 +950,7 @@ namespace SIL.Archiving
 		/// ------------------------------------------------------------------------------------
 		public void SetCreationDate(DateTime date)
 		{
-			SetCreationDate(date.ToString("yyyy-MM-dd"));
+			SetCreationDate(date.ToISO8601TimeFormatDateOnlyString());
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -998,7 +999,7 @@ namespace SIL.Archiving
 		{
 			PreventDuplicateMetadataProperty(MetadataProperties.ModifiedDate);
 
-			_metsPairs.Add(JSONUtils.MakeKeyValuePair(kDateModified, date.ToString("yyyy-MM-dd")));
+			_metsPairs.Add(JSONUtils.MakeKeyValuePair(kDateModified, date.ToISO8601TimeFormatDateOnlyString()));
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/SIL.DictionaryServices.Tests/Lift/LiftWriterTests.cs
+++ b/SIL.DictionaryServices.Tests/Lift/LiftWriterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -902,15 +902,12 @@ namespace SIL.DictionaryServices.Tests.Lift
 		}
 
 		/// <summary>
-		/// Regression: WS-34576
+		/// Regression: WS-34576, LT-20698
 		/// </summary>
 		[Test]
-		public void Add_CultureUsesPeriodForTimeSeparator_DateAttributesOutputWithColon()
+		public void Add_CultureUsesPeriodForTimeSeparator_DateAttributesOutputWithColon([Values("en-US", "de-DE")] string culture)
 		{
-			var culture = new CultureInfo("en-US");
-			culture.DateTimeFormat.TimeSeparator = ".";
-
-			Thread.CurrentThread.CurrentCulture = culture;
+			Thread.CurrentThread.CurrentCulture = new CultureInfo(culture) {DateTimeFormat = {TimeSeparator = "."}};
 
 			using (var session = new LiftExportAsFragmentTestSession())
 			{
@@ -922,9 +919,8 @@ namespace SIL.DictionaryServices.Tests.Lift
 				session.LiftWriter.End();
 				string result = session.StringBuilder.ToString();
 				AssertThatXmlIn.String(result).HasAtLeastOneMatchForXpath(
-					String.Format("//entry[@dateModified=\"{0}\"]",
-								  entry.ModificationTime.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture))
-					);
+					$"//entry[@dateModified=\"{entry.ModificationTime.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)}\"]"
+				);
 				Assert.IsTrue(result.Contains(":"), "should contain colons");
 				Assert.IsFalse(result.Contains("."), "should not contain periods");
 			}

--- a/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
+++ b/SIL.WritingSystems.Tests/LdmlDataMapperTests.cs
@@ -1351,9 +1351,30 @@ namespace SIL.WritingSystems.Tests
 			}
 		}
 
+		[Test]
+		[SetCulture("zh")]
+		public void Write_LdmlIsNicelyFormatted_Chinese()
+		{
+			Write_LdmlIsNicelyFormatted(null);
+		}
+
+		[Test]
+		[SetCulture("en")]
+		public void Write_LdmlIsNicelyFormatted_English()
+		{
+			Write_LdmlIsNicelyFormatted(null);
+		}
+
+		[Test]
+		[SetCulture("de")]
+		public void Write_LdmlIsNicelyFormatted_German()
+		{
+			Write_LdmlIsNicelyFormatted(null);
+		}
+
 		[TestCase(null)]
 		[TestCase("\u0000\u0000")]
-		public void Write_LdmlIsNicelyFormatted(string curentContent)
+		public void Write_LdmlIsNicelyFormatted(string currentContent)
 		{
 			using (var file = new TempFile())
 			{
@@ -1361,7 +1382,7 @@ namespace SIL.WritingSystems.Tests
 				var adaptor = new LdmlDataMapper(new TestWritingSystemFactory());
 				var ws = new WritingSystemDefinition("en-Zxxx-x-audio");
 				ws.DateModified = new DateTime(01, 01, 01, 0, 0, 0, DateTimeKind.Utc);
-				Stream existingDataStream = curentContent == null ? null : new MemoryStream(Encoding.UTF8.GetBytes(curentContent));
+				Stream existingDataStream = currentContent == null ? null : new MemoryStream(Encoding.UTF8.GetBytes(currentContent));
 				adaptor.Write(file.Path, ws, existingDataStream);
 
 				//change the read writing system and write it out again


### PR DESCRIPTION
In Germany, sometimes a dot is used instead of the colon to separate hours, minutes, and seconds: "16.12" for "16:12".

* Use DateTimeExtensions to write DateTimes to files (in the few places that didn't already)
* Test that LDML data is written in an invariant culture (LIFT writing was already tested).

https://jira.sil.org/browse/LT-20698

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="right" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1210)
<!-- Reviewable:end -->
