### PR TITLE
Updated copyright date. Suppressed generation of package files for test apps

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Company>SIL International</Company>
     <Authors>SIL International</Authors>
     <Product>libpalaso</Product>
-    <Copyright>Copyright © 2010-2023 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2024 SIL International</Copyright>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/SIL.WritingSystems.Tests/Properties/AssemblyInfo.cs
+++ b/SIL.WritingSystems.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-using System.Runtime.InteropServices;
 using SIL.TestUtilities;
 
 [assembly: OfflineSldr]

--- a/SIL.WritingSystems.Tests/WritingSystemOrphanFinderTests.cs
+++ b/SIL.WritingSystems.Tests/WritingSystemOrphanFinderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,15 +21,12 @@ namespace SIL.WritingSystems.Tests
 			{
 				WritingSystemRepository = new TestLdmlInFolderWritingSystemRepository(WritingSystemsPath);
 				_file = _folder.GetNewTempFile(true);
-				File.WriteAllText(_file.Path, String.Format("|{0}||{0}||{1}|", id1, id2));
+				File.WriteAllText(_file.Path, $"|{id1}||{id1}||{id2}|");
 			}
 
-			private string WritingSystemsPath
-			{
-				get { return _folder.Combine("WritingSystems"); }
-			}
+			private string WritingSystemsPath => _folder.Combine("WritingSystems");
 
-			public LdmlInFolderWritingSystemRepository WritingSystemRepository { get; private set; }
+			public LdmlInFolderWritingSystemRepository WritingSystemRepository { get; }
 
 			public void Dispose()
 			{
@@ -56,13 +53,7 @@ namespace SIL.WritingSystems.Tests
 				File.WriteAllText(_file.Path, fileContent);
 			}
 
-			public string FileContent
-			{
-				get
-				{
-					return File.ReadAllText(_file.Path);
-				}
-			}
+			public string FileContent => File.ReadAllText(_file.Path);
 		}
 
 		[Test]

--- a/TestApps/ArchivingTestApp/ArchivingTestApp.csproj
+++ b/TestApps/ArchivingTestApp/ArchivingTestApp.csproj
@@ -4,6 +4,8 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <SignAssembly>false</SignAssembly>
+    <IsPackable>false</IsPackable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>

--- a/TestApps/ClipboardTestApp/ClipboardTestApp.csproj
+++ b/TestApps/ClipboardTestApp/ClipboardTestApp.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <SignAssembly>false</SignAssembly>
+    <IsPackable>false</IsPackable>
     <UseWindowsForms>true</UseWindowsForms>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
ClipboardTestApp and ArchivingTestApp should not be published and therefore don't need to be signed or have nupkg files created.
Also did a little minor (unrelated) refactoring in Writing System tests.