### PR TITLE
Added using to ensure that the XSL stream gets disposed in DoOneMigrationStep

### DIFF
--- a/SIL.Lift/Migration/Migrator.cs
+++ b/SIL.Lift/Migration/Migrator.cs
@@ -56,12 +56,15 @@ namespace SIL.Lift.Migration
 
 		private static void DoOneMigrationStep(string xslName, string migrationSourcePath, string migrationTargetPath)
 		{
-			Stream xslstream = Assembly.GetExecutingAssembly().GetManifestResourceStream(xslName);
-			if (xslstream != null)
+			using (var xslstream =
+			       Assembly.GetExecutingAssembly().GetManifestResourceStream(xslName))
 			{
-				XslCompiledTransform xsl = new XslCompiledTransform();
-				xsl.Load(new XmlTextReader(xslstream));
-				xsl.Transform(migrationSourcePath, migrationTargetPath);
+				if (xslstream != null)
+				{
+					XslCompiledTransform xsl = new XslCompiledTransform();
+					xsl.Load(new XmlTextReader(xslstream));
+					xsl.Transform(migrationSourcePath, migrationTargetPath);
+				}
 			}
 		}
 


### PR DESCRIPTION
Seems to be used only in WorldPad, which isn't even available for download, so I don't know how much we care about this, But it's a public method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1332)
<!-- Reviewable:end -->
