### PR TITLE
[SIL.WritingSystems] Update langtags.json, ianaSubtagRegistry.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Tests.Text] In test class MultiTextBaseTests, renamed method AnnotationOfMisssingAlternative to AnnotationOfMissingAlternative.
 - [SIL.Windows.Forms.Keyboarding.Tests] In test class XkbKeyboardAdapterTests, renamed method Errorkeyboards to ErrorKeyboards.
 - [SIL.Windows.Forms.Keyboarding.Windows] In internal interface ITfInputProcessorProfileMgr, renamed method RegisterProfile parameter hklsubstitute to hklSubstitute.
-- [SIL.Windows.Forms.Reporting] In class ProblemNotificationDialog, renamed internal property _reoccurenceMessage to _reoccurrenceMessage.
+- [SIL.Windows.Forms.Reporting] In class ProblemNotificationDialog, renamed internal property \_reoccurenceMessage to \_reoccurrenceMessage.
 - [SIL.WritingSystems] In class LanguageLookup changed private method AddLanguage parameter threelettercode to threeLetterCode.
+- [SIL.WritingSystems] Updated langtags.json and ianaSubtagRegistry.txt in Resources.
 - [SIL.Xml] (Breaking change!) In class XmlUtils, renamed method GetIndendentedXml to GetIndentedXml.
 - [SIL.UsbDrive.Linux] (Breaking change!) In interface IUDiskDevice renamed method DriveAtaSmartInitiateSelftest to DriveAtaSmartInitiateSelfTest and property DevicePresentationNopolicy to DevicePresentationNoPolicy.
 - [SIL.DictionaryServices.Model] (Breaking change!) In class LexEntry, renamed WellKnownProperties.FlagSkipBaseform to WellKnownProperties.FlagSkipBaseForm and GetSomeMeaningToUseInAbsenseOfHeadWord to GetSomeMeaningToUseInAbsenceOfHeadWord.

--- a/SIL.WritingSystems/Resources/ianaSubtagRegistry.txt
+++ b/SIL.WritingSystems/Resources/ianaSubtagRegistry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-10-16
+File-Date: 2025-02-06
 %%
 Type: language
 Subtag: aa
@@ -882,6 +882,7 @@ Type: language
 Subtag: sa
 Description: Sanskrit
 Added: 2005-10-16
+Scope: macrolanguage
 %%
 Type: language
 Subtag: sc
@@ -5949,6 +5950,7 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: bql
+Description: Karian
 Description: Bilakura
 Added: 2009-07-29
 %%
@@ -8028,6 +8030,12 @@ Description: Lowland Oaxaca Chontal
 Added: 2009-07-29
 %%
 Type: language
+Subtag: cls
+Description: Classical Sanskrit
+Added: 2024-03-04
+Macrolanguage: sa
+%%
+Type: language
 Subtag: clt
 Description: Lautu Chin
 Added: 2012-08-12
@@ -9076,6 +9084,7 @@ Scope: collection
 %%
 Type: language
 Subtag: daz
+Description: Moi-Wadea
 Description: Dao
 Added: 2009-07-29
 %%
@@ -9283,6 +9292,8 @@ Type: language
 Subtag: dek
 Description: Dek
 Added: 2009-07-29
+Deprecated: 2024-12-12
+Preferred-Value: sqm
 %%
 Type: language
 Subtag: del
@@ -9395,6 +9406,7 @@ Macrolanguage: doi
 %%
 Type: language
 Subtag: dgr
+Description: Tlicho
 Description: Dogrib
 Description: Tłı̨chǫ
 Added: 2005-10-16
@@ -14074,6 +14086,12 @@ Added: 2009-07-29
 Macrolanguage: hmn
 %%
 Type: language
+Subtag: hnm
+Description: Hainanese
+Added: 2024-12-12
+Macrolanguage: zh
+%%
+Type: language
 Subtag: hnn
 Description: Hanunoo
 Added: 2009-07-29
@@ -15246,6 +15264,11 @@ Type: language
 Subtag: isu
 Description: Isu (Menchum Division)
 Added: 2009-07-29
+%%
+Type: language
+Subtag: isv
+Description: Interslavic
+Added: 2024-05-15
 %%
 Type: language
 Subtag: itb
@@ -21068,6 +21091,12 @@ Description: Laua
 Added: 2009-07-29
 %%
 Type: language
