### PR TITLE
Fixed bug in GetLongestUsefulCommonSubstring when string ends with an ORC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [SIL.Core] Fixed bug in extension method GetLongestUsefulCommonSubstring when string ends with an Object replacement character
+
 ## [13.0.0] - 2023-12-07
 
 ### Added

--- a/SIL.Core.Tests/Extensions/StringExtensionTests.cs
+++ b/SIL.Core.Tests/Extensions/StringExtensionTests.cs
@@ -587,6 +587,21 @@ namespace SIL.Tests.Extensions
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
+		/// Test the GetLongestUsefulCommonSubstring method. This test ensures that we don't get
+		/// an index-out-of-range exception.
+		/// </summary>
+		/// ------------------------------------------------------------------------------------
+		[Test]
+		public void GetLongestUsefulCommonSubstring_StringEndsWithORC_NoIndexOutOfRangeError()
+		{
+			var s1 = "Cuándo pelearon el " + kObjReplacementChar + " y " + kObjReplacementChar;
+			var s2 = "Qué hicieron el " + kObjReplacementChar + " y " + kObjReplacementChar;
+			Assert.AreEqual("el", s1.GetLongestUsefulCommonSubstring(s2, out var fWholeWord));
+			Assert.IsTrue(fWholeWord);
+		}
+
+		/// ------------------------------------------------------------------------------------
+		/// <summary>
 		/// Test the GetLongestUsefulCommonSubstring method. This test tests that leading punctuation is
 		/// included in the match.
 		/// </summary>

--- a/SIL.Core/Extensions/StringExtensions.cs
+++ b/SIL.Core/Extensions/StringExtensions.cs
@@ -460,7 +460,7 @@ namespace SIL.Extensions
 				int ichOrc = s1.IndexOf(kszObject, ich, cchMatch, StringComparison.Ordinal);
 				if (ichOrc >= 0)
 				{
-					ich += ichOrc;
+					ich = ichOrc;
 					continue;
 				}
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1309)
<!-- Reviewable:end -->
