### PR TITLE
Added .NET Standard 2.0 to SIL.Archiving

### DIFF
--- a/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
@@ -99,7 +99,7 @@ namespace SIL.Archiving.Tests
 			var writable = _model.IsPathWritable(dir);
 			Assert.False(writable);
 			Assert.AreEqual(1, m_messages.Count);
-			Assert.AreEqual("Test implementation message for PathNotWritable", m_messages[0].MsgText);
+			Assert.IsTrue(m_messages[0].MsgText.ToLower().Contains("path"), "Error should mention the path in its explanation.");
 			Assert.AreEqual(ArchivingDlgViewModel.MessageType.Warning, m_messages[0].MsgType);
 		}
 
@@ -111,7 +111,7 @@ namespace SIL.Archiving.Tests
 			var writable = _model.IsPathWritable(dir);
 			Assert.False(writable);
 			Assert.AreEqual(1, m_messages.Count);
-			Assert.IsTrue(m_messages[0].MsgText.Contains("path"), "Error should mention the path in its explanation.");
+			Assert.IsTrue(m_messages[0].MsgText.ToLower().Contains("path"), "Error should mention the path in its explanation.");
 			Assert.AreEqual(ArchivingDlgViewModel.MessageType.Warning, m_messages[0].MsgType);
 		}
 
@@ -122,7 +122,7 @@ namespace SIL.Archiving.Tests
 			var writable = _model.IsPathWritable(dir);
 			Assert.False(writable);
 			Assert.AreEqual(1, m_messages.Count);
-			Assert.IsTrue(m_messages[0].MsgText.Contains("path"), "Error should mention the path in its explanation.");
+			Assert.IsTrue(m_messages[0].MsgText.ToLower().Contains("path"), "Error should mention the path in its explanation.");
 			Assert.AreEqual(ArchivingDlgViewModel.MessageType.Warning, m_messages[0].MsgType);
 		}
 

--- a/SIL.Archiving.Tests/SIL.Archiving.Tests.csproj
+++ b/SIL.Archiving.Tests/SIL.Archiving.Tests.csproj
@@ -7,6 +7,7 @@
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SIL.Archiving/SIL.Archiving.csproj
+++ b/SIL.Archiving/SIL.Archiving.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>SIL.Archiving</RootNamespace>
     <AssemblyTitle>SIL.Archiving</AssemblyTitle>
     <Description>SIL.Archiving contains classes for archiving data to REAP and IMDI.</Description>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Test library targets .NET8. I did have to make a few tests which were testing for exact strings a little less specific, since the message varies between frameworks. They are different, since directory checking works differently between frameworks, but the core failure+warning is present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1347)
<!-- Reviewable:end -->
