### PR TITLE
+semver:major Added properties to ArchivingDlgViewModel to facilitate customizing the initial summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Archiving] Added public extensions class LinkLabelExtensions with some methods that were formerly in Extensions class (now in SIL.Archiving).
 - [SIL.Archiving] Added public property isValid to IMDIPackage.
 - [SIL.Archiving] Added public event InitializationFailed to IMDIArchivingDlgViewModel.
+- [SIL.Archiving] Added the following properties to ArchivingDlgViewModel as an alternative way to customize the initial summary displayed: GetOverriddenPreArchivingMessages, InitialFileGroupDisplayMessageType, OverrideGetFileGroupDisplayMessage
 
 ### Changed
 
@@ -71,6 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Archiving] Changed IArchivingSession.Files (and Session.Files) into an IReadonlyList.
 - [SIL.Archiving] Made IMDIPackage.CreateIMDIPackage asynchronous, changing its signature to take a CancellationToken parameter and return Task<bool>.
 - [SIL.Archiving] Made MetaTranscript.WriteCorpusImdiFile asynchronous, changing its signature to return Task<bool>.
+- [SIL.Archiving] Changed the name of the third parameter in ArchivingDlgViewModel.AddFileGroup from progressMessage to addingToArchiveProgressMessage.
 
 ### Fixed
 - [SIL.Archiving] Fixed typo in RampArchivingDlgViewModel for Ethnomusicology performance collection.

--- a/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
@@ -366,21 +366,16 @@ namespace SIL.Archiving.Tests
 				Assert.Fail($"Initialization threw an exception: {ex}");
 			}
 
-			Assert.That(messagesDisplayed.Count, Is.EqualTo(7));
-			Assert.That(messagesDisplayed[0].Item1, Is.EqualTo("First pre-archiving message"));
-			Assert.That(messagesDisplayed[0].Item2, Is.EqualTo(Warning));
-			Assert.That(messagesDisplayed[1].Item1, Is.EqualTo("Second pre-archiving message"));
-			Assert.That(messagesDisplayed[1].Item2, Is.EqualTo(Indented));
-			Assert.That(messagesDisplayed[2].Item1, Is.EqualTo("Frogs"));
-			Assert.That(messagesDisplayed[2].Item2, Is.EqualTo(Success));
-			Assert.That(messagesDisplayed[3].Item1, Is.EqualTo("green.frog"));
-			Assert.That(messagesDisplayed[3].Item2, Is.EqualTo(Bullet));
-			Assert.That(messagesDisplayed[4].Item1, Is.EqualTo("Label: Toads"));
-			Assert.That(messagesDisplayed[4].Item2, Is.EqualTo(Success));
-			Assert.That(messagesDisplayed[5].Item1, Is.EqualTo("red.toad"));
-			Assert.That(messagesDisplayed[5].Item2, Is.EqualTo(Bullet));
-			Assert.That(messagesDisplayed[6].Item1, Is.EqualTo("blue.toad"));
-			Assert.That(messagesDisplayed[6].Item2, Is.EqualTo(Bullet));
+			Assert.That(messagesDisplayed, Is.EqualTo(new[]
+			{
+				("First pre-archiving message", Warning).ToTuple(),
+				("Second pre-archiving message", Indented).ToTuple(),
+				("Frogs", Success).ToTuple(),
+				("green.frog", Bullet).ToTuple(),
+				("Label: Toads", Success).ToTuple(),
+				("red.toad", Bullet).ToTuple(),
+				("blue.toad", Bullet).ToTuple()
+			}));
 			Assert.That(progress.Step, Is.EqualTo(1));
 		}
 	}

--- a/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
@@ -69,7 +69,6 @@ namespace SIL.Archiving.Tests
 		[Test]
 		public void NormalizeFilename_FileName_NormalizedFileName()
 		{
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(NormalizeFilename_FileName_NormalizedFileName)}");
 			const string fileName = "My# \nFile %\t Name&^%.mp3";
 			var normalized = _model.NormalizeFilename("", fileName);
 			Assert.AreEqual("My+File+Name_.mp3", normalized);

