### PR TITLE
+semver:minor Add environment variable to disable `GlobalMutex` across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- [SIL.Core] Add environment variable to disable `GlobalMutex` across processes. Helpful for snap packages in Linux.
+
 ### Changed
 - [SIL.TestUtilities] Made FluentAssertXml classes use "Assert.That" so they can work in clients that use NUnit 4.
 - [SIL.Windows.Forms] Removed protected members from FadingMessageWindow: MsgThread, MsgForm, Text, MsgPoint, and ShowForm. (The underlying implementation needed to be changed, and the existing implementation was such that these members would be unlikely to have been meaningful or helpful in a derived class anyway.)

--- a/SIL.Core.Tests/Threading/GlobalMutexTests.cs
+++ b/SIL.Core.Tests/Threading/GlobalMutexTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+using System;
 using NUnit.Framework;
 using SIL.Threading;
 

--- a/SIL.Core.Tests/Threading/GlobalMutexTests.cs
+++ b/SIL.Core.Tests/Threading/GlobalMutexTests.cs
@@ -93,30 +93,5 @@ namespace SIL.Tests.Threading
 				}
 			}
 		}
-
-		[Test, Timeout(1000)]
-		public void DisposingTheMutexReleasesTheLock()
-		{
-			using (var mutex = new GlobalMutex("test"))
-			{
-				mutex.Initialize();
-				//Explicitly not disposing the release
-				//which Lock returns to ensure that when the mutex is disposed, the lock is released
-				_ = mutex.Lock();
-			}
-
-			var otherThread = new Thread(() =>
-			{
-				using (var mutex = new GlobalMutex("test"))
-				{
-					//Should be able to take the lock again, threading is important here otherwise
-					//if the previous mutex still held the lock,
-					//this would be fine since they were the same thread
-					using (mutex.InitializeAndLock()) { }
-				}
-			});
-			otherThread.Start();
-			otherThread.Join();
-		}
 	}
 }

--- a/SIL.Core.Tests/Threading/GlobalMutexTests.cs
+++ b/SIL.Core.Tests/Threading/GlobalMutexTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using NUnit.Framework;
 using SIL.Threading;
 
@@ -91,6 +92,31 @@ namespace SIL.Tests.Threading
 					using (mutex.Lock()) {}
 				}
 			}
+		}
+
+		[Test, Timeout(1000)]
+		public void DisposingTheMutexReleasesTheLock()
+		{
+			using (var mutex = new GlobalMutex("test"))
+			{
+				mutex.Initialize();
+				//Explicitly not disposing the release
+				//which Lock returns to ensure that when the mutex is disposed, the lock is released
+				_ = mutex.Lock();
+			}
+
+			var otherThread = new Thread(() =>
+			{
+				using (var mutex = new GlobalMutex("test"))
+				{
+					//Should be able to take the lock again, threading is important here otherwise
+					//if the previous mutex still held the lock,
+					//this would be fine since they were the same thread
+					using (mutex.InitializeAndLock()) { }
+				}
+			});
+			otherThread.Start();
+			otherThread.Join();
 		}
 	}
 }

--- a/SIL.Core.Tests/Threading/GlobalMutexTests.cs
+++ b/SIL.Core.Tests/Threading/GlobalMutexTests.cs
@@ -1,11 +1,25 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using SIL.Threading;
 
 namespace SIL.Tests.Threading
 {
-	[TestFixture]
+	[TestFixture(true)]
+	[TestFixture(false)]
 	public class GlobalMutexTests
 	{
+		public GlobalMutexTests(bool localOnly)
+		{
+			if (localOnly)
+			{
+				Environment.SetEnvironmentVariable("SIL_CORE_MAKE_GLOBAL_MUTEX_LOCAL_ONLY", "true");
+			}
+			else
+			{
+				Environment.SetEnvironmentVariable("SIL_CORE_MAKE_GLOBAL_MUTEX_LOCAL_ONLY", null);
+			}
+		}
+
 		[Test]
 		public void Initialize_CreatedNew_ReturnsTrue()
 		{
@@ -54,7 +68,7 @@ namespace SIL.Tests.Threading
 			}
 		}
 
-		[Test]
+		[Test, Timeout(1000)]
 		public void InitializeAndLock_Reentrancy_DoesNotBlock()
 		{
 			using (var mutex = new GlobalMutex("test"))
@@ -66,7 +80,7 @@ namespace SIL.Tests.Threading
 			}
 		}
 
