### PR TITLE
change detection of a unit test context

### DIFF
--- a/SIL.Core/Reflection/ReflectionHelper.cs
+++ b/SIL.Core/Reflection/ReflectionHelper.cs
@@ -1,7 +1,9 @@
 using SIL.IO;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using Mono.Unix.Native;
 
 namespace SIL.Reflection
 {
@@ -461,13 +463,21 @@ namespace SIL.Reflection
 			}
 		}
 
+		private static readonly bool RunningFromUnitTest = AppDomain.CurrentDomain.GetAssemblies()
+			.Any(assem => 
+				assem.FullName.StartsWith("nunit.framework", StringComparison.OrdinalIgnoreCase)
+				|| assem.FullName.StartsWith("Microsoft.VisualStudio.QualityTools.UnitTestFramework", StringComparison.OrdinalIgnoreCase)
+				|| assem.FullName.StartsWith("Microsoft.VisualStudio.TestPlatform.TestFramework", StringComparison.OrdinalIgnoreCase)
+				|| assem.FullName.StartsWith("xunit.core", StringComparison.OrdinalIgnoreCase)
+			);
+
 		public static string DirectoryOfTheApplicationExecutable
 		{
 			get
 			{
 				string path;
-				bool unitTesting = Assembly.GetEntryAssembly() == null;
-				if (unitTesting)
+				// checking for assembly == null is for backwards compatibility with old code that may unintentionally take the unit test path
+				if (RunningFromUnitTest || Assembly.GetEntryAssembly() == null)
 				{
 					path = new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath;
 					path = Uri.UnescapeDataString(path);


### PR DESCRIPTION
Previously `DirectoryOfTheApplicationExecutable` was determining that it was in a testing context by checking if `Assembly.GetEntryAssembly() == null` this is no longer always true, for example running tests in Rider.

This PR changes the code to use the presence of a loaded unit testing dll as the indicator that we're running tests. I have preserved the check for `Assembly.GetEntryAssembly() == null` so as to not break backwards compatibility with any code that currently depends on the unit test path running when the assembly is null. This should reduce this to only changing functionality when running tests and not in any other cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1253)
<!-- Reviewable:end -->