--- a/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using NUnit.Framework;
@@ -15,7 +14,7 @@ namespace SIL.Archiving.Tests
 	[TestFixture]
 	[OfflineSldr]
 	[Category("Archiving")]
-	internal class IMDIArchivingDlgViewModelTests
+	public class IMDIArchivingDlgViewModelTests
 	{
 		private class MessageData
 		{
@@ -70,6 +69,7 @@ namespace SIL.Archiving.Tests
 		[Test]
 		public void NormalizeFilename_FileName_NormalizedFileName()
 		{
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(NormalizeFilename_FileName_NormalizedFileName)}");
 			const string fileName = "My# \nFile %\t Name&^%.mp3";
 			var normalized = _model.NormalizeFilename("", fileName);
 			Assert.AreEqual("My+File+Name_.mp3", normalized);
@@ -275,6 +275,8 @@ namespace SIL.Archiving.Tests
 		[Test]
 		public async Task DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted()
 		{
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)}");
+
 			ErrorReport.IsOkToInteractWithUser = false;
 
 			bool filesToArchiveCalled = false;
@@ -320,6 +322,8 @@ namespace SIL.Archiving.Tests
 		[Test]
 		public async Task DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides()
 		{
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)}");
+
 			ErrorReport.IsOkToInteractWithUser = false;
 
 			void SetFilesToArchive(ArchivingDlgViewModel model, CancellationToken cancellationToken)

--- a/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/IMDIArchivingDlgViewModelTests.cs
@@ -274,8 +274,6 @@ namespace SIL.Archiving.Tests
 		[Test]
 		public async Task DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted()
 		{
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)}");
-
 			ErrorReport.IsOkToInteractWithUser = false;
 
 			bool filesToArchiveCalled = false;
@@ -321,8 +319,6 @@ namespace SIL.Archiving.Tests
 		[Test]
 		public async Task DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides()
 		{
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)}");
-
 			ErrorReport.IsOkToInteractWithUser = false;
 
 			void SetFilesToArchive(ArchivingDlgViewModel model, CancellationToken cancellationToken)

--- a/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
@@ -739,6 +739,22 @@ namespace SIL.Archiving.Tests
 		#endregion
 	}
 
+	internal class TestRampArchivingDlgViewModel : RampArchivingDlgViewModel
+	{
+		public TestRampArchivingDlgViewModel(
+			Action<ArchivingDlgViewModel, CancellationToken> setFilesToArchive) :
+			base("Test App", "Test Title", "tst", setFilesToArchive,
+				(k, f) => throw new NotImplementedException())
+		{
+		}
+
+		protected override bool DoArchiveSpecificInitialization()
+		{
+			DisplayMessage("Base implementation overridden", MessageType.Volatile);
+			return true;
+		}
+	}
+
 	[TestFixture]
 	[Category("Archiving")]
 	public class RampArchivingDlgViewModelWithOverrideDisplayInitialSummarySetTests
@@ -751,15 +767,13 @@ namespace SIL.Archiving.Tests
 
 			bool filesToArchiveCalled = false;
 
-			var model = new RampArchivingDlgViewModel("Test App", "Test Title", "tst",
-				(a, b) => { filesToArchiveCalled = true; }, (k, f) => throw new NotImplementedException());
+			var model = new TestRampArchivingDlgViewModel((a, b) => { filesToArchiveCalled = true; });
 
 			var progress = new TestProgress("RAMP");
 			var customSummaryShown = 0;
 
 			model.OverrideDisplayInitialSummary = (d, c) =>
 			{
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)} overriding initial display");
 				customSummaryShown++;
 				progress.IncrementProgress();
 			};
