### PR TITLE
Update copyrights to 2025 SIL Global

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SIL International
+# Copyright (c) 2017-2025 SIL Global
 # This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 
 root = true

--- a/AddSortKey/AddSortKey.csproj
+++ b/AddSortKey/AddSortKey.csproj
@@ -10,7 +10,7 @@
     <Company>SIL Global</Company>
     <Authors>SIL Global</Authors>
     <Product>libpalaso</Product>
-    <Copyright>Copyright © 2010-2024 SIL Global</Copyright>
+    <Copyright>Copyright © 2010-2025 SIL Global</Copyright>
     <OutputPath>../output/$(Configuration)</OutputPath>
     <SignAssembly>true</SignAssembly>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net48</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <Company>SIL International</Company>
-    <Authors>SIL International</Authors>
+    <Company>SIL Global</Company>
+    <Authors>SIL Global</Authors>
     <Product>libpalaso</Product>
-    <Copyright>Copyright © 2010-2024 SIL International</Copyright>
+    <Copyright>Copyright © 2010-2025 SIL Global</Copyright>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/ExtractCopyright.Tests/ExtractCopyrightTests.cs
+++ b/ExtractCopyright.Tests/ExtractCopyrightTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 SIL Global
+// Copyright (c) 2017-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -19,7 +19,7 @@ Upstream-Contact: Steve McConnel <stephen_mcconnel@sil.org>
 Source: https://github.com/BloomBooks/BloomDesktop
 
 Files: *
-Copyright: 2015 SIL International
+Copyright: 2025 SIL Global
 License: MIT
 
 License: MIT

--- a/ExtractCopyright/CopyrightFile.cs
+++ b/ExtractCopyright/CopyrightFile.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/ExtractCopyright/DebianControl.cs
+++ b/ExtractCopyright/DebianControl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/ExtractCopyright/DebianField.cs
+++ b/ExtractCopyright/DebianField.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/ExtractCopyright/DebianParagraph.cs
+++ b/ExtractCopyright/DebianParagraph.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 

--- a/ExtractCopyright/ExtractCopyright.csproj
+++ b/ExtractCopyright/ExtractCopyright.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
     <Authors>SIL Global</Authors>
     <Company>SIL Global</Company>
-    <Copyright>Copyright © 2010-2024 SIL Global</Copyright>
+    <Copyright>Copyright © 2010-2025 SIL Global</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ExtractCopyright/Program.cs
+++ b/ExtractCopyright/Program.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 SIL Global
+// Copyright (c) 2017-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2007-2014 SIL International
+Copyright (c) 2007-2025 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SIL.Archiving.Tests/ArchivingFileSystemTests.cs
+++ b/SIL.Archiving.Tests/ArchivingFileSystemTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Archiving/Generic/ArchivingFileSystem.cs
+++ b/SIL.Archiving/Generic/ArchivingFileSystem.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -13,7 +13,7 @@ namespace SIL.Archiving.Generic
 		internal const string kAccessProtocolFolderName = "Archiving";
 		private const string MacFolderRoot = "/Users/Shared";
 		internal const string LinuxFolderRoot = "/var/lib";
