### PR TITLE
This is to fix running on Ubuntu 22x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms] Make `PalasoImage.FromFile(Robustly)` methods more robust
+- [SIL.Windows.Forms] Update dll to `libdl.so.2` to make compatible with Ubuntu 22.x.  Affects multiple projects.
 - [SIL.Core] Fixed `BulkObservableList.MoveRange` method when moving a single item forward.
 
 ## [12.0.0] - 2023-02-14

--- a/SIL.Windows.Forms/Clipboarding/LinuxClipboard.NativeMethods.cs
+++ b/SIL.Windows.Forms/Clipboarding/LinuxClipboard.NativeMethods.cs
@@ -22,7 +22,7 @@ namespace SIL.Windows.Forms.Clipboarding
 
 		private const int RTLD_NOW = 2;
 
-		private const string LIBDL_NAME   = "libdl.so";
+		private const string LIBDL_NAME   = "libdl.so.2";
 		private const string LIBGLIB_NAME = "libglib-2.0.so.0";
 
 		[DllImport(LIBDL_NAME, SetLastError = true)]


### PR DESCRIPTION
- they don't have libdl.so - but only libdl.so.2
- see https://stackoverflow.com/questions/75855053/how-to-address-crash-due-to-missing-libdl-so-on-ubuntu-22

This work is untested

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1250)
<!-- Reviewable:end -->