@@ -770,9 +784,7 @@ namespace SIL.Archiving.Tests
 
 			try
 			{
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)} before SUT");
 				await model.Initialize(progress, new CancellationToken()).ConfigureAwait(false);
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)} after SUT");
 			}
 			catch (Exception ex)
 			{
@@ -798,22 +810,17 @@ namespace SIL.Archiving.Tests
 
 			void SetFilesToArchive(ArchivingDlgViewModel model, CancellationToken cancellationToken)
 			{
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} starting to set files to archive");
-
 				model.AddFileGroup(String.Empty, new[] { "green.frog" }, "These messages should not be displayed");
 				model.AddFileGroup("Toads", new[] { "red.toad", "blue.toad" }, "because in this test we do not create a package.");
 
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} done setting files to archive");
 			}
 
-			var model = new RampArchivingDlgViewModel("Test App", "Test Title", "tst",
-				SetFilesToArchive, (k, f) => throw new NotImplementedException());
+			var model = new TestRampArchivingDlgViewModel(SetFilesToArchive);
 
 			var messagesDisplayed = new List<Tuple<string, ArchivingDlgViewModel.MessageType>>();
 
 			void ReportMessage(string msg, ArchivingDlgViewModel.MessageType type)
 			{
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} reporting {msg}");
 				messagesDisplayed.Add(new Tuple<string, ArchivingDlgViewModel.MessageType>(msg, type));
 			}
 
@@ -821,8 +828,6 @@ namespace SIL.Archiving.Tests
 
 			IEnumerable<Tuple<string, ArchivingDlgViewModel.MessageType>> GetMessages(IDictionary<string, Tuple<IEnumerable<string>, string>> arg)
 			{
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} getting pre-archiving messages");
-
 				yield return new Tuple<string, ArchivingDlgViewModel.MessageType>(
 					"First pre-archiving message", Warning);
 				yield return new Tuple<string, ArchivingDlgViewModel.MessageType>(
@@ -836,9 +841,7 @@ namespace SIL.Archiving.Tests
 			var progress = new TestProgress("RAMP");
 			try
 			{
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} before SUT");
 				await model.Initialize(progress, new CancellationToken()).ConfigureAwait(false);
-				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} after SUT");
 			}
 			catch (Exception ex)
 			{
@@ -847,7 +850,7 @@ namespace SIL.Archiving.Tests
 
 			Assert.That(messagesDisplayed, Is.EqualTo(new[]
 			{
-				("Test implementation message for SearchingForArchiveUploadingProgram", ArchivingDlgViewModel.MessageType.Volatile).ToTuple(),
+				("Base implementation overridden", ArchivingDlgViewModel.MessageType.Volatile).ToTuple(),
 				("First pre-archiving message", Warning).ToTuple(),
 				("Second pre-archiving message", Indented).ToTuple(),
 				("Frogs", Success).ToTuple(),

--- a/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
@@ -759,6 +759,7 @@ namespace SIL.Archiving.Tests
 
 			model.OverrideDisplayInitialSummary = (d, c) =>
 			{
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)} overriding initial display");
 				customSummaryShown++;
 				progress.IncrementProgress();
 			};
@@ -769,7 +770,9 @@ namespace SIL.Archiving.Tests
 
 			try
 			{
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)} before SUT");
 				await model.Initialize(progress, new CancellationToken()).ConfigureAwait(false);
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverrideDisplayInitialSummaryIsSet_DefaultBehaviorOmitted)} after SUT");
 			}
 			catch (Exception ex)
 			{
@@ -806,6 +809,7 @@ namespace SIL.Archiving.Tests
 
 			void ReportMessage(string msg, ArchivingDlgViewModel.MessageType type)
 			{
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} reporting {msg}");
 				messagesDisplayed.Add(new Tuple<string, ArchivingDlgViewModel.MessageType>(msg, type));
 			}
 
