### PR TITLE
make all test projects packable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,8 @@
     <OutputPath>$(MSBuildThisFileDirectory)/output/$(Configuration)</OutputPath>
     <PackageOutputPath>$(MSBuildThisFileDirectory)/output</PackageOutputPath>
     <SignAssembly>true</SignAssembly>
+<!--    required to ensure test projects are marked as packable, otherwise Microsoft.NET.Test.Sdk marks them as not -->
+    <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/palaso.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
by adding `<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />` to our test projects they were marked as `IsPackable` false, which usually makes sense, this reverts that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1356)
<!-- Reviewable:end -->