-  
+
 		/// <summary />
 		public static string SilCommonDataFolder
 		{

--- a/SIL.Archiving/Properties/AssemblyInfo.cs
+++ b/SIL.Archiving/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 SIL Global
+// Copyright (c) 2016-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Desktop.Tests/IO/DirectoryUtilitiesTests.cs
+++ b/SIL.Core.Desktop.Tests/IO/DirectoryUtilitiesTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.IO;

--- a/SIL.Core.Desktop.Tests/IO/FileLocatorTests.cs
+++ b/SIL.Core.Desktop.Tests/IO/FileLocatorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.Core.Desktop.Tests/SetupFixture.cs
+++ b/SIL.Core.Desktop.Tests/SetupFixture.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.Core.Desktop.Tests/UsbDrive/UsbDeviceInfoTests.cs
+++ b/SIL.Core.Desktop.Tests/UsbDrive/UsbDeviceInfoTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Desktop/IO/DirectoryUtilities.cs
+++ b/SIL.Core.Desktop/IO/DirectoryUtilities.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 SIL Global
+// Copyright (c) 2017-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Desktop/IO/FileLocator.cs
+++ b/SIL.Core.Desktop/IO/FileLocator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Desktop/UsbDrive/Linux/UDisks.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UDisks.cs
@@ -1,5 +1,5 @@
 #if !NETSTANDARD
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks2.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks2.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 #if !NETSTANDARD
 using System;

--- a/SIL.Core.Desktop/UsbDrive/UsbDriveInfo.cs
+++ b/SIL.Core.Desktop/UsbDrive/UsbDriveInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Tests/Acknowledgements/AcknowledgementAttributeTests.cs
+++ b/SIL.Core.Tests/Acknowledgements/AcknowledgementAttributeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.IO;

--- a/SIL.Core.Tests/Acknowledgements/AcknowledgementsProviderTests.cs
+++ b/SIL.Core.Tests/Acknowledgements/AcknowledgementsProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Core.Tests/Email/LinuxEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/LinuxEmailProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 using System.Text;

--- a/SIL.Core.Tests/Email/MAPIHelperTests.cs
+++ b/SIL.Core.Tests/Email/MAPIHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.Core.Tests/Email/MacOsXEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/MacOsXEmailProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Tests/Email/MailToEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/MailToEmailProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 using System.Text;

--- a/SIL.Core.Tests/Email/ThunderbirdEmailProviderTests.cs
+++ b/SIL.Core.Tests/Email/ThunderbirdEmailProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Core.Tests/Extensions/ProcessExtensionsTests.cs
+++ b/SIL.Core.Tests/Extensions/ProcessExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Diagnostics;

--- a/SIL.Core.Tests/IO/DirectoryHelperTests.cs
+++ b/SIL.Core.Tests/IO/DirectoryHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -308,7 +308,7 @@ namespace SIL.Tests.IO
 		[Platform(Exclude = "Win", Reason="Don't know how to test this on Windows")]
 		public void Move_MoveDirToDifferentVolume()
 		{
-			// On Linux, /tmp is typicall a ram disk and therefore a different partition from
+			// On Linux, /tmp is typically a ram disk and therefore a different partition from
 			// /var/tmp which is supposed to persist across reboots.
 			// On Mac, /tmp isn't usually a ram disk. However, it's possible to create and mount
 			// loop filesystems (disk images) without root privileges. So it would be possible
@@ -333,7 +333,7 @@ namespace SIL.Tests.IO
 		[Platform(Exclude = "Win", Reason="Don't know how to test this on Windows")]
 		public void Move_MoveFileToDifferentVolume()
 		{
-			// On Linux, /tmp is typicall a ram disk and therefore a different partition from
+			// On Linux, /tmp is typically a ram disk and therefore a different partition from
 			// /var/tmp which is supposed to persist across reboots.
 			// On Mac, /tmp isn't usually a ram disk. However, it's possible to create and mount
 			// loop filesystems (disk images) without root privileges. So it would be possible

--- a/SIL.Core.Tests/IO/FileHelperTests.cs
+++ b/SIL.Core.Tests/IO/FileHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.IO;

--- a/SIL.Core.Tests/IO/FileTestEnvironment.cs
+++ b/SIL.Core.Tests/IO/FileTestEnvironment.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Tests/IO/PathHelperTests.cs
+++ b/SIL.Core.Tests/IO/PathHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.Core.Tests/IO/PathUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/PathUtilitiesTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 SIL Global
+// Copyright (c) 2014-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Tests/IO/RobustFileTests.cs
+++ b/SIL.Core.Tests/IO/RobustFileTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
+++ b/SIL.Core.Tests/PlatformUtilities/PlatformTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core.Tests/Reporting/ErrorReportTests.cs
+++ b/SIL.Core.Tests/Reporting/ErrorReportTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using NUnit.Framework;

--- a/SIL.Core.Tests/Reporting/ExceptionHandlerTests.cs
+++ b/SIL.Core.Tests/Reporting/ExceptionHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using NUnit.Framework;
@@ -75,7 +75,7 @@ namespace SIL.Tests
 		{
 			Assert.That(ExceptionHandler.TypeOfExistingHandler, Is.Null);
 		}
-		
+
 		[Test]
 		public void TypeOfExistingHandler_Initialized_ReturnsTypeOfHandler()
 		{

--- a/SIL.Core/Acknowledgements/AcknowledgementAttribute.cs
+++ b/SIL.Core/Acknowledgements/AcknowledgementAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
+++ b/SIL.Core/Acknowledgements/AcknowledgementsProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Annotations/Annotatable.cs
+++ b/SIL.Core/Annotations/Annotatable.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2024 SIL Global
+// Copyright (c) 2007-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Annotations/Annotation.cs
+++ b/SIL.Core/Annotations/Annotation.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2024 SIL Global
+// Copyright (c) 2007-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/CommandLineProcessing/CommandLineRunner.cs
+++ b/SIL.Core/CommandLineProcessing/CommandLineRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Email/EmailProviderFactory.cs
+++ b/SIL.Core/Email/EmailProviderFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2008-2024 SIL Global
+// Copyright (c) 2008-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/SIL.Core/Email/LinuxEmailProvider.cs
+++ b/SIL.Core/Email/LinuxEmailProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Core/Email/MacOsXEmailProvider.cs
+++ b/SIL.Core/Email/MacOsXEmailProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Core/Email/MailToEmailProvider.cs
+++ b/SIL.Core/Email/MailToEmailProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Core/Email/ThunderbirdEmailProvider.cs
+++ b/SIL.Core/Email/ThunderbirdEmailProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 using System.Text;

--- a/SIL.Core/Extensions/ProcessExtensions.cs
+++ b/SIL.Core/Extensions/ProcessExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024 SIL Global
+// Copyright (c) 2014-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Extensions/XAttributeExtensions.cs
+++ b/SIL.Core/Extensions/XAttributeExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Globalization;
 using System.IO;
@@ -25,7 +25,7 @@ namespace SIL.Extensions
 		// ends up as
 		// {http://www.w3.org/2000/xmlns/}flex="http://fieldworks.sil.org"
 		// This extension method works around this problem by copying some code from
-		// the referencesource implementation.
+		// the reference source implementation.
 		public static string ToStringMonoWorkaround(this XAttribute attr)
 		{
 			using (var sw = new StringWriter(CultureInfo.InvariantCulture)) {

--- a/SIL.Core/IO/DirectoryHelper.cs
+++ b/SIL.Core/IO/DirectoryHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Core/IO/FileHelper.cs
+++ b/SIL.Core/IO/FileHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.IO;

--- a/SIL.Core/IO/FileModeOverride.cs
+++ b/SIL.Core/IO/FileModeOverride.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using JetBrains.Annotations;

--- a/SIL.Core/IO/PathHelper.cs
+++ b/SIL.Core/IO/PathHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/IO/PathUtilities.cs
+++ b/SIL.Core/IO/PathUtilities.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -332,7 +332,7 @@ namespace SIL.IO
 		public static void OpenDirectoryInExplorer(string directory)
 		{
 			//Enhance: on Windows, use ShellExecuteExW instead, as it will probably be able to
-			//handle languages with combining characters (diactrics), whereas this explorer
+			//handle languages with combining characters (diacritics), whereas this explorer
 			//approach will fail (at least as of windows 8.1)
 
 			var fileManager = DefaultFileManager;

--- a/SIL.Core/IO/RobustFile.cs
+++ b/SIL.Core/IO/RobustFile.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/IO/RobustIO.cs
+++ b/SIL.Core/IO/RobustIO.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/IO/TempFile.cs
+++ b/SIL.Core/IO/TempFile.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -11,10 +11,10 @@ namespace SIL.IO
 {
 	/// <summary>
 	/// This is useful a temporary file is needed. When it is disposed, it will delete the file.
-	/// 
-	/// Sometimes it is useful to make a temp file and NOT have the TempFile class delete it. 
-	/// In such cases, simply do not Dispose() the TempFile. To make this possible and reliable, 
-	/// this class deliberately does NOT implement a destructor or do anything to ensure 
+	///
+	/// Sometimes it is useful to make a temp file and NOT have the TempFile class delete it.
+	/// In such cases, simply do not Dispose() the TempFile. To make this possible and reliable,
+	/// this class deliberately does NOT implement a destructor or do anything to ensure
 	/// the file is deleted if the TempFile is not disposed. Please don't change this.
 	/// </summary>
 	/// <example>using(f = new TempFile())</example>

--- a/SIL.Core/Keyboarding/IInputLanguage.cs
+++ b/SIL.Core/Keyboarding/IInputLanguage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/PlatformUtilities/Platform.cs
+++ b/SIL.Core/PlatformUtilities/Platform.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 // Parts based on code by MJ Hutchinson http://mjhutchinson.com/journal/2010/01/25/integrating_gtk_application_mac
 // Parts based on code by bugsnag-dotnet (https://github.com/bugsnag/bugsnag-dotnet/blob/v1.4/src/Bugsnag/Diagnostics.cs)

--- a/SIL.Core/Program/Process.cs
+++ b/SIL.Core/Program/Process.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 //
 using System;

--- a/SIL.Core/Progress/ConsoleProgress.cs
+++ b/SIL.Core/Progress/ConsoleProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/FileLogProgress.cs
+++ b/SIL.Core/Progress/FileLogProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/GenericProgress.cs
+++ b/SIL.Core/Progress/GenericProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/IProgress.cs
+++ b/SIL.Core/Progress/IProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/MultiPhaseProgressIndicator.cs
+++ b/SIL.Core/Progress/MultiPhaseProgressIndicator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024 SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Threading;

--- a/SIL.Core/Progress/MultiProgress.cs
+++ b/SIL.Core/Progress/MultiProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/NullProgress.cs
+++ b/SIL.Core/Progress/NullProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/NullProgressIndicator.cs
+++ b/SIL.Core/Progress/NullProgressIndicator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Threading;

--- a/SIL.Core/Progress/ProgressIndicatorForMultiProgress.cs
+++ b/SIL.Core/Progress/ProgressIndicatorForMultiProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/StatusProgress.cs
+++ b/SIL.Core/Progress/StatusProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Progress/StringBuilderProgress.cs
+++ b/SIL.Core/Progress/StringBuilderProgress.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Properties/AssemblyInfo.cs
+++ b/SIL.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024 SIL Global
+// Copyright (c) 2016-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Core/Providers/BaseProvider.cs
+++ b/SIL.Core/Providers/BaseProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 

--- a/SIL.Core/Providers/DateTimeProvider.cs
+++ b/SIL.Core/Providers/DateTimeProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 

--- a/SIL.Core/Providers/GuidProvider.cs
+++ b/SIL.Core/Providers/GuidProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 

--- a/SIL.Core/Reporting/ExceptionHelper.cs
+++ b/SIL.Core/Reporting/ExceptionHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2002-2024 SIL Global
+// Copyright (c) 2002-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections;
@@ -135,7 +135,7 @@ namespace SIL.Reporting
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets the hiearchical exception info.
+		/// Gets the hierarchical exception info.
 		/// </summary>
 		/// <param name="error">The error.</param>
 		/// <param name="innerMostException">The inner most exception or null if the error is

--- a/SIL.DblBundle.Tests/DBLMetadataTests.cs
+++ b/SIL.DblBundle.Tests/DBLMetadataTests.cs
@@ -28,7 +28,7 @@ namespace SIL.DblBundle.Tests
 		<iso>ach</iso>
 	</language>
 	<copyright>
-		<statement contentType=""xhtml"">© 2015, SIL Inc. All rights reserved.</statement>
+		<statement contentType=""xhtml"">© 2025 SIL Global. All rights reserved.</statement>
 	</copyright>
 	<promotion>
 		<promoVersionInfo contentType=""xhtml"">
@@ -84,7 +84,7 @@ namespace SIL.DblBundle.Tests
 		[Test]
 		public void GetCopyrightStatement()
 		{
-			const string expectedValue = @"© 2015, SIL Inc. All rights reserved.";
+			const string expectedValue = @"© 2025 SIL Global. All rights reserved.";
 			Assert.AreEqual(expectedValue, m_metadata.Copyright.Statement.Xhtml);
 			Assert.AreEqual("xhtml", m_metadata.Copyright.Statement.ContentType);
 		}
@@ -192,7 +192,7 @@ namespace SIL.DblBundle.Tests
 				},
 				Copyright = new DblMetadataCopyright
 				{
-					Statement = new DblMetadataXhtmlContentNode { Xhtml = @"© 2015, SIL Inc. All rights reserved." }
+					Statement = new DblMetadataXhtmlContentNode { Xhtml = @"© 2025 SIL Global. All rights reserved." }
 				},
 				Promotion = new DblMetadataPromotion
 				{
@@ -210,7 +210,7 @@ namespace SIL.DblBundle.Tests
 		<systemId type=""type"">Idvalue</systemId>
 	</identification>
 	<copyright>
-		<statement contentType=""xhtml"">© 2015, SIL Inc. All rights reserved.</statement>
+		<statement contentType=""xhtml"">© 2025 SIL Global. All rights reserved.</statement>
 	</copyright>
 	<promotion>
 		<promoVersionInfo contentType=""xhtml"">

--- a/SIL.DictionaryServices/Model/IExtensible.cs
+++ b/SIL.DictionaryServices/Model/IExtensible.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.DictionaryServices/Model/LexField.cs
+++ b/SIL.DictionaryServices/Model/LexField.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 using System.Linq;

--- a/SIL.DictionaryServices/Model/LexTrait.cs
+++ b/SIL.DictionaryServices/Model/LexTrait.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2010-2024 SIL Global
+// Copyright (c) 2010-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Lift/EmbeddedXmlCollection.cs
+++ b/SIL.Lift/EmbeddedXmlCollection.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Lift/IPalasoDataObjectProperty.cs
+++ b/SIL.Lift/IPalasoDataObjectProperty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Lift/IReceivePropertyChangeNotifications.cs
+++ b/SIL.Lift/IReceivePropertyChangeNotifications.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace SIL.Lift

--- a/SIL.Lift/IReferenceContainer.cs
+++ b/SIL.Lift/IReferenceContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace SIL.Lift

--- a/SIL.Lift/IReportEmptiness.cs
+++ b/SIL.Lift/IReportEmptiness.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using JetBrains.Annotations;
 

--- a/SIL.Lift/ListEventHelper.cs
+++ b/SIL.Lift/ListEventHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2024 SIL Global
+// Copyright (c) 2009-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.ComponentModel;

--- a/SIL.Media/AlsaAudio/AudioAlsaSession.cs
+++ b/SIL.Media/AlsaAudio/AudioAlsaSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Media/AlsaAudio/AudioRecorder.cs
+++ b/SIL.Media/AlsaAudio/AudioRecorder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 SIL Global
+// Copyright (c) 2017-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;
@@ -40,7 +40,7 @@ namespace SIL.Media.AlsaAudio
 			_maxMinutes = maxMinutes;	// ignored -- not sure what to do with this.
 			RecordingFormat = new WaveFormat(44100, 1);
 			SelectedDevice = RecordingDevice.DefaultDevice;
-			MicrophoneLevel = -1;	//unknown level.
+			MicrophoneLevel = -1;	// unknown level.
 		}
 
 		protected virtual void Dispose(bool disposing)

--- a/SIL.Media/AlsaAudio/RecordingDevice.cs
+++ b/SIL.Media/AlsaAudio/RecordingDevice.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Media/IAudioRecorder.cs
+++ b/SIL.Media/IAudioRecorder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 SIL Global
+// Copyright (c) 2017-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;
@@ -31,7 +31,7 @@ namespace SIL.Media
 		void Stop();
 		IRecordingDevice SelectedDevice { get; set; }
 		event EventHandler SelectedDeviceChanged;
-		[PublicAPI]		
+		[PublicAPI]
 		double MicrophoneLevel { get; set; }
 		RecordingState RecordingState { get; }
 		/// <summary>Fired when the transition from recording to monitoring is complete</summary>

--- a/SIL.Media/IRecordingDevice.cs
+++ b/SIL.Media/IRecordingDevice.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using JetBrains.Annotations;
 using NAudio.Wave;

--- a/SIL.Media/ShortSoundFieldControl.cs
+++ b/SIL.Media/ShortSoundFieldControl.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Media/WindowsAudioSession.cs
+++ b/SIL.Media/WindowsAudioSession.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2024 SIL Global
+// Copyright (c) 2015-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Scripture.Tests/BCVRefTests.cs
+++ b/SIL.Scripture.Tests/BCVRefTests.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Scripture.Tests/BCVRefTests.cs
+++ b/SIL.Scripture.Tests/BCVRefTests.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class originated in FieldWorks (under the GNU Lesser General Public License), but we
 // decided to move the class it tests into SIL.Scripture to make it more readily available to
 // other projects.

--- a/SIL.Scripture.Tests/MultilingScrBooksTests.cs
+++ b/SIL.Scripture.Tests/MultilingScrBooksTests.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2002' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: MultilingScrBooksTest.cs
 // --------------------------------------------------------------------------------------------
 using System;
@@ -50,7 +50,7 @@ namespace SIL.Scripture.Tests
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Test the <see cref="MultilingScrBooks.GetBookAbbrev"/> method. Test with 
+		/// Test the <see cref="MultilingScrBooks.GetBookAbbrev"/> method. Test with
 		/// non-existing encoding.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -67,7 +67,7 @@ namespace SIL.Scripture.Tests
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[Test]
@@ -79,7 +79,7 @@ namespace SIL.Scripture.Tests
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[TestCase("jud", ExpectedResult = 65001001)]
@@ -193,7 +193,7 @@ namespace SIL.Scripture.Tests
 		[TestCase("LUK 5३15", ExpectedResult = 42001001)]
 		// ३,५ are Devanagari digits 3,4, which are not supported as chapter/verse identifiers
 		[TestCase("LUK ३:५", ExpectedResult = 42001001)]
-		
+
 		[TestCase("Luk 5,15", ExpectedResult = 42005015)]
 		[TestCase("luk 5.15", ExpectedResult = 42005015)]
 		[TestCase("LUK5:15", ExpectedResult = 42005015)]

--- a/SIL.Scripture.Tests/MultilingScrBooksTests.cs
+++ b/SIL.Scripture.Tests/MultilingScrBooksTests.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2002' to='2024' company='SIL Global'>
+// <copyright from='2002' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Scripture.Tests/TestScrVers.cs
+++ b/SIL.Scripture.Tests/TestScrVers.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2013' to='2024' company='SIL Global'>
+// <copyright from='2013' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Scripture.Tests/TestScrVers.cs
+++ b/SIL.Scripture.Tests/TestScrVers.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2013' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//	
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: TestScrVers.cs
 // --------------------------------------------------------------------------------------------
 using Moq;

--- a/SIL.Scripture/BCVRef.cs
+++ b/SIL.Scripture/BCVRef.cs
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2005' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.   
-//	
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class originated in FieldWorks (under the GNU Lesser General Public License), but we
 // decided to make it available in SIL.Scripture to make it more readily available to other
 // projects.
@@ -342,7 +342,7 @@ namespace SIL.Scripture
 			return BBCCCVVV;
 		}
 		#endregion
-		
+
 		#region Properties
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -697,7 +697,7 @@ namespace SIL.Scripture
 			return MakeReferenceString(bookName, startRef, endRef, chapterVerseSeparator,
 				verseBridge, true);
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Handy little utility function for making a Reference string. When the end reference
@@ -807,13 +807,13 @@ namespace SIL.Scripture
 
 				return bookName + " " + sref;
 			}
-			
+
 			if (startRef.Verse != endRef.Verse)
 			{
 				return bookName + " " + startRef.Chapter + chapterVerseSeparator +
 					startRef.Verse + verseBridge + endRef.Verse;
 			}
-			
+
 			if (startRef.Verse != 0)
 			{
 				return bookName + " " + startRef.Chapter + chapterVerseSeparator +
@@ -842,7 +842,7 @@ namespace SIL.Scripture
 		{
 			if (literal == String.Empty)
 				return String.Empty;
-		
+
 			return " " + (literal ?? chapter.ToString());
 		}
 
@@ -916,7 +916,7 @@ namespace SIL.Scripture
 				m_chapter = m_verse = 1;
 				return;
 			}
-			
+
 			m_chapter = 0;
 			m_verse = -1;
 
@@ -1024,7 +1024,7 @@ namespace SIL.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// A version of VerseToInt that returns the starting verse value. 
+		/// A version of VerseToInt that returns the starting verse value.
 		/// </summary>
 		/// <param name="sourceString"></param>
 		/// <returns>the starting verse value</returns>
@@ -1038,7 +1038,7 @@ namespace SIL.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// A version of VerseToInt that returns the ending verse value. 
+		/// A version of VerseToInt that returns the ending verse value.
 		/// </summary>
 		/// <param name="sourceString"></param>
 		/// <returns>the ending verse value</returns>
@@ -1215,9 +1215,9 @@ namespace SIL.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Extract the verse numbers from a verse string. Determine verse number begin and end 
+		/// Extract the verse numbers from a verse string. Determine verse number begin and end
 		/// values as well as verse segment values. Ignore any unusual syntax.
-		/// Limitations: This class does not have access to the FDO Scripture bridge character 
+		/// Limitations: This class does not have access to the FDO Scripture bridge character
 		/// or to a character property engine with PUA character information.
 		/// </summary>
 		/// <param name="sourceString">string from which to attempt extracting verse numbers
@@ -1509,12 +1509,12 @@ namespace SIL.Scripture
 		/// </summary>
 		/// <param name="obj">An object to compare with this instance.</param>
 		/// <returns>
-		/// A 32-bit signed integer that indicates the relative order of the objects being 
-		/// compared. The return value has these meanings: 
-		/// 
-		/// Value				Meaning 
-		/// Less than zero		This instance is less than <paramref name="obj"/>. 
-		/// Zero				This instance is equal to <paramref name="obj"/>. 
+		/// A 32-bit signed integer that indicates the relative order of the objects being
+		/// compared. The return value has these meanings:
+		///
+		/// Value				Meaning
+		/// Less than zero		This instance is less than <paramref name="obj"/>.
+		/// Zero				This instance is equal to <paramref name="obj"/>.
 		/// Greater than zero	This instance is greater than <paramref name="obj"/>.
 		/// </returns>
 		/// <exception cref="T:System.ArgumentException">

--- a/SIL.Scripture/BCVRef.cs
+++ b/SIL.Scripture/BCVRef.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2005' to='2024' company='SIL Global'>
+// <copyright from='2005' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Scripture/BookLabel.cs
+++ b/SIL.Scripture/BookLabel.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2008' to='2024' company='SIL Global'>
+// <copyright from='2008' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Scripture/BookLabel.cs
+++ b/SIL.Scripture/BookLabel.cs
@@ -1,10 +1,10 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2008' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global.
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
 // --------------------------------------------------------------------------------------------
 namespace SIL.Scripture
@@ -49,4 +49,4 @@ namespace SIL.Scripture
 		}
 	}
 	#endregion
-} 
+}

--- a/SIL.Scripture/IScrVers.cs
+++ b/SIL.Scripture/IScrVers.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 20124 SIL Global.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2008' to='2014' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//	
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: IScrVers.cs
 // --------------------------------------------------------------------------------------------
 using JetBrains.Annotations;

--- a/SIL.Scripture/MultilingScrBooks.cs
+++ b/SIL.Scripture/MultilingScrBooks.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2008' to='2024' company='SIL Global'>
+// <copyright from='2008' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Scripture/MultilingScrBooks.cs
+++ b/SIL.Scripture/MultilingScrBooks.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2008' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: MultilingScrBooks.cs
 // --------------------------------------------------------------------------------------------
 using System;
@@ -51,7 +51,7 @@ namespace SIL.Scripture
 
 			/// --------------------------------------------------------------------------------
 			/// <summary>
-			/// 
+			///
 			/// </summary>
 			/// <param name="nBookNum"></param>
 			/// <param name="sName"></param>
@@ -258,11 +258,11 @@ namespace SIL.Scripture
 		[Description("Array of encodings requested by the caller.")]
 		public List<string > RequestedEncodings
 		{
-			get 
+			get
 			{
 				return m_requestedEncodings;
 			}
-			set 
+			set
 			{
 				m_requestedEncodings = value;
 
@@ -271,7 +271,7 @@ namespace SIL.Scripture
 					m_requestedEncodings.Add(kWsSilCodes); // Add to the end
 			}
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// ProcessDeuteroCanonical property
@@ -284,9 +284,9 @@ namespace SIL.Scripture
 		{
 			get {return m_fProcessDeuteroCanonical;}
 			set {m_fProcessDeuteroCanonical = false;}	// nScrBooksLim = 66;
-			// This impletation does not support deutero-canonical book names.
+			// This implementation does not support deutero-canonical book names.
 		}
-				
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// ReferenceFormat property
@@ -346,7 +346,7 @@ namespace SIL.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="icuLocale">The ISO 639-3 identifier for the writing system</param>
 		/// <returns>The WsNames object for the given ws, if it exists</returns>
@@ -425,7 +425,7 @@ namespace SIL.Scripture
 				}
 			}
 