-		[Test]
+		[Test, Timeout(1000)]
 		public void Lock_Reentrancy_DoesNotBlock()
 		{
 			using (var mutex = new GlobalMutex("test"))

--- a/SIL.Core.Tests/Threading/GlobalMutexTests.cs
+++ b/SIL.Core.Tests/Threading/GlobalMutexTests.cs
@@ -118,33 +118,5 @@ namespace SIL.Tests.Threading
 			otherThread.Start();
 			otherThread.Join();
 		}
-
-		//this test might seem contrived, but if it was async, with an await inside the using statement,
-		//then the dispose/release may be executed on a different thread which would cause an exception.
-		//I used threads here to make that explicit
-		//as tasks are not guaranteed to be executed on a different thread
-		[Test]
-		public void TakingTheLockFromOneThreadAndReleasingItFromAnotherThreadShouldNotThrow()
-		{
-			using (var mutex = new GlobalMutex("test"))
-			{
-				var release = mutex.InitializeAndLock();
-				Exception exception = null;
-				var otherThread = new Thread(() =>
-				{
-					try
-					{
-						release.Dispose();
-					}
-					catch (Exception e)
-					{
-						exception = e;
-					}
-				});
-				otherThread.Start();
-				otherThread.Join();
-				Assert.That(exception, Is.Null);
-			}
-		}
 	}
 }

--- a/SIL.Core/Threading/GlobalMutex.cs
+++ b/SIL.Core/Threading/GlobalMutex.cs
@@ -236,7 +236,8 @@ namespace SIL.Threading
 			public void Dispose()
 			{
 				Unlink();
-				if (Monitor.IsEntered(_lock)) Monitor.Exit(_lock);
+				if (Monitor.IsEntered(_lock))
+					throw new AbandonedMutexException($"LocalOnlyMutexAdapter \"{_name}\" was disposed while locked");
 			}
 		}
 

--- a/SIL.Core/Threading/GlobalMutex.cs
+++ b/SIL.Core/Threading/GlobalMutex.cs
@@ -22,7 +22,7 @@ namespace SIL.Threading
 	/// Note that in .NET 8.0 and later (and perhaps starting sooner than version 8), a named mutex can be used across
 	/// processes in Linux and macOS. However, software using the previous method of locking would not recognize the
 	/// new method of locking, so Linux continues to use the old, file-based approach internally.
-	/// 
+	///
 	/// To complicate things further, applications running in confined security contexts (e.g., Snap, Flatpak, Docker,
 	/// etc.) may not be able to establish a global mutex of any kind due to permission limitations. In those cases,
 	/// the "SIL_CORE_MAKE_GLOBAL_MUTEX_LOCAL_ONLY" environment variable can be set to "true" to use a local-only
@@ -236,6 +236,7 @@ namespace SIL.Threading
 			public void Dispose()
 			{
 				Unlink();
+				if (Monitor.IsEntered(_lock)) Monitor.Exit(_lock);
 			}
 		}
 


### PR DESCRIPTION
On Linux, snap package confinement prevents reading and writing from many places in the system. That includes `/var/lock` which is used by GlobalMutex. We need a way to disable GlobalMutex in these situations. This PR provides an environment variable that can be set which makes GlobalMutex no longer global. It sill does some locking, though, in case something within the same process relies on a GlobalMutex for local locking.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1378)
<!-- Reviewable:end -->
