### PR TITLE
Changed build date in SILAboutBox to be computed using the last write time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - [SIL.TestUtilities] Made FluentAssertXml classes use "Assert.That" so they can work in clients that use NUnit 4.
+- 
+### Fixed
+- [SIL.Windows.Forms] Changed build date in SILAboutBox to be computed using the last write time instead of creation time.
 
 ## [15.0.0] - 2025-01-06
 

--- a/SIL.Windows.Forms/Miscellaneous/SILAboutBox.cs
+++ b/SIL.Windows.Forms/Miscellaneous/SILAboutBox.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, SIL Global
+// Copyright (c) 2016-2025, SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -38,7 +38,7 @@ namespace SIL.Windows.Forms.Miscellaneous
 		/// parts of the version number, i.e. "MajorVersion.MinorVersion.Build",
 		/// <c>true</c> to display the full version number as found in Application.ProductVersion.
 		/// Passing <c>true</c> is useful if you want to display, for example, the git revision of
-		/// the build. Typically this would be set in the AssemblyInformationalVersion.</param>
+		/// the build. Typically, this would be set in the AssemblyInformationalVersion.</param>
 		/// <param name="logoVariant">If specified, allows caller to indicate particular SIL logo
 		/// variant to display. By default, a variant is chosen at random.</param>
 		public SILAboutBox(string pathToAboutBoxHtml, bool useFullVersionNumber = false,
@@ -161,7 +161,9 @@ namespace SIL.Windows.Forms.Miscellaneous
 
 			// Use UTC for calculation of build-on-date so that we get the same date regardless
 			// of timezone setting.
-			return string.Format(LocalizationManager.GetString("AboutDialog.BuiltOnDate", "Built on {0}", "{0} is the date the application was built"), fi.CreationTimeUtc.ToString("dd-MMM-yyyy"));
+			return string.Format(LocalizationManager.GetString("AboutDialog.BuiltOnDate",
+					"Built on {0}", "{0} is the date the application was built"),
+				fi.LastWriteTimeUtc.ToString("dd-MMM-yyyy"));
 		}
 
 		private string GetShortVersionInfo()

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -152,7 +152,7 @@ namespace SIL.Windows.Forms.TestApp
 			{
 				File.WriteAllText(tempfile.Path,
 					@"<html><head><meta charset='UTF-8' /></head><body>" +
-					@"<h3>Copyright 2024 <a href=""http://sil.org"">SIL Global</a></h3>" +
+					@"<h3>Copyright 2025 <a href=""http://sil.org"">SIL Global</a></h3>" +
 					@"<p>Testing the <b>about box</b></p><ul>#DependencyAcknowledgements#</ul></body></html>");
 				var uri = new Uri(tempfile.Path);
 				using (var dlg = new SILAboutBox(uri.AbsoluteUri, useFullVersionNumber))


### PR DESCRIPTION
Probably never matters for production builds, which start clean each time, but using the creation time makes the build date look wrong for local builds where the entry assembly is merely updated by the build and not re-created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1374)
<!-- Reviewable:end -->
