### PR TITLE
fix l10n workflows by using latest dotnet version

### DIFF
--- a/.github/workflows/l10n-packaging.yml
+++ b/.github/workflows/l10n-packaging.yml
@@ -6,7 +6,7 @@ on:
     tags: [ v* ]
   workflow_dispatch:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-package-l10ns
   cancel-in-progress: true
 
@@ -25,9 +25,7 @@ jobs:
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
-      with:
-        dotnet-version: 5.0.x
+      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe (Windows OS)

--- a/.github/workflows/l10n-source.yml
+++ b/.github/workflows/l10n-source.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
   workflow_dispatch:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-update-l10n
   cancel-in-progress: true
 
@@ -23,11 +23,9 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
+      # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
-      with:
-        dotnet-version: 5.0.x
+      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe (Windows OS)


### PR DESCRIPTION
the Update l10n workflow is [broken](https://github.com/sillsdev/libpalaso/actions/runs/10400639520) since #1336 was merged in. This wasn't caught as part of the PR because those workflows don't run.

Now these 2 workflows will always use the latest version of dotnet, this should help us avoid this issue in the future if projects target dotnet 9 etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1339)
<!-- Reviewable:end -->
