### PR TITLE
Renamed and reimplemented GetFromRegistryProgramThatOpensFileType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Archiving] Made MetaTranscript.WriteCorpusImdiFile asynchronous, changing its signature to return Task<bool>.
 - [SIL.Archiving] Changed the name of the third parameter in ArchivingDlgViewModel.AddFileGroup from progressMessage to addingToArchiveProgressMessage.
 - [SIL.Windows.Forms.Archiving] Changed Cancel Button to say Close instead in IMDIArchivingDlg.
+- [SIL.Core.Desktop] Renamed GetFromRegistryProgramThatOpensFileType to GetDefaultProgramForFileType.
 
 ### Fixed
 - [SIL.Archiving] Fixed typo in RampArchivingDlgViewModel for Ethnomusicology performance collection.
 - [SIL.Archiving] Changed URLs that used http: to https: in resource EmptyMets.xml.
+- [SIL.Core.Desktop] Implemented GetDefaultProgramForFileType (as trenamed) in a way that works on Windows 11, Mono (probably) and MacOS (untested).
 
 ### Removed
 

--- a/SIL.Archiving/ArchivingPrograms.cs
+++ b/SIL.Archiving/ArchivingPrograms.cs
@@ -31,7 +31,7 @@ namespace SIL.Archiving
 			if (ArchivingDlgViewModel.IsMono)
 				exeFile = FileLocationUtilities.LocateInProgramFiles("ramp", true);
 			else
-				exeFile = FileLocator.GetFromRegistryProgramThatOpensFileType(rampFileExtension) ??
+				exeFile = FileLocator.GetDefaultProgramForFileType(rampFileExtension) ??
 					FileLocationUtilities.LocateInProgramFiles("ramp.exe", true, "ramp");
 
 			// make sure the file exists

--- a/SIL.Core.Desktop.Tests/IO/FileLocatorTests.cs
+++ b/SIL.Core.Desktop.Tests/IO/FileLocatorTests.cs
@@ -30,27 +30,21 @@ namespace SIL.Tests.IO
 		}
 
 		[Test]
-		[Platform(Exclude="Unix")]
-		[Category("KnownMonoIssue")]
-		public void GetFromRegistryProgramThatOpensFileType_SendInvalidType_ReturnsNull()
+		public void GetDefaultProgramForFileType_SendInvalidType_ReturnsNull()
 		{
-			Assert.IsNull(FileLocator.GetFromRegistryProgramThatOpensFileType(".blah"));
+			Assert.IsNull(FileLocator.GetDefaultProgramForFileType(".blah"));
 		}
 
 		[Test]
-		[Platform(Exclude="Unix")]
-		[Category("KnownMonoIssue")]
-		public void GetFromRegistryProgramThatOpensFileType_SendValidType_ReturnsProgramPath()
+		public void GetDefaultProgramForFileType_SendValidType_ReturnsProgramPath()
 		{
-			Assert.IsNotNull(FileLocator.GetFromRegistryProgramThatOpensFileType(".txt"));
+			Assert.IsNotNull(FileLocator.GetDefaultProgramForFileType(".txt"));
 		}
 
 		[Test]
-		[Platform(Exclude="Unix")]
-		[Category("KnownMonoIssue")]
-		public void GetFromRegistryProgramThatOpensFileType_SendExtensionWithoutPeriod_ReturnsProgramPath()
+		public void GetDefaultProgramForFileType_SendExtensionWithoutPeriod_ReturnsProgramPath()
 		{
-			Assert.IsNotNull(FileLocator.GetFromRegistryProgramThatOpensFileType("txt"));
+			Assert.IsNotNull(FileLocator.GetDefaultProgramForFileType("txt"));
 		}
 	}
 }


### PR DESCRIPTION
Renamed GetFromRegistryProgramThatOpensFileType to GetDefaultProgramForFileType and implemented it in a way that works on Windows 11, Mono (probably) and MacOS (untested).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1361)
<!-- Reviewable:end -->
