### PR TITLE
+semver:major Moved versions of CanWriteToDirectories and CanWriteToDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] `ImageToolboxControl.ImageChanged` (selected or cropped) and `ImageToolboxControl.MetadataChanged` events
 - [SIL.Windows.Forms] Interop.WIA.dll for MSIL (doesn't seem to work with 32-bit apps, so the existing dll remains unchanged)
 - [SIL.Scripture] Made static methods TryGetVerseNum, ParseVerseNumberRange, and ParseVerseNumber public
+- [SIL.Core] `CanWriteToDirectories` and `CanWriteToDirectory`
 - [SIL.Windows.Forms] `CanWriteToDirectories`, `CanWriteToDirectory` and `ReportDefenderProblem`
 
 ### Changed

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -78,6 +78,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Saami/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SLDR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=standarderror/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdirectory/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subitem/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subtags/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=taskbar/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Windows.Forms/Miscellaneous/WindowsUtilities.cs
+++ b/SIL.Windows.Forms/Miscellaneous/WindowsUtilities.cs
@@ -1,13 +1,9 @@
 using System;
-using System.IO;
 using JetBrains.Annotations;
 using L10NSharp;
 using SIL.IO;
-using SIL.PlatformUtilities;
 using SIL.Reporting;
 using static System.Environment;
-using static System.Environment.SpecialFolder;
-using static System.IO.Path;
 
 namespace SIL.Windows.Forms.Miscellaneous
 {
@@ -29,38 +25,12 @@ namespace SIL.Windows.Forms.Miscellaneous
 		/// (Can pass null to just return false to the caller without reporting the problem, but it
 		/// will not be obvious which folder was not writable.)</param>
 		/// <param name="foldersToCheck">The folders to test for write access.</param>
+		/// <remarks><seealso cref="DirectoryHelper.CanWriteToDirectories"/></remarks>
 		[PublicAPI]
 		public static bool CanWriteToDirectories(string applicationName,
 			params string[] foldersToCheck)
 		{
-			return CanWriteToDirectories(GetReportingMethodFor(applicationName), foldersToCheck);
-		}
-		/// <summary>
-		/// Returns 'true' unless we find we can't write to all the specified folders, in which
-		/// case it performs the specified report action. Note that the action will never be
-		/// performed more than once, since this method does not keep checking additional folders
-		/// once it finds one that is not writable.
-		/// In Oct of 2017, a Windows update to Defender on some machines set Protections on
-		/// certain basic folders, like MyDocuments! This resulted in throwing an exception any
-		/// time Bloom tried to write out CollectionSettings files! More recently (especially on
-		/// Windows 11), some other apps have been having similar failures due to enhanced anti-
-		/// ransomware checking.
-		/// </summary>
-		/// <param name="report">Action to perform if a folder is found which is not writable (or
-		/// null to just return false)
-		/// </param>
-		/// <param name="foldersToCheck">The folders to test for write access.</param>
-		[PublicAPI]
-		public static bool CanWriteToDirectories(Action<Exception, string> report,
-			params string[] foldersToCheck)
-		{
-			foreach (var folder in foldersToCheck)
-			{
-				if (!CanWriteToDirectory(report, folder))
-					return false;
-			}
-
-			return true;
+			return DirectoryHelper.CanWriteToDirectories(GetReportingMethodFor(applicationName), foldersToCheck);
 		}
 
 		/// <summary>
@@ -76,71 +46,12 @@ namespace SIL.Windows.Forms.Miscellaneous
 		/// (Leave as null to just return false to the caller without reporting the problem.)
 		/// </param>
 		/// <param name="folderToCheck">An optional folder to test for write access.</param>
+		/// <remarks><seealso cref="DirectoryHelper.CanWriteToDirectory"/></remarks>
 		[PublicAPI]
 		public static bool CanWriteToDirectory(string applicationName = null,
 			string folderToCheck = null)
 		{
-			return CanWriteToDirectory(GetReportingMethodFor(applicationName), folderToCheck);
-		}
-
-		/// <summary>
-		/// Returns 'true' unless we find we can't write to the specified folder, in which
-		/// case it performs the specified report action.
-		/// In Oct of 2017, a Windows update to Defender on some machines set Protections on
-		/// certain basic folders, like MyDocuments! This resulted in throwing an exception any
-		/// time Bloom tried to write out CollectionSettings files! More recently (especially on
-		/// Windows 11), some other apps have been having similar failures due to enhanced anti-
-		/// ransomware checking.
-		/// </summary>
-		/// <param name="report">Action to perform if a folder is found which is not writable
-		/// </param>
-		/// <param name="folderToCheck">An optional folder to test for write access.</param>
-		[PublicAPI]
-		public static bool CanWriteToDirectory(Action<Exception, string> report,
-			string folderToCheck = null)
-		{
-			if (!Platform.IsWindows)
-				return true;
-
-			if (string.IsNullOrEmpty(folderToCheck))
-				folderToCheck = GetFolderPath(MyDocuments);
-			else
-			{
-				if (!Directory.Exists(folderToCheck))
-					throw new ArgumentException(
-						"Folder provided should be an existing directory.",
-						nameof(folderToCheck));
-			}
-
-			string testPath = GetTestFileName(folderToCheck);
-
-			try
-			{
-				RobustFile.WriteAllText(testPath, "test contents");
-			}
-			catch (Exception exc)
-			{
-				// Creating a previously non-existent file under these conditions just gives a WinIOError, "could not find file".
-				report?.Invoke(exc, GetDirectoryName(testPath));
-				return false;
-			}
-			finally
-			{
-				Cleanup(testPath);
-			}
-			return true;
-		}
-
-		private static string GetTestFileName(string folderToCheck)
-		{
-			while (true)
-			{
-				var testPath = Combine(folderToCheck,
-					GetFileName(TempFile.CreateAndGetPathButDontMakeTheFile().Path));
-				// Really unlikely that the temp file name would exist, but let's check to be sure.
-				if (!File.Exists(testPath) && !Directory.Exists(testPath))
-					return testPath;
-			}
+			return DirectoryHelper.CanWriteToDirectory(GetReportingMethodFor(applicationName), folderToCheck);
 		}
 
 		private static Action<Exception, string> GetReportingMethodFor(string applicationName)
@@ -162,19 +73,6 @@ namespace SIL.Windows.Forms.Miscellaneous
 				"software) to allow this program to work.");
 			var msg = string.Format(heading, applicationName, failingFolder) + NewLine + NewLine + mainMsg;
 			ErrorReport.NotifyUserOfProblem(exc, msg);
-		}
-
-		private static void Cleanup(string testPath)
-		{
-			// try to clean up behind ourselves
-			try
-			{
-				RobustFile.Delete(testPath);
-			}
-			catch (Exception)
-			{
-				// but don't try too hard
-			}
 		}
 	}
 }


### PR DESCRIPTION
One version of each of these methods does not require Windows Forms. So by putting them into SIL.Core, they will be available for non-Forms applications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1271)
<!-- Reviewable:end -->
