### PR TITLE
Support keyboarding in Ubuntu 22.04, and other improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,11 @@
 			"env": {
 			  // Use this mono.
 			  // "PATH": "/opt/mono5-sil/bin:${env:PATH}",
+			  "SIL_REPORTING_LOGGING": "foreground",
+			  // Electron overrides XDG_CURRENT_DESKTOP with "Unity" (see
+			  // https://www.electronjs.org/docs/latest/api/environment-variables ).
+			  // Undo this for a more accurate keyboard test.
+			  "XDG_CURRENT_DESKTOP": "${env:ORIGINAL_XDG_CURRENT_DESKTOP}"
 			},
 			"type": "mono",
 			"request": "launch",

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -335,7 +335,7 @@ namespace SIL.PlatformUtilities
 		/// <returns>The returned output</returns>
 		private static string RunTerminalCommand(string cmd, string args = null)
 		{
-			var proc = new Process {
+			using (var proc = new Process {
 				EnableRaisingEvents = false,
 				StartInfo = {
 					FileName = cmd,
@@ -343,11 +343,13 @@ namespace SIL.PlatformUtilities
 					UseShellExecute = false,
 					RedirectStandardOutput = true
 				}
-			};
-			proc.Start();
-			proc.WaitForExit();
-			var output = proc.StandardOutput.ReadToEnd();
-			return output.Trim();
+			})
+			{
+				proc.Start();
+				proc.WaitForExit();
+				var output = proc.StandardOutput.ReadToEnd();
+				return output.Trim();
+			}
 		}
 
 		/// <summary>

--- a/SIL.Windows.Forms.Keyboarding.Tests/CombinedIbusKeyboardRetrievingAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/CombinedIbusKeyboardRetrievingAdaptorTests.cs
@@ -43,5 +43,14 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 
 			return sut.CallHasKeyboards();
 		}
