### PR TITLE
fix bug where a dll was treated as a folder when trying to find a directory

### DIFF
--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -168,7 +168,7 @@ namespace SIL.IO
 			if (Directory.Exists(path))
 				return path;
 
-			var thisDirectory = GetProjectDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+			var thisDirectory = GetProjectDirectory(Path.GetDirectoryName(typeof(FileLocationUtilities).Assembly.Location));
 			if (thisDirectory != DirectoryOfApplicationOrSolution)
 			{
 				path = GetDirectoryDistributedWithApplication(thisDirectory, subPath);

--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -168,7 +168,7 @@ namespace SIL.IO
 			if (Directory.Exists(path))
 				return path;
 
-			var thisDirectory = GetProjectDirectory(Assembly.GetExecutingAssembly().Location);
+			var thisDirectory = GetProjectDirectory(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
 			if (thisDirectory != DirectoryOfApplicationOrSolution)
 			{
 				path = GetDirectoryDistributedWithApplication(thisDirectory, subPath);


### PR DESCRIPTION
When calling `GetDirectoryDistributedWithApplication` and it doesn't find the path on the first try, it will attempt to use the location of the executing assembly. However the code incorrectly assumes that `Assembly.GetExecutingAssembly().Location` returns a directory path, when it actually returns a file path. This change fixes that.

I have not run any test. However I checked `Assembly.GetExecutingAssembly().Location` via linqpad against .Net 7 and .Net framework and they both return a file path. I have verified that `Path.GetDirectoryName` returns the full path, not just the name of the parent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1252)
<!-- Reviewable:end -->