+Subtag: luh
+Description: Leizhou Chinese
+Added: 2024-12-12
+Macrolanguage: zh
+%%
+Type: language
 Subtag: lui
 Description: Luiseno
 Added: 2005-10-16
@@ -22837,6 +22866,8 @@ Added: 2009-07-29
 %%
 Type: language
 Subtag: mmi
+Description: Hember Avu
+Description: Amben
 Description: Musar
 Added: 2009-07-29
 %%
@@ -26628,6 +26659,8 @@ Type: language
 Subtag: nte
 Description: Nathembo
 Added: 2009-07-29
+Deprecated: 2024-12-12
+Preferred-Value: eko
 %%
 Type: language
 Subtag: ntg
@@ -30916,6 +30949,11 @@ Description: Ririo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: rrm
+Description: Moriori
+Added: 2024-03-04
+%%
+Type: language
 Subtag: rro
 Description: Waima
 Added: 2009-07-29
@@ -32127,6 +32165,12 @@ Type: language
 Subtag: sjb
 Description: Sajau Basap
 Added: 2009-07-29
+%%
+Type: language
+Subtag: sjc
+Description: Shaojiang Chinese
+Added: 2024-12-12
+Macrolanguage: zh
 %%
 Type: language
 Subtag: sjd
@@ -37660,6 +37704,12 @@ Description: Venezuelan Sign Language
 Added: 2009-07-29
 %%
 Type: language
+Subtag: vsn
+Description: Vedic Sanskrit
+Added: 2024-03-04
+Macrolanguage: sa
+%%
+Type: language
 Subtag: vsv
 Description: Valencian Sign Language
 Description: Llengua de signes valenciana
@@ -41278,6 +41328,11 @@ Description: Aluo
 Added: 2009-07-29
 %%
 Type: language
+Subtag: ynb
+Description: Yamben
+Added: 2025-02-06
+%%
+Type: language
 Subtag: ynd
 Description: Yandruwandha
 Added: 2009-07-29
@@ -43592,6 +43647,14 @@ Preferred-Value: hks
 Prefix: sgn
 %%
 Type: extlang
+Subtag: hnm
+Description: Hainanese
+Added: 2024-12-12
+Preferred-Value: hnm
+Prefix: zh
+Macrolanguage: zh
+%%
+Type: extlang
 Subtag: hos
 Description: Ho Chi Minh City Sign Language
 Added: 2009-07-29
@@ -43932,6 +43995,14 @@ Added: 2010-03-11
 Preferred-Value: ltg
 Prefix: lv
 Macrolanguage: lv
+%%
+Type: extlang
+Subtag: luh
+Description: Leizhou Chinese
+Added: 2024-12-12
+Preferred-Value: luh
+Prefix: zh
+Macrolanguage: zh
 %%
 Type: extlang
 Subtag: lvs
@@ -44367,6 +44438,14 @@ Added: 2009-07-29
 Preferred-Value: shu
 Prefix: ar
 Macrolanguage: ar
+%%
+Type: extlang
+Subtag: sjc
+Description: Shaojiang Chinese
+Added: 2024-12-12
+Preferred-Value: sjc
+Prefix: zh
+Macrolanguage: zh
 %%
 Type: extlang
 Subtag: slf
@@ -44818,6 +44897,11 @@ Subtag: Beng
 Description: Bengali
 Description: Bangla
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Berf
+Description: Beria Erfe
+Added: 2025-02-06
 %%
 Type: script
 Subtag: Bhks
@@ -47559,6 +47643,13 @@ Comments: Aluku dialect of the "Busi Nenge Tongo" English-based Creole
   continuum in Eastern Suriname and Western French Guiana
 %%
 Type: variant
+Subtag: anpezo
+Description: Anpezo standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Anpezo
+%%
+Type: variant
 Subtag: ao1990
 Description: Portuguese Language Orthographic Agreement of 1990 (Acordo
   Ortográfico da Língua Portuguesa de 1990)
@@ -47779,6 +47870,22 @@ Added: 2012-02-05
 Prefix: en
 %%
 Type: variant
+Subtag: fascia
+Description: Fascia standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Fascia which
+  unified the three subvarieties Cazet, Brach and Moenat
+%%
+Type: variant
+Subtag: fodom
+Description: Fodom standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Livinallongo
+  and Colle Santa Lucia
+%%
+Type: variant
 Subtag: fonipa
 Description: International Phonetic Alphabet
 Added: 2006-12-11
