### PR TITLE
PG-1487: Added support for USX version 3 (chapter end nodes).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- [SIL.DblBundle] Added const strings to UsxNode for the various USX element names.
+- [SIL.DblBundle] Added protected method GetAttribute to UsxNode.
+- [SIL.DblBundle] Added sealed subclasses of UsxNode: UsxPara and UsxChar.
+- [SIL.DblBundle] Added property IsChapterStart to UsxChapter.
+
+### Fixed
+- [SIL.DblBundle] Attempting to construct a UsxNode based on an invalid XmlNode now throws an exception in the constructor in most cases rather than later when properties are accessed.
+- [SIL.DblBundle] Accessing UsxChapter.ChapterNumber on a chapter end node returns the chapter umber (from the eid attribute) instead of throwing an exception.
+
+### Changed
+- [SIL.DblBundle.Tests] Added optional parameter to GetChaptersAndParasForMarkOneContaining2Verses.
+- [SIL.DblBundle] Made UsxNode abstract.
+- [SIL.DblBundle] Made UsxNode.StyleTag virtual. Calling UsxChapter.StyleTag on a chapter end node returns null instead of throwing an exception.
+- [SIL.DblBundle] Made UsxChapter sealed.
+
 ## [10.1.0] - 2022-08-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - [SIL.DblBundle] Attempting to construct a UsxNode based on an invalid XmlNode now throws an exception in the constructor in most cases rather than later when properties are accessed.
-- [SIL.DblBundle] Accessing UsxChapter.ChapterNumber on a chapter end node returns the chapter umber (from the eid attribute) instead of throwing an exception.
+- [SIL.DblBundle] Accessing UsxChapter.ChapterNumber on a chapter end node returns the chapter number (from the eid attribute) instead of throwing an exception.
 
 ### Changed
-- [SIL.DblBundle.Tests] Added optional parameter to GetChaptersAndParasForMarkOneContaining2Verses.
+- [SIL.DblBundle.Tests] Made GetChaptersAndParasForMarkOneContaining2Verses private.
 - [SIL.DblBundle] Made UsxNode abstract.
 - [SIL.DblBundle] Made UsxNode.StyleTag virtual. Calling UsxChapter.StyleTag on a chapter end node returns null instead of throwing an exception.
 - [SIL.DblBundle] Made UsxChapter sealed.

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -33,6 +33,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenames/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fran_00E7ais/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=glist/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Glyssen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Iana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ibus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IETF/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.DblBundle.Tests/Usx/UsxDocumentTests.cs
+++ b/SIL.DblBundle.Tests/Usx/UsxDocumentTests.cs
@@ -35,10 +35,9 @@ namespace SIL.DblBundle.Tests.Usx
 			return xmlDoc;
 		}
 
-		public static XmlNodeList GetChaptersAndParasForMarkOneContaining2Verses(bool includeChapterEndNode = false)
+		private XmlNodeList GetChaptersAndParasForMarkOneContaining2Verses()
 		{
-			var usxDocument = new UsxDocument(CreateMarkOneDoc(kParaNodeText +
-				(includeChapterEndNode ? "<chapter eid=\"MRK 1\" />" : "")));
+			var usxDocument = new UsxDocument(CreateMarkOneDoc(kParaNodeText));
 			return usxDocument.GetChaptersAndParas();
 		}
 

--- a/SIL.DblBundle.Tests/Usx/UsxDocumentTests.cs
+++ b/SIL.DblBundle.Tests/Usx/UsxDocumentTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Xml;
+using System.Xml;
 using NUnit.Framework;
 using SIL.DblBundle.Usx;
 
@@ -35,9 +35,10 @@ namespace SIL.DblBundle.Tests.Usx
 			return xmlDoc;
 		}
 
-		public static XmlNodeList GetChaptersAndParasForMarkOneContaining2Verses()
+		public static XmlNodeList GetChaptersAndParasForMarkOneContaining2Verses(bool includeChapterEndNode = false)
 		{
-			var usxDocument = new UsxDocument(CreateMarkOneDoc(kParaNodeText));
+			var usxDocument = new UsxDocument(CreateMarkOneDoc(kParaNodeText +
+				(includeChapterEndNode ? "<chapter eid=\"MRK 1\" />" : "")));
 			return usxDocument.GetChaptersAndParas();
 		}
 

