### PR TITLE
RetryUtility now retries for subclasses of exceptions listed (BL-12363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [SIL.Windows.Forms] `ImageToolboxControl.ImageChanged` (selected or cropped) and `ImageToolboxControl.MetadataChanged` events
 
+### Fixed
+
+- [SIL.Core] Make RetryUtility retry for exceptions that are subclasses of the ones listed to try. For example, by default (IOException) it will now retry for FileNotFoundException.
+
 ## [12.0.1] - 2023-05-26
 
 ### Fixed

--- a/SIL.Core.Tests/Code/RetryUtilityTests.cs
+++ b/SIL.Core.Tests/Code/RetryUtilityTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SIL.Code;
+
+namespace SIL.Tests.Code
+{
+	/// <summary>
+	/// This is a work in progress. At this point it only has a test for one recently-added bit of functionality.
+	/// </summary>
+	public class RetryUtilityTests
+	{
+		[Test]
+		public void TypesIncludes_MainClassAndSubclasses_ButNotSuperclass()
+		{
+			var types = new HashSet<Type> ( new[] {typeof(IOException), typeof(NullReferenceException)} );
+			Assert.That(RetryUtility.TypesIncludes(types, typeof(NullReferenceException)), Is.True);
+			Assert.That(RetryUtility.TypesIncludes(types, typeof(IOException)), Is.True);
+			Assert.That(RetryUtility.TypesIncludes(types, typeof(FileNotFoundException)), Is.True);
+			Assert.That(RetryUtility.TypesIncludes(types, typeof(SystemException)), Is.False);
+		}
+	}
+}

--- a/SIL.Core/Code/RetryUtility.cs
+++ b/SIL.Core/Code/RetryUtility.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -45,7 +45,7 @@ namespace SIL.Code
 				}
 				catch (Exception e)
 				{
-					if (exceptionTypesToRetry.Contains(e.GetType()))
+					if (TypesIncludes(exceptionTypesToRetry, e.GetType()))
 					{
 						if (attempt == maxRetryAttempts)
 						{
@@ -59,6 +59,19 @@ namespace SIL.Code
 				}
 			}
 			return default(T);
+		}
+
+		internal static bool TypesIncludes(ISet<Type> types, Type typeToTest)
+		{
+			if (types.Contains(typeToTest)) // fast check for root types
+				return true;
+			foreach (var type in types)
+			{
+				if (typeToTest.IsSubclassOf(type))
+					return true;
+			}
+
+			return false;
 		}
 	}
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1257)
<!-- Reviewable:end -->
