### PR TITLE
Fixed i18n problem: SettingsProtection.LauncherButtonLabel was ID for two different strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [SIL.Core] Make RetryUtility retry for exceptions that are subclasses of the ones listed to try. For example, by default (IOException) it will now retry for FileNotFoundException.
 - [SIL.Windows.Forms] Spelling of `CreativeCommonsLicense.IntergovernmentalOrganizationQualifier`
+- [SIL.Windows.Forms] Fixed internationalization problem: SettingsProtection.LauncherButtonLabel was used as ID for two different strings.
 
 ### Removed
 - [SIL.Windows.Forms] ImageGalleryControl.InSomeoneElesesDesignMode (seemingly unused and misspelled)

--- a/DistFiles/Palaso.en.xlf
+++ b/DistFiles/Palaso.en.xlf
@@ -653,6 +653,10 @@
         <source xml:lang="en">Script and Variant</source>
         <note>ID: ScriptsAndVariantsDialog.ScriptsAndVariants</note>
       </trans-unit>
+      <trans-unit id="SettingsLauncherButton.LauncherButtonLabel">
+        <source xml:lang="en">Settings...</source>
+        <note>ID: SettingsLauncherButton.LauncherButtonLabel</note>
+      </trans-unit>
       <trans-unit id="SettingsProtection.AlsoHideOthersNotice">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
@@ -666,7 +670,7 @@
         <note>ID: SettingsProtection.CtrlShiftHint.MenuItem</note>
       </trans-unit>
       <trans-unit id="SettingsProtection.LauncherButtonLabel">
-        <source xml:lang="en">Settings...</source>
+        <source xml:lang="en">Settings Protection...</source>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>
       <trans-unit id="SettingsProtection.NormallyHiddenCheckbox">

--- a/DistFiles/Palaso.es.xlf
+++ b/DistFiles/Palaso.es.xlf
@@ -947,6 +947,11 @@
         <target xml:lang="es-ES" state="final">Escritura y variante</target>
         <note>ID: ScriptsAndVariantsDialog.ScriptsAndVariants</note>
       </trans-unit>
+      <trans-unit id="SettingsLauncherButton.LauncherButtonLabel">
+        <source xml:lang="en">Settings...</source>
+        <target xml:lang="es-ES" state="final">Configuraciones...</target>
+        <note>ID: SettingsLauncherButton.LauncherButtonLabel</note>
+      </trans-unit>
       <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <target xml:lang="es-ES" state="final">Esto también puede ocultar otros botones que no son necesarios para el usuario no avanzado.</target>
@@ -963,7 +968,7 @@
         <note>ID: SettingsProtection.CtrlShiftHint.MenuItem</note>
       </trans-unit>
       <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
-        <source xml:lang="en">Settings...</source>
+        <source xml:lang="en">Settings Protection...</source>
         <target xml:lang="es-ES" state="final">Protección de configuraciones...</target>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
       </trans-unit>

--- a/DistFiles/Palaso.fr.xlf
+++ b/DistFiles/Palaso.fr.xlf
@@ -933,6 +933,11 @@
         <note>ID: ScriptsAndVariantsDialog.ScriptsAndVariants</note>
         <target xml:lang="fr" state="translated">Écriture et variante</target>
       </trans-unit>
+      <trans-unit id="SettingsLauncherButton.LauncherButtonLabel" approved="yes">
+        <source xml:lang="en">Settings...</source>
+        <note>ID: SettingsLauncherButton.LauncherButtonLabel</note>
+        <target xml:lang="fr" state="final">Paramètres...</target>
+      </trans-unit>
       <trans-unit id="SettingsProtection.AlsoHideOthersNotice" approved="yes">
         <source xml:lang="en">This may also hide other buttons which are not needed by the non-advanced user.</source>
         <note>ID: SettingsProtection.AlsoHideOthersNotice</note>
@@ -949,7 +954,7 @@
         <target xml:lang="fr" state="needs-translation">The menu item will show up when you hold down the Ctrl and Shift keys together.</target>
       </trans-unit>
       <trans-unit id="SettingsProtection.LauncherButtonLabel" approved="yes">
-        <source xml:lang="en">Settings...</source>
+        <source xml:lang="en">Settings Protection...</source>
         <note>ID: SettingsProtection.LauncherButtonLabel</note>
         <target xml:lang="fr" state="final">Protection des paramètres...</target>
       </trans-unit>

--- a/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.Designer.cs
@@ -1,4 +1,4 @@
-﻿using SIL.Windows.Forms.Widgets;
+using SIL.Windows.Forms.Widgets;
 
 namespace SIL.Windows.Forms.SettingProtection
 {
@@ -72,7 +72,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			this.betterLinkLabel1.ForeColor = System.Drawing.Color.Blue;
 			this.l10NSharpExtender1.SetLocalizableToolTip(this.betterLinkLabel1, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this.betterLinkLabel1, null);
-			this.l10NSharpExtender1.SetLocalizingId(this.betterLinkLabel1, "SettingsProtection.LauncherButtonLabel");
+			this.l10NSharpExtender1.SetLocalizingId(this.betterLinkLabel1, "SettingsLauncherButton.LauncherButtonLabel");
 			this.betterLinkLabel1.Location = new System.Drawing.Point(23, 3);
 			this.betterLinkLabel1.Multiline = true;
 			this.betterLinkLabel1.Name = "betterLinkLabel1";
@@ -91,7 +91,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			this.Controls.Add(this._image);
 			this.l10NSharpExtender1.SetLocalizableToolTip(this, null);
 			this.l10NSharpExtender1.SetLocalizationComment(this, null);
-			this.l10NSharpExtender1.SetLocalizingId(this, "SettingsLauncherButton.SettingsLauncherButton");
+			this.l10NSharpExtender1.SetLocalizingId(this, "SettingsLauncherButton");
 			this.Margin = new System.Windows.Forms.Padding(0);
 			this.Name = "SettingsLauncherButton";
 			this.Size = new System.Drawing.Size(194, 22);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1284)
<!-- Reviewable:end -->
