### PR TITLE
Make FileUtils.ReplaceFileWithUserInteractionIfNeeded robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.Core.Desktop] Make FileUtils.ReplaceFileWithUserInteractionIfNeeded robust
+- [SIL.Core] Make RobustFile.ReplaceByCopyDelete truly robust
 - [SIL.Core] Make RetryUtility retry for exceptions that are subclasses of the ones listed to try. For example, by default (IOException) it will now retry for FileNotFoundException.
 - [SIL.Windows.Forms] Spelling of `CreativeCommonsLicense.IntergovernmentalOrganizationQualifier`
 - [SIL.Windows.Forms] Fixed internationalization problem: SettingsProtection.LauncherButtonLabel was used as ID for two different strings.

--- a/SIL.Core.Desktop/IO/FileUtils.cs
+++ b/SIL.Core.Desktop/IO/FileUtils.cs
@@ -139,7 +139,7 @@ namespace SIL.IO
 						||
 						!PathHelper.AreOnSameVolume(sourcePath, destinationPath)
 						||
-						!File.Exists(destinationPath)
+						!RobustFile.Exists(destinationPath)
 						)
 					{
 						//can't use File.Replace or File.Move across volumes (sigh)
@@ -154,7 +154,7 @@ namespace SIL.IO
 							theProblem = null;
 							try
 							{
-								File.Replace(sourcePath, destinationPath, backupPath);
+								RobustFile.Replace(sourcePath, destinationPath, backupPath);
 							}
 							catch (UnauthorizedAccessException uae)
 							{

--- a/SIL.Core/IO/RobustFile.cs
+++ b/SIL.Core/IO/RobustFile.cs
@@ -246,12 +246,12 @@ namespace SIL.IO
 
 		public static void ReplaceByCopyDelete(string sourcePath, string destinationPath, string backupPath)
 		{
-			if (!string.IsNullOrEmpty(backupPath) && File.Exists(destinationPath))
+			if (!string.IsNullOrEmpty(backupPath) && RobustFile.Exists(destinationPath))
 			{
-				File.Copy(destinationPath, backupPath, true);
+				RobustFile.Copy(destinationPath, backupPath, true);
 			}
-			File.Copy(sourcePath, destinationPath, true);
-			File.Delete(sourcePath);
+			RobustFile.Copy(sourcePath, destinationPath, true);
+			RobustFile.Delete(sourcePath);
 		}
 
 		public static void SetAttributes(string path, FileAttributes fileAttributes)


### PR DESCRIPTION
This fixes a robustness hole discovered in Bloom (BL-12669).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1297)
<!-- Reviewable:end -->
