### PR TITLE
add audio monitoring without exception catching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Scripture] Made static methods TryGetVerseNum, ParseVerseNumberRange, and ParseVerseNumber public
 - [SIL.Core] `CanWriteToDirectories` and `CanWriteToDirectory`
 - [SIL.Windows.Forms] `CanWriteToDirectories`, `CanWriteToDirectory` and `ReportDefenderProblem`
+- [SIL.Media.NAudio] added an overload to `BeginMonitoring` with `catchAndReportExceptions` parameter
 
 ### Changed
 

--- a/SIL.Media/Naudio/AudioRecorder.cs
+++ b/SIL.Media/Naudio/AudioRecorder.cs
@@ -175,9 +175,6 @@ namespace SIL.Media.Naudio
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// For the IAudioRecorder interface. <see cref="BeginMonitoring(bool)"/> </summary>
-		/// <remarks>
-		/// Methods in this class should not call this method (i.e., from inside code that has
-		/// a lock on this). Instead use <see cref="BeginMonitoringIfNeeded()"/>. </remarks>
 		/// ------------------------------------------------------------------------------------
 		public virtual void BeginMonitoring()
 		{
@@ -206,9 +203,6 @@ namespace SIL.Media.Naudio
 		/// thrown as a result of this call (besides the documented exception) will be caught
 		/// and reported via <see cref="ErrorReport.NotifyUserOfProblem(string,object[])"/>.
 		/// </param>
-		/// <remarks> Methods in this class should not call this method (i.e., from inside
-		/// code that has a lock on this). Instead use <see cref="BeginMonitoringIfNeeded()"/>.
-		/// </remarks>
 		/// ------------------------------------------------------------------------------------
 		public virtual void BeginMonitoring(bool catchAndReportExceptions)
 		{

--- a/SIL.Media/Naudio/AudioRecorder.cs
+++ b/SIL.Media/Naudio/AudioRecorder.cs
@@ -216,6 +216,19 @@ namespace SIL.Media.Naudio
 		}
 
 		/// ------------------------------------------------------------------------------------
+		/// <summary>
+		/// Same as BeginMonitoring method above but without catching exceptions
+		/// ------------------------------------------------------------------------------------
+		public void BeginMonitoringWithThrow()
+		{
+			bool monitoringStarted = false;
+			monitoringStarted = BeginMonitoringIfNeeded();
+			if (!monitoringStarted)
+				throw new InvalidOperationException("Only call this once for a new WaveIn device" +
+					" (i.e., when RecordingState is NotYetStarted or Stopped.");
+		}
+
+		/// ------------------------------------------------------------------------------------
 		/// <summary>Begins monitoring if in the correct state to do so</summary>
 		/// <returns><c>true</c> if monitoring was started; <c>false</c> if not in a state where
 		/// monitoring could be started (e.g., already monitoring or recording, or stopped

--- a/SIL.Media/Naudio/AudioRecorder.cs
+++ b/SIL.Media/Naudio/AudioRecorder.cs
@@ -174,11 +174,10 @@ namespace SIL.Media.Naudio
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// For the IAudioRecorder interface. See BeginMonitoring(bool catchAndReportException)
-		/// </summary>
+		/// For the IAudioRecorder interface. <see cref="BeginMonitoring(bool)"/> </summary>
 		/// <remarks>
 		/// Methods in this class should not call this method (i.e., from inside code that has
-		/// a lock on this). Instead use the private internal version.</remarks>
+		/// a lock on this). Instead use <see cref="BeginMonitoringIfNeeded()"/>. </remarks>
 		/// ------------------------------------------------------------------------------------
 		public virtual void BeginMonitoring()
 		{
@@ -208,7 +207,8 @@ namespace SIL.Media.Naudio
 		/// and reported via <see cref="ErrorReport.NotifyUserOfProblem(string,object[])"/>.
 		/// </param>
 		/// <remarks> Methods in this class should not call this method (i.e., from inside
-		/// code that has a lock on this). Instead use the private internal version.</remarks>
+		/// code that has a lock on this). Instead use <see cref="BeginMonitoringIfNeeded()"/>.
+		/// </remarks>
 		/// ------------------------------------------------------------------------------------
 		public virtual void BeginMonitoring(bool catchAndReportExceptions)
 		{


### PR DESCRIPTION
For Bloom https://issues.bloomlibrary.org/youtrack/issue/BL-12406/Dont-show-error-Dialog-if-mic-access-is-off
Create a version of BeginMonitoring that doesn't catch the exceptions so that they can be handled by the caller

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1280)
<!-- Reviewable:end -->