--- a/SIL.DblBundle.Tests/Usx/UsxNodeTests.cs
+++ b/SIL.DblBundle.Tests/Usx/UsxNodeTests.cs
@@ -1,14 +1,52 @@
-﻿using System.Xml;
+using System;
+using System.Xml;
 using NUnit.Framework;
 using SIL.DblBundle.Usx;
 
 namespace SIL.DblBundle.Tests.Usx
 {
 	/// <summary>
-	/// Tests the UsxNode class
+	/// Tests the (abstract) UsxNode class
 	/// </summary>
 	[TestFixture]
 	public class UsxNodeTests
+	{
+		/// <summary>
+		/// Tests that the <see cref="UsxNode"/> constructor throws an <see>ArgumentException</see>
+		/// if the underlying USX node has no attributes.
+		/// </summary>
+		[Test]
+		public void Constructor_UnderlyingNodeIsNotAnElement_ThrowsArgumentException()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<para style=\"p\">This is some text</para>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			Assert.That(() => new UsxPara(usxDoc.GetChaptersAndParas()[0].Attributes[0]),
+				Throws.ArgumentException.With.Message.StartsWith(
+					"Given node is not a valid USX element."));
+		}
+
+		/// <summary>
+		/// Tests that the <see cref="UsxNode"/> constructor throws an <see>ArgumentException</see>
+		/// if the underlying USX node has no attributes.
+		/// </summary>
+		[Test]
+		public void Constructor_UnderlyingNodeHasNoAttributes_ThrowsArgumentException()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<para>This is some text</para>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			Assert.That(() => new UsxPara(usxDoc.GetChaptersAndParas()[0]),
+				Throws.ArgumentException.With.Message.StartsWith(
+					"Invalid USX node. Must have at least one attribute."));
+		}
+	}
+
+	/// <summary>
+	/// Tests the UsxPara class
+	/// </summary>
+	[TestFixture]
+	public class UsxParaTests
 	{
 		private XmlNodeList m_nodes;
 
@@ -22,23 +60,180 @@ namespace SIL.DblBundle.Tests.Usx
 		}
 
 		/// <summary>
-		/// Tests that correct StyleTag is obtained from the UsxNode.
+		/// Tests that the <see cref="UsxPara"/> constructor throws an <see>ArgumentException</see>
+		/// if the underlying USX node is not a para element.
 		/// </summary>
 		[Test]
