### PR TITLE
Remove superfluous issues permission on publish-test-results workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,6 @@ jobs:
     permissions:
       checks: write
       contents: read
-      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
Follow-up to #1395, removing a superfluous permission.