### PR TITLE
Don't throw trying to report errors

### DIFF
--- a/SIL.Windows.Forms/Reporting/WinFormsExceptionHandler.cs
+++ b/SIL.Windows.Forms/Reporting/WinFormsExceptionHandler.cs
@@ -13,13 +13,7 @@ namespace SIL.Windows.Forms.Reporting
 		// see comment on ExceptionReportingDialog.s_reportDataStack
 		internal static Control ControlOnUIThread { get; private set; }
 
-		internal static bool InvokeRequired
-		{
-			get
-			{
-				return !ControlOnUIThread.IsDisposed && ControlOnUIThread.InvokeRequired;
-			}
-		}
+		internal static bool InvokeRequired => ControlOnUIThread is { IsDisposed: false, InvokeRequired: true };
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>


### PR DESCRIPTION
Check ControlOnUIThread for null first
(this is the fancy syntax R# recommended)

Fixes the crash reported in https://jira.sil.org/browse/LT-21467 which swallows the crash reported in https://github.com/sillsdev/libpalaso/issues/1275

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1277)
<!-- Reviewable:end -->
