### PR TITLE
Add a macOS-compatible global lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [SIL.Core] Added macOS support for `GlobalMutex`
+
 ## [14.1.1] - 2024-05-23
 
 ### Fixed


### PR DESCRIPTION
The Linux approach for generating a lock doesn't work on macOS because `/var/lock` doesn't exist on macOS.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1327)
<!-- Reviewable:end -->