@@ -813,6 +817,8 @@ namespace SIL.Archiving.Tests
 
 			IEnumerable<Tuple<string, ArchivingDlgViewModel.MessageType>> GetMessages(IDictionary<string, Tuple<IEnumerable<string>, string>> arg)
 			{
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} getting pre-archiving messages");
+
 				yield return new Tuple<string, ArchivingDlgViewModel.MessageType>(
 					"First pre-archiving message", Warning);
 				yield return new Tuple<string, ArchivingDlgViewModel.MessageType>(
@@ -826,7 +832,9 @@ namespace SIL.Archiving.Tests
 			var progress = new TestProgress("RAMP");
 			try
 			{
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} before SUT");
 				await model.Initialize(progress, new CancellationToken()).ConfigureAwait(false);
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} after SUT");
 			}
 			catch (Exception ex)
 			{

--- a/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
@@ -845,22 +845,18 @@ namespace SIL.Archiving.Tests
 				Assert.Fail($"Initialization threw an exception: {ex}");
 			}
 
-			Assert.That(messagesDisplayed.Count, Is.EqualTo(8));
-			Assert.That(messagesDisplayed[0].Item1, Is.EqualTo("Test implementation message for SearchingForArchiveUploadingProgram"));
-			Assert.That(messagesDisplayed[1].Item1, Is.EqualTo("First pre-archiving message"));
-			Assert.That(messagesDisplayed[1].Item2, Is.EqualTo(Warning));
-			Assert.That(messagesDisplayed[2].Item1, Is.EqualTo("Second pre-archiving message"));
-			Assert.That(messagesDisplayed[2].Item2, Is.EqualTo(Indented));
-			Assert.That(messagesDisplayed[3].Item1, Is.EqualTo("Frogs"));
-			Assert.That(messagesDisplayed[3].Item2, Is.EqualTo(Success));
-			Assert.That(messagesDisplayed[4].Item1, Is.EqualTo("green.frog"));
-			Assert.That(messagesDisplayed[4].Item2, Is.EqualTo(Bullet));
-			Assert.That(messagesDisplayed[5].Item1, Is.EqualTo("Label: Toads"));
-			Assert.That(messagesDisplayed[5].Item2, Is.EqualTo(Success));
-			Assert.That(messagesDisplayed[6].Item1, Is.EqualTo("red.toad"));
-			Assert.That(messagesDisplayed[6].Item2, Is.EqualTo(Bullet));
-			Assert.That(messagesDisplayed[7].Item1, Is.EqualTo("blue.toad"));
-			Assert.That(messagesDisplayed[7].Item2, Is.EqualTo(Bullet));
+			Assert.That(messagesDisplayed, Is.EqualTo(new[]
+			{
+				("Test implementation message for SearchingForArchiveUploadingProgram", ArchivingDlgViewModel.MessageType.Volatile).ToTuple(),
+				("First pre-archiving message", Warning).ToTuple(),
+				("Second pre-archiving message", Indented).ToTuple(),
+				("Frogs", Success).ToTuple(),
+				("green.frog", Bullet).ToTuple(),
+				("Label: Toads", Success).ToTuple(),
+				("red.toad", Bullet).ToTuple(),
+				("blue.toad", Bullet).ToTuple()
+			}));
+
 			Assert.False(File.Exists(model.PackagePath));
 			Assert.That(progress.Step, Is.EqualTo(1));
 		}

--- a/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
+++ b/SIL.Archiving.Tests/RampArchivingDlgViewModelTests.cs
@@ -798,8 +798,12 @@ namespace SIL.Archiving.Tests
 
 			void SetFilesToArchive(ArchivingDlgViewModel model, CancellationToken cancellationToken)
 			{
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} starting to set files to archive");
+
 				model.AddFileGroup(String.Empty, new[] { "green.frog" }, "These messages should not be displayed");
 				model.AddFileGroup("Toads", new[] { "red.toad", "blue.toad" }, "because in this test we do not create a package.");