+
+		[TestCase("", ExpectedResult = new string[] {})]
+		[TestCase("[]", ExpectedResult = new string[] {})]
+		[TestCase("['aaa']", ExpectedResult = new string[] {"aaa"})]
+		[TestCase("['aaa', 'bbb']", ExpectedResult = new string[] {"aaa", "bbb"})]
+		public string[] ToStringArray(string input)
+		{
+			return KeyboardRetrievingHelper.ToStringArray(input);
+		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding.Tests/Linux/GnomeShellIbusKeyboardSwitchingAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/Linux/GnomeShellIbusKeyboardSwitchingAdaptorTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 SIL International
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using SIL.Windows.Forms.Keyboarding.Linux;
+
+namespace SIL.Windows.Forms.Keyboarding.Tests
+{
+	[TestFixture]
+	[Platform(Include = "Linux", Reason = "Linux specific tests")]
+	public class GnomeShellIbusKeyboardSwitchingAdaptorTests
+	{
+		[TestCase(new string[] {
+				"xkb;;us+mac",
+				"xkb;;ru",
+				"ibus;;und-Latn:/home/USER/.local/share/keyman/sil_ipa/sil_ipa.kmx",
+				"ibus;;table:thai"
+			},
+			"[('xkb', 'us+mac'), " +
+			"('xkb', 'ru'), " +
+			"('ibus', 'und-Latn:/home/USER/.local/share/keyman/sil_ipa/sil_ipa.kmx'), " +
+			"('ibus', 'table:thai')]",
+			TestName = "Transforms mixed list of xkb, keyman, and ibus keyboards")]
+		[TestCase(new string[] {"xkb;;us"},
+			"[('xkb', 'us')]",
+			TestName = "Transforms list of one item")]
+		[TestCase(new string[] {}, "[]")]
+		public void ToInputSourcesFormat(string[] input, string expected)
+		{
+			Assert.That(GnomeShellIbusKeyboardSwitchingAdaptor.ToInputSourcesFormat(input), Is.EqualTo(expected));
+		}
+	}
+}

--- a/SIL.Windows.Forms.Keyboarding.Tests/LinuxKeyboardControllerTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/LinuxKeyboardControllerTests.cs
@@ -147,6 +147,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 
 		[Test]
 		[Category("No IM Running")]
+		[Ignore("It can leave keyboard settings changed from running tests")]
 		public void Deactivate_NoIMRunning_DoesNotThrow()
 		{
 			Keyboard.Controller.ActivateDefaultKeyboard();

--- a/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
+++ b/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
@@ -297,6 +297,7 @@
     <Compile Include="WindowsKeyboardControllerTests.cs" />
     <Compile Include="XkbKeyboardAdapterTests.cs" />
     <Compile Include="XklEngineTests.cs" />
+    <Compile Include="Linux/GnomeShellIbusKeyboardSwitchingAdaptorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SIL.Core.Desktop\SIL.Core.Desktop.csproj">

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -168,11 +168,28 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			{
 				try
 				{
-					if (!GlibHelper.SchemaIsInstalled(GSettingsSchema))
-						return false;
-					_settingsGeneral = Unmanaged.g_settings_new(GSettingsSchema);
-					if (_settingsGeneral == IntPtr.Zero)
-						return false;
+					if (Platform.IsFlatpak)
+					{
+						// It's less important what schema is available in the flatpak
+						// environment, and more important what is available on the host.
+						// Unfortunately `gsettings` does not make use of success and
+						// failure return codes, so parse the output.
+						if (KeyboardRetrievingHelper
+							.RunOnHostEvenIfFlatpak("gsettings", $"list-keys {GSettingsSchemaId}").StandardOutput
+							.StartsWith("No such schema"))
+						{
+							return false;
+						}
+					}
+					else
+					{
+						if (!GlibHelper.SchemaIsInstalled(GSettingsSchemaId))
+							return false;
+						_settingsGeneral = Unmanaged.g_settings_new(GSettingsSchemaId);
+						if (_settingsGeneral == IntPtr.Zero)
+							return false;
+					}
+
 					if (!base.IsApplicable)
 						return false;
 				}

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -52,6 +52,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		protected virtual string[] GetMyKeyboards(IntPtr settingsGeneral)
 		{
+			IntPtr sources = IntPtr.Zero;
 			string[] list = null;
 			if (Platform.IsFlatpak)
 			{
@@ -59,13 +60,21 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			}
 			else
 			{
-				// This is the proper path for the combined keyboard handling on Cinnamon with IBus.
-				var sources = Unmanaged.g_settings_get_value(settingsGeneral, "preload-engines");
-				if (sources == IntPtr.Zero)
-					return null;
-				list = KeyboardRetrievingHelper.GetStringArrayFromGVariantArray(sources);
-				Unmanaged.g_variant_unref(sources);
+				try
+				{
+					// This is the proper path for the combined keyboard handling on Cinnamon with IBus.
+					sources = Unmanaged.g_settings_get_value(settingsGeneral, "preload-engines");
+					if (sources == IntPtr.Zero)
+						return null;
+					list = KeyboardRetrievingHelper.GetStringArrayFromGVariantArray(sources);
+				}
+				finally
+				{
+					if (sources != IntPtr.Zero)
+						Unmanaged.g_variant_unref(sources);
+				}
 			}
+
 			// Call these only once per run of the program.
 			if (CombinedIbusKeyboardSwitchingAdaptor.DefaultLayout == null)
 				LoadDefaultXkbSettings();

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -160,7 +160,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			string useXModmapKey = "use-xmodmap";
 			bool useXModmap = false;
 			if (Platform.IsFlatpak)
-				useXModmap = GSettingsGetBooleanFromHost(GSettingsSchemaId, useXModmapKey);
+				useXModmap = KeyboardRetrievingHelper.GSettingsGetBooleanFromHost(GSettingsSchemaId, useXModmapKey);
 			else
 				useXModmap = Unmanaged.g_settings_get_boolean(settingsGeneral, useXModmapKey);
 			CombinedIbusKeyboardSwitchingAdaptor.UseXmodmap = useXModmap;
@@ -173,11 +173,11 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		private static string[] GetXkbLatinLayouts(IntPtr settingsGeneral)
 		{
+			// xkb-latin-layouts is type "as" (https://github.com/ibus/ibus/blob/main/data/dconf/org.freedesktop.ibus.gschema.xml)
 			string keyName = "xkb-latin-layouts";
 			if (Platform.IsFlatpak)
 			{
-				string output = KeyboardRetrievingHelper.RunOnHostEvenIfFlatpak("gsettings", $"get {GSettingsSchemaId} {keyName}").StandardOutput;
-				return KeyboardRetrievingHelper.ToStringArray(output);
+				return KeyboardRetrievingHelper.GSettingsGetStringArrayFromHost(GSettingsSchemaId, keyName);
 			}
 			else
 			{
@@ -193,14 +193,6 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 						Unmanaged.g_variant_unref(value);
 				}
 			}
-		}
-
-
-		private static bool GSettingsGetBooleanFromHost(string schemaId, string key)
-		{
-			string output = KeyboardRetrievingHelper.RunOnHostEvenIfFlatpak("gsettings", $"get {schemaId} {key}")
-				.StandardOutput.Trim();
-			return output == "true";
 		}
 
 		#region Specific implementations of IKeyboardRetriever

--- a/SIL.Windows.Forms.Keyboarding/Linux/GlibHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GlibHelper.cs
@@ -9,6 +9,9 @@ using System.Text;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
+	/// <summary>
+	/// Helps interacting with GIO (https://docs.gtk.org/gio/index.html).
+	/// </summary>
 	public static class GlibHelper
 	{
 		/// <summary>

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
@@ -2,7 +2,12 @@
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using SIL.PlatformUtilities;
+using SIL.Progress;
 using SIL.Reporting;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -22,39 +27,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		protected override void SelectKeyboard(KeyboardDescription keyboard)
 		{
 			var ibusKeyboard = (IbusKeyboardDescription) keyboard;
-			var index = ibusKeyboard.SystemIndex;
-
-			var okay = false;
-			// https://askubuntu.com/a/1039964
-			try
-			{
-				using (var proc = new Process {
-					EnableRaisingEvents = false,
-					StartInfo = {
-						FileName = "/usr/bin/gdbus",
-						Arguments =
-							"call --session --dest org.gnome.Shell --object-path /org/gnome/Shell " +
-							"--method org.gnome.Shell.Eval " +
-							$"\"imports.ui.status.keyboard.getInputSourceManager().inputSources[{index}].activate()\"",
-						UseShellExecute = false
-					}
-				})
-				{
-					proc.Start();
-					proc.WaitForExit();
-					okay = proc.ExitCode == 0;
-				}
-			}
-			finally
-			{
-				if (!okay)
-				{
-					var msg =
-						$"GnomeShellIbusKeyboardSwitchingAdaptor.SelectKeyboard({index}) failed";
-					Console.WriteLine(msg);
-					Logger.WriteEvent(msg);
-				}
-			}
+			SetGnomeKeyboard(ibusKeyboard);
 		}
 
 		/// <summary>
@@ -73,6 +46,57 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		public void SetDefaultKeyboard(KeyboardDescription keyboard)
 		{
 			_defaultKeyboard = keyboard;
+		}
+
+		/// <summary>
+		/// Change the keyboard input method by limiting the scope of available input methods to
+		/// the chosen one, and then restore the original list. In Gnome 42, this updates the
+		/// panel icon for keyboard input methods, as well as setting the keyboard.
+		/// </summary>
+		/// <remarks>
+		/// In Gnome 41, the ability to run org.gnome.Shell.Eval was changed, so we can not run
+		/// getInputSourceManager().inputSources[n].activate(). In addition to setting
+		/// input-sources, other solutions could include using a Gnome extension (eg
+		/// https://askubuntu.com/a/1428946 , https://github.com/ramottamado/eval-gjs), or
+		/// changing the engine by running ibus (eg `ibus engine table:thai`). Running ibus
+		/// works, but doesn't update the Gnome panel, and may result in other poor
+		/// experiences.
+		/// </remarks>
+		private void SetGnomeKeyboard(IbusKeyboardDescription keyboard)
+		{
+			string[] configuredInputSources = UnityKeyboardRetrievingHelper.GetMyKeyboards();
+			// If we set only the desired keyboard, the panel keyboarding icon is removed,
+			// causing a noticeable flicker when it disappears and a new one reappears.
+			// Instead, set the reduced scope list to the desired keyboard first, and an
+			// additional keyboard. The additional keyboard can't just be a duplicate of
+			// the first to still affect.
+			string desiredKeyboardAfront = $"[{keyboard.GnomeInputSourceIdentifier}, ('xkb', 'ie')]";
+			string program = "gsettings";
+			string arguments = $"set org.gnome.desktop.input-sources sources";
+			KeyboardRetrievingHelper.RunOnHostEvenIfFlatpak(program,
+				$"{arguments} \"{desiredKeyboardAfront}\"");
+			// Set keyboards back. Note that one source (https://unix.stackexchange.com/a/711918) suggested to
+			// briefly pause between the two settings. This does not appear to be needed in Ubuntu 22.04.
+			KeyboardRetrievingHelper.RunOnHostEvenIfFlatpak(program,
+				$"{arguments} \"{ToInputSourcesFormat(configuredInputSources)}\"");
+		}
+
+		/// <summary>
+		/// Transform a list of keyboards into the a(ss) format expected by
+		/// input-sources. For example,
+		/// ["xkb;;us", "ibus;;table:thai"] becomes
+		/// "[('xkb', 'us'), ('ibus', 'table:thai')]".
+		/// </summary>
+		internal static string ToInputSourcesFormat(string[] input)
+		{
+			if (input == null || input.Length < 1)
+				return "[]";
+			IEnumerable<string> keyboards = input.Select((string item) =>
+			{
+				string[] parts = item.Split(new string[]{";;"}, StringSplitOptions.None);
+				return $"('{parts[0]}', '{parts[1]}')";
+			});
+			return $"[{string.Join(", ", keyboards)}]";
 		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
@@ -24,6 +24,15 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		}
 
 		/// <summary>
+		/// Identifier for this keyboard in the format used by org.gnome.desktop.input-sources sources.
+		/// For example, ('xkb', 'us+mac') or ('ibus', 'table:thai')  See
+		/// https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/blob/master/schemas/org.gnome.desktop.input-sources.gschema.xml.in
+		/// </summary>
+		public virtual string GnomeInputSourceIdentifier => $"('{GnomeInputSourceType}', '{GnomeInputSourceLayout}')";
+		protected virtual string GnomeInputSourceType => "ibus";
+		protected virtual string GnomeInputSourceLayout => IBusKeyboardEngine.LongName;
+
+		/// <summary>
 		/// Produce IBus keyboard identifier which is similar to the actual ibus switcher menu.
 		/// </summary>
 		private static string FormatKeyboardIdentifier(string layout, string locale)

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
@@ -8,6 +8,7 @@ using System.IO;
 using IBusDotNet;
 using SIL.Keyboarding;
 using SIL.PlatformUtilities;
+using SIL.Reporting;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
 {
@@ -189,6 +190,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			}
 			return () =>
 			{
+				Logger.WriteEvent($"Launching keyboard setup: {setupApp} {args}");
 				using (Process.Start(setupApp, args)) { }
 			};
 		}
@@ -206,6 +208,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				{
 					KeyboardRetrievingHelper.ToFlatpakSpawn(ref program, ref arguments);
 				}
+				Logger.WriteEvent($"Launching secondary keyboard setup: {program} {arguments}");
 				using (Process.Start(program, arguments)) { }
 			};
 		}

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusXkbKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusXkbKeyboardDescription.cs
@@ -15,6 +15,12 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		{
 		}
 
+		protected override string GnomeInputSourceType => "xkb";
+		protected override string GnomeInputSourceLayout =>
+			string.IsNullOrEmpty(IBusKeyboardEngine.LayoutVariant)
+				? IBusKeyboardEngine.Layout
+				: $"{IBusKeyboardEngine.Layout}+{IBusKeyboardEngine.LayoutVariant}";
+
 		protected override string KeyboardIdentifier => _ibusKeyboard.Name;
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -49,12 +49,26 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			ErrorReport.AddProperty("IbusVersion", version);
 		}
 
