### PR TITLE
Fix typos in SIL.DictionaryServices/Lift/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [SIL.DictionaryServices] Renamed parameter of LiftWriter.WriteHeader from headerConentsNotIncludingHeaderElement to headerContentsNotIncludingHeaderElement
 - [SIL.WritingSystems] Updated langtags.json and ianaSubtagRegistry.txt
 - [SIL.Core] Enhanced ErrorReport.GetOperatingSystemLabel method to report Windows 11+ and list the version as well.
 - [SIL.Core] Enhanced RetryUtility.Retry methods to optionally improve debugging messages, and fixed existing RobustFile and RobustIO methods to use the new optional debugging parameter

--- a/SIL.DictionaryServices/Lift/HtmlArticleMaker.cs
+++ b/SIL.DictionaryServices/Lift/HtmlArticleMaker.cs
@@ -16,7 +16,7 @@ namespace Palaso.DictionaryServices.Lift
 	public class HtmlArticleMaker
 	{
 		private readonly XslCompiledTransform _transformer;
-		private readonly XsltArgumentList _tranformArguments;
+		private readonly XsltArgumentList _transformArguments;
 
 		public HtmlArticleMaker(string pathToWritingSystemPrefs, string pathToPartsOfSpeech)
 		{
@@ -33,11 +33,11 @@ namespace Palaso.DictionaryServices.Lift
 				stream.Close();
 			}
 
-			_tranformArguments = new XsltArgumentList();
-			_tranformArguments.AddParam("writing-system-info-file",
+			_transformArguments = new XsltArgumentList();
+			_transformArguments.AddParam("writing-system-info-file",
 										string.Empty,
 										pathToWritingSystemPrefs);
-			_tranformArguments.AddParam("grammatical-info-optionslist-file",
+			_transformArguments.AddParam("grammatical-info-optionslist-file",
 										string.Empty,
 										pathToPartsOfSpeech);
 		}
@@ -58,7 +58,7 @@ namespace Palaso.DictionaryServices.Lift
 					StringBuilder builder = new StringBuilder();
 					using (XmlWriter writer = XmlWriter.Create(builder)) // Don't forget to use CanonicalXmlSettings CP 2011-01
 					{
-						_transformer.Transform(reader, _tranformArguments, writer);
+						_transformer.Transform(reader, _transformArguments, writer);
 						return builder.ToString();
 					}
 				}

--- a/SIL.DictionaryServices/Lift/LiftWriter.cs
+++ b/SIL.DictionaryServices/Lift/LiftWriter.cs
@@ -77,10 +77,10 @@ namespace SIL.DictionaryServices.Lift
 			// _writer.WriteAttributeString("xmlns", "flex", null, "http://fieldworks.sil.org");
 		}
 
-		public void WriteHeader(string headerConentsNotIncludingHeaderElement)
+		public void WriteHeader(string headerContentsNotIncludingHeaderElement)
 		{
 			Writer.WriteStartElement("header");
-			Writer.WriteRaw(headerConentsNotIncludingHeaderElement);
+			Writer.WriteRaw(headerContentsNotIncludingHeaderElement);
 			Writer.WriteEndElement();
 		}
 
@@ -194,10 +194,10 @@ namespace SIL.DictionaryServices.Lift
 //  ok if no form is given          if (!MultiTextBase.IsEmpty(etymology))
 //            {
 				Writer.WriteStartElement("etymology");
-				//type is required, so add the attribute even if it's emtpy
+				//type is required, so add the attribute even if it's empty
 				Writer.WriteAttributeString("type", etymology.Type.Trim());
 
-				//source is required, so add the attribute even if it's emtpy
+				//source is required, so add the attribute even if it's empty
 				Writer.WriteAttributeString("source", etymology.Source.Trim());
 				AddMultitextGlosses(string.Empty, etymology.Gloss);
 				WriteCustomMultiTextField("comment", etymology.Comment);
@@ -244,7 +244,7 @@ namespace SIL.DictionaryServices.Lift
 		}
 
 		/// <summary>
-		/// in the plift subclass, we add a pronounciation if we have an audio writing system alternative on the lexical unit
+		/// in the plift subclass, we add a pronunciation if we have an audio writing system alternative on the lexical unit
 		/// </summary>
 		 protected virtual void InsertPronunciationIfNeeded(LexEntry entry, List<string> propertiesAlreadyOutput)
 		{
@@ -379,7 +379,7 @@ namespace SIL.DictionaryServices.Lift
 		}
 
 		/// <summary>
-		/// this base implementationg is for when we're just exporting to lift, and dont' want to filter or order.
+		/// this base implementation is for when we're just exporting to lift, and don't want to filter or order.
 		/// It is overridden in a child class for writing presentation-ready lift, when
 		/// we do want to filter and order
 		/// </summary>


### PR DESCRIPTION
Noticed one of these variable misspellings when debugging an issue in The Combine.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1306)
<!-- Reviewable:end -->