+
+				Console.WriteLine($"RAMP Tests TEMP: {nameof(DisplayInitialSummary_OverridenPropertiesForDisplayInitialSummaryAreSet_MessagesReflectOverrides)} done setting files to archive");
 			}
 
 			var model = new RampArchivingDlgViewModel("Test App", "Test Title", "tst",

--- a/SIL.Archiving/ArchivingDlgViewModel.cs
+++ b/SIL.Archiving/ArchivingDlgViewModel.cs
@@ -284,22 +284,36 @@ namespace SIL.Archiving
 		public async Task<bool> Initialize(IArchivingProgressDisplay progress, CancellationToken cancellationToken)
 		{
 			Progress = progress ?? throw new ArgumentNullException(nameof(progress));
-			
+
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} start");
+
 			if (!DoArchiveSpecificInitialization())
 				return false;
 
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} archive-specific initialization complete");
+
 			await SetFilesToArchive(cancellationToken);
+
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} {nameof(SetFilesToArchive)} complete");
+
 			DisplayInitialSummary(cancellationToken);
+
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} end");
 
 			return true;
 		}
 
 		protected virtual async Task SetFilesToArchive(CancellationToken cancellationToken)
 		{
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(SetFilesToArchive)} start");
+
 			await Task.Run(() =>
 			{
 				_setFilesToArchive(this, cancellationToken);
+				Console.WriteLine($"{ArchiveType} Tests TEMP: calling _setFilesToArchive finished");
 			}, cancellationToken);
+
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(SetFilesToArchive)} end");
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -332,7 +346,7 @@ namespace SIL.Archiving
 		/// ------------------------------------------------------------------------------------
 		private void DisplayInitialSummary(CancellationToken cancellationToken)
 		{
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} start");
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} start");
 
 			if (OverrideDisplayInitialSummary != null)
 			{
@@ -340,12 +354,12 @@ namespace SIL.Archiving
 				return;
 			}
 
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after override");
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after override");
 
 			foreach (var message in AdditionalMessages)
 				DisplayMessage(message.Key + "\n", message.Value);
 
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after additional");
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after additional");
 
 			if (GetOverriddenPreArchivingMessages != null)
 			{
@@ -361,14 +375,14 @@ namespace SIL.Archiving
 						DisplayMessage(msg.Item1, msg.Item2);
 				}
 
-				Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after overridden Pre-Archiving messages");
+				Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after overridden Pre-Archiving messages");
 			}
 			else
 			{
 				ReportProgress(Progress.GetMessage(StringId.PreArchivingStatus),
 					MessageType.Normal, cancellationToken);
 
-				Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after normal Pre-Archiving message");
+				Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after normal Pre-Archiving message");
 			}
 
 			foreach (var kvp in FileLists)
@@ -384,7 +398,7 @@ namespace SIL.Archiving
 					DisplayMessage(Path.GetFileName(file), MessageType.Bullet);
 			}
 
-			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} end");
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} end");
 		}
 
 		protected virtual string FileGroupDisplayMessage(string groupKey)

--- a/SIL.Archiving/ArchivingDlgViewModel.cs
+++ b/SIL.Archiving/ArchivingDlgViewModel.cs
@@ -332,14 +332,20 @@ namespace SIL.Archiving
 		/// ------------------------------------------------------------------------------------
 		private void DisplayInitialSummary(CancellationToken cancellationToken)
 		{
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} start");
+
 			if (OverrideDisplayInitialSummary != null)
 			{
 				OverrideDisplayInitialSummary(FileLists, cancellationToken);
 				return;
 			}
 
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after override");
+
 			foreach (var message in AdditionalMessages)
 				DisplayMessage(message.Key + "\n", message.Value);
+
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after additional");
 
 			if (GetOverriddenPreArchivingMessages != null)
 			{
@@ -354,10 +360,16 @@ namespace SIL.Archiving
 					else
 						DisplayMessage(msg.Item1, msg.Item2);
 				}
+
+				Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after overridden Pre-Archiving messages");
 			}
 			else
-				ReportProgress(Progress.GetMessage(StringId.PreArchivingStatus), MessageType.Normal,
-					cancellationToken);
+			{
+				ReportProgress(Progress.GetMessage(StringId.PreArchivingStatus),
+					MessageType.Normal, cancellationToken);
+
+				Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} after normal Pre-Archiving message");
+			}
 
 			foreach (var kvp in FileLists)
 			{
@@ -371,6 +383,8 @@ namespace SIL.Archiving
 				foreach (var file in kvp.Value.Item1)
 					DisplayMessage(Path.GetFileName(file), MessageType.Bullet);
 			}