-			// No abbreviation found in primary writing system; get SIL code instead		
+			// No abbreviation found in primary writing system; get SIL code instead
 			wsNames = GetWsNames(kWsSilCodes); // SIL codes
 			Debug.Assert (wsNames != null);
 			sAbbrev = wsNames.Name[nBook - 1]; // full SIL code is the .Name
@@ -474,7 +474,7 @@ namespace SIL.Scripture
 		/// Parses the user typed in string. Creates and returns a ScrReference object.
 		/// </summary>
 		/// <param name="sTextToBeParsed">Reference string the user types in.</param>
-		/// <param name="startingBook">The 0-based index of starting book to consider when 
+		/// <param name="startingBook">The 0-based index of starting book to consider when
 		/// parsing reference.</param>
 		/// <returns>The generated scReference object.</returns>
 		/// ------------------------------------------------------------------------------------
@@ -521,7 +521,7 @@ namespace SIL.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Generates a cannonical text form of the given reference, consisting of
+		/// Generates a canonical text form of the given reference, consisting of
 		/// book abbreviation (in primary writing system), chapter nbr, colon, verse nbr.
 		/// </summary>
 		/// <param name="scRef">The given scReference object.</param>

--- a/SIL.TestUtilities.Tests/NUnitExtensions/IsTests.cs
+++ b/SIL.TestUtilities.Tests/NUnitExtensions/IsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Xml.Linq;

--- a/SIL.TestUtilities.Tests/NUnitExtensions/ValueEquatableConstraintTests.cs
+++ b/SIL.TestUtilities.Tests/NUnitExtensions/ValueEquatableConstraintTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.TestUtilities.Tests/NUnitExtensions/XmlEquatableConstraintTests.cs
+++ b/SIL.TestUtilities.Tests/NUnitExtensions/XmlEquatableConstraintTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Xml;

--- a/SIL.TestUtilities/ConstrainStringByLine.cs
+++ b/SIL.TestUtilities/ConstrainStringByLine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 // This file is a copy (with different namespace and minus the public class Is) of SIL.BuildTasks.Tests\ConstrainStringByLine.cs

--- a/SIL.TestUtilities/NUnitExtensions/Is.cs
+++ b/SIL.TestUtilities/NUnitExtensions/Is.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using SIL.ObjectModel;
 using JetBrains.Annotations;

--- a/SIL.TestUtilities/NUnitExtensions/ValueEquatableConstraint.cs
+++ b/SIL.TestUtilities/NUnitExtensions/ValueEquatableConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework.Constraints;

--- a/SIL.TestUtilities/NUnitExtensions/XmlEquatableConstraint.cs
+++ b/SIL.TestUtilities/NUnitExtensions/XmlEquatableConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.TestUtilities/Providers/ReproducibleDateTimeProvider.cs
+++ b/SIL.TestUtilities/Providers/ReproducibleDateTimeProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using JetBrains.Annotations;

--- a/SIL.TestUtilities/Providers/ReproducibleGuidProvider.cs
+++ b/SIL.TestUtilities/Providers/ReproducibleGuidProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using JetBrains.Annotations;

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBase.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -387,7 +387,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 				MoveInputFocusBackToAWinFormsControl();
 
 				// Setting the ActiveControl ensure a Focus event occurs on the control focus is moving to.
-				// And this allows us to call RemoveinputFocus at the neccessary time.
+				// And this allows us to call RemoveinputFocus at the necessary time.
 				// This prevents keypress still going to the gecko controls when a winform TextBox has focus
 				// and the mouse is over a gecko control.
 				Form.ActiveForm.ActiveControl = control;
@@ -428,7 +428,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			base.OnEnter(e);
 		}
 		/// <summary>
-		/// This gives a move sensible result than the default winform implemenentation.
+		/// This gives a move sensible result than the default winform implementation.
 		/// </summary>
 		/// <value><c>true</c> if focused; otherwise, <c>false</c>.</value>
 		public override bool Focused
@@ -439,7 +439,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			}
 		}
 		/// <summary>
-		/// If Browser control dosesn't have X11 input focus.
+		/// If Browser control doesn't have X11 input focus.
 		/// then Ensure that it does..
 		/// </summary>
 		protected void EnsureFocusedGeckoControlHasInputFocus()
@@ -452,7 +452,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			// Attempt to do it right away.
 			this._browser.SetInputFocus();
 
-			// Othewise do it on the first idle event.
+			// Otherwise do it on the first idle event.
 			Action setInputFocus = null;
 			setInputFocus = () =>
 			{

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBox.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBox.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -90,7 +90,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		}
 
 		public Control TheControl { get { return this; } }
-		
+
 		public void Select(int start, int length)
 		{
 			base.Select();

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoFxWebBrowserAdapter.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoFxWebBrowserAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -271,9 +271,9 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			}
 			catch(Exception e)
 			{
-				MessageBox.Show("Unable to load geckofx dependancy. Files may not have been included in the build.",
+				MessageBox.Show("Unable to load geckofx dependency. Files may not have been included in the build.",
 					"Failed to load geckofx", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				throw new ApplicationException("Unable to load geckofx dependancy", e);
+				throw new ApplicationException("Unable to load geckofx dependency", e);
 			}
 		}
 
@@ -294,7 +294,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		/// <summary>
 		/// Call a browser method which returns a specific type.
 		/// Looks up the method name by reflection and calls that method
-		/// on the given webbrowser instance and return the value.
+		/// on the given web browser instance and return the value.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
 		/// <param name="webBrowser"></param>
@@ -331,7 +331,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 
 		/// <summary>
 		/// Look up a method name from the browser that matches the method name and
-		/// the type of the parameters given and then call that on the given webbrowser
+		/// the type of the parameters given and then call that on the given web browser
 		/// instance.
 		/// </summary>
 		private bool CallBrowserMethod(object webBrowser, string methodName, object[] parameters)
@@ -403,7 +403,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		public void Dispose()
 		{
 			CallBrowserMethod(_webBrowser, "Dispose", null);
-			// Call GC.SupressFinalize to take this object off the finalization queue
+			// Call GC.SuppressFinalize to take this object off the finalization queue
 			// and prevent finalization code for this object from executing a second time.
 			GC.SuppressFinalize(this);
 		}

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/NativeReplacements.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/NativeReplacements.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -264,8 +264,8 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		private static MethodInfo _sendMessage;
 
 		/// <summary>
-		/// Please don't use this unless your really have to, and then only if its for sending messages internaly within the application.
-		/// For example sending WM_NCPAINT maybe portable but sending WM_USER + N to another application is definitely not poratable.
+		/// Please don't use this unless your really have to, and then only if its for sending messages internally within the application.
+		/// For example sending WM_NCPAINT maybe portable but sending WM_USER + N to another application is definitely not portable.
 		/// </summary>
 		public static void SendMessage(IntPtr hWnd, uint Msg, int wParam, int lParam)
 		{

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/NativeX11Methods.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/NativeX11Methods.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -24,7 +24,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			public IntPtr res_class;
 		}
 
-		#region Code from mono project (www.mono-project.com/‎) X11Structs.cs
+		#region Code from mono project (www.mono-project.com) X11Structs.cs
 
 		[Flags]
 		internal enum XWMHintsFlags

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/ProgressUtils.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/ProgressUtils.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -71,7 +71,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 						};
 
 						// Since ManagedThreadId isn't fixed on .NET/Windows we use just invoke
-						// on windows. (Which should peform a BeginInvoke/EndInvoke if the control was
+						// on windows. (Which should perform a BeginInvoke/EndInvoke if the control was
 						// created by the main UI thread)
 						// Enhance: if uiSynchronizationForm isn't yet created then this may not work.
 						if (Platform.IsDotNet)
