### PR TITLE
Fixed backwards logic for LocalizationIncompleteViewModel.ShouldShowDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [SIL.Windows.Forms] Fixed backwards logic for LocalizationIncompleteViewModel.ShouldShowDialog (Technically this is a breaking contractual change, since effectively the behavior is the opposite of the original implementation, but the name so clearly indicates the desired behavior that it seems unlikely any subclass implementation would have implemented the logic according to the previously expected backwards behavior.)
+
 ## [14.0.0] - 2024-04-09
 
 ### Changed

--- a/SIL.Windows.Forms/Extensions/ToolStripExtensions.cs
+++ b/SIL.Windows.Forms/Extensions/ToolStripExtensions.cs
@@ -134,7 +134,7 @@ namespace SIL.Windows.Forms.Extensions
 						return;
 
 					if (localizationIncompleteViewModel != null &&
-					    !localizationIncompleteViewModel.ShouldShowDialog(languageId))
+					    localizationIncompleteViewModel.ShouldShowDialog(languageId))
 					{
 						using (var dlg = new LocalizationIncompleteDlg.LocalizationIncompleteDlg(localizationIncompleteViewModel))
 							if (dlg.ShowDialog(item.GetCurrentParent().FindForm()) == DialogResult.Cancel)

--- a/SIL.Windows.Forms/LocalizationIncompleteDlg/LocalizationIncompleteViewModel.cs
+++ b/SIL.Windows.Forms/LocalizationIncompleteDlg/LocalizationIncompleteViewModel.cs
@@ -56,10 +56,20 @@ namespace SIL.Windows.Forms.LocalizationIncompleteDlg
 			_issueRequestForLocalization = issueRequestForLocalization;
 		}
 
+		/// <summary>
+		/// Gets a value to determine whether the Localization Incomplete dialog box should be
+		/// shown to the user. The default implementation simply checks to see whether the
+		/// requested locale is supported by the primary localization manager, but subclasses
+		/// can override this to provide more nuanced logic.
+		/// </summary>
+		/// <param name="languageId">The IETF language tag to evaluate. Note that if a client
+		/// supports variants of the general code for some purpose but the primary localization
+		/// manager contains only the general code, the client should override this method (and
+		/// call the base implementation, if appropriate, passing in the general code).</param>
 		public virtual bool ShouldShowDialog(string languageId)
 		{
 			RequestedLanguageId = languageId;
-			return PrimaryLocalizationManager != null && PrimaryLocalizationManager
+			return PrimaryLocalizationManager == null || !PrimaryLocalizationManager
 				.GetAvailableUILanguageTags().Contains(RequestedLanguageId);
 		}
 


### PR DESCRIPTION
(Technically this is a breaking contractual change, since effectively the behavior is the opposite of the original implementation, but the name so clearly indicates the desired behavior that it seems unlikely any subclass implementation would have implemented the logic according to the previously expected backwards behavior.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1318)
<!-- Reviewable:end -->
