### PR TITLE
Prevent editing combobox controls for Script and Variant dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.Windows.Forms.WritingSystem.WSIdentifiers] Changed ComboBox controls in WSIdentifierView and ScriptRegionVariantView to DropDownList style to prevent accidental editing that shouldn't happen
 - [SIL.Windows.Forms.ClearShare] Make Metadata.Write (and a few other methods) more robust
 - [SIL.Core.Desktop] Make FileUtils.ReplaceFileWithUserInteractionIfNeeded robust
 - [SIL.Core] Make RobustFile.ReplaceByCopyDelete truly robust

--- a/SIL.Windows.Forms.WritingSystems/WSIdentifiers/ScriptRegionVariantView.Designer.cs
+++ b/SIL.Windows.Forms.WritingSystems/WSIdentifiers/ScriptRegionVariantView.Designer.cs
@@ -1,4 +1,4 @@
-﻿using SIL.Windows.Forms.Widgets;
+using SIL.Windows.Forms.Widgets;
 
 namespace SIL.Windows.Forms.WritingSystems.WSIdentifiers
 {
@@ -62,6 +62,7 @@ namespace SIL.Windows.Forms.WritingSystems.WSIdentifiers
 			this._scriptCombo.Name = "_scriptCombo";
 			this._scriptCombo.Size = new System.Drawing.Size(161, 21);
 			this._scriptCombo.TabIndex = 6;
+			this._scriptCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._scriptCombo.SelectedIndexChanged += new System.EventHandler(this.ScriptCombo_OnSelectedIndexChanged);
 			// 
 			// _variant
@@ -137,6 +138,7 @@ namespace SIL.Windows.Forms.WritingSystems.WSIdentifiers
 			this._regionCombo.Name = "_regionCombo";
 			this._regionCombo.Size = new System.Drawing.Size(161, 21);
 			this._regionCombo.TabIndex = 9;
+			this._regionCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._regionCombo.SelectedIndexChanged += new System.EventHandler(this.RegionCombo_OnSelectedIndexChanged);
 			// 
 			// _warningLabel

--- a/SIL.Windows.Forms.WritingSystems/WSIdentifiers/WSIdentifierView.cs
+++ b/SIL.Windows.Forms.WritingSystems/WSIdentifiers/WSIdentifierView.cs
@@ -58,6 +58,7 @@ namespace SIL.Windows.Forms.WritingSystems.WSIdentifiers
 			_specialTypeComboBox.DisplayMember = "ChoiceName";
 			_specialTypeComboBox.SelectedIndex = 0;
 			UpdateFromModel();
+			_specialTypeComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
 			_specialTypeComboBox.SelectedIndexChanged += specialTypeComboBox_SelectedIndexChanged;
 			if (_model.IsSpecialComboLocked)
 			{


### PR DESCRIPTION
This fixes a bug reported by Bloom in BL-12373.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1304)
<!-- Reviewable:end -->