@@ -80,9 +80,9 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 						}
 						else
 						{
-							// This is more reliable that calling InvokeRequried,
-							// as InvokeRequred requires the control to be created.
-							// Mono's Control.Invoke implementation uses InvokeRequred to determin if
+							// This is more reliable than calling InvokeRequired,
+							// as InvokeRequired requires the control to be created.
+							// Mono's Control.Invoke implementation uses InvokeRequired to determine if
 							// The delegate can just be run or if BeginInvoke needs to be called.
 							if (Thread.CurrentThread.ManagedThreadId != 1)
 							{

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/ReflectiveGeckoBrowser.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/ReflectiveGeckoBrowser.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -147,9 +147,9 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			}
 			catch(Exception e)
 			{
-				MessageBox.Show("Unable to load geckofx dependancy. Files may not have been included in the build.",
+				MessageBox.Show("Unable to load geckofx dependency. Files may not have been included in the build.",
 					"Failed to load geckofx", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				throw new ApplicationException("Unable to load geckofx dependancy", e);
+				throw new ApplicationException("Unable to load geckofx dependency", e);
 			}
 		}
 

--- a/SIL.Windows.Forms.Keyboarding.Tests/CombinedIbusKeyboardRetrievingAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/CombinedIbusKeyboardRetrievingAdaptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding.Tests/CombinedIbusKeyboardSwitchingAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/CombinedIbusKeyboardSwitchingAdaptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using IBusDotNet;
 using Moq;

--- a/SIL.Windows.Forms.Keyboarding.Tests/GnomeKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/GnomeKeyboardRetrievingHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding.Tests/GnomeShellIbusKeyboardRetrievingAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/GnomeShellIbusKeyboardRetrievingAdaptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Linq;

--- a/SIL.Windows.Forms.Keyboarding.Tests/GnomeShellIbusKeyboardSwitchingAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/GnomeShellIbusKeyboardSwitchingAdaptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.Windows.Forms.Keyboarding.Tests/IbusDefaultEventHandlerTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/IbusDefaultEventHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 
 using System;
@@ -143,7 +143,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 
 		/// <summary>
 		/// This test simulates a kind of keyboard similar to the IPA ibus keyboard which calls
-		/// commit after earch character. This test simulates the first commit call without a
+		/// commit after each character. This test simulates the first commit call without a
 		/// preceding OnUpdatePreeditText.
 		/// </summary>
 		[Test]
@@ -162,7 +162,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 
 		/// <summary>
 		/// This test simulates a kind of keyboard similar to the IPA ibus keyboard which calls
-		/// commit after earch character. This test simulates the callbacks we get from the IPA
+		/// commit after each character. This test simulates the callbacks we get from the IPA
 		/// keyboard when the user presses 'n' + '>'. The IPA ibus keyboard commits the 'n',
 		/// sends us a backspace and then commits the 'ŋ'. This hypothetical keyboard doesn't
 		/// use the SurroundingText IBus capability.
@@ -187,7 +187,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 
 		/// <summary>
 		/// This test simulates a kind of keyboard similar to the IPA ibus keyboard which calls
-		/// commit after earch character. This test simulates the callbacks we get from the IPA
+		/// commit after each character. This test simulates the callbacks we get from the IPA
 		/// keyboard when the user presses 'n' + '>'. The IPA ibus keyboard commits the 'n',
 		/// sends us a backspace and then commits the 'ŋ'. This keyboard does
 		/// use the SurroundingText IBus capability.

--- a/SIL.Windows.Forms.Keyboarding.Tests/IbusKeyboardAdaptorTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/IbusKeyboardAdaptorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding.Tests/IbusKeyboardDescriptionTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/IbusKeyboardDescriptionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.Windows.Forms.Keyboarding.Tests/IbusXkbKeyboardDescriptionTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/IbusXkbKeyboardDescriptionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using IBusDotNet;

--- a/SIL.Windows.Forms.Keyboarding.Tests/InputLanguageWrapperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/InputLanguageWrapperTests.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2013' to='2024' company='SIL Global'>
+// <copyright from='2013' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Keyboarding.Tests/InputLanguageWrapperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/InputLanguageWrapperTests.cs
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2013' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.   
-//	
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class originated in FieldWorks (under the GNU Lesser General Public License), but we
 // decided to move the class it tests into SIL.Windows.Forms.Keyboarding to make it more readily
 // available to other projects.

--- a/SIL.Windows.Forms.Keyboarding.Tests/KeyboardControllerTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/KeyboardControllerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding.Tests/TestHelper/BusEngineDescDouble.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/TestHelper/BusEngineDescDouble.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using IBusDotNet;

--- a/SIL.Windows.Forms.Keyboarding.Tests/TestHelper/GnomeKeyboardRetrievingHelperDouble.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/TestHelper/GnomeKeyboardRetrievingHelperDouble.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using SIL.Windows.Forms.Keyboarding.Linux;

--- a/SIL.Windows.Forms.Keyboarding.Tests/TestHelper/GnomeShellIbusKeyboardRetrievingAdaptorDouble.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/TestHelper/GnomeShellIbusKeyboardRetrievingAdaptorDouble.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using IBusDotNet;
 using SIL.Reflection;

--- a/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/UnityKeyboardRetrievingHelperTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2011' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.   
-//	
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class originated in FieldWorks (under the GNU Lesser General Public License), but we
 // decided to make it available in SIL.Windows.Forms.Keyboarding to make it more readily
 // available to other projects.
@@ -398,7 +398,7 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 			IEnumerable<IKeyboardDefinition> keyboards = Keyboard.Controller.AvailableKeyboards;
 			Assert.AreEqual(0, keyboards.Count());
 			//Assert.AreEqual(1, KeyboardController.ErrorKeyboards.Count);
-			//Assert.AreEqual("Fake", KeyboardController.Errorkeyboards.First().Details);
+			//Assert.AreEqual("Fake", KeyboardController.ErrorKeyboards.First().Details);
 		}
 
 		/// <summary/>

--- a/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2011' to='2024' company='SIL Global'>
+// <copyright from='2011' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Keyboarding.Tests/XklEngineTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/XklEngineTests.cs
@@ -1,16 +1,16 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright (c) 2024 SIL Global.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2013' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.
-//	
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class originated in FieldWorks (under the GNU Lesser General Public License), but we
 // decided to make it available in SIL.Scripture to make it more readily available to other
 // projects.
-// 
+//
 // Original author: MarkS 2013-01-04 XklEngineTests.cs
 // ---------------------------------------------------------------------------------------------
 using System;

--- a/SIL.Windows.Forms.Keyboarding.Tests/XklEngineTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/XklEngineTests.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2013' to='2024' company='SIL Global'>
+// <copyright from='2013' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Keyboarding/IKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/IKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/IKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/IKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace SIL.Windows.Forms.Keyboarding

--- a/SIL.Windows.Forms.Keyboarding/InputLanguageWrapper.cs
+++ b/SIL.Windows.Forms.Keyboarding/InputLanguageWrapper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardController.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/KeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/KeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using SIL.Keyboarding;

--- a/SIL.Windows.Forms.Keyboarding/Linux/AlternateLanguageCodes.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/AlternateLanguageCodes.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/CombinedIbusKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GList.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GList.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GlibHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GlibHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2024, SIL Global
+// Copyright (c) 2015-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GlobalCachedInputContext.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GlobalCachedInputContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using IBusDotNet;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeKeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeKeyboardRetrievingHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2024, SIL Global
+// Copyright (c) 2015-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeShellIbusKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Linux/GnomeXkbInfo.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/GnomeXkbInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Linux/IIbusCommunicator.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IIbusCommunicator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using System;
 using System.Windows.Forms;
@@ -71,7 +71,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		/// </summary>
 		void CreateInputContext();
 
-		/// <summary>Occurs when the composition string gets commited, e.g. after the user pressed
+		/// <summary>Occurs when the composition string gets committed, e.g. after the user pressed
 		/// the space bar.</summary>
 		event Action<object> CommitText;
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/IIbusEventHandler.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IIbusEventHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 
 using System.Drawing;

--- a/SIL.Windows.Forms.Keyboarding/Linux/IUnityKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IUnityKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace SIL.Windows.Forms.Keyboarding.Linux

--- a/SIL.Windows.Forms.Keyboarding/Linux/IXklEngine.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IXklEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using System;
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusCommunicator.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusCommunicator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using System;
 using System.Windows.Forms;
@@ -37,7 +37,7 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 		#endregion
 
 		/// <summary>
-		/// Create a Connection to Ibus. If successfull Connected property is true.
+		/// Create a Connection to Ibus. If successful, Connected property is true.
 		/// </summary>
 		public IbusCommunicator()
 		{

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusDefaultEventHandler.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusDefaultEventHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using System;
 using System.Diagnostics;

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using System.Windows.Forms;
 using IBusDotNet;

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2024, SIL Global
+// Copyright (c) 2015-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusXkbKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusXkbKeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using IBusDotNet;

--- a/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/KeyboardRetrievingHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2024, SIL Global
+// Copyright (c) 2015-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityIbusKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using SIL.Reporting;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/UnityXkbKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using X11.XKlavier;
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/Unmanaged.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.IO;

--- a/SIL.Windows.Forms.Keyboarding/Linux/X11.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/X11.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;
@@ -27,11 +27,11 @@ namespace X11
 	{
 		/// <summary>
 		/// Gets the X11 display connection that Mono already has open, rather than
-		/// carefully opening and closing it on our own in a way that doesnt crash (FWNX-895).
+		/// carefully opening and closing it on our own in a way that doesn't crash (FWNX-895).
 		/// </summary>
 		/// <remarks><para>NOTE: The display connection should not be closed!</para>
 		/// <para>NOTE: when running unit tests Mono's DisplayHandle might not be initialized.
-		/// One way to get it intialized is to create a control.</para></remarks>
+		/// One way to get it initialized is to create a control.</para></remarks>
 		internal static IntPtr GetDisplayConnection()
 		{
 			var swfAssembly = Assembly.GetAssembly(typeof(System.Windows.Forms.Form));

--- a/SIL.Windows.Forms.Keyboarding/Linux/X11KeyConverter.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/X11KeyConverter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using System;
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbIbusEngineDesc.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbIbusEngineDesc.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using IBusDotNet;

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 using SIL.Keyboarding;
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardSwitchingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardSwitchingAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Windows.Forms.Keyboarding/Linux/XklConfigRegistry.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XklConfigRegistry.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/SIL.Windows.Forms.Keyboarding/Linux/XklEngine.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XklEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Runtime.InteropServices;

--- a/SIL.Windows.Forms.Keyboarding/NullKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/NullKeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2024, SIL Global
+// Copyright (c) 2011-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace SIL.Windows.Forms.Keyboarding
@@ -13,7 +13,7 @@ namespace SIL.Windows.Forms.Keyboarding
 		public NullKeyboardDescription()
 			: base(string.Empty, DefaultKeyboardName, DefaultKeyboardName, string.Empty, false, null)
 		{
-			
+
 		}
 
 		public override string ToString()

--- a/SIL.Windows.Forms.Keyboarding/RegisterEventArgs.cs
+++ b/SIL.Windows.Forms.Keyboarding/RegisterEventArgs.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global.
+// Copyright (c) 2025 SIL Global
 // Distributable under the terms of the MIT license (http://opensource.org/licenses/MIT).
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -350,7 +350,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 		{
 			Dispose(true);
 			// This object will be cleaned up by the Dispose method.
-			// Therefore, you should call GC.SupressFinalize to
+			// Therefore, you should call GC.SuppressFinalize to
 			// take this object off the finalization queue
 			// and prevent finalization code for this object
 			// from executing a second time.

--- a/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, SIL Global
+// Copyright (c) 2014-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Security;

--- a/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardSwitchingAdapter.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardSwitchingAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Windows.Forms;

--- a/SIL.Windows.Forms.Keyboarding/Windows/LayoutName.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/LayoutName.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 namespace SIL.Windows.Forms.Keyboarding.Windows
 {

--- a/SIL.Windows.Forms.Keyboarding/Windows/LegacyKeymanKeyboardSwitchingAdapter.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/LegacyKeymanKeyboardSwitchingAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using Keyman7Interop;

--- a/SIL.Windows.Forms.Keyboarding/Windows/MsTsfInterfaces.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/MsTsfInterfaces.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Runtime.CompilerServices;

--- a/SIL.Windows.Forms.Keyboarding/Windows/Win32.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/Win32.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -317,7 +317,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 		{
 			Dispose(true);
 			// This object will be cleaned up by the Dispose method.
-			// Therefore, you should call GC.SupressFinalize to
+			// Therefore, you should call GC.SuppressFinalize to
 			// take this object off the finalization queue
 			// and prevent finalization code for this object
 			// from executing a second time.

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardDescription.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardDescription.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using Keyman10Interop;

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardUtils.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardUtils.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Globalization;
@@ -17,13 +17,13 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 	{
 		internal static LayoutName GetLayoutNameEx(IntPtr handle)
 		{
-			// InputLanguage.LayoutName is not to be trusted, especially where there are mutiple
+			// InputLanguage.LayoutName is not to be trusted, especially where there are multiple
 			// layouts (input methods) associated with a language. This function also provides
 			// the additional benefit that it does not matter whether a user switches from using
 			// InKey in Portable mode to using it in Installed mode (perhaps as the project is
 			// moved from one computer to another), as this function will identify the correct
 			// input language regardless, rather than (unhelpfully ) calling an InKey layout in
-			// portable mode the "US" layout. The layout is identified soley by the high-word of
+			// portable mode the "US" layout. The layout is identified solely by the high-word of
 			// the HKL (a.k.a. InputLanguage.Handle).  (The low word of the HKL identifies the
 			// language.)
 			// This function determines an HKL's LayoutName based on the following order of

--- a/SIL.Windows.Forms.Keyboarding/Windows/WindowsKeyboardSwitchingAdapter.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WindowsKeyboardSwitchingAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -190,7 +190,7 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 		{
 			Dispose(true);
 			// This object will be cleaned up by the Dispose method.
-			// Therefore, you should call GC.SupressFinalize to
+			// Therefore, you should call GC.SuppressFinalize to
 			// take this object off the finalization queue
 			// and prevent finalization code for this object
 			// from executing a second time.

--- a/SIL.Windows.Forms.Scripture.Tests/ScrPassageControlTests.cs
+++ b/SIL.Windows.Forms.Scripture.Tests/ScrPassageControlTests.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Scripture.Tests/ScrPassageControlTests.cs
+++ b/SIL.Windows.Forms.Scripture.Tests/ScrPassageControlTests.cs
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.
+//		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
 // </copyright>
@@ -710,7 +710,7 @@ namespace SIL.Windows.Forms.Scripture.Tests
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Tries the DoEvents a few times to give the DropDownWindow a chance to become active.
-		/// Tests were occassionally failing due to a null DropDownWindow reference.
+		/// Tests were occasionally failing due to a null DropDownWindow reference.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private static void WaitForDropDownWindow(DummyScrPassageControl spc, int expectedCount)

--- a/SIL.Windows.Forms.Scripture/DropDownContainer.cs
+++ b/SIL.Windows.Forms.Scripture/DropDownContainer.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.   
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: DropDownContainer.cs
 // --------------------------------------------------------------------------------------------
 using System.Diagnostics.CodeAnalysis;
@@ -24,14 +24,14 @@ namespace SIL.Windows.Forms.Scripture
 		/// <summary>Handles AfterDropDownClose events.</summary>
 		public delegate void AfterDropDownClosedHandler(DropDownContainer dropDownContainer,
 			object eventData);
-		
+
 		/// <summary>Event which occurs after a drop-down is closed.</summary>
 		public event AfterDropDownClosedHandler AfterDropDownClosed;
 
 		/// <summary>Handles BeforeDropDownClose events.</summary>
 		public delegate void BeforeDropDownOpenedHandler(DropDownContainer dropDownContainer,
 			object eventData);
-		
+
 		/// <summary>Event which occurs before a drop-down is closed.</summary>
 		public event BeforeDropDownOpenedHandler BeforeDropDownOpened;
 
@@ -117,7 +117,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="cancel"></param>
 		/// ------------------------------------------------------------------------------------
@@ -129,7 +129,7 @@ namespace SIL.Windows.Forms.Scripture
 		#region Overrides
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
@@ -147,7 +147,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
@@ -155,9 +155,9 @@ namespace SIL.Windows.Forms.Scripture
 		{
 			if (this.Visible)
 				this.Hide();
-			
+
 			base.OnDeactivate(e);
-			
+
 			BeforeDropDownOpenedEventData = null;
 
 			// Call this delegate if there are any subscribers.

--- a/SIL.Windows.Forms.Scripture/DropDownContainer.cs
+++ b/SIL.Windows.Forms.Scripture/DropDownContainer.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Scripture/LabelButton.cs
+++ b/SIL.Windows.Forms.Scripture/LabelButton.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Scripture/LabelButton.cs
+++ b/SIL.Windows.Forms.Scripture/LabelButton.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: LabelButton.cs
 // --------------------------------------------------------------------------------------------
 
@@ -34,7 +34,7 @@ namespace SIL.Windows.Forms.Scripture
 		public event PaintEventHandler PaintText;
 		/// <summary>Event which occurs when the control's image is being painted.</summary>
 		public event PaintEventHandler PaintImage;
-		
+
 		private bool m_mouseIsOver;
 		private bool m_mouseIsDown;
 		private bool m_shadeWhenMouseOver = true;
@@ -72,12 +72,12 @@ namespace SIL.Windows.Forms.Scripture
 		{
 			SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint |
 				ControlStyles.DoubleBuffer, true);
-			
+
 			BackColor = Color.FromArgb(200, SystemColors.Control);
 			TextAlign = ContentAlignment.MiddleCenter;
 			Name = "LabelButton";
 			ResizeRedraw = true;
-			
+
 			SetTextAlignment();
 		}
 
@@ -109,7 +109,7 @@ namespace SIL.Windows.Forms.Scripture
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public TextFormatFlags FormatFlags { get; set; }
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets or sets a value for the number of pixels of margin to insert before the text
@@ -177,7 +177,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		protected bool ButtonIsOn => State == ButtonState.Pushed;
@@ -187,7 +187,7 @@ namespace SIL.Windows.Forms.Scripture
 		#region Overrides
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
@@ -197,7 +197,7 @@ namespace SIL.Windows.Forms.Scripture
 				OnPaintBackground(e);
 			else
 				PaintBackground(this, e);
-			
+
 			if (PaintText == null)
 				OnPaintText(e);
 			else
@@ -211,7 +211,7 @@ namespace SIL.Windows.Forms.Scripture
 					PaintImage(this, e);
 			}
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Paints the background and border portion of the button.
@@ -229,7 +229,7 @@ namespace SIL.Windows.Forms.Scripture
 
 				brush.Color = GetBackColorShade(m_paintState, BackColor);
 				e.Graphics.FillRectangle(brush, ClientRectangle);
-				
+
 				if (m_paintState != PaintState.Normal)
 				{
 					Rectangle rc = ClientRectangle;
@@ -256,7 +256,7 @@ namespace SIL.Windows.Forms.Scripture
 					rc.Offset(-1, -1);
 				else
 					rc.Height--;
-				
+
 				// Account for any specified leading margin.
 				if (TextLeadingMargin > 0)
 				{
@@ -264,7 +264,7 @@ namespace SIL.Windows.Forms.Scripture
 					if (RightToLeft == RightToLeft.No)
 						rc.X += TextLeadingMargin;
 				}
-				
+
 				// Now we'll draw the text.
 				e.Graphics.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
 				Size sz;
@@ -366,12 +366,12 @@ namespace SIL.Windows.Forms.Scripture
 				rc.Height++;
 			}
 
-			DrawImage(e.Graphics, Image, rc, ImageAlign);			
+			DrawImage(e.Graphics, Image, rc, ImageAlign);
 		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
@@ -381,10 +381,10 @@ namespace SIL.Windows.Forms.Scripture
 			m_mouseIsOver = true;
 			Invalidate();
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
@@ -439,18 +439,18 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
 			base.OnMouseMove(e);
-			
+
 			if (m_mouseIsDown)
 			{
 				bool inBounds = MouseInBounds(e.X, e.Y);
-				
+
 				if (inBounds != m_mouseIsOver)
 				{
 					m_mouseIsOver = inBounds;
@@ -458,12 +458,12 @@ namespace SIL.Windows.Forms.Scripture
 				}
 			}
 		}
-		
+
 		#endregion
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="state"></param>
 		/// <returns></returns>
@@ -475,7 +475,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="state"></param>
 		/// <param name="normalBack"></param>
@@ -492,13 +492,13 @@ namespace SIL.Windows.Forms.Scripture
 					case PaintState.Pushed:		return Color.FromArgb(40, SystemColors.ActiveCaption);
 				}
 			}
-			
+
 			return normalBack;
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <returns></returns>
 		/// ------------------------------------------------------------------------------------
@@ -521,7 +521,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="x"></param>
 		/// <param name="y"></param>

--- a/SIL.Windows.Forms.Scripture/SantaFeFocusMessageHandler.cs
+++ b/SIL.Windows.Forms.Scripture/SantaFeFocusMessageHandler.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2007' to='2024' company='SIL Global'>
+// <copyright from='2007' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Scripture/SantaFeFocusMessageHandler.cs
+++ b/SIL.Windows.Forms.Scripture/SantaFeFocusMessageHandler.cs
@@ -1,7 +1,7 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2007' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.
+//		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
 // </copyright>
@@ -94,7 +94,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Notify all Santa Fe windows that a Scripture Reference focus change has occured.
+		/// Notify all Santa Fe windows that a Scripture Reference focus change has occurred.
 		/// </summary>
 		/// <param name="sRef">The string representation of the reference (e.g. MAT 1:1)</param>
 		/// ------------------------------------------------------------------------------------

--- a/SIL.Windows.Forms.Scripture/ScrPassageControl.cs
+++ b/SIL.Windows.Forms.Scripture/ScrPassageControl.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Scripture/ScrPassageControl.cs
+++ b/SIL.Windows.Forms.Scripture/ScrPassageControl.cs
@@ -1,7 +1,7 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global.
+//		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
 // </copyright>
@@ -93,7 +93,7 @@ namespace SIL.Windows.Forms.Scripture
 
 			if (!Platform.IsWindows)
 			{
-				// Setting MinumumSize allows mono's buggy ToolStrip layout of ToolStripControlHost's to work.
+				// Setting MinimumSize allows mono's buggy ToolStrip layout of ToolStripControlHost's to work.
 				MinimumSize = new Size(100, 20);
 			}
 		}

--- a/SIL.Windows.Forms.Scripture/ScrPassageDropDown.cs
+++ b/SIL.Windows.Forms.Scripture/ScrPassageDropDown.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Scripture/ScrPassageDropDown.cs
+++ b/SIL.Windows.Forms.Scripture/ScrPassageDropDown.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: ScrPassageDropDown.cs
 // --------------------------------------------------------------------------------------------
 using System;
@@ -19,7 +19,7 @@ namespace SIL.Windows.Forms.Scripture
 {
 	/// ----------------------------------------------------------------------------------------
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// ----------------------------------------------------------------------------------------
 	public class ScrPassageDropDown : DropDownContainer
@@ -27,17 +27,17 @@ namespace SIL.Windows.Forms.Scripture
 		#region Data members
 		/// <summary>Delegate for BookSelected event.</summary>
 		public delegate void BookSelectedHandler(int bookNumber);
-		
+
 		/// <summary>Delegate for ChapterSelected event.</summary>
 		public delegate void ChapterSelectedHandler(int bookNumber, int chapterNumber);
-		
+
 		/// <summary>Delegate for VerseSelected event.</summary>
 		public delegate void VerseSelectedHandler(int bookNumber, int chapterNumber,
 			int verseNumber);
 
 		/// <summary>Event that occurs when a book is selected.</summary>
 		public event BookSelectedHandler BookSelected;
-		
+
 		/// <summary>Event that occurs when a chapter is selected.</summary>
 		public event ChapterSelectedHandler ChapterSelected;
 
@@ -68,7 +68,7 @@ namespace SIL.Windows.Forms.Scripture
 			14, 14, 17, 14, 16, 16, 16, 16, 16, 16, 18, 18, 15, 15, 15,	// 151 - 165
 			14, 14, 14, 17, 17, 19, 16, 16, 16, 16, 16					// 166 - 176
 		};
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// The types of information shown in the Scripture passage drop-down.
@@ -99,7 +99,7 @@ namespace SIL.Windows.Forms.Scripture
 		private IScrVers m_versification;
 		#endregion
 
-		#region Contructor and initialization
+		#region Constructor and initialization
 		/// -----------------------------------------------------------------------------------
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ScrPassageDropDown"/> class.
@@ -146,7 +146,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private void InitializeComponent()
@@ -155,9 +155,9 @@ namespace SIL.Windows.Forms.Scripture
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ScrPassageDropDown));
 			this.tipBook = new System.Windows.Forms.ToolTip(this.components);
 			this.SuspendLayout();
-			// 
+			//
 			// ScrPassageDropDown
-			// 
+			//
 			resources.ApplyResources(this, "$this");
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
 			this.Name = "ScrPassageDropDown";
@@ -167,7 +167,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private void InitializeButtons()
@@ -319,7 +319,7 @@ namespace SIL.Windows.Forms.Scripture
 		{
 			get { return m_buttons[m_currButton]; }
 		}
-	
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
 		/// Gets the current button's book, chapter or verse value.
@@ -370,10 +370,10 @@ namespace SIL.Windows.Forms.Scripture
 			base.OnDeactivate(e);
 			Close();
 		}
-		
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="e"></param>
 		/// ------------------------------------------------------------------------------------
@@ -395,7 +395,7 @@ namespace SIL.Windows.Forms.Scripture
 						Close(fCancel);
 					}
 					else
-						buttonToGoTo = CurrentButton.ButtonBelow; 
+						buttonToGoTo = CurrentButton.ButtonBelow;
 					break;
 
 				case Keys.Enter:
@@ -435,7 +435,7 @@ namespace SIL.Windows.Forms.Scripture
 					}
 					break;
 			}