-		public void StyleTag_GetsCorrectStyleTagFromUsxNode()
+		public void Constructor_UnderlyingNodeIsNotAParaElement_ThrowsArgumentException()
 		{
-			var usxNode = new UsxNode(m_nodes[0]);
-			Assert.AreEqual("c", usxNode.StyleTag);
+			Assert.That(() => new UsxPara(m_nodes[0]),
+				Throws.ArgumentException.With.Message.StartsWith("Not a valid para node."));
+		}
+
+		/// <summary>
+		/// Tests that correct StyleTag is obtained from the UsxPara.
+		/// </summary>
+		[Test]
+		public void StyleTag_ChapterStart_GetsCorrectStyleTagFrom()
+		{
+			Assert.AreEqual("p", new UsxPara(m_nodes[1]).StyleTag);
+		}
+	}
+
+	/// <summary>
+	/// Tests the UsxChar class
+	/// </summary>
+	[TestFixture]
+	public class UsxCharTests
+	{
+		/// <summary>
+		/// Tests that the <see cref="UsxPara"/> constructor throws an <see>ArgumentException</see>
+		/// if the underlying USX node is not a para element.
+		/// </summary>
+		[Test]
+		public void Constructor_UnderlyingNodeIsNotACharElement_ThrowsArgumentException()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<para style=\"p\">This is some text</para>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			Assert.That(() => new UsxChar(usxDoc.GetChaptersAndParas()[0]),
+				Throws.ArgumentException.With.Message.StartsWith("Not a valid char node."));
+		}
+
+		/// <summary>
+		/// Tests that correct StyleTag is obtained from the UsxPara.
+		/// </summary>
+		[Test]
+		public void StyleTag_ChapterStart_GetsCorrectStyleTagFrom()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<para style=\"p\">This is some text that should <char style=\"add\">be</char> good.</para>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			var para = new UsxPara(usxDoc.GetChaptersAndParas()[0]);
+			Assert.AreEqual("add", new UsxChar(para.ChildNodes[1]).StyleTag);
+		}
+	}
+
+	/// <summary>
+	/// Tests the UsxChapter class
+	/// </summary>
+	[TestFixture]
+	public class UsxChapterTests
+	{
+		private XmlNodeList m_nodes;
+
+		/// <summary>
+		/// Test fixture setup
+		/// </summary>
+		[OneTimeSetUp]
+		public void TestFixtureSetUp()
+		{
+			m_nodes = UsxDocumentTests.GetChaptersAndParasForMarkOneContaining2Verses(true);
+		}
+
+		/// <summary>
+		/// Tests that Constructor throws an <see>ArgumentException</see> if
+		/// the underlying USX node is not a chapter node.
+		/// </summary>
+		[Test]
+		public void Constructor_NotAChapterNode_ThrowsArgumentException()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<para chapter=\"2\" style=\"c\"/>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			Assert.That(() => { new UsxChapter(usxDoc.GetChaptersAndParas()[0]); },
+				Throws.ArgumentException);
+		}
+		
+		/// <summary>
+		/// Tests that correct StyleTag is obtained from the UsxChapter.
+		/// </summary>
+		[Test]
+		public void StyleTag_ChapterStart_GetsCorrectStyleTag()
+		{
+			Assert.AreEqual("c", new UsxChapter(m_nodes[0]).StyleTag);
+		}
+
+		/// <summary>
+		/// Tests that StyleTag returns null if the UsxNode is a chapter end.
+		/// </summary>
+		[Test]
+		public void StyleTag_ChapterEnd_ReturnsNull()
+		{
+			var usxNode = new UsxChapter(m_nodes[m_nodes.Count - 1]);
+			Assert.IsNull(usxNode.StyleTag);
+		}
+
+		/// <summary>
+		/// Tests that IsChapterStart returns <c>true</c> when the object is based on a node that
+		/// does not have an sid or eid attribute.
+		/// </summary>
+		[Test]
+		public void IsChapterStart_StartNoSid_ReturnsTrue()
+		{
+			var usxChapterNode = new UsxChapter(m_nodes[0]);
+			Assert.IsTrue(usxChapterNode.IsChapterStart);
+		}
+
+		/// <summary>
+		/// Tests that IsChapterStart returns <c>true</c> when the object is based on a node that
+		/// has an sid attribute.
+		/// </summary>
+		[Test]
+		public void IsChapterStart_StartWithSid_ReturnsTrue()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<chapter number=\"2\" style=\"c\" sid=\"MRK 2\"/>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			var usxChapterNode = new UsxChapter(usxDoc.GetChaptersAndParas()[0]);
+			Assert.IsTrue(usxChapterNode.IsChapterStart);
+		}
+
+		/// <summary>
+		/// Tests that IsChapterStart returns <c>true</c> when the object is based on a node that
+		/// has an sid attribute.
+		/// </summary>
+		[Test]
+		public void IsChapterStart_End_ReturnsFalse()
+		{
+			var usxChapter = new UsxChapter(m_nodes[m_nodes.Count - 1]);
+			Assert.IsFalse(usxChapter.IsChapterStart);
 		}
 
 		/// <summary>
 		/// Texts that the correct chapter number is obtained from the UsxChapter.
 		/// </summary>
 		[Test]
