### PR TITLE
Add an optional parameter to XmlUtils.WriteNode to preserve specific namespaces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Publish logs on failure
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: binary-logs
         path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
+- [SIL.Core] Added optional parameter, preserveNamespaces, to XmlUtils.WriteNode
 - [SIL.Core] Added optional parameter, includeSystemLibraries, to AcknowledgementsProvider.CollectAcknowledgements
 - [SIL.Windows.Forms] Added ability to select which SIL logo(s) to use in SILAboutBox.
 - [SIL.Windows.Forms] Added public enum Widgets.SilLogoVariant

--- a/SIL.Core.Tests/Xml/XmlUtilsTests.cs
+++ b/SIL.Core.Tests/Xml/XmlUtilsTests.cs
@@ -176,6 +176,62 @@ namespace SIL.Tests.Xml
 			}
 			Assert.That(output.ToString(), Is.EqualTo(expectedOutput));
 		}
+
+		[Test]
+		public void WriteNode_PreserveNamespacesArePreserved()
+		{
+			string input = @"<text><span class='bold' xml:space='preserve'> </span></text>";
+			string expectedOutput =
+				"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n"
+				+ "<root>\r\n"
+				+ "	<text>\r\n"
+				+ "		<span\r\n"
+				+ "			class=\"bold\"\r\n"
+				+ "			xml:space=\"preserve\"> </span>\r\n"
+				+ "	</text>\r\n"
+				+ "</root>";
+			var output = new StringBuilder();
+			var preserveNamespace = new HashSet<string>();
+			preserveNamespace.Add("xml");
+			using (var writer = XmlWriter.Create(output, CanonicalXmlSettings.CreateXmlWriterSettings()))
+			{
+				writer.WriteStartDocument();
+				writer.WriteStartElement("root");
+				XmlUtils.WriteNode(writer, input, new HashSet<string>(), preserveNamespace);
+				writer.WriteEndElement();
+				writer.WriteEndDocument();
+			}
+			Assert.That(output.ToString(), Is.EqualTo(expectedOutput));
+		}
+
+		[Test]
+		public void WriteNode_ProtectsAgainstXmlnsFormatThrashing()
+		{
+			string input = @"<text><span class='bold' xmlns:fw='http://software.sil.org/fieldworks' fw:special='yes' xml:space='preserve'> </span></text>";
+			string expectedOutput =
+				"<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n"
+				+ "<root>\r\n"
+				+ "	<text>\r\n"
+				+ "		<span\r\n"
+				+ "			class=\"bold\"\r\n"
+				+ "			xmlns:fw=\"http://software.sil.org/fieldworks\"\r\n"
+				+ "			fw:special=\"yes\"\r\n"
+				+ "			xml:space=\"preserve\"> </span>\r\n"
+				+ "	</text>\r\n"
+				+ "</root>";
+			var output = new StringBuilder();
+			var preserveNamespace = new HashSet<string>();
+			preserveNamespace.Add("xml");
+			preserveNamespace.Add("xmlns");
+			preserveNamespace.Add("fw");
+			using (var writer = XmlWriter.Create(output, CanonicalXmlSettings.CreateXmlWriterSettings()))
+			{
+				writer.WriteStartDocument();
+				writer.WriteStartElement("root");
+				Assert.Throws<ArgumentException>(()=> XmlUtils.WriteNode(writer, input, new HashSet<string>(), preserveNamespace));
+			}
+		}
+
 		/// <summary>
 		/// This verifies that suppressing pretty-printing of children works for spans nested in spans nested in text.
 		/// </summary>
@@ -191,8 +247,10 @@ namespace SIL.Tests.Xml
 				+ "				class=\"italic\">bit</span>bt</span></text>\r\n"
 				+ "</root>";
 			var output = new StringBuilder();
-			var suppressIndentingChildren = new HashSet<string>();
-			suppressIndentingChildren.Add("text");
+			var suppressIndentingChildren = new HashSet<string>
+			{
+			   "text"
+			};
 			using (var writer = XmlWriter.Create(output, CanonicalXmlSettings.CreateXmlWriterSettings()))
 			{
 				writer.WriteStartDocument();


### PR DESCRIPTION
We need this for FlexBridge to avoid some occasional data mangling during Send/Receive
I left the original behavior intact assuming that it was intentional, if it wasn't we could simply always write out the namespace names.

I also updated one of our gha dependencies in this PR, that is unrelated to the core change. (If someone else decides to merge this please rebase rather than merge to keep the changes separate)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1357)
<!-- Reviewable:end -->