-			
+
 			if (buttonToGoTo > -1)
 			{
 				CurrentButton.ShadeWhenMouseOver = false;
@@ -455,13 +455,13 @@ namespace SIL.Windows.Forms.Scripture
 			m_canceled = fCancel;
 			Close();
 		}
-		
+
 		#endregion
 
 		#region Button handling methods
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private void LoadBooksButtons()
@@ -478,7 +478,7 @@ namespace SIL.Windows.Forms.Scripture
 
 			CurrentListType = ListTypes.Books;
 			PrepareLayout(numberOfButtons, BookButtonPreferredWidth, out numberRows,
-				out buttonWidth);			
+				out buttonWidth);
 
 			Point pt = new Point(1, 1);
 			int row = 0;
@@ -495,7 +495,7 @@ namespace SIL.Windows.Forms.Scripture
 				Controls.Add(m_buttons[i]);
 				pt.Y += ButtonHeight + 1;
 				row++;
-				
+
 				if (i > 0)
 					m_buttons[i].ButtonAbove = i - 1;
 				if (i < numberOfButtons - 1)
@@ -519,7 +519,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private void LoadCVButtons(List<int> list, int initialCV)
@@ -530,14 +530,14 @@ namespace SIL.Windows.Forms.Scripture
 
 			int buttonWidth;
 			int numberRows;