-		private static string GSettingsGetStringFromHost(string schemaId, string key)
+		internal static string GSettingsGetStringFromHost(string schemaId, string key)
 		{
 			return RunOnHostEvenIfFlatpak("gsettings", $"get {schemaId} {key}")
 				.StandardOutput
 				.Trim()
 				.Trim('\'');
+		}
+
+		internal static bool GSettingsGetBooleanFromHost(string schemaId, string key)
+		{
+			string output = RunOnHostEvenIfFlatpak("gsettings", $"get {schemaId} {key}")
+				.StandardOutput.Trim();
+			return output == "true";
+		}
+
+		/// <summary>Return a string array. For querying gsettings with type "as".</summary>
+		internal static string[] GSettingsGetStringArrayFromHost(string schemaId, string key)
+		{
+			return ToStringArray(RunOnHostEvenIfFlatpak("gsettings", $"get {schemaId} {key}")
+				.StandardOutput);
 		}
 
 		/// <summary>

--- a/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -5,7 +5,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using SIL.CommandLineProcessing;
 using SIL.PlatformUtilities;
+using SIL.Progress;
 using SIL.Reporting;
 
 namespace SIL.Windows.Forms.Keyboarding.Linux
@@ -164,6 +166,17 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		{
 			arguments = $"--host --directory=/ {program} {arguments}";
 			program = "flatpak-spawn";
+		}
+
+		/// <summary>Run a program. If the current process is in flatpak, then run the program
+		/// on the host system that is hosting flatpak, via spawn.</summary>
+		internal static ExecutionResult RunOnHostEvenIfFlatpak(string program, string arguments)
+		{
+			if (Platform.IsFlatpak)
+				KeyboardRetrievingHelper.ToFlatpakSpawn(ref program, ref arguments);
+			Logger.WriteEvent($"Running {program} {arguments}");
+			return CommandLineRunner.Run(program, arguments,
+				"/", 10, new StringBuilderProgress());
 		}
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -148,8 +148,31 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			// GNOME
 			else if (File.Exists($"{prefix}/usr/bin/gnome-control-center"))
 			{
-				arguments = "region layouts";
 				program = "/usr/bin/gnome-control-center";
+				// Different versions of Gnome Control Center have needed different
+				// arguments to jump to the right place for keyboard layout configuration.
+				// Set arguments accordingly. Fall back to a default of using the arguments
+				// for the latest supported Gnome Control Center.
+				arguments = "keyboard";
+				try
+				{
+					string output = KeyboardRetrievingHelper.RunOnHostEvenIfFlatpak(program, "--version").StandardOutput;
+					// output looks like "gnome-control-center 41.7".
+					string version = output.Split(' ')[1];
+					string majorVersion = version.Split('.')[0];
+					int majorVersionNumber = 0;
+					if (int.TryParse(majorVersion, out majorVersionNumber))
+					{
+						if (majorVersionNumber >= 3)
+							arguments = "region";
+						if (majorVersionNumber >= 41)
+							arguments = "keyboard";
+					}
+				}
+				catch (Exception e)
+				{
+					Logger.WriteEvent($"Ignoring exception when looking for gnome-control-center version: {e}");
+				}
 			}
 			// KDE
 			else if (File.Exists($"{prefix}/usr/bin/kcmshell4"))