@@ -47817,6 +47924,13 @@ Description: Gascon
 Added: 2018-04-22
 Prefix: oc
 Comments: Occitan variant spoken in Gascony
+%%
+Type: variant
+Subtag: gherd
+Description: Gherdëina standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in Gherdëina
 %%
 Type: variant
 Subtag: grclass
@@ -47937,6 +48051,16 @@ Added: 2008-10-14
 Prefix: kw
 %%
 Type: variant
+Subtag: kleinsch
+Description: Kleinschmidt orthography
+Description: Allattaasitaamut
+Added: 2024-07-20
+Prefix: kl
+Prefix: kl-tunumiit
+Comments: Orthography for Greenlandic designed by Samuel Kleinschmidt,
+  used from 1851 to 1973.
+%%
+Type: variant
 Subtag: kociewie
 Description: The Kociewie dialect of Polish
 Added: 2014-11-27
@@ -47955,7 +48079,16 @@ Type: variant
 Subtag: laukika
 Description: Classical Sanskrit
 Added: 2010-07-28
+Deprecated: 2024-06-08
 Prefix: sa
+Comments: Preferred tag is cls
+%%
+Type: variant
+Subtag: leidentr
+Description: Ancient Egyptian in Leiden Unified Transliteration
+Added: 2025-02-06
+Prefix: egy
+Comments: Recommended by the International Association of Egyptologists
 %%
 Type: variant
 Subtag: lemosin
@@ -48000,6 +48133,19 @@ Added: 2010-10-10
 Prefix: ru
 Comments: Russian orthography as established by the 1917/1918
   orthographic reforms
+%%
+Type: variant
+Subtag: mdcegyp
+Description: Ancient Egyptian hieroglyphs encoded in Manuel de Codage
+Added: 2025-02-06
+Prefix: egy
+%%
+Type: variant
+Subtag: mdctrans
+Description: Ancient Egyptian transliteration encoded in Manuel de
+  Codage
+Added: 2025-02-06
+Prefix: egy
 %%
 Type: variant
 Subtag: metelko
@@ -48118,6 +48264,15 @@ Prefix: la
 Comments: Peano’s Interlingua, created in 1903 by Giuseppe Peano as an
   international auxiliary language
 Added: 2020-03-12
+%%
+Type: variant
+Subtag: pehoeji
+Description: Hokkien Vernacular Romanization System
+Description: Pe̍h-ōe-jī orthography/romanization
+Added: 2024-03-04
+Prefix: nan-Latn
+Comments: Modern Hokkien Vernacular Romanization System, evolved from
+  the New Dictionary in the Amoy by John Van Nest Talmage in 1894
 %%
 Type: variant
 Subtag: petr1708
@@ -48254,6 +48409,16 @@ Added: 2021-07-17
 Prefix: da
 %%
 Type: variant
+Subtag: tailo
+Description: Taiwanese Hokkien Romanization System for Hokkien
+  languages
+Description: Tâi-lô orthography/romanization
+Added: 2024-03-04
+Prefix: nan-Latn
+Comments: Taiwanese Hokkien Romanization System (Tâi-lô) published in
+  2006 by the Taiwan Ministry of Education
+%%
+Type: variant
 Subtag: tarask
 Description: Belarusian in Taraskievica orthography
 Added: 2007-04-27
@@ -48312,9 +48477,20 @@ Type: variant
 Subtag: vaidika
 Description: Vedic Sanskrit
 Added: 2010-07-28
+Deprecated: 2024-06-08
 Prefix: sa
 Comments: The most ancient dialect of Sanskrit used in verse and prose
   composed until about the 4th century B.C.E.
+Comments: Preferred tag is vsn
+%%
+Type: variant
+Subtag: valbadia
+Description: Val Badia standard of Ladin
+Added: 2024-03-04
+Prefix: lld
+Comments: Represents the standard written form of Ladin in the Val
+  Badia, unifying the three variants Marô, Mesaval and Badiot spoken
+  in this valley
 %%
 Type: variant
 Subtag: valencia


### PR DESCRIPTION
Followed the instructions on https://github.com/sillsdev/libpalaso/tree/master/SIL.WritingSystems#silwritingsystems-library:

- langtags.json is from 2024-06-03
- ianaSubtagRegistry.txt is from 2025-02-06

Fixes #1084

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1393)
<!-- Reviewable:end -->
