### PR TITLE
Fix requesting LDML file with default user id

### DIFF
--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -287,7 +287,7 @@ namespace SIL.WritingSystems
 					var requestedElements = string.Empty;
 					if (topLevelElementsArray.Length > 0)
 						requestedElements = $"&inc[]={string.Join("&inc[]=", topLevelElementsArray)}";
-					var requestedUserId = !string.IsNullOrEmpty(uid) ? $"&uid={uid}" : string.Empty;
+					var requestedUserId = !string.IsNullOrEmpty(uid) && uid != DefaultUserId ? $"&uid={uid}" : string.Empty;
 					var requestedRevid = !string.IsNullOrEmpty(revid) ? $"&revid={revid}" : string.Empty;
 					var url = BuildLdmlRequestUrl(sldrLanguageTag, requestedElements, requestedUserId, requestedRevid);
 


### PR DESCRIPTION
Previous implementation caused us to request `uid=unknown` to which the server replied with `501 not implemented`. Since that was treated the same as the server not being available this wasn't noticeable unless you ran the tests marked as Explicit.

This change compares the uid with the default user id and omits the parameter if necessary. That causes the server to send a proper response and causes the explicit tests to pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1235)
<!-- Reviewable:end -->
