### PR TITLE
ImageGalleryControl API corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - [SIL.Media] Changed the FrameRate reported in VideoInfo from FrameRate to AvgFrameRate.
+- [SIL.Windows.Forms] Fixed spelling error in ImageGalleryControl, renaming SetIntialSearchTerm to SetInitialSearchTerm.
 
 ### Fixed
 
 - [SIL.Core] Make RetryUtility retry for exceptions that are subclasses of the ones listed to try. For example, by default (IOException) it will now retry for FileNotFoundException.
+
+### Removed
+- [SIL.Windows.Forms] ImageGalleryControl.InSomeoneElesesDesignMode (ssemingly unused and misspelled)
 
 ## [12.0.1] - 2023-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Make RetryUtility retry for exceptions that are subclasses of the ones listed to try. For example, by default (IOException) it will now retry for FileNotFoundException.
 
 ### Removed
-- [SIL.Windows.Forms] ImageGalleryControl.InSomeoneElesesDesignMode (ssemingly unused and misspelled)
+- [SIL.Windows.Forms] ImageGalleryControl.InSomeoneElesesDesignMode (seemingly unused and misspelled)
 
 ## [12.0.1] - 2023-05-26
 

--- a/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageGallery/ImageGalleryControl.cs
@@ -19,7 +19,6 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 	{
 		private ImageCollectionManager _imageCollectionManager;
 		private PalasoImage _previousImage;
-		public bool InSomeoneElesesDesignMode;
 
 		public ImageGalleryControl()
 		{
@@ -55,9 +54,19 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 		/// use if the calling app already has some notion of what the user might be looking for (e.g. the definition in a dictionary program)
 		/// </summary>
 		/// <param name="searchTerm"></param>
-		public void SetIntialSearchTerm(string searchTerm)
+		public void SetInitialSearchTerm(string searchTerm)
 		{
 			_searchTermsBox.Text = searchTerm;
+		}
+
+		/// <summary>
+		/// use if the calling app already has some notion of what the user might be looking for (e.g. the definition in a dictionary program)
+		/// </summary>
+		/// <param name="searchTerm"></param>
+		[Obsolete("Use SetInitialSearchTerm (spelling corrected)")]
+		public void SetIntialSearchTerm(string searchTerm)
+		{
+			SetInitialSearchTerm(searchTerm);
 		}
 
 		/// <summary>
@@ -99,9 +108,19 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 						_messageLabel.Visible = false;
 						_downloadInstallerLink.Visible = false;
 						_thumbnailViewer.LoadItems(results);
-						var fmt = "Found {0} images".Localize("ImageToolbox.MatchingImages", "The {0} will be replaced by the number of matching images");
+						var fmt = results.Count == 1 ?
+							"Found 1 image".Localize("ImageToolbox.MatchingImageSingle") :
+							"Found {0} images".Localize("ImageToolbox.MatchingImages", "The {0} will be replaced by the number of matching images");
 						if (!foundExactMatches)
-							fmt = "Found {0} images with names close to \u201C{1}\u201D".Localize("ImageToolbox.AlmostMatchingImages", "The {0} will be replaced by the number of images found.  The {1} will be replaced with the search string.");
+						{
+							fmt = results.Count == 1 ?
+								"Found 1 image with a name close to \u201C{1}\u201D".Localize("ImageToolbox.AlmostMatchingImageSingle",
+									"The {1} will be replaced with the search string.") :
+								"Found {0} images with names close to \u201C{1}\u201D".Localize(
+								"ImageToolbox.AlmostMatchingImages",
+								"The {0} will be replaced by the number of images found. The {1} will be replaced with the search string.");
+						}
+
 						_searchResultStats.Text = string.Format(fmt, results.Count, _searchTermsBox.Text);
 						_searchResultStats.ForeColor = foundExactMatches ? Color.Black : Color.FromArgb(0x34, 0x65, 0xA4); //#3465A4
 						_searchResultStats.Font = new Font("Segoe UI", 9F, foundExactMatches ? FontStyle.Regular : FontStyle.Bold);
@@ -226,7 +245,7 @@ namespace SIL.Windows.Forms.ImageToolbox.ImageGallery
 					_collectionDropDown.Visible = true;
 					_collectionDropDown.Text =
 						"Galleries".Localize("ImageToolbox.Galleries");
-					if(ImageToolboxSettings.Default.DisabledImageCollections == null)
+					if (ImageToolboxSettings.Default.DisabledImageCollections == null)
 					{
 						ImageToolboxSettings.Default.DisabledImageCollections = new StringCollection();
 					}


### PR DESCRIPTION
Fixed a spelling error in an API method for ImageGalleryControl and removed an unused/misspelled public field

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1269)
<!-- Reviewable:end -->