-			
+
 			SuspendLayout();
 			Controls.Clear();
 			ResetPointersToSurroundingButtons();
-			
+
 			PrepareLayout(numberOfButtons, CVButtonPreferredWidth, out numberRows,
-				out buttonWidth);			
-			
+				out buttonWidth);
+
 			Point pt = new Point(1, 1);
 			int row = 0;
 
@@ -558,7 +558,7 @@ namespace SIL.Windows.Forms.Scripture
 				// Determine the button to make current when the list is first shown.
 				if (chapNumber == initialCV)
 					m_currButton = i;
-				
+
 				if (i > 0)
 					m_buttons[i].ButtonAbove = i - 1;
 				if (i < numberOfButtons - 1)
@@ -602,7 +602,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="numberOfButtons"></param>
 		/// <param name="preferredButtonWidth"></param>
@@ -613,7 +613,7 @@ namespace SIL.Windows.Forms.Scripture
 			out int numberRows, out int buttonWidth)
 		{
 			System.Diagnostics.Debug.Assert(numberOfButtons > 0);
-			
+
 			if (m_nowShowing == ListTypes.Books)
 			{
 				System.Diagnostics.Debug.Assert(numberOfButtons <= m_rowsInBookDropDown.Length);
@@ -630,7 +630,7 @@ namespace SIL.Windows.Forms.Scripture
 			if (Decimal.Remainder(numberOfButtons, numberRows) > 0)
 				numberCols++;
 
-			// Because .Net or Windows restricts the minimun width of a form (in this case the
+			// Because .Net or Windows restricts the minimum width of a form (in this case the
 			// the drop-down form), adjust the width of the buttons when there are fewer than
 			// four columns.
 			if (numberCols == 1 && preferredButtonWidth < 120)
@@ -659,7 +659,7 @@ namespace SIL.Windows.Forms.Scripture
 		private void SetSizeAndLocationOfPopupDropDown(int width, int height)
 		{
 			Size dropDownSize = new Size(width, height);
-			
+
 			if (AttachedControl == null && AttachedControl.Width < dropDownSize.Width)
 			{
 				Size = dropDownSize;
@@ -672,7 +672,7 @@ namespace SIL.Windows.Forms.Scripture
 			// Get the working area (i.e. the screen's rectangle) in which the attached
 			// control lies.
 			Rectangle rcScreen = Screen.GetWorkingArea(AttachedControl);
-			
+
 			// Check if the right edge of the drop-down goes off the screen. If so,
 			// align its right edge with that of the attached control's right edge.
 			// The assumption is the right edge of the control isn't off the right
@@ -684,7 +684,7 @@ namespace SIL.Windows.Forms.Scripture
 			// align its bottom edge with that of the attached control's top edge.
 			if (dropDownLocation.Y + dropDownSize.Height > rcScreen.Bottom)
 				dropDownLocation.Y -= (dropDownSize.Height + AttachedControl.Height);
-			
+
 			Size = dropDownSize;
 			Location = dropDownLocation;
 		}
@@ -698,7 +698,7 @@ namespace SIL.Windows.Forms.Scripture
 		{
 			Point pt = new Point(CurrentButton.Width / 2,
 				CurrentButton.Height / 2);
-				
+
 			Cursor.Position = CurrentButton.PointToScreen(pt);
 		}
 		#endregion
@@ -725,11 +725,11 @@ namespace SIL.Windows.Forms.Scripture
 				tipBook.SetToolTip(button, button.Text);
 				tipBook.Active = true;
 			}
-		}	
+		}
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
@@ -737,13 +737,13 @@ namespace SIL.Windows.Forms.Scripture
 		private void ButtonMouseMove(object sender, MouseEventArgs e)
 		{
 			Point pt = new Point(e.X, e.Y);
-			
+
 			// if the mouse didn't move to another point, then ignore this message.
 			// ignore this mouse move message.
 			if (m_saveMousePos == pt)
 				return;
 
-			m_saveMousePos = pt; 
+			m_saveMousePos = pt;
 			ScrDropDownButton button = (ScrDropDownButton)sender;
 
 			// Make sure the button the mouse is over will look shaded, now that the
@@ -793,14 +793,14 @@ namespace SIL.Windows.Forms.Scripture
 				InternalChapterSelected(button.BCVValue);
 			else
 				InternalVerseSelected(button);
-		}	
+		}
 
 		#endregion
 
 		#region Methods called when Book, Chapter, or Verse is selected
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private void InternalBookSelected(ScrDropDownButton button)
@@ -857,7 +857,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="newChapter">The chapter</param>
 		/// ------------------------------------------------------------------------------------
@@ -874,7 +874,7 @@ namespace SIL.Windows.Forms.Scripture
 			List<int> verseList = new List<int>();
 			for (int i = 1; i <= m_versification.GetLastVerse(m_scRef.Book, m_scRef.Chapter); i++)
 				verseList.Add(i);
-			
+
 			if (ChapterSelected != null)
 				ChapterSelected(m_scRef.Book, m_scRef.Chapter);
 
@@ -885,7 +885,7 @@ namespace SIL.Windows.Forms.Scripture
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="button"></param>
 		/// ------------------------------------------------------------------------------------
@@ -913,7 +913,7 @@ namespace SIL.Windows.Forms.Scripture
 		{
 			internal delegate void SelectedHandler(ScrDropDownButton button);
 			internal event SelectedHandler Selected;
-			
+
 			private int m_index = -1;
 			private int m_buttonAbove = -1;
 			private int m_buttonBelow = -1;
@@ -950,7 +950,7 @@ namespace SIL.Windows.Forms.Scripture
 
 			/// --------------------------------------------------------------------------------
 			/// <summary>
-			/// Gets or sets the index of the button that directly preceeds this button.
+			/// Gets or sets the index of the button that directly precedes this button.
 			/// </summary>
 			/// --------------------------------------------------------------------------------
 			public int ButtonAbove
@@ -1000,7 +1000,7 @@ namespace SIL.Windows.Forms.Scripture
 			/// <remarks>
 			/// I used to subscribe to the label button's Click event (in the
 			/// ScrPassageDropDown class) but after I did all kinds of processing due to a
-			/// click event, the label button's base class OnMouseUp event occured and undid
+			/// click event, the label button's base class OnMouseUp event occurred and undid
 			/// some of those things. Therefore, I override this in order to get the base
 			/// classes implementation of OnMouseUp out of the way before I do what I need to
 			/// in the ScrPassageDropDown class (where a bunch of these buttons are
@@ -1016,7 +1016,7 @@ namespace SIL.Windows.Forms.Scripture
 					Selected(this);
 			}
 		}
-	
+
 		#endregion
 	}
 }

--- a/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
+++ b/SIL.Windows.Forms.Tests/ClearShare/MetadataTests.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2024 SIL Global 
-// This software is licensed under the MIT License (http://opensource.org/licenses/MIT) 
+// Copyright (c) 2025 SIL Global
+// This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Drawing;
 using NUnit.Framework;

--- a/SIL.Windows.Forms.Tests/ScreenHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/ScreenHelperTests.cs
@@ -1,6 +1,6 @@
 // --------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2003' to='2024' company='SIL Global'>
+// <copyright from='2003' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms.Tests/ScreenHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/ScreenHelperTests.cs
@@ -1,12 +1,12 @@
 // --------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2003' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: ScreenHelperTests.cs
 // --------------------------------------------------------------------------------------------
 using System.Drawing;
