### PR TITLE
Build SIL.Core for net6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.DblBundle] Added sealed subclasses of UsxNode: UsxPara and UsxChar.
 - [SIL.DblBundle] Added property IsChapterStart to UsxChapter.
 - [SIL.Reporting] Added TypeOfExistingHandler property to ExceptionHandler.
+- [SIL.Core] Additionally build for net6.0.
 
 ### Fixed
 - [SIL.DblBundle] Attempting to construct a UsxNode based on an invalid XmlNode now throws an exception in the constructor in most cases rather than later when properties are accessed.

--- a/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
+++ b/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
@@ -42,7 +42,13 @@ namespace SIL.Acknowledgements
 			if (entryAssembly != null) // Can happen in tests
 			{
 				var assemblyName = GetNonUriExecutingAssemblyName(execAssembly);
-				var codeBase = Path.GetDirectoryName(GetFullNonUriFileName(entryAssembly.CodeBase));
+				var codeBase = Path.GetDirectoryName(GetFullNonUriFileName(
+#if NET461
+					// CodeBase gives us original path if assembly is shadow-copied
+					entryAssembly.CodeBase));
+#else
+					entryAssembly.Location));
+#endif
 				var components = Directory.EnumerateFiles(codeBase).Where(
 					file => Path.HasExtension(file) &&
 					(Path.GetExtension(file).ToLowerInvariant() == ".exe" || Path.GetExtension(file).ToLowerInvariant() == ".dll") &&
@@ -107,7 +113,7 @@ namespace SIL.Acknowledgements
 
 		private static string GetNonUriExecutingAssemblyName(Assembly execAssembly)
 		{
-			var assemblyName = GetFullNonUriFileName(execAssembly.CodeBase);
+			var assemblyName = GetFullNonUriFileName(execAssembly.Location);
 			// On Windows, GetExecutingAssembly().CodeBase puts the file extension in UPPERCASE! Why!?
 			if (Platform.IsWindows)
 			{

--- a/SIL.Core/EntryAssembly.cs
+++ b/SIL.Core/EntryAssembly.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace SIL
 {
-	public class EntryAssembly
+	public static class EntryAssembly
 	{
 		public static string Location
 		{

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -5,7 +5,7 @@
 
 using System;
 using System.Diagnostics;
-#if !NETSTANDARD2_0
+#if NET461
 using System.Management;
 #endif
 using System.Runtime.InteropServices;
@@ -39,14 +39,7 @@ namespace SIL.PlatformUtilities
 
 		public static bool IsPreWindows10 => IsWindows && OperatingSystemDescription != "Windows 10";
 
-#if NETSTANDARD2_0
-		public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-		public static bool IsMac => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-		public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-		public static bool IsDotNetCore => RuntimeInformation.FrameworkDescription == ".NET Core";
-		public static bool IsDotNetFramework => IsDotNet && RuntimeInformation.FrameworkDescription == ".NET Framework";
-#elif NET461
+#if NET461
 		private static readonly string UnixNameMac = "Darwin";
 		private static readonly string UnixNameLinux = "Linux";
 
@@ -89,6 +82,13 @@ namespace SIL.PlatformUtilities
 
 		[DllImport("libc")]
 		private static extern int uname(IntPtr buf);
+#else
+		public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+		public static bool IsMac => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+		public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+		public static bool IsDotNetCore => RuntimeInformation.FrameworkDescription == ".NET Core";
+		public static bool IsDotNetFramework => IsDotNet && RuntimeInformation.FrameworkDescription == ".NET Framework";
 #endif
 
 		/// <summary>

--- a/SIL.Core/Reflection/ReflectionHelper.cs
+++ b/SIL.Core/Reflection/ReflectionHelper.cs
@@ -444,7 +444,7 @@ namespace SIL.Reflection
 					version += " (apparent build date: ";
 					try
 					{
-						string path = PathHelper.StripFilePrefix(assembly.CodeBase);
+						string path = PathHelper.StripFilePrefix(assembly.Location);
 						version += File.GetLastWriteTimeUtc(path).ToString("dd-MMM-yyyy") + ")";
 					}
 					catch
@@ -469,7 +469,13 @@ namespace SIL.Reflection
 				bool unitTesting = Assembly.GetEntryAssembly() == null;
 				if (unitTesting)
 				{
-					path = new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath;
+#if net461
+					// CodeBase gives us original path if assembly is shadow-copied
+					var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+#else
+					var codeBase = Assembly.GetExecutingAssembly().Location;
+#endif
+					path = new Uri(codeBase).AbsolutePath;
 					path = Uri.UnescapeDataString(path);
 				}
 				else

--- a/SIL.Core/Reporting/ErrorReport.cs
+++ b/SIL.Core/Reporting/ErrorReport.cs
@@ -200,7 +200,7 @@ namespace SIL.Reporting
 			{
 				var asm = Assembly.GetEntryAssembly();
 				var ver = asm.GetName().Version;
-				var file = PathHelper.StripFilePrefix(asm.CodeBase);
+				var file = PathHelper.StripFilePrefix(asm.Location);
 				var fi = new FileInfo(file);
 
 				return $"Version {ver.Major}.{ver.Minor}.{ver.Build} Built on {fi.CreationTime:dd-MMM-yyyy}";
@@ -216,7 +216,7 @@ namespace SIL.Reporting
 		{
 #if NETSTANDARD
 			return ".NET Standard";
-#else
+#elif net461
 			if (!Platform.IsWindows)
 				return string.Empty;
 
@@ -224,6 +224,8 @@ namespace SIL.Reporting
 			{
 				return key == null ? "(unable to determine)" : $"{key.GetValue("Version")} ({key.GetValue("Release")})";
 			}
+#else
+			return RuntimeInformation.FrameworkDescription;
 #endif
 		}
 

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6.0</TargetFrameworks>
     <Description>SIL.Core provides general utilities for language software. It is the base library for all Palaso libraries.</Description>
   </PropertyGroup>
 
@@ -12,6 +12,7 @@
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This builds SIL.Core for net6.0 in addition to netstandard2.0 and .NET 4.6.1.

Also fix `GetDirectoryDistributedWithApplication`. When running under net6.0 our previous detection of unit tests no longer works because `GetEntryAssembly()` returns a value. This change additionally takes the directory where SIL.Core.dll is located in consideration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1226)
<!-- Reviewable:end -->