-		public void ChapterNumber_GetsCorrectStyleTagFromUsxChapter()
+		public void ChapterNumber_StartNoSid_GetsCorrectChapterNumberFromNumberAttribute()
 		{
 			var usxChapter = new UsxChapter(m_nodes[0]);
 			Assert.AreEqual("1", usxChapter.ChapterNumber);
+		}
+
+		/// <summary>
+		/// Tests that StyleTag returns null if the UsxNode is a chapter end.
+		/// </summary>
+		[Test]
+		public void ChapterNumber_ChapterEnd_GetsCorrectChapterNumberFromEidAttribute()
+		{
+			var usxChapter = new UsxChapter(m_nodes[m_nodes.Count - 1]);
+			Assert.AreEqual("1", usxChapter.ChapterNumber);
+		}
+
+		/// <summary>
+		/// Tests that IsChapterStart throws a <see>NullReferenceException</see> if
+		/// the underlying USX node is a chapter with neither a "number" attribute
+		/// nor an "eid" attribute.
+		/// </summary>
+		[Test]
+		public void ChapterNumber_InvalidUnderlyingNode_ThrowsNullReferenceException()
+		{
+			var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+			xmlDoc.LoadXml("<chapter sid=\"JHN 5\"/>");
+			var usxDoc = new UsxDocument(xmlDoc);
+			var usxChapterNode = new UsxChapter(usxDoc.GetChaptersAndParas()[0]);
+			Assert.That(() => usxChapterNode.ChapterNumber,
+				Throws.Exception.TypeOf<NullReferenceException>());
 		}
 	}
 }

--- a/SIL.DblBundle/Bundle.cs
+++ b/SIL.DblBundle/Bundle.cs
@@ -296,9 +296,9 @@ namespace SIL.DblBundle
 		/// For version 2, it is stored in the version attribute.
 		/// Here's hoping they don't move it again in version 3...
 		/// </summary>
-		private Version? GetVersionFromMetadata(string metadataPath)
+		private Version GetVersionFromMetadata(string metadataPath)
 		{
-			XmlDocument doc = new XmlDocument();
+			var doc = new XmlDocument();
 			doc.Load(metadataPath);
 			string versionStr = string.Empty;
 			var versionAttr = doc.SelectSingleNode("/DBLMetadata/@version");
@@ -312,7 +312,6 @@ namespace SIL.DblBundle
 			}
 			return Version.TryParse(versionStr, out var version) ? version : null;
 		}
-
 		#endregion
 
 		#region IDisposable Members

--- a/SIL.DblBundle/Usx/UsxNode.cs
+++ b/SIL.DblBundle/Usx/UsxNode.cs
@@ -58,7 +58,7 @@ namespace SIL.DblBundle.Usx
 	}
 
 	/// <summary>
