### PR TITLE
Fix crash if the LocalKeyboard is in KnownKeyboards

### DIFF
--- a/SIL.Lexicon.Tests/UserLexiconSettingsWritingSystemDataMapperTests.cs
+++ b/SIL.Lexicon.Tests/UserLexiconSettingsWritingSystemDataMapperTests.cs
@@ -61,6 +61,33 @@ namespace SIL.Lexicon.Tests
 		}
 
 		[Test]
+		public void Read_LocalKeyboardInKnownKeyboards_DoesNotCrash()
+		{
+			const string userSettingsXml =
+				@"<UserLexiconSettings>
+  <WritingSystems>
+    <WritingSystem id=""en-US"">
+      <LocalKeyboard>sil_cameroon_azerty</LocalKeyboard>
+      <KnownKeyboards>
+        <KnownKeyboard>sil_cameroon_azerty</KnownKeyboard>
+        <KnownKeyboard>sil_cameroon_qwerty</KnownKeyboard>
+      </KnownKeyboards>
+      <DefaultFontName>Times New Roman</DefaultFontName>
+    </WritingSystem>
+  </WritingSystems>
+</UserLexiconSettings>";
+
+			var userSettingsDataMapper = new UserLexiconSettingsWritingSystemDataMapper(new MemorySettingsStore { SettingsElement = XElement.Parse(userSettingsXml) });
+
+			var ws1 = new WritingSystemDefinition("en-US");
+			userSettingsDataMapper.Read(ws1);
+
+			Assert.That(ws1.LocalKeyboard.Id, Is.EqualTo("sil_cameroon_azerty"));
+			Assert.That(ws1.KnownKeyboards[0].Id, Is.EqualTo("sil_cameroon_azerty"));
+			Assert.That(ws1.KnownKeyboards[1].Id, Is.EqualTo("sil_cameroon_qwerty"));
+		}
+
+		[Test]
 		public void Read_EmptyXml_NothingSet()
 		{
 			var userSettingsDataMapper = new UserLexiconSettingsWritingSystemDataMapper(new MemorySettingsStore());

--- a/SIL.Lexicon/UserLexiconSettingsWritingSystemDataMapper.cs
+++ b/SIL.Lexicon/UserLexiconSettingsWritingSystemDataMapper.cs
@@ -49,7 +49,8 @@ namespace SIL.Lexicon
 					IKeyboardDefinition keyboard;
 					if (!Keyboard.Controller.TryGetKeyboard(id, out keyboard))
 						keyboard = Keyboard.Controller.CreateKeyboard(id, KeyboardFormat.Unknown, Enumerable.Empty<string>());
-					if (!ws.KnownKeyboards.Contains(keyboard))
+					// Check KnownKeyboards for a keyboard with the same identifier, not for the object we just created
+					if (!ws.KnownKeyboards.Contains(id))
 						ws.KnownKeyboards.Add(keyboard);
 				}
 			}


### PR DESCRIPTION
This only happens if the LocalKeyboard does not get added
to the KeyboardController (e.g. invalid)

See: https://jira.sil.org/browse/LT-21112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1217)
<!-- Reviewable:end -->
