### PR TITLE
Lt 21652

### DIFF
--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataDisplayControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataDisplayControl.cs
@@ -69,7 +69,7 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 					if (licenseImage != null)
 					{
 						pictureBox = new PictureBox();
-						pictureBox.Size = new System.Drawing.Size(124, 40);
+						pictureBox.Size = new System.Drawing.Size(124, 140);
 						pictureBox.SizeMode = PictureBoxSizeMode.Zoom;
 						pictureBox.Image = licenseImage;
 						_table.Controls.Add(pictureBox);
@@ -81,7 +81,7 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 					if (!string.IsNullOrEmpty(metaData.License.Url))
 					{
 						//AddHyperLink(LocalizationManager.GetString("License Info", metaData.License.Url, 1);
-						AddHyperLink("License Info".Localize("MetadataDisplay.LicenseInfo"), metaData.License.Url, 1);
+						AddHyperLink("Hi! License Info".Localize("MetadataDisplay.LicenseInfo"), metaData.License.Url, 1);
 					}
 					else if(pictureBox!=null)
 					{

--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataDisplayControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/MetadataDisplayControl.cs
@@ -97,9 +97,11 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 			using (var g = this.CreateGraphics())
 			{
 				var w = this.Width - 10;
-				// UserControl does not have UseCompatibleTextRendering.
-				var h = TextRenderer.MeasureText(g, label, this.Font, new System.Drawing.Size(w, Int32.MaxValue), TextFormatFlags.WordBreak).Height;
-				var linkLabel = new LinkLabel() {Text = label, Width = this.Width - 10, Height = (int) (h + 5)};
+				var linkLabel = new LinkLabel() { Padding = Padding.Empty, Text = label };
+
+				// Let link label automatically determine its height, capping width at w.
+				linkLabel.MaximumSize = new System.Drawing.Size(w, 0);
+				linkLabel.AutoSize = true;
 
 				linkLabel.Click += new EventHandler((x, y) => SIL.Program.Process.SafeStart(url));
 				_table.Controls.Add(linkLabel);


### PR DESCRIPTION
Fix the hyperlink wrap cutoff in picture properties dialog. First part of issue [LT-21652](https://jira.sil.org/browse/LT-21652).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1298)
<!-- Reviewable:end -->
