### PR TITLE
Fixed error in BetterGrid.OnCellContentClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Spelling of `CreativeCommonsLicense.IntergovernmentalOrganizationQualifier`
 - [SIL.Windows.Forms] Fixed internationalization problem: SettingsProtection.LauncherButtonLabel was used as ID for two different strings.
 - [SIL.Windows.Forms] Fix 4 img metadata methods that could fail due to cloud or scanning interference
+- [SIL.Windows.Forms] Fixed error in BetterGrid.OnCellContentClick to make it so the delete button works correctly if there is no "new row."
 
 ### Removed
 

--- a/SIL.Windows.Forms/Widgets/BetterGrid/BetterGrid.cs
+++ b/SIL.Windows.Forms/Widgets/BetterGrid/BetterGrid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -600,7 +600,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 				CommitEdit(DataGridViewDataErrorContexts.Commit);
 				EndEdit();
 			}
-			else if (e.RowIndex < NewRowIndex && RemoveRowAction != null && IsRemoveRowColumn(e.ColumnIndex))
+			else if (e.RowIndex < RowCountLessNewRow && RemoveRowAction != null && IsRemoveRowColumn(e.ColumnIndex))
 			{
 				RemoveRowAction(e.RowIndex);
 				if (VirtualMode)


### PR DESCRIPTION
This change should make it so the delete button works correctly if there is no "new row"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1307)
<!-- Reviewable:end -->