@@ -33,12 +33,12 @@ namespace SIL.Windows.Forms.Tests
 		{
 			foreach (Screen scrn in Screen.AllScreens)
 			{
-				// We want to skip a screen if it is vitual
+				// We want to skip a screen if it is virtual
 				if (ScreenHelper.ScreenIsVirtual(scrn))
 					continue;
 
 				Rectangle realScreenArea = ScreenHelper.AdjustedWorkingArea(scrn);
-				
+
 				// Make test rectangle half the height and width of the screen's working area.
 				Rectangle rcAdjusted = scrn.WorkingArea;
 				rcAdjusted.Width /= 2;
@@ -55,7 +55,7 @@ namespace SIL.Windows.Forms.Tests
 				// comes back fully contained within the screen.
 				rcAdjusted.Y = scrn.WorkingArea.Bottom - rcAdjusted.Height + 15;
 				ScreenHelper.EnsureVisibleRect(ref rcAdjusted);
-				Assert.IsTrue(realScreenArea.Contains(rcAdjusted), 
+				Assert.IsTrue(realScreenArea.Contains(rcAdjusted),
 					"Bottom edge test failed: " + scrn.DeviceName);
 
 				// Move rectangle so right and bottom edges are off the screen and test that

--- a/SIL.Windows.Forms.Tests/SettingsProviderTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProviderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/ClearShare/Metadata.cs
+++ b/SIL.Windows.Forms/ClearShare/Metadata.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2024 SIL Global
+// Copyright (c) 2018-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -907,8 +907,8 @@ namespace SIL.Windows.Forms.ClearShare
 
 		/// <summary>
 		/// A super compact form of credits that doesn't introduce any English.
-		/// Jane Doe, © 2008 SIL Global. CC BY-NC 3.0
-		/// International Illustrations: Art Of Reading, © 2009 SIL Global. CC ND 4.0
+		/// Jane Doe, © 2025 SIL Global. CC BY-NC 3.0
+		/// International Illustrations: Art Of Reading, © 2025 SIL Global. CC ND 4.0
 		/// Sam Smith, Free Pictures by Sam. CC0 1.0
 		/// CC0 1.0
 		/// </summary>

--- a/SIL.Windows.Forms/Clipboarding/IClipboard.cs
+++ b/SIL.Windows.Forms/Clipboarding/IClipboard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Drawing;

--- a/SIL.Windows.Forms/Clipboarding/LinuxClipboard.NativeMethods.cs
+++ b/SIL.Windows.Forms/Clipboarding/LinuxClipboard.NativeMethods.cs
@@ -1,4 +1,4 @@
-// // Copyright (c) 2024 SIL Global
+// // Copyright (c) 2025 SIL Global
 // // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/Clipboarding/LinuxClipboard.cs
+++ b/SIL.Windows.Forms/Clipboarding/LinuxClipboard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/Clipboarding/WindowsClipboard.cs
+++ b/SIL.Windows.Forms/Clipboarding/WindowsClipboard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/FileSystem/ConfirmFileOverwriteDlg.cs
+++ b/SIL.Windows.Forms/FileSystem/ConfirmFileOverwriteDlg.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2013' to='2024' company='SIL Global'>
+// <copyright from='2013' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms/FileSystem/ConfirmFileOverwriteDlg.cs
+++ b/SIL.Windows.Forms/FileSystem/ConfirmFileOverwriteDlg.cs
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2013' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
-//    
+//		Copyright (c) 2025 SIL Global
+//
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: ConfirmFileOverwriteDlg.cs
 // ---------------------------------------------------------------------------------------------
 using System;

--- a/SIL.Windows.Forms/HtmlBrowser/IWebBrowser.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/IWebBrowser.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/HtmlBrowser/IWebBrowserCallbacks.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/IWebBrowserCallbacks.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/HtmlBrowser/WinFormsBrowserAdapter.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/WinFormsBrowserAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/HtmlBrowser/XWebBrowser.Designer.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/XWebBrowser.Designer.cs
@@ -1,17 +1,17 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 namespace SIL.Windows.Forms.HtmlBrowser
 {
 	partial class XWebBrowser
 	{
-		/// <summary> 
+		/// <summary>
 		/// Required designer variable.
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
 		private bool disposed = false;
-		/// <summary> 
+		/// <summary>
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -32,8 +32,8 @@ namespace SIL.Windows.Forms.HtmlBrowser
 
 		#region Component Designer generated code
 
-		/// <summary> 
-		/// Required method for Designer support - do not modify 
+		/// <summary>
+		/// Required method for Designer support - do not modify
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent()

--- a/SIL.Windows.Forms/HtmlBrowser/XWebBrowser.cs
+++ b/SIL.Windows.Forms/HtmlBrowser/XWebBrowser.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -296,7 +296,7 @@ namespace SIL.Windows.Forms.HtmlBrowser
 
 		void IWebBrowserCallbacks.OnNavigating(WebBrowserNavigatingEventArgs e)
 		{
-			//we're interpretting AllowNavigation==false as meaning "links should open in an external browser"
+			//we're interpreting AllowNavigation==false as meaning "links should open in an external browser"
 			if (GetShouldThisNavigationUseExternalBrowser(e.Url.AbsolutePath))
 			{
 				try

--- a/SIL.Windows.Forms/Miscellaneous/FormForUsingPortableClipboard.cs
+++ b/SIL.Windows.Forms/Miscellaneous/FormForUsingPortableClipboard.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System.Windows.Forms;

--- a/SIL.Windows.Forms/Miscellaneous/GraphicsManager.cs
+++ b/SIL.Windows.Forms/Miscellaneous/GraphicsManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using JetBrains.Annotations;

--- a/SIL.Windows.Forms/Miscellaneous/X11.cs
+++ b/SIL.Windows.Forms/Miscellaneous/X11.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2024, SIL Global
+// Copyright (c) 2012-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Reflection;

--- a/SIL.Windows.Forms/ParentFormBase.cs
+++ b/SIL.Windows.Forms/ParentFormBase.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2021' to='2024' company='SIL Global'>
+// <copyright from='2021' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms/ParentFormBase.cs
+++ b/SIL.Windows.Forms/ParentFormBase.cs
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL Global
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2021' to='2024' company='SIL Global'>
-//		Copyright (c) 2024 SIL Global
+//		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // File: ParentFormBase.cs
 // ---------------------------------------------------------------------------------------------
 using System;

--- a/SIL.Windows.Forms/PortableSettingsProvider/PortableSettingsProvider.cs
+++ b/SIL.Windows.Forms/PortableSettingsProvider/PortableSettingsProvider.cs
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------------------------------
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2010' to='2024' company='SIL Global'>
+// <copyright from='2010' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/SIL.Windows.Forms/PortableSettingsProvider/PortableSettingsProvider.cs
+++ b/SIL.Windows.Forms/PortableSettingsProvider/PortableSettingsProvider.cs
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------------------------
-#region // Copyright 2024 SIL GlobalAll Rights Reserved.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2010' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global. All Rights Reserved.
+//		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class (as ported) originated in FieldWorks (under the GNU Lesser General Public License),
 // but we decided to make it available in SIL.Windows.Forms to make it more readily available to
 // other projects.

--- a/SIL.Windows.Forms/Reporting/MemoryManagement.cs
+++ b/SIL.Windows.Forms/Reporting/MemoryManagement.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Diagnostics;

--- a/SIL.Windows.Forms/Widgets/BetterLinkLabel.cs
+++ b/SIL.Windows.Forms/Widgets/BetterLinkLabel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/Widgets/IControlThatKnowsWritingSystem.cs
+++ b/SIL.Windows.Forms/Widgets/IControlThatKnowsWritingSystem.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using SIL.WritingSystems;

--- a/SIL.Windows.Forms/Widgets/ITextInputBox.cs
+++ b/SIL.Windows.Forms/Widgets/ITextInputBox.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/Widgets/PasswordBox.cs
+++ b/SIL.Windows.Forms/Widgets/PasswordBox.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2024, SIL Global
+// Copyright (c) 2014-2025 SIL Global
 
 using System;
 using System.Drawing;

--- a/SIL.Windows.Forms/Widgets/PasswordBox.designer.cs
+++ b/SIL.Windows.Forms/Widgets/PasswordBox.designer.cs
@@ -1,15 +1,15 @@
-// Copyright (c) 2014-2024, SIL Global
+// Copyright (c) 2014-2025 SIL Global
 
 namespace SIL.Windows.Forms.Widgets
 {
 	partial class PasswordBox
 	{
-		/// <summary> 
+		/// <summary>
 		/// Required designer variable.
 		/// </summary>
 		private System.ComponentModel.IContainer components = null;
 
-		/// <summary> 
+		/// <summary>
 		/// Clean up any resources being used.
 		/// </summary>
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -25,16 +25,16 @@ namespace SIL.Windows.Forms.Widgets
 
 		#region Component Designer generated code
 
-		/// <summary> 
-		/// Required method for Designer support - do not modify 
+		/// <summary>
+		/// Required method for Designer support - do not modify
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent()
 		{
 			this.SuspendLayout();
-			// 
+			//
 			// PasswordBox
-			// 
+			//
 			this.ResumeLayout(false);
 
 		}

--- a/SIL.Windows.Forms/Widgets/StdTextInputBox.cs
+++ b/SIL.Windows.Forms/Widgets/StdTextInputBox.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.Windows.Forms/Widgets/TextInputBox.cs
+++ b/SIL.Windows.Forms/Widgets/TextInputBox.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.WritingSystems.Tests/CLDRNumberingSystemsTests.cs
+++ b/SIL.WritingSystems.Tests/CLDRNumberingSystemsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using NUnit.Framework;

--- a/SIL.WritingSystems/CLDRNumberingSystems.cs
+++ b/SIL.WritingSystems/CLDRNumberingSystems.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System.Collections.Generic;
 using System.Linq;

--- a/SIL.WritingSystems/IcuRulesCollator.cs
+++ b/SIL.WritingSystems/IcuRulesCollator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/SIL.WritingSystems/LanguageLookup.cs
+++ b/SIL.WritingSystems/LanguageLookup.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, SIL Global
+// Copyright (c) 2016-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -45,7 +45,7 @@ namespace SIL.WritingSystems
 		/// </summary>
 		public LanguageLookup(bool ensureDefaultTags = false)
 		{
-			Sldr.InitializeLanguageTags(); // initialise SLDR language tags for implicit script codes
+			Sldr.InitializeLanguageTags(); // initialize SLDR language tags for implicit script codes
 
 			string langTagsContent = LanguageRegistryResources.langTags;
 			// The cached file is renamed if it's invalid during Sldr.InitializeLanguageTags().

--- a/SIL.WritingSystems/NumberingSystemDefinition.cs
+++ b/SIL.WritingSystems/NumberingSystemDefinition.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, SIL Global
+// Copyright (c) 2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;

--- a/TestApps/SIL.Windows.Forms.TestApp/Properties/AssemblyInfo.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2024, SIL Global
+// Copyright (c) 2016-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using SIL.Acknowledgements;

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
@@ -2,7 +2,7 @@
 using SIL.Windows.Forms.Keyboarding;
 
 #region // Copyright (c) 2025 SIL Global
-// <copyright from='2013' to='2024' company='SIL Global'>
+// <copyright from='2013' to='2025' company='SIL Global'>
 //		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
@@ -1,14 +1,14 @@
 // ---------------------------------------------------------------------------------------------
 using SIL.Windows.Forms.Keyboarding;
 
-#region // Copyright 2024 SIL GlobalAll Rights Reserved.
+#region // Copyright (c) 2025 SIL Global
 // <copyright from='2013' to='2024' company='SIL Global'>
-//		Copyright (c) 2024, SIL Global. All Rights Reserved.
+//		Copyright (c) 2025 SIL Global
 //
 //		Distributable under the terms of the MIT License (http://sil.mit-license.org/)
-// </copyright> 
+// </copyright>
 #endregion
-// 
+//
 // This class was originally licensed under the GNU Lesser General Public License.
 // ---------------------------------------------------------------------------------------------
 using SIL.Windows.Forms.SuperToolTip;
@@ -88,9 +88,9 @@ namespace SIL.Windows.Forms.TestApp
 			this._btnShowFadingMessage = new System.Windows.Forms.Button();
 			this.toolStrip1.SuspendLayout();
 			this.SuspendLayout();
-			// 
+			//
 			// toolStrip1
-			// 
+			//
 			this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this._uiLanguageMenu});
 			this.toolStrip1.Location = new System.Drawing.Point(0, 0);
@@ -98,18 +98,18 @@ namespace SIL.Windows.Forms.TestApp
 			this.toolStrip1.Size = new System.Drawing.Size(187, 25);
 			this.toolStrip1.TabIndex = 9;
 			this.toolStrip1.Text = "toolStrip1";
-			// 
+			//
 			// _uiLanguageMenu
-			// 
+			//
 			this._uiLanguageMenu.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
 			this._uiLanguageMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this._uiLanguageMenu.Name = "_uiLanguageMenu";
 			this._uiLanguageMenu.Size = new System.Drawing.Size(58, 22);
 			this._uiLanguageMenu.Text = "English";
 			this._uiLanguageMenu.ToolTipText = "User-interface Language";
-			// 
+			//
 			// btnThrowException
-			// 
+			//
 			this.btnThrowException.Location = new System.Drawing.Point(12, 440);
 			this.btnThrowException.Name = "btnThrowException";
 			this.btnThrowException.Size = new System.Drawing.Size(157, 23);
@@ -117,9 +117,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnThrowException.Text = "Throw Unhandled Exception";
 			this.btnThrowException.UseVisualStyleBackColor = true;
 			this.btnThrowException.Click += new System.EventHandler(this.btnThrowException_Click);
-			// 
+			//
 			// btnShowFormWithModalChild
-			// 
+			//
 			this.btnShowFormWithModalChild.Location = new System.Drawing.Point(12, 411);
 			this.btnShowFormWithModalChild.Name = "btnShowFormWithModalChild";
 			this.btnShowFormWithModalChild.Size = new System.Drawing.Size(157, 23);
@@ -127,9 +127,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnShowFormWithModalChild.Text = "Form w/ Modal Child...";
 			this.btnShowFormWithModalChild.UseVisualStyleBackColor = true;
 			this.btnShowFormWithModalChild.Click += new System.EventHandler(this.btnShowFormWithModalChild_Click);
-			// 
+			//
 			// btnTestContributorsList
-			// 
+			//
 			this.btnTestContributorsList.Location = new System.Drawing.Point(12, 382);
 			this.btnTestContributorsList.Name = "btnTestContributorsList";
 			this.btnTestContributorsList.Size = new System.Drawing.Size(157, 23);
@@ -137,9 +137,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnTestContributorsList.Text = "Test Contributors List...";
 			this.btnTestContributorsList.UseVisualStyleBackColor = true;
 			this.btnTestContributorsList.Click += new System.EventHandler(this.btnTestContributorsList_Click);
-			// 
+			//
 			// recordPlayButton
-			// 
+			//
 			this.recordPlayButton.Location = new System.Drawing.Point(12, 353);
 			this.recordPlayButton.Name = "recordPlayButton";
 			this.recordPlayButton.Size = new System.Drawing.Size(157, 23);
@@ -148,9 +148,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.recordPlayButton.UseVisualStyleBackColor = true;
 			this.recordPlayButton.MouseDown += new System.Windows.Forms.MouseEventHandler(this.recordPlayButton_MouseDown);
 			this.recordPlayButton.MouseUp += new System.Windows.Forms.MouseEventHandler(this.recordPlayButton_MouseUp);
-			// 
+			//
 			// btnFlexibleMessageBox
-			// 
+			//
 			this.btnFlexibleMessageBox.Location = new System.Drawing.Point(12, 324);
 			this.btnFlexibleMessageBox.Name = "btnFlexibleMessageBox";
 			this.btnFlexibleMessageBox.Size = new System.Drawing.Size(157, 23);
@@ -158,9 +158,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnFlexibleMessageBox.Text = "Flexible Message Box";
 			this.btnFlexibleMessageBox.UseVisualStyleBackColor = true;
 			this.btnFlexibleMessageBox.Click += new System.EventHandler(this.btnFlexibleMessageBox_Click);
-			// 
+			//
 			// btnSettingProtectionDialog
-			// 
+			//
 			this.btnSettingProtectionDialog.Location = new System.Drawing.Point(12, 294);
 			this.btnSettingProtectionDialog.Name = "btnSettingProtectionDialog";
 			this.btnSettingProtectionDialog.Size = new System.Drawing.Size(157, 23);
@@ -168,9 +168,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSettingProtectionDialog.Text = "SettingProtectionDialog";
 			this.btnSettingProtectionDialog.UseVisualStyleBackColor = true;
 			this.btnSettingProtectionDialog.Click += new System.EventHandler(this.btnSettingProtectionDialog_Click);
-			// 
+			//
 			// _silAboutBoxGecko
-			// 
+			//
 			this._silAboutBoxGecko.Location = new System.Drawing.Point(12, 179);
 			this._silAboutBoxGecko.Name = "_silAboutBoxGecko";
 			this._silAboutBoxGecko.Size = new System.Drawing.Size(157, 23);
@@ -178,9 +178,9 @@ namespace SIL.Windows.Forms.TestApp
 			this._silAboutBoxGecko.Text = "SIL AboutBox (Gecko)";
 			this._silAboutBoxGecko.UseVisualStyleBackColor = true;
 			this._silAboutBoxGecko.Click += new System.EventHandler(this.OnSilAboutBoxGeckoClicked);
-			// 
+			//
 			// label1
-			// 
+			//
 			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this.label1.AutoSize = true;
 			this.label1.Location = new System.Drawing.Point(12, 569);
@@ -202,9 +202,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.superToolTip1.SetSuperStuff(this.label1, superToolTipInfoWrapper1);
 			this.label1.TabIndex = 1;
 			this.label1.Text = "Hover over me to see a tooltip";
-			// 
+			//
 			// label2
-			// 
+			//
 			this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			this.label2.AutoSize = true;
 			this.label2.Location = new System.Drawing.Point(12, 589);
@@ -221,9 +221,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.superToolTip2.SetSuperStuff(this.label2, superToolTipInfoWrapper2);
 			this.label2.TabIndex = 1;
 			this.label2.Text = "Hover for simple, long tooltip";
-			// 
+			//
 			// btnSelectFile
-			// 
+			//
 			this.btnSelectFile.Location = new System.Drawing.Point(12, 265);
 			this.btnSelectFile.Name = "btnSelectFile";
 			this.btnSelectFile.Size = new System.Drawing.Size(157, 23);
@@ -231,9 +231,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSelectFile.Text = "Select File";
 			this.btnSelectFile.UseVisualStyleBackColor = true;
 			this.btnSelectFile.Click += new System.EventHandler(this.OnSelectFileClicked);
-			// 
+			//
 			// btnMetaDataEditor
-			// 
+			//
 			this.btnMetaDataEditor.Location = new System.Drawing.Point(12, 236);
 			this.btnMetaDataEditor.Name = "btnMetaDataEditor";
 			this.btnMetaDataEditor.Size = new System.Drawing.Size(157, 23);
@@ -241,9 +241,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnMetaDataEditor.Text = "Meta Data Editor";
 			this.btnMetaDataEditor.UseVisualStyleBackColor = true;
 			this.btnMetaDataEditor.Click += new System.EventHandler(this.OnShowMetaDataEditorClicked);
-			// 
+			//
 			// btnShowReleaseNotes
-			// 
+			//
 			this.btnShowReleaseNotes.Location = new System.Drawing.Point(12, 207);
 			this.btnShowReleaseNotes.Name = "btnShowReleaseNotes";
 			this.btnShowReleaseNotes.Size = new System.Drawing.Size(157, 23);
@@ -251,9 +251,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnShowReleaseNotes.Text = "Show Release Notes";
 			this.btnShowReleaseNotes.UseVisualStyleBackColor = true;
 			this.btnShowReleaseNotes.Click += new System.EventHandler(this.OnShowReleaseNotesClicked);
-			// 
+			//
 			// btnSilAboutBox
-			// 
+			//
 			this.btnSilAboutBox.Location = new System.Drawing.Point(12, 150);
 			this.btnSilAboutBox.Name = "btnSilAboutBox";
 			this.btnSilAboutBox.Size = new System.Drawing.Size(157, 23);
@@ -261,16 +261,16 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnSilAboutBox.Text = "SIL AboutBox";
 			this.btnSilAboutBox.UseVisualStyleBackColor = true;
 			this.btnSilAboutBox.Click += new System.EventHandler(this.OnSilAboutBoxClicked);
-			// 
+			//
 			// btnImageToolbox
-			// 
+			//
 			this.btnImageToolbox.Location = new System.Drawing.Point(0, 0);
 			this.btnImageToolbox.Name = "btnImageToolbox";
 			this.btnImageToolbox.Size = new System.Drawing.Size(75, 23);
 			this.btnImageToolbox.TabIndex = 13;
-			// 
+			//
 			// btnWritingSystemSetupDialog
-			// 
+			//
 			this.btnWritingSystemSetupDialog.Location = new System.Drawing.Point(12, 92);
 			this.btnWritingSystemSetupDialog.Name = "btnWritingSystemSetupDialog";
 			this.btnWritingSystemSetupDialog.Size = new System.Drawing.Size(157, 23);
@@ -278,9 +278,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnWritingSystemSetupDialog.Text = "WritingSystemSetupDialog";
 			this.btnWritingSystemSetupDialog.UseVisualStyleBackColor = true;
 			this.btnWritingSystemSetupDialog.Click += new System.EventHandler(this.OnWritingSystemSetupDialogClicked);
-			// 
+			//
 			// btnLookupISOCodeDialog
-			// 
+			//
 			this.btnLookupISOCodeDialog.Location = new System.Drawing.Point(12, 63);
 			this.btnLookupISOCodeDialog.Name = "btnLookupISOCodeDialog";
 			this.btnLookupISOCodeDialog.Size = new System.Drawing.Size(157, 23);
@@ -288,9 +288,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnLookupISOCodeDialog.Text = "LanguageLookupDialog";
 			this.btnLookupISOCodeDialog.UseVisualStyleBackColor = true;
 			this.btnLookupISOCodeDialog.Click += new System.EventHandler(this.OnLanguageLookupDialogClicked);
-			// 
+			//
 			// btnFolderBrowserControl
-			// 
+			//
 			this.btnFolderBrowserControl.Location = new System.Drawing.Point(12, 34);
 			this.btnFolderBrowserControl.Name = "btnFolderBrowserControl";
 			this.btnFolderBrowserControl.Size = new System.Drawing.Size(157, 23);
@@ -298,17 +298,17 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnFolderBrowserControl.Text = "FolderBrowserControl";
 			this.btnFolderBrowserControl.UseVisualStyleBackColor = true;
 			this.btnFolderBrowserControl.Click += new System.EventHandler(this.OnFolderBrowserControlClicked);
-			// 
+			//
 			// superToolTip1
-			// 
+			//
 			this.superToolTip1.FadingInterval = 10;
-			// 
+			//
 			// superToolTip2
-			// 
+			//
 			this.superToolTip2.FadingInterval = 10;
-			// 
+			//
 			// btnMediaFileInfo
-			// 
+			//
 			this.btnMediaFileInfo.Location = new System.Drawing.Point(12, 468);
 			this.btnMediaFileInfo.Margin = new System.Windows.Forms.Padding(2);
 			this.btnMediaFileInfo.Name = "btnMediaFileInfo";
@@ -317,9 +317,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnMediaFileInfo.Text = "Get Media File Info";
 			this.btnMediaFileInfo.UseVisualStyleBackColor = true;
 			this.btnMediaFileInfo.Click += new System.EventHandler(this.btnMediaFileInfo_Click);
-			// 
+			//
 			// btnShowFileOverwriteDlg
-			// 
+			//
 			this.btnShowFileOverwriteDlg.Location = new System.Drawing.Point(12, 496);
 			this.btnShowFileOverwriteDlg.Margin = new System.Windows.Forms.Padding(2);
 			this.btnShowFileOverwriteDlg.Name = "btnShowFileOverwriteDlg";
@@ -328,9 +328,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnShowFileOverwriteDlg.Text = "Show File Overwrite Dialog";
 			this.btnShowFileOverwriteDlg.UseVisualStyleBackColor = true;
 			this.btnShowFileOverwriteDlg.Click += new System.EventHandler(this.btnShowFileOverwriteDlg_Click);
-			// 
+			//
 			// btnOpenProject
-			// 
+			//
 			this.btnOpenProject.Location = new System.Drawing.Point(12, 523);
 			this.btnOpenProject.Margin = new System.Windows.Forms.Padding(2);
 			this.btnOpenProject.Name = "btnOpenProject";
@@ -339,9 +339,9 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnOpenProject.Text = "Open Project";
 			this.btnOpenProject.UseVisualStyleBackColor = true;
 			this.btnOpenProject.Click += new System.EventHandler(this.btnOpenProject_Click);
-			// 
+			//
 			// _btnShowFadingMessage
-			// 
+			//
 			this._btnShowFadingMessage.Location = new System.Drawing.Point(12, 121);
 			this._btnShowFadingMessage.Name = "_btnShowFadingMessage";
 			this._btnShowFadingMessage.Size = new System.Drawing.Size(157, 23);
@@ -349,9 +349,9 @@ namespace SIL.Windows.Forms.TestApp
 			this._btnShowFadingMessage.Text = "Show Fading Message";
 			this._btnShowFadingMessage.UseVisualStyleBackColor = true;
 			this._btnShowFadingMessage.Click += new System.EventHandler(this._btnShowFadingMessage_Click);
-			// 
+			//
 			// TestAppForm
-			// 
+			//
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.ClientSize = new System.Drawing.Size(187, 613);

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2024, SIL Global
+// Copyright (c) 2013-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;

--- a/debian-src/copyright
+++ b/debian-src/copyright
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2008 SIL International
+Copyright (c) 2008-2025 SIL Global
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/l10n/l10n.proj
+++ b/l10n/l10n.proj
@@ -6,7 +6,7 @@
     <PackageId>SIL.libpalaso.l10ns</PackageId>
     <Version>$(GitVersion_NuGetVersion)</Version>
     <Authors>Jason Naylor</Authors>
-    <Company>SIL International</Company>
+    <Company>SIL Global</Company>
 	<RestartBuild Condition="'$(PkgGitVersion_GitVersion_MsBuild)' == ''
 	  OR '$(PkgL10NSharp_ExtractXliff)' == ''
 	  OR '$(PkgMSBuild_Extension_Pack)' == ''
@@ -14,7 +14,7 @@
 	  OR '$(PkgSIL_BuildTasks)' == ''">true</RestartBuild>
 	<RestartBuild Condition="'$(RestartBuild)' == ''">false</RestartBuild>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.9.0" GeneratePathProperty="true">
       <PrivateAssets>All</PrivateAssets>
@@ -24,22 +24,22 @@
     <PackageReference Include="NuGet.CommandLine" Version="6.1.0" GeneratePathProperty="true" />
     <PackageReference Include="SIL.BuildTasks" Version="2.3.0-beta.14" GeneratePathProperty="true" />
   </ItemGroup>
-  
+
   <UsingTask TaskName="NormalizeLocales" AssemblyFile="$(PkgSIL_BuildTasks)\tools\SIL.BuildTasks.dll" />
-  
+
   <Target Name="UpdateCrowdin">
 	<Message Text="RestartBuild=$(RestartBuild)"/>
 	<CallTarget Targets="RestoreBuildDependencies"/>
 	<CallTarget Targets="UpdateCrowdinInternal" Condition="!$(RestartBuild)" />
   </Target>
-  
+
   <Target Name="RestoreBuildDependencies" DependsOnTargets="restore">
 	<MSBuild Projects="$(MSBuildProjectFullPath)" Targets="UpdateCrowdinInternal" Properties="Configuration=$(Configuration)" Condition="$(RestartBuild)" />
   </Target>
-	
+
   <Target Name="UpdateCrowdinInternal" DependsOnTargets="GetVersion">
 	<!-- Remove "not found" messages that are appended each run (Can't MatchWholeLine because leading spaces are trimmed from Lines).
-		These messages accumulate linearly and inifinitely at each ExtractXliff run and are not removed if the string is later found.
+		These messages accumulate linearly and infinitely at each ExtractXliff run and are not removed if the string is later found.
 		Removing these lines before running ExtractXliff ensures that only unfound strings are annotated, and only once.
 		See https://github.com/sillsdev/l10nsharp/issues/113 -->
 	<MSBuild.ExtensionPack.FileSystem.File TaskAction="RemoveLines" Files="Palaso.en.xlf" AvoidRegex="true"
@@ -48,7 +48,7 @@
 	<MSBuild Projects="..\build\Palaso.proj" Targets="Build" Properties="Configuration=Release" />
 	<Exec Command="&quot;$(PkgL10NSharp_ExtractXliff)\tools\ExtractXliff.exe&quot; -n SIL -o Palaso.dll -b Palaso.en.xlf -x Palaso.en.xlf -p $(GitVersion_NuGetVersion) -m SIL.Localizer.GetString -m SIL.Localizer.Localize -g ../Output/Release/net462/SIL.*.dll" />
   </Target>
-  
+
   <Target Name="PackageL10ns" DependsOnTargets="restore;GetVersion">
 	<!-- Expects `crowdin download -i CROWDIN_PROJECT_ID -T CROWDIN_ACCESS_TOKEN` to have been run first -->
 	<NormalizeLocales L10nsDirectory="." />

--- a/l10n/l10ns.nuspec
+++ b/l10n/l10ns.nuspec
@@ -8,7 +8,7 @@
         <authors>Jason Naylor</authors>
 		<license type="expression">MIT</license>
 		<projectUrl>https://github.com/sillsdev/libpalaso</projectUrl>
-		<copyright>Copyright © 2010-2023 SIL International</copyright>
+		<copyright>Copyright © 2010-2025 SIL Global</copyright>
     </metadata>
 	<files>
 	  <file src="**\Palaso.*.xlf" target="content" />


### PR DESCRIPTION
Follow-up to #1350 

- Change the last few "SIL Inc" and "SIL International" to "SIL Global"
- Update copyright year from 2024 to 2025
- Fix misc. comment typos
- Remove EOL whitespace

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1379)
<!-- Reviewable:end -->