-	/// A USX node that specifies a chapter start or end
+	/// A USX node that represents a paragraph (including poetry lines, etc.)
 	/// </summary>
 	public sealed class UsxPara : UsxNode
 	{
@@ -118,15 +118,14 @@ namespace SIL.DblBundle.Usx
 		/// Gets whether this node represents the start (as opposed to the end) of a chapter.
 		/// </summary>
 		/// <remarks>Starting with USX v. 3, chapter nodes can have an "eid" attribute (and no
-		/// "number" attribute) to indicate that the end of a chapter. A chapter node should
-		/// never have both and "sid" and an "eid" attribute, but to accommodate older versions
-		/// of USX, we can't just check for the presence of an "sid" attribute. We probably
-		/// could just check for the presence of a "number" attribute or the absence of an "eid"
-		/// attribute, but just in case some future version of USX allows the number to be
-		/// specified for an end node or the possibility of both an "sid" and an "eid" in the
-		/// same node (neither of which seems likely, since this would definitely break backwards
-		/// compatibility), we'll take this safer approach of explicitly looking for an "sid" or
-		/// the absence of an "eid".</remarks>
+		/// "number" attribute) to indicate the end of a chapter. A chapter node should never have
+		/// both an "sid" and an "eid" attribute, but to accommodate older versions of USX, we
+		/// can't just check for the presence of an "sid" attribute. We probably could just check
+		/// for the presence of a "number" attribute or the absence of an "eid" attribute, but just
+		/// in case some future version of USX allows the number to be specified for an end node or
+		/// the possibility of both an "sid" and an "eid" in the same node (neither of which seems
+		/// likely, since this would definitely break backwards compatibility), we'll take this
+		/// safer approach of explicitly looking for an "sid" or the absence of an "eid".</remarks>
 		public bool IsChapterStart => GetAttribute("sid") != null || GetAttribute("eid") == null;
 
 		/// <summary>

--- a/SIL.DblBundle/Usx/UsxNode.cs
+++ b/SIL.DblBundle/Usx/UsxNode.cs
@@ -1,67 +1,147 @@
-﻿using System.Xml;
+using System;
+using System.Linq;
+using System.Xml;
 
 namespace SIL.DblBundle.Usx
 {
 	/// <summary>
-	/// An XML node in a USX file (Scripture file in XML format)
+	/// An XML node in a USX file (XML representation of USFM Scripture)
 	/// </summary>
-	public class UsxNode
+	public abstract class UsxNode
 	{
+		public const string kCharNodeName = "char";
+		public const string kChapterNodeName = "chapter";
+		public const string kParaNodeName = "para";
+		public const string kVerseNodeName = "verse";
+		public const string kMilestoneNodeName = "ms";
+
 		private readonly XmlNode m_node;
+
+		protected XmlNode GetAttribute(string attributeName) =>
+			m_node.Attributes.GetNamedItem(attributeName);
 
 		/// <summary>
 		/// Constructs a USX XML node
 		/// </summary>
+		/// <exception cref="ArgumentException">Given underlying node is not an XML element or
+		/// has no attributes. A valid USX element will typically have a style attribute, but
+		/// an end milestone will just have an eid attribute.</exception>
 		public UsxNode(XmlNode node)
 		{
-			m_node = node;
+			m_node = node ?? throw new ArgumentNullException(nameof(node));
+			if (m_node.NodeType != XmlNodeType.Element)
+			{
+				throw new ArgumentException("Given node is not a valid USX element.",
+					nameof(node));
+			}
+			if (m_node.Attributes == null || m_node.Attributes.Count == 0)
+			{
+				throw new ArgumentException("Invalid USX node. Must have at least one attribute.",
+					nameof(node));
+			}
 		}
 
 		/// <summary>
 		/// This XML node
 		/// </summary>
-		protected XmlNode Node
-		{
-			get { return m_node; }
-		}
+		protected XmlNode Node => m_node;
 
 		/// <summary>
-		/// Gets style applied to current node
+		/// Gets the style tag (SFM without the leading backslash) of this node.
 		/// </summary>
-		public string StyleTag
-		{
-			get { return m_node.Attributes.GetNamedItem("style").Value; }
-		}
+		public virtual string StyleTag => GetAttribute("style").Value;
 
 		/// <summary>
 		/// List of nodes that are children of this node.
 		/// </summary>
-		public XmlNodeList ChildNodes
+		public XmlNodeList ChildNodes => m_node.ChildNodes;
+	}
+
+	/// <summary>
+	/// A USX node that specifies a chapter start or end
+	/// </summary>
+	public sealed class UsxPara : UsxNode
+	{
+		/// <summary>
+		/// Creates a an object representing a USX paragraph based on a USX node.
+		/// </summary>
+		public UsxPara(XmlNode node) : base(node)
 		{
-			get { return m_node.ChildNodes; }
+			if (node.Name != kParaNodeName)
+				throw new ArgumentException($"Not a valid {kParaNodeName} node.",
+					nameof(node));
 		}
 	}
 
 	/// <summary>
-	/// A USX node that specifies the chapter
+	/// A USX node that specifies the start or end of a run of text marked with a character style
 	/// </summary>
-	public class UsxChapter : UsxNode
+	public sealed class UsxChar : UsxNode
 	{
 		/// <summary>
-		/// Creates a chapter XML node 
+		/// Creates a an object representing a USX paragraph based on a USX node.
 		/// </summary>
-		public UsxChapter(XmlNode paraNode)
-			: base(paraNode)
+		public UsxChar(XmlNode node) : base(node)
 		{
+			if (node.Name != kCharNodeName)
+				throw new ArgumentException($"Not a valid {kCharNodeName} node.",
+					nameof(node));
+		}
+	}
+
+	/// <summary>
+	/// A USX node that specifies a chapter start or end
+	/// </summary>
+	public sealed class UsxChapter : UsxNode
+	{
+		/// <summary>
+		/// Creates a an object representing the start or end of a chapter based
+		/// on a USX node.
+		/// </summary>
+		public UsxChapter(XmlNode node) : base(node)
+		{
+			if (node.Name != kChapterNodeName)
+				throw new ArgumentException($"Not a valid {kChapterNodeName} node.",
+					nameof(node));
 		}
 
 		/// <summary>
-		/// Gets the chapter number
+		/// Gets the style tag (SFM without the leading backslash) of this node.
 		/// </summary>
-		public string ChapterNumber
-		{
-			get { return Node.Attributes.GetNamedItem("number").Value; }
-		}
+		/// <remarks>chapter end nodes do not correspond to any specific marker in USFM and
+		/// therefore do not have a StyleTag defined. Rather than returning <c>null</c>, we could
+		/// return "c" or a fictitious "c*" or even throw an exception (as we used to do), but
+		/// <c>null</c> seems to best represent the situation.</remarks>
+		public override string StyleTag => IsChapterStart ? base.StyleTag : null;
 
+		/// <summary>
+		/// Gets whether this node represents the start (as opposed to the end) of a chapter.
+		/// </summary>
+		/// <remarks>Starting with USX v. 3, chapter nodes can have an "eid" attribute (and no
+		/// "number" attribute) to indicate that the end of a chapter. A chapter node should
+		/// never have both and "sid" and an "eid" attribute, but to accommodate older versions
+		/// of USX, we can't just check for the presence of an "sid" attribute. We probably
+		/// could just check for the presence of a "number" attribute or the absence of an "eid"
+		/// attribute, but just in case some future version of USX allows the number to be
+		/// specified for an end node or the possibility of both an "sid" and an "eid" in the
+		/// same node (neither of which seems likely, since this would definitely break backwards
+		/// compatibility), we'll take this safer approach of explicitly looking for an "sid" or
+		/// the absence of an "eid".</remarks>
+		public bool IsChapterStart => GetAttribute("sid") != null || GetAttribute("eid") == null;
+
+		/// <summary>
+		/// Gets the chapter number.
+		/// </summary>
+		/// <exception cref="NullReferenceException">This object was constructed from an invalid
+		/// USX chapter node (having neither a "number" attribute nor an "eid" attribute).
+		/// </exception>
+		/// <remarks>Previously this would throw an exception if accessed for a chapter node
+		/// that is not a chapter start, but now it correctly retrieves the chapter number
+		/// from the "eid" attribute if it is formatted correctly. This is (subtly) a breaking
+		/// change since this used to throw an (unadvertised) exception in this case. A caller
+		/// must now explicitly check the <see cref="IsChapterStart"/> property to know how to
+		/// interpret this property.</remarks>
+		public string ChapterNumber =>
+			GetAttribute("number")?.Value ?? GetAttribute("eid").Value.Split(' ').Last();
 	}
 }

--- a/SIL.DblBundle/Usx/UsxNode.cs
+++ b/SIL.DblBundle/Usx/UsxNode.cs
@@ -63,7 +63,7 @@ namespace SIL.DblBundle.Usx
 	public sealed class UsxPara : UsxNode
 	{
 		/// <summary>
-		/// Creates a an object representing a USX paragraph based on a USX node.
+		/// Creates an object representing a USX paragraph based on a USX node.
 		/// </summary>
 		public UsxPara(XmlNode node) : base(node)
 		{
@@ -79,7 +79,7 @@ namespace SIL.DblBundle.Usx
 	public sealed class UsxChar : UsxNode
 	{
 		/// <summary>
-		/// Creates a an object representing a USX paragraph based on a USX node.
+		/// Creates an object representing a USX paragraph based on a USX node.
 		/// </summary>
 		public UsxChar(XmlNode node) : base(node)
 		{
@@ -95,7 +95,7 @@ namespace SIL.DblBundle.Usx
 	public sealed class UsxChapter : UsxNode
 	{
 		/// <summary>
-		/// Creates a an object representing the start or end of a chapter based
+		/// Creates an object representing the start or end of a chapter based
 		/// on a USX node.
 		/// </summary>
 		public UsxChapter(XmlNode node) : base(node)


### PR DESCRIPTION
Made UsxNode abstract and added sealed subclasses, with tighter checking to ensure correct use.
Improved documentation

https://jira.sil.org/browse/PG-1487

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1220)
<!-- Reviewable:end -->