+
+			Console.WriteLine($"IMDI Tests TEMP: {nameof(DisplayInitialSummary)} end");
 		}
 
 		protected virtual string FileGroupDisplayMessage(string groupKey)

--- a/SIL.Archiving/ArchivingDlgViewModel.cs
+++ b/SIL.Archiving/ArchivingDlgViewModel.cs
@@ -403,7 +403,7 @@ namespace SIL.Archiving
 
 		protected virtual string FileGroupDisplayMessage(string groupKey)
 		{
-			return OverrideGetFileGroupDisplayMessage == null ? groupKey : OverrideGetFileGroupDisplayMessage(groupKey);
+			return OverrideGetFileGroupDisplayMessage?.Invoke(groupKey) ?? groupKey;
 		}
 		#endregion
 

--- a/SIL.Archiving/ArchivingDlgViewModel.cs
+++ b/SIL.Archiving/ArchivingDlgViewModel.cs
@@ -285,35 +285,23 @@ namespace SIL.Archiving
 		{
 			Progress = progress ?? throw new ArgumentNullException(nameof(progress));
 
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} start");
-
 			if (!DoArchiveSpecificInitialization())
 				return false;
 
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} archive-specific initialization complete");
-
 			await SetFilesToArchive(cancellationToken);
 
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} {nameof(SetFilesToArchive)} complete");
-
 			DisplayInitialSummary(cancellationToken);
-
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(Initialize)} end");
 
 			return true;
 		}
 
 		protected virtual async Task SetFilesToArchive(CancellationToken cancellationToken)
 		{
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(SetFilesToArchive)} start");
-
 			await Task.Run(() =>
 			{
 				_setFilesToArchive(this, cancellationToken);
-				Console.WriteLine($"{ArchiveType} Tests TEMP: calling _setFilesToArchive finished");
 			}, cancellationToken);
 
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(SetFilesToArchive)} end");
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -346,20 +334,14 @@ namespace SIL.Archiving
 		/// ------------------------------------------------------------------------------------
 		private void DisplayInitialSummary(CancellationToken cancellationToken)
 		{
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} start");
-
 			if (OverrideDisplayInitialSummary != null)
 			{
 				OverrideDisplayInitialSummary(FileLists, cancellationToken);
 				return;
 			}
 
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after override");
-
 			foreach (var message in AdditionalMessages)
 				DisplayMessage(message.Key + "\n", message.Value);
-
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after additional");
 
 			if (GetOverriddenPreArchivingMessages != null)
 			{
@@ -374,15 +356,11 @@ namespace SIL.Archiving
 					else
 						DisplayMessage(msg.Item1, msg.Item2);
 				}
-
-				Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after overridden Pre-Archiving messages");
 			}
 			else
 			{
 				ReportProgress(Progress.GetMessage(StringId.PreArchivingStatus),
 					MessageType.Normal, cancellationToken);
-
-				Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} after normal Pre-Archiving message");
 			}
 
 			foreach (var kvp in FileLists)
@@ -397,8 +375,6 @@ namespace SIL.Archiving
 				foreach (var file in kvp.Value.Item1)
 					DisplayMessage(Path.GetFileName(file), MessageType.Bullet);
 			}
-
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {nameof(DisplayInitialSummary)} end");
 		}
 
 		protected virtual string FileGroupDisplayMessage(string groupKey)

