### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ init:
       set GitVersion_NoNormalizeEnabled=true
       set IGNORE_NORMALISATION_GIT_HEAD_MOVE=1
 install:
-  - choco install gitversion.portable -pre -y
+  - choco install gitversion.portable --version 5.11.1 -y
 nuget:
   disable_publish_on_pr: true
   disable_publish_octopus: true


### PR DESCRIPTION
Don't use pre-release version of GitVersion since that fails on AppVeyor. Instead hard-code version 5.11.1 which is the one that previously worked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1241)
<!-- Reviewable:end -->