--- a/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -177,10 +177,10 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 					int majorVersionNumber = 0;
 					if (int.TryParse(majorVersion, out majorVersionNumber))
 					{
-						if (majorVersionNumber >= 3)
-							arguments = "region";
 						if (majorVersionNumber >= 41)
 							arguments = "keyboard";
+						else if (majorVersionNumber >= 3)
+							arguments = "region";
 					}
 				}
 				catch (Exception e)
@@ -246,6 +246,5 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				.Select((string item) => item.Trim('\''))
 				.ToArray<string>();
 		}
-
 	}
 }

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
@@ -20,13 +20,14 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		{
 			const string schema = "org.gnome.desktop.input-sources";
 			bool okay = true;
+			IntPtr settings = IntPtr.Zero;
 			try
 			{
 				okay &= GlibHelper.SchemaIsInstalled(schema);
 				if (!okay)
 					return;
 
-				var settings = Unmanaged.g_settings_new(schema);
+				settings = Unmanaged.g_settings_new(schema);
 				okay &= settings != IntPtr.Zero;
 				if (!okay)
 					return;
@@ -35,6 +36,9 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			}
 			finally
 			{
+				if (settings != IntPtr.Zero)
+					Unmanaged.g_object_unref(settings);
+
 				if (!okay)
 				{
 					Console.WriteLine("UnityIbusKeyboardAdaptor.SelectKeyboard({0}) failed", index);

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
@@ -93,7 +93,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// Returns the list of keyboards or <c>null</c> if we can't get the combined keyboards
 		/// list.
 		/// </summary>
-		private static string[] GetMyKeyboards()
+		internal static string[] GetMyKeyboards()
 		{
 			if (Platform.IsFlatpak)
 			{

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
@@ -142,9 +142,9 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 		/// <summary>
 		/// Parses a keyboard list from gdbus into a list of keyboards.
-		/// For example, parses "(<<[('xkb', 'us'), ('ibus', 'table:thai')]>>,)\n" to
-		/// the list { "xkb;;us", "ibus;;table:thai" }.
 		/// </summary>
+		// For example, parses "(<<[('xkb', 'us'), ('ibus', 'table:thai')]>>,)\n" to
+		// the list { "xkb;;us", "ibus;;table:thai" }.
 		internal static List<string> ParseGDBusKeyboardList(string keyboardList)
 		{
 			string[] keyboards = keyboardList.Split(new string[] {"), "},

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityKeyboardRetrievingHelper.cs
@@ -125,6 +125,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// <summary>
 		/// Return list of GNOME input sources, as queried of gsettings by way of a dbus Flatpak portal.
 		/// https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.portal.Settings
+		/// Note: This wouldn't need to stay implemented via a portal, but could flatpak-spawn gsettings since other things are.
 		/// </summary>
 		internal static string[] GnomeInputSourcesViaFlatpakPortal()
 		{

--- a/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
@@ -19,6 +19,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		[DllImport("libgobject-2.0.so")]
 		internal extern static void g_object_unref(IntPtr obj);
 
+		/// <summary>See https://docs.gtk.org/gio/struct.SettingsSchemaSource.html</summary>
 		[DllImport("libgio-2.0.so")]
 		internal extern static IntPtr g_settings_schema_source_get_default();
 
@@ -26,6 +27,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		internal extern static IntPtr g_settings_schema_source_lookup(IntPtr source,
 				string schema_id, bool recursive);
 
+		/// <summary>See https://docs.gtk.org/gio/class.Settings.html</summary>
 		[DllImport("libgio-2.0.so")]
 		internal extern static IntPtr g_settings_new(string schema_id);
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -214,6 +214,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				return null;
 			}
 			return () => {
+				Logger.WriteEvent($"Launching keyboard setup: {setupApp} {args}");
 				using (Process.Start(setupApp, args)) { }
 			};
 		}

--- a/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
+++ b/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
@@ -273,7 +273,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\output\Debug\icu.net.dll</HintPath>
     </Reference>
-    <Reference Include="L10NSharp, Version=2.0.40.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="L10NSharp">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Debug\L10NSharp.dll</HintPath>
     </Reference>

--- a/TestApps/TestAppKeyboard/KeyboardForm.Designer.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.Designer.cs
@@ -200,6 +200,7 @@ namespace TestAppKeyboard
 			this.cbOnEnter.TabIndex = 1;
 			this.cbOnEnter.Text = "Set keyboard on enter";
 			this.cbOnEnter.UseVisualStyleBackColor = true;
+			this.cbOnEnter.Checked = true;
 			// 
 			// label7
 			// 

--- a/TestApps/TestAppKeyboard/KeyboardForm.cs
+++ b/TestApps/TestAppKeyboard/KeyboardForm.cs
@@ -22,13 +22,13 @@ namespace TestAppKeyboard
 			KeyboardController.RegisterControl(testAreaB, eventHandler);
 			KeyboardController.RegisterControl(testAreaC, eventHandler);
 
-			LoadKeyboards(keyboardsA);
-			LoadKeyboards(keyboardsB);
-			LoadKeyboards(keyboardsC);
-			LoadKeyboards(currentKeyboard);
+			LoadKeyboards(keyboardsA, 0);
+			LoadKeyboards(keyboardsB, 1);
+			LoadKeyboards(keyboardsC, 2);
+			LoadKeyboards(currentKeyboard, 0);
 		}
 
-		private static void LoadKeyboards(ComboBox comboBox)
+		private static void LoadKeyboards(ComboBox comboBox, int preferredInitialKeyboard)
 		{
 			IEnumerable<IKeyboardDefinition> keyboards = Keyboard.Controller.AvailableKeyboards;
 			foreach (var keyboard in keyboards)
@@ -43,7 +43,10 @@ namespace TestAppKeyboard
 				return;
 			}
 
-			comboBox.SelectedIndex = 0;
+			if (preferredInitialKeyboard < comboBox.Items.Count)
+				comboBox.SelectedIndex = preferredInitialKeyboard;
+			else
+				comboBox.SelectedIndex = 0;
 		}
 
 		private void testAreaA_Enter(object sender, EventArgs e)

--- a/build/buildupdate.mono.sh
+++ b/build/buildupdate.mono.sh
@@ -105,8 +105,8 @@ mkdir -p ../lib/DebugMono
 mkdir -p ../lib/ReleaseMono
 
 # download artifact dependencies
-copy_auto http://build.palaso.org/guestAuth/repository/download/L10NSharp_L10NSharpMasterMonoContinuous/latest.lastSuccessful/L10NSharp.dll ../lib/ReleaseMono/L10NSharp.dll
-copy_auto http://build.palaso.org/guestAuth/repository/download/L10NSharp_L10NSharpMasterMonoContinuous/latest.lastSuccessful/L10NSharp.dll ../lib/DebugMono/L10NSharp.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/L10NSharp_L10NSharpMasterMonoContinuous/libpalaso-6.0.0-692.tcbuildtag/L10NSharp.dll ../lib/ReleaseMono/L10NSharp.dll
+copy_auto http://build.palaso.org/guestAuth/repository/download/L10NSharp_L10NSharpMasterMonoContinuous/libpalaso-6.0.0-692.tcbuildtag/L10NSharp.dll ../lib/DebugMono/L10NSharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt411/latest.lastSuccessful/taglib-sharp.dll ../lib/ReleaseMono/taglib-sharp.dll
 copy_auto http://build.palaso.org/guestAuth/repository/download/bt411/latest.lastSuccessful/taglib-sharp.dll ../lib/DebugMono/taglib-sharp.dll
 # End of script


### PR DESCRIPTION
The work is split in separate commits, which may also help when reviewing.

With these changes, keyboarding is working in Flatpak FieldWorks 9.0 in each of
  - Ubuntu 20.04 (Gnome)
  - Ubuntu 22.04 (Gnome)
  - Wasta 20.04 (Cinnamon)
  - Wasta 22.04 (Cinnamon)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1239)
<!-- Reviewable:end -->