--- a/SIL.Archiving/ArchivingDlgViewModel.cs
+++ b/SIL.Archiving/ArchivingDlgViewModel.cs
@@ -343,8 +343,17 @@ namespace SIL.Archiving
 
 			if (GetOverriddenPreArchivingMessages != null)
 			{
+				bool firstMsg = true;
 				foreach (var msg in GetOverriddenPreArchivingMessages(FileLists))
-					ReportProgress(msg.Item1, msg.Item2, cancellationToken);
+				{
+					if (firstMsg)
+					{
+						ReportProgress(msg.Item1, msg.Item2, cancellationToken);
+						firstMsg = false;
+					}
+					else
+						DisplayMessage(msg.Item1, msg.Item2);
+				}
 			}
 			else
 				ReportProgress(Progress.GetMessage(StringId.PreArchivingStatus), MessageType.Normal,

--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -335,7 +335,11 @@ namespace SIL.Archiving
 
 		protected override async Task SetFilesToArchive(CancellationToken cancellationToken)
 		{
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {GetType().Name}.{nameof(SetFilesToArchive)} start");
+
 			await base.SetFilesToArchive(cancellationToken);
+
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {GetType().Name}.{nameof(SetFilesToArchive)} done calling base");
 
 			if (cancellationToken.IsCancellationRequested)
 				throw new OperationCanceledException();
@@ -346,6 +350,7 @@ namespace SIL.Archiving
 					Path.GetFileName(fileList.Value.Item1.First()));
 				_progressMessages[normalizedName] = fileList.Value.Item2;
 			}
+			Console.WriteLine($"{ArchiveType} Tests TEMP: {GetType().Name}.{nameof(SetFilesToArchive)} end");
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/SIL.Archiving/RampArchivingDlgViewModel.cs
+++ b/SIL.Archiving/RampArchivingDlgViewModel.cs
@@ -335,11 +335,7 @@ namespace SIL.Archiving
 
 		protected override async Task SetFilesToArchive(CancellationToken cancellationToken)
 		{
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {GetType().Name}.{nameof(SetFilesToArchive)} start");
-
 			await base.SetFilesToArchive(cancellationToken);
-
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {GetType().Name}.{nameof(SetFilesToArchive)} done calling base");
 
 			if (cancellationToken.IsCancellationRequested)
 				throw new OperationCanceledException();
@@ -350,7 +346,6 @@ namespace SIL.Archiving
 					Path.GetFileName(fileList.Value.Item1.First()));
 				_progressMessages[normalizedName] = fileList.Value.Item2;
 			}
-			Console.WriteLine($"{ArchiveType} Tests TEMP: {GetType().Name}.{nameof(SetFilesToArchive)} end");
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/TestApps/ArchivingTestApp/MainForm.cs
+++ b/TestApps/ArchivingTestApp/MainForm.cs
@@ -32,8 +32,17 @@ namespace ArchivingTestApp
 			var title = GetTitle();
 			var model = new RampArchivingDlgViewModel(kAppName, title,
 				title.ToLatinOnly("~", "_", ""), SetFilesToArchive, GetFileDescription);
+			if (ModifierKeys == Keys.Shift)
+			{
+				model.OverrideGetFileGroupDisplayMessage = s => $"override: {s}";
+				model.GetOverriddenPreArchivingMessages = d =>
+					new[] {new Tuple<string, ArchivingDlgViewModel.MessageType>($"Count: {d.Count}", ArchivingDlgViewModel.MessageType.Error) };
+				model.InitialFileGroupDisplayMessageType =
+					ArchivingDlgViewModel.MessageType.Warning;
+			}
+
 			using (var rampArchiveDlg = new ArchivingDlg(model, LocalizationManager.GetString(
-				"ArchivingTestApp.MainForm.AdditionalArchiveProcessInfo", "This is just a test.")))
+				       "ArchivingTestApp.MainForm.AdditionalArchiveProcessInfo", "This is just a test.")))
 			{
 				rampArchiveDlg.ShowDialog(this);
 			}


### PR DESCRIPTION
Added unit tests and changed test app to illustrate intended usage of the new properties. Improved/added some comments in ArchivingDlgViewModel

Note: I considered removing OverrideDisplayInitialSummary because with this change, I anticipate that it will no longer be needed, but since it is inexpensive to leave in and allows for maximum flexibility, I decided to leave it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1349)
<!-- Reviewable:end -->
