### PR TITLE
Fix BulkObservableList.MoveRange when moving a single item forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [SIL.Core] Fixed `BulkObservableList.MoveRange` method when moving a single item forward.
+
 ## [12.0.0] - 2023-02-14
 
 ### Added

--- a/SIL.Core.Tests/ObjectModel/BulkObservableListTests.cs
+++ b/SIL.Core.Tests/ObjectModel/BulkObservableListTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using SIL.ObjectModel;
+
+namespace SIL.Tests.ObjectModel
+{
+	[TestFixture]
+	public class BulkObservableListTests
+	{
+		[Test]
+		public void MoveRange_MoveSingleForward()
+		{
+			var list = new BulkObservableList<string> { "item1", "item2", "item3" };
+			list.MoveRange(0, 1, 1);
+			Assert.That(list, Is.EqualTo(new[] { "item2", "item1", "item3" }));
+		}
+
+		[Test]
+		public void MoveRange_MoveSingleBackward()
+		{
+			var list = new BulkObservableList<string> { "item1", "item2", "item3" };
+			list.MoveRange(1, 1, 0);
+			Assert.That(list, Is.EqualTo(new[] { "item2", "item1", "item3" }));
+		}
+
+		[Test]
+		public void MoveRange_MoveMultipleForward()
+		{
+			var list = new BulkObservableList<string> { "item1", "item2", "item3", "item4" };
+			list.MoveRange(0, 2, 3);
+			Assert.That(list, Is.EqualTo(new[] { "item3", "item1", "item2", "item4" }));
+		}
+
+		[Test]
+		public void MoveRange_MoveMultipleBackward()
+		{
+			var list = new BulkObservableList<string> { "item1", "item2", "item3", "item4" };
+			list.MoveRange(1, 2, 0);
+			Assert.That(list, Is.EqualTo(new[] { "item2", "item3", "item1", "item4" }));
+		}
+	}
+}

--- a/SIL.Core/ObjectModel/BulkObservableList.cs
+++ b/SIL.Core/ObjectModel/BulkObservableList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -139,7 +139,7 @@ namespace SIL.ObjectModel
 
 			IList moved = RemoveItems(oldIndex, count);
 			int index = newIndex;
-			if (newIndex > oldIndex)
+			if (newIndex - count > oldIndex)
 				index -= count;
 
 			bool prevUpdating = _updating;
@@ -189,7 +189,7 @@ namespace SIL.ObjectModel
 
 		private class BulkUpdater : IDisposable
 		{
-			private readonly BulkObservableList<T> _coll; 
+			private readonly BulkObservableList<T> _coll;
 
 			public BulkUpdater(BulkObservableList<T> coll)
 			{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1247)
<!-- Reviewable:end -->
