### PR TITLE
SP-2353 ContributorsListControl thread safety improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Changed build date in SILAboutBox to be computed using the last write time instead of creation time.
 - [SIL.Windows.Forms] Made FadingMessageWindow implement all UI logic on the main UI thread in a thread-safe way. Fixes crashes like SP-2340.
 - [SIL.Windows.Forms] Made ContributorsListControl more threadsafe. Possibly fixes crashes like SP-2353 or at least makes them less likely.
+- [SIL.WritingSystems] Added check to Subtag.Equals to ensure two subtags being compared are of same derived type. This could potentially be a subtle breaking change in the unlikely event that someone was intentionally relying on the previous errant behavior.
 
 ## [15.0.0] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.WritingSystems] Added public DownloadLanguageTags method for updating the cached langtags.json from the SLDR repository.
 - [SIL.Core] Add environment variable to disable `GlobalMutex` across processes. Helpful for snap packages in Linux.
 - [SIL.Core] Added string extension method SplitLines.
+- [SIL.Windows.Forms] Added ContributorsListControl.Initialize method to allow the model to be set later when using the (existing) parameterless constructor in Designer.
 
 ### Changed
 
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [SIL.Windows.Forms] Changed build date in SILAboutBox to be computed using the last write time instead of creation time.
 - [SIL.Windows.Forms] Made FadingMessageWindow implement all UI logic on the main UI thread in a thread-safe way. Fixes crashes like SP-2340.
+- [SIL.Windows.Forms] Made ContributorsListControl more threadsafe. Possibly fixes crashes like SP-2353 or at least makes them less likely.
 
 ## [15.0.0] - 2025-01-06
 

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -104,6 +104,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Paratext/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=parsable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pashto/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Pisin/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Preprint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Prepublication/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Qaaa/@EntryIndexedValue">True</s:Boolean>
@@ -120,6 +121,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subdirectory/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=subitem/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Subtags/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=suggestor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=taskbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=triglot/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=vcodec/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Windows.Forms.WritingSystems.Tests/Tree/WritingSystemVariantSuggestorTests.cs
+++ b/SIL.Windows.Forms.WritingSystems.Tests/Tree/WritingSystemVariantSuggestorTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using SIL.TestUtilities;
@@ -61,10 +61,10 @@ namespace SIL.Windows.Forms.WritingSystems.Tests.Tree
 
 
 		/// <summary>
-		/// For English, it's very unlikely that they'll want to add IPA, in a app like wesay
+		/// For English, it's very unlikely that they'll want to add IPA, in an app like WeSay
 		/// </summary>
 		[Test, Category("KnownMonoIssue")]
-		public void GetSuggestions_MajorWorlLanguage_SuggestsOnlyIfSuppressSuggesstionsForMajorWorldLanguagesIsFalse()
+		public void GetSuggestions_MajorWorldLanguage_SuggestsOnlyIfSuppressSuggestionsForMajorWorldLanguagesIsFalse()
 		{
 			var english = new WritingSystemDefinition("en", string.Empty, string.Empty, string.Empty, "eng", false);
 			var list = new List<WritingSystemDefinition>(new[] { english });

--- a/SIL.Windows.Forms/ClearShare/ContributorsListControlViewModel.cs
+++ b/SIL.Windows.Forms/ClearShare/ContributorsListControlViewModel.cs
@@ -26,10 +26,7 @@ namespace SIL.Windows.Forms.ClearShare
 		}
 
 		/// ------------------------------------------------------------------------------------
-		public IEnumerable<Role> OlacRoles
-		{
-			get { return _olacSystem.GetRoles(); }
-		}
+		public IEnumerable<Role> OlacRoles => _olacSystem.GetRoles();
 
 		/// ------------------------------------------------------------------------------------
 		public GridSettings ContributorsGridSettings
@@ -53,8 +50,7 @@ namespace SIL.Windows.Forms.ClearShare
 		{
 			Contributions = (list ?? new ContributionCollection());
 
-			if (_saveAction != null)
-				_saveAction();
+			_saveAction?.Invoke();
 		}
 
 		/// ------------------------------------------------------------------------------------

--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.designer.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.designer.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 using SIL.Windows.Forms.Widgets.BetterGrid;
 
 namespace SIL.Windows.Forms.ClearShare.WinFormsUI
@@ -16,9 +16,16 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				if (_model != null)
+				{
+					_model.NewContributionListAvailable -= HandleNewContributionListAvailable;
+					_model = null;
+				}
+
+				if (components != null)
+					components.Dispose();
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/Extensions/ControlExtensions.cs
+++ b/SIL.Windows.Forms/Extensions/ControlExtensions.cs
@@ -168,15 +168,15 @@ namespace SIL.Windows.Forms.Extensions
 					// between the time we invoke and the time the action is executed. All we really need from SafeInvoke is that little
 					// bit of code at the start that checks for IsDisposed, but re-using SafeInvoke for the delegate is probably better
 					// than repeating that bit of code. Rechecking InvokeRequired should be lightning fast.
-					var delgate = (Action)delegate
+					var actionToInvoke = (Action)delegate
 					{
 						treatInvalidOperationExceptionAsObjectDisposedException = false;
 						control.SafeInvoke(action, nameForErrorReporting, errorHandling, forceSynchronous);
 					};
 					if (forceSynchronous)
-						control.Invoke(delgate);
+						control.Invoke(actionToInvoke);
 					else
-						return control.BeginInvoke(delgate);
+						return control.BeginInvoke(actionToInvoke);
 				}
 				catch (InvalidOperationException e)
 				{

--- a/SIL.Windows.Forms/Widgets/BetterGrid/BetterGrid.cs
+++ b/SIL.Windows.Forms/Widgets/BetterGrid/BetterGrid.cs
@@ -7,6 +7,8 @@ using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
+using JetBrains.Annotations;
+using SIL.Windows.Forms.Extensions;
 using SIL.Windows.Forms.Properties;
 
 namespace SIL.Windows.Forms.Widgets.BetterGrid
@@ -14,6 +16,8 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 	/// ----------------------------------------------------------------------------------------
 	public class BetterGrid : DataGridView
 	{
+		private const string kRemoveRowCol = "removerow";
+
 		/// ------------------------------------------------------------------------------------
 		public delegate KeyValuePair<object, IEnumerable<object>> GetComboCellListHandler(object sender,
 			DataGridViewCell cell, DataGridViewEditingControlShowingEventArgs args);
@@ -78,14 +82,12 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// row until someone enters data into it).
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public int RowCountLessNewRow
-		{
-			get { return (NewRowIndex == RowCount - 1 && RowCount > 0 ? RowCount - 1 : RowCount); }
-		}
+		public int RowCountLessNewRow =>
+			(NewRowIndex == RowCount - 1 && RowCount > 0 ? RowCount - 1 : RowCount);
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets or sets a value indicating whether or not the grid's contents are dirty.
+		/// Gets or sets a value indicating whether the grid's contents are dirty.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		[Browsable(false)]
@@ -93,7 +95,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		public bool IsDirty
 		{
-			get { return _isDirty; }
+			get => _isDirty;
 			set
 			{
 				_isDirty = value;
@@ -133,7 +135,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets or sets a value determining whether or not to draw a border around a text
+		/// Gets or sets a value determining whether to draw a border around a text
 		/// box cell's edit control when the cell is in the edit mode.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -194,13 +196,13 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		#region Watermark handling methods
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets or sets a value indicating whether or not a water mark is shown when the grid
+		/// Gets or sets a value indicating whether a watermark is shown when the grid
 		/// is dirty.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public bool ShowWaterMarkWhenDirty
 		{
-			get { return _showWaterMarkWhenDirty; }
+			get => _showWaterMarkWhenDirty;
 			set
 			{
 				_showWaterMarkWhenDirty = value;
@@ -211,12 +213,12 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets or sets the character displayed as the water mark.
+		/// Gets or sets the character displayed as the watermark.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		public string WaterMark
 		{
-			get { return _waterMark; }
+			get => _waterMark;
 			set
 			{
 				_waterMark = value;
@@ -239,7 +241,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 				if (Rows.Count > 0 && Columns.Count > 0 && FirstDisplayedCell != null)
 				{
-					// Determine whether or not the vertical scroll bar is showing.
+					// Determine whether the vertical scroll bar is showing.
 					int visibleRows = Rows.GetRowCount(DataGridViewElementStates.Visible);
 					rc = GetCellDisplayRectangle(0, FirstDisplayedCell.RowIndex, false);
 					if (rc.Height * visibleRows >= ClientSize.Height)
@@ -270,7 +272,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets a R, G, or B value that is noticeably distinct (somewhat lighter or darker)
+		/// Gets an R, G, or B value that is noticeably distinct (somewhat lighter or darker)
 		/// from the given value.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -281,7 +283,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Update the water mark when the grid changes size.
+		/// Update the watermark when the grid changes size.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		protected override void OnSizeChanged(EventArgs e)
@@ -290,7 +292,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 			if (PaintWaterMark)
 			{
-				// Clear previous water mark.
+				// Clear previous watermark.
 				PaintWaterMark = false;
 				Invalidate();
 			}
@@ -326,6 +328,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		}
 
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public VScrollBar VScrollBar
 		{
 			get { return Controls.OfType<VScrollBar>().Select(ctrl => ctrl).FirstOrDefault(); }
@@ -351,7 +354,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 	    /// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Update the water mark when the grid scrolls.
+		/// Update the watermark when the grid scrolls.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		protected override void OnScroll(ScrollEventArgs e)
@@ -360,7 +363,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 			if (PaintWaterMark)
 			{
-				// Clear previous water mark.
+				// Clear previous watermark.
 				PaintWaterMark = false;
 				Invalidate();
 			}
@@ -402,7 +405,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Paints a water mark when the results are stale (i.e. the query settings have been
+		/// Paints a watermark when the results are stale (i.e. the query settings have been
 		/// changed since the results were shown).
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -418,7 +421,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 			FontFamily family = FontFamily.GenericSerif;
 
 			// Find the first font size equal to or smaller than 256 that
-			// fits in the water mark rectangle.
+			// fits in the watermark rectangle.
 			for (int size = 256; size >= 0; size -= 2)
 			{
 				using (Font fnt = FontHelper.MakeFont(family.Name, size, FontStyle.Bold))
@@ -463,10 +466,8 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 					return true;
 				}
 
-				if (EditingControl is TextBox)
+				if (EditingControl is TextBox txtBox)
 				{
-					var txtBox = ((TextBox)EditingControl);
-
 					// Only override the default behavior when all the text in the edit control is selected.
 					if (keyData == Keys.Home || keyData == Keys.End && txtBox.SelectedText == txtBox.Text)
 					{
@@ -596,7 +597,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 			if (Columns[e.ColumnIndex] is DataGridViewCheckBoxColumn)
 			{
-				// Force commital of the click's change.
+				// Force commit of the click's change.
 				CommitEdit(DataGridViewDataErrorContexts.Commit);
 				EndEdit();
 			}
@@ -789,7 +790,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 			AlwaysShowRemoveRowIcon = alwaysShowIcon;
 			GetRemoveRowToolTipText = getRemoveRowToolTipText;
 
-			var col = CreateImageColumn("removerow");
+			var col = CreateImageColumn(kRemoveRowCol);
 			col.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
 			col.HeaderText = string.Empty;
 			col.SortMode = DataGridViewColumnSortMode.NotSortable;
@@ -805,7 +806,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		private bool IsRemoveRowColumn(int columnIndex)
 		{
-			return GetColumnName(columnIndex) == "removerow";
+			return GetColumnName(columnIndex) == kRemoveRowCol;
 		}
 
 		/// ------------------------------------------------------------------------------------
@@ -867,6 +868,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// heights automatically, then adds the extra amount specified.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public void AdjustGridRows(int extraAmount)
 		{
 			try
@@ -905,12 +907,14 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		}
 
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public string GetCurrentColumnName()
 		{
 			return GetColumnName(CurrentCellAddress.X);
 		}
 
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public void MakeFirstVisibleCellCurrentInRow(int rowIndex)
 		{
 			if (rowIndex < 0 || rowIndex >= RowCount)
@@ -941,7 +945,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 				// At this point, we know we're looking at a combo box column
 				// whose style is DropDown. Therefore, make sure the item is in
-				// it's list and if not, add it.
+				// its list and if not, add it.
 				if (items[i] != null && !col.Items.Contains(items[i]))
 					col.Items.Add(items[i]);
 			}
@@ -956,6 +960,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// the row.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public void VerifyComboItemsFromRow(DataGridViewRow row)
 		{
 			foreach (DataGridViewCell cell in row.Cells)
@@ -964,9 +969,8 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 				if (col == null || (col.DefaultCellStyle.Tag as string) != kDropDownStyle)
 					continue;
 
-				// At this point, we know we're looking at a combo box column
-				// whose style is DropDown. Therefore, make sure the item is in
-				// it's list and if not, add it.
+				// At this point, we know we're looking at a combo box column whose style is
+				// DropDown. Therefore, make sure the item is in its list and if not, add it.
 				if (cell.Value != null && !col.Items.Contains(cell.Value))
 					col.Items.Add(cell.Value);
 			}
@@ -983,13 +987,14 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// Otherwise, false is returned.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public bool SelectAdjacentVisibleColumn(bool searchLeftFirst)
 		{
 			// Can't select a cell in the current row if there is no current row.
 			if (CurrentCellAddress.Y < 0)
 				return false;
 
-			int inc = (searchLeftFirst ? -1 : 1);
+			int inc = searchLeftFirst ? -1 : 1;
 
 			for (int pass = 0; pass < 2; pass++)
 			{
@@ -1023,8 +1028,9 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 				// invoked unless the handle is created. It's possible that somewhere
 				// down the road, a client will need it to be invoked before the handle
 				// is created. But I hope not.
-				if (IsHandleCreated && !Disposing)
-					BeginInvoke((Action<EventArgs>)OnCurrentRowChanged, EventArgs.Empty);
+				this.SafeInvoke(() => { OnCurrentRowChanged(EventArgs.Empty); },
+					nameof(OnCurrentCellChanged),
+					ControlExtensions.ErrorHandlingAction.IgnoreAll);
 			}
 		}
 
@@ -1054,7 +1060,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 			// Make sure the remove row cell in the new row (if there is a new row) doesn't
 			// contain the default no image, image (i.e. white square box containing a red x).
 			if (e.RowIndex == NewRowIndex && IsRemoveRowColumn(e.ColumnIndex))
-				e.Value = ((DataGridViewImageColumn)Columns["removerow"]).Image;
+				e.Value = ((DataGridViewImageColumn)Columns[kRemoveRowCol]).Image;
 
 			base.OnCellFormatting(e);
 		}
@@ -1066,6 +1072,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// client area the message is drawn.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public void DrawMessageInCenterOfGrid(Graphics g, string message, int verticalOffset)
 		{
 			using (var fnt = new Font(Font.FontFamily, 12f, FontStyle.Regular))
@@ -1276,7 +1283,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 				return;
 			}
 
-			// Determine whether or not there is any gap between the right edge of the last
+			// Determine whether there is any gap between the right edge of the last
 			// displayed cell and the right edge of the client area.
 			var sumOfColWidths = Columns.GetColumnsWidth(DataGridViewElementStates.Displayed);
 			if (sumOfColWidths > ClientSize.Width)
@@ -1324,12 +1331,12 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		{
 			if (!VirtualMode)
 			{
-				var col = Columns["removerow"];
+				var col = Columns[kRemoveRowCol];
 				if (col != null)
 					InvalidateColumn(col.Index);
 			}
-			if (CurrentRowChanged != null)
-				CurrentRowChanged(this, EventArgs.Empty);
+
+			CurrentRowChanged?.Invoke(this, EventArgs.Empty);
 		}
 
 		#region Static methods for creating various column types
@@ -1338,6 +1345,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// Creates a text box grid column.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static DataGridViewColumn CreateTextBoxColumn(string name)
 		{
 			return CreateTextBoxColumn(name, name);
@@ -1366,6 +1374,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// Creates a calendar control grid column that hosts calendar (date) cells.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static DataGridViewColumn CreateCalendarControlColumn(string name)
 		{
 			return CreateCalendarControlColumn(name, name);
@@ -1425,6 +1434,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// drop-down list.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static DataGridViewComboBoxColumn CreateDropDownListComboBoxColumn(string name,
 			ArrayList items)
 		{
@@ -1470,6 +1480,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// validated.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static DataGridViewComboBoxColumn CreateDropDownComboBoxColumn(string name, IEnumerable<string> items)
 		{
 			return CreateDropDownComboBoxColumn(name, items.Cast<object>());
@@ -1498,6 +1509,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// validated.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static DataGridViewComboBoxColumn CreateDropDownComboBoxColumn(string name,
 			ArrayList items)
 		{
@@ -1528,9 +1540,10 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Creates a check box grid column.
+		/// Creates a checkbox grid column.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static DataGridViewCheckBoxColumn CreateCheckBoxColumn(string name)
 		{
 			var col = new DataGridViewCheckBoxColumn();
@@ -1570,6 +1583,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// Creates a SilButtonColumn grid column.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
+		[PublicAPI]
 		public static PushButtonColumn CreatePushButtonColumn(string name)
 		{
 			var col = new PushButtonColumn(name);
@@ -1587,7 +1601,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Returns a value indicating whether or not visual style rendering is supported
+		/// Returns a value indicating whether visual style rendering is supported
 		/// in the application and if the specified element can be rendered.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -1598,7 +1612,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Returns a value indicating whether or not visual style rendering is supported
+		/// Returns a value indicating whether visual style rendering is supported
 		/// in the application.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
@@ -1614,7 +1628,7 @@ namespace SIL.Windows.Forms.Widgets.BetterGrid
 		/// <summary>
 		/// Creates a StringFormat object based on the GenericDefault string format but
 		/// includes vertical centering, EllipsisCharacter trimming and the NoWrap format
-		/// flag. Horizontal alignment is centered when horizontalCenter is true. Otherwise
+		/// flag. Horizontal alignment is centered when horizontalCenter is true. Otherwise,
 		/// horizontal alignment is near.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -284,6 +284,17 @@ namespace SIL.WritingSystems.Tests
 		}
 		#endregion
 
+		[Test]
+		public void Equals_DifferentSubtagType_ReturnsFalse()
+		{
+			var languageSubTag = new LanguageSubtag("xmin", "mine", true, "xkal");
+			var scriptSubTag = new ScriptSubtag("xmin", "mine", true, false);
+			Assert.That(languageSubTag, Is.Not.EqualTo(scriptSubTag));
+			Assert.That(scriptSubTag, Is.Not.EqualTo(languageSubTag));
+			object obj = languageSubTag;
+			Assert.That(scriptSubTag, Is.Not.EqualTo(obj));
+		}
+
 		#region Canonicalize
 		[Test]
 		public void Canonicalize_ImplicitScript_SuppressesScript()

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -287,12 +287,12 @@ namespace SIL.WritingSystems.Tests
 		[Test]
 		public void Equals_DifferentSubtagType_ReturnsFalse()
 		{
-			var languageSubTag = new LanguageSubtag("xmin", "mine", true, "xkal");
-			var scriptSubTag = new ScriptSubtag("xmin", "mine", true, false);
-			Assert.That(languageSubTag, Is.Not.EqualTo(scriptSubTag));
-			Assert.That(scriptSubTag, Is.Not.EqualTo(languageSubTag));
-			object obj = languageSubTag;
-			Assert.That(scriptSubTag, Is.Not.EqualTo(obj));
+			var languageSubtag = new LanguageSubtag("xmin", "mine", true, "xkal");
+			var scriptSubtag = new ScriptSubtag("xmin", "mine", true, false);
+			Assert.That(languageSubtag, Is.Not.EqualTo(scriptSubtag));
+			Assert.That(languageSubtag, Is.Not.EqualTo(scriptSubtag));
+			object obj = languageSubtag;
+			Assert.That(scriptSubtag, Is.Not.EqualTo(obj));
 		}
 
 		#region Canonicalize

--- a/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
+++ b/SIL.WritingSystems.Tests/IetfLanguageTagTests.cs
@@ -290,7 +290,7 @@ namespace SIL.WritingSystems.Tests
 			var languageSubtag = new LanguageSubtag("xmin", "mine", true, "xkal");
 			var scriptSubtag = new ScriptSubtag("xmin", "mine", true, false);
 			Assert.That(languageSubtag, Is.Not.EqualTo(scriptSubtag));
-			Assert.That(languageSubtag, Is.Not.EqualTo(scriptSubtag));
+			Assert.That(scriptSubtag, Is.Not.EqualTo(languageSubtag));
 			object obj = languageSubtag;
 			Assert.That(scriptSubtag, Is.Not.EqualTo(obj));
 		}

--- a/SIL.WritingSystems/Subtag.cs
+++ b/SIL.WritingSystems/Subtag.cs
@@ -81,10 +81,7 @@ namespace SIL.WritingSystems
 		/// <returns>
 		/// 	<c>true</c> if the specified <see cref="T:System.Object"/> is equal to this instance; otherwise, <c>false</c>.
 		/// </returns>
-		/// <exception cref="T:System.NullReferenceException">
-		/// The <paramref name="obj"/> parameter is null.
-		/// </exception>
-		public override bool Equals(object obj) => Equals(obj as Subtag);
+		public override bool Equals(object obj) => obj is Subtag subtag && Equals(subtag);
 
 		/// <summary>
 		/// Determines whether the specified <see cref="T:Subtag"/> is equal to this instance.

--- a/SIL.WritingSystems/Subtag.cs
+++ b/SIL.WritingSystems/Subtag.cs
@@ -81,7 +81,7 @@ namespace SIL.WritingSystems
 		/// <returns>
 		/// 	<c>true</c> if the specified <see cref="T:System.Object"/> is equal to this instance; otherwise, <c>false</c>.
 		/// </returns>
-		public override bool Equals(object obj) => obj is Subtag subtag && Equals(subtag);
+		public override bool Equals(object obj) => Equals(obj as Subtag);
 
 		/// <summary>
 		/// Determines whether the specified <see cref="T:Subtag"/> is equal to this instance.
@@ -90,7 +90,10 @@ namespace SIL.WritingSystems
 		/// <returns></returns>
 		public bool Equals(Subtag other)
 		{
-			return other != null && other.Code.Equals(Code, StringComparison.InvariantCultureIgnoreCase) && other.Name == Name && other.IsPrivateUse == IsPrivateUse;
+			return other != null && GetType() == other.GetType() &&
+				other.Code.Equals(Code, StringComparison.InvariantCultureIgnoreCase) &&
+				other.Name == Name &&
+				other.IsPrivateUse == IsPrivateUse;
 		}
 
 		/// <summary>

--- a/SIL.WritingSystems/Subtag.cs
+++ b/SIL.WritingSystems/Subtag.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace SIL.WritingSystems
@@ -8,10 +8,7 @@ namespace SIL.WritingSystems
 	/// </summary>
 	public abstract class Subtag
 	{
-		private readonly string _code;
 		private readonly string _name;
-		private readonly bool _isPrivateUse;
-		private readonly bool _isDeprecated;
 		private readonly int _hashCode;
 
 		protected Subtag(string code, bool isPrivateUse, bool isDeprecated)
@@ -29,19 +26,19 @@ namespace SIL.WritingSystems
 		protected Subtag(string code, string name, bool isPrivateUse, bool isDeprecated)
 		{
 			if (code == null)
-				throw new ArgumentNullException("code");
+				throw new ArgumentNullException(nameof(code));
 			if (code.Any(c => !IsValidChar(c)))
-				throw new ArgumentException("The code contains invalid characters.", "code");
+				throw new ArgumentException("The code contains invalid characters.", nameof(code));
 
-			_code = code;
+			Code = code;
 			_name = name;
-			_isPrivateUse = isPrivateUse;
-			_isDeprecated = isDeprecated;
+			IsPrivateUse = isPrivateUse;
+			IsDeprecated = isDeprecated;
 
 			_hashCode = 23;
-			_hashCode = _hashCode * 31 + _code.ToLowerInvariant().GetHashCode();
+			_hashCode = _hashCode * 31 + Code.ToLowerInvariant().GetHashCode();
 			_hashCode = _hashCode * 31 + Name.GetHashCode();
-			_hashCode = _hashCode * 31 + _isPrivateUse.GetHashCode();
+			_hashCode = _hashCode * 31 + IsPrivateUse.GetHashCode();
 		}
 
 		private static bool IsValidChar(char c)
@@ -55,19 +52,13 @@ namespace SIL.WritingSystems
 		/// Gets the code.
 		/// </summary>
 		/// <value>The code.</value>
-		public string Code
-		{
-			get { return _code; }
-		}
+		public string Code { get; }
 
 		/// <summary>
 		/// Gets the name.
 		/// </summary>
 		/// <value>The name.</value>
-		public string Name
-		{
-			get { return _name ?? string.Empty; }
-		}
+		public string Name => _name ?? string.Empty;
 
 		/// <summary>
 		/// Gets or sets a value indicating whether this instance is private use.
@@ -75,16 +66,13 @@ namespace SIL.WritingSystems
 		/// <value>
 		/// 	<c>true</c> if this instance is private use; otherwise, <c>false</c>.
 		/// </value>
-		public bool IsPrivateUse
-		{
-			get { return _isPrivateUse; }
-		}
+		public bool IsPrivateUse { get; }
 
 		/// <summary>
 		/// Gets a value indicating whether this tag is deprecated.
 		/// </summary>
 		/// <c>true</c> if this tag is deprecated and should not be used; otherwise, <c>false</c>.
-		public bool IsDeprecated { get {return _isDeprecated;} }
+		public bool IsDeprecated { get; }
 
 		/// <summary>
 		/// Determines whether the specified <see cref="T:System.Object"/> is equal to this instance.
@@ -96,10 +84,7 @@ namespace SIL.WritingSystems
 		/// <exception cref="T:System.NullReferenceException">
 		/// The <paramref name="obj"/> parameter is null.
 		/// </exception>
-		public override bool Equals(object obj)
-		{
-			return Equals(obj as Subtag);
-		}
+		public override bool Equals(object obj) => Equals(obj as Subtag);
 
 		/// <summary>
 		/// Determines whether the specified <see cref="T:Subtag"/> is equal to this instance.
@@ -108,7 +93,7 @@ namespace SIL.WritingSystems
 		/// <returns></returns>
 		public bool Equals(Subtag other)
 		{
-			return other != null && other._code.Equals(_code, StringComparison.InvariantCultureIgnoreCase) && other.Name == Name && other._isPrivateUse == _isPrivateUse;
+			return other != null && other.Code.Equals(Code, StringComparison.InvariantCultureIgnoreCase) && other.Name == Name && other.IsPrivateUse == IsPrivateUse;
 		}
 
 		/// <summary>
@@ -117,10 +102,7 @@ namespace SIL.WritingSystems
 		/// <returns>
 		/// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
 		/// </returns>
-		public override int GetHashCode()
-		{
-			return _hashCode;
-		}
+		public override int GetHashCode() => _hashCode;
 
 		/// <summary>
 		/// Returns a <see cref="T:System.String"/> that represents this instance.
@@ -130,9 +112,7 @@ namespace SIL.WritingSystems
 		/// </returns>
 		public override string ToString()
 		{
-			if (!string.IsNullOrEmpty(_name))
-				return _name;
-			return _code;
+			return !string.IsNullOrEmpty(_name) ? _name : Code;
 		}
 
 		/// <summary>
@@ -156,14 +136,8 @@ namespace SIL.WritingSystems
 		/// <param name="x">The x.</param>
 		/// <param name="y">The y.</param>
 		/// <returns>The result of the operator.</returns>
-		public static bool operator !=(Subtag x, Subtag y)
-		{
-			return !(x == y);
-		}
+		public static bool operator !=(Subtag x, Subtag y) => !(x == y);
 
-		public static implicit operator string(Subtag subtag)
-		{
-			return subtag == null ? null : subtag._code;
-		}
+		public static implicit operator string(Subtag subtag) => subtag?.Code;
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.Designer.cs
@@ -19,14 +19,12 @@ namespace SIL.Windows.Forms.TestApp
 
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
 			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
 			this._tableLayout = new System.Windows.Forms.TableLayoutPanel();
 			this._contributorsControl = new SIL.Windows.Forms.ClearShare.WinFormsUI.ContributorsListControl();
 			this._contributorNames = new SIL.Windows.Forms.Widgets.BetterGrid.BetterGrid();
 			this.colName = new System.Windows.Forms.DataGridViewTextBoxColumn();
 			this.btnUpdateContributorNames = new System.Windows.Forms.Label();
-			this.timerToTestNonUiThreadAccess = new System.Windows.Forms.Timer(this.components);
 			this._tableLayout.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this._contributorNames)).BeginInit();
 			this.SuspendLayout();
@@ -119,10 +117,6 @@ namespace SIL.Windows.Forms.TestApp
 			this.btnUpdateContributorNames.Text = "Hover over this text to Update Contributors";
 			this.btnUpdateContributorNames.MouseHover += new System.EventHandler(this.UpdateNames);
 			// 
-			// timerToTestNonUiThreadAccess
-			// 
-			this.timerToTestNonUiThreadAccess.Tick += new System.EventHandler(this.timerToTestNonUiThreadAccess_Tick);
-			// 
 			// ContributorsForm
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -146,6 +140,5 @@ namespace SIL.Windows.Forms.TestApp
 		private SIL.Windows.Forms.Widgets.BetterGrid.BetterGrid _contributorNames;
 		private System.Windows.Forms.Label btnUpdateContributorNames;
 		private System.Windows.Forms.DataGridViewTextBoxColumn colName;
-		private Timer timerToTestNonUiThreadAccess;
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.Designer.cs
@@ -1,0 +1,151 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+using SIL.Windows.Forms.ClearShare.WinFormsUI;
+
+namespace SIL.Windows.Forms.TestApp
+{
+	partial class ContributorsForm
+	{
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		private void InitializeComponent()
+		{
+			this.components = new System.ComponentModel.Container();
+			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+			this._tableLayout = new System.Windows.Forms.TableLayoutPanel();
+			this._contributorsControl = new SIL.Windows.Forms.ClearShare.WinFormsUI.ContributorsListControl();
+			this._contributorNames = new SIL.Windows.Forms.Widgets.BetterGrid.BetterGrid();
+			this.colName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.btnUpdateContributorNames = new System.Windows.Forms.Label();
+			this.timerToTestNonUiThreadAccess = new System.Windows.Forms.Timer(this.components);
+			this._tableLayout.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)(this._contributorNames)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// _tableLayout
+			// 
+			this._tableLayout.AutoSize = true;
+			this._tableLayout.ColumnCount = 2;
+			this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this._tableLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this._tableLayout.Controls.Add(this._contributorsControl, 0, 0);
+			this._tableLayout.Controls.Add(this._contributorNames, 0, 1);
+			this._tableLayout.Controls.Add(this.btnUpdateContributorNames, 1, 1);
+			this._tableLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+			this._tableLayout.Location = new System.Drawing.Point(0, 0);
+			this._tableLayout.Name = "_tableLayout";
+			this._tableLayout.RowCount = 2;
+			this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this._tableLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+			this._tableLayout.Size = new System.Drawing.Size(700, 350);
+			this._tableLayout.TabIndex = 0;
+			// 
+			// _contributorsControl
+			// 
+			this._contributorsControl.BackColor = System.Drawing.Color.Transparent;
+			this._tableLayout.SetColumnSpan(this._contributorsControl, 2);
+			this._contributorsControl.Dock = System.Windows.Forms.DockStyle.Fill;
+			this._contributorsControl.Location = new System.Drawing.Point(3, 3);
+			this._contributorsControl.Name = "_contributorsControl";
+			this._contributorsControl.Size = new System.Drawing.Size(694, 169);
+			this._contributorsControl.TabIndex = 0;
+			this._contributorsControl.ValidatingContributor += new SIL.Windows.Forms.ClearShare.WinFormsUI.ContributorsListControl.ValidatingContributorHandler(this.HandleValidatingContributor);
+			// 
+			// _contributorNames
+			// 
+			this._contributorNames.AllowUserToAddRows = false;
+			this._contributorNames.AllowUserToDeleteRows = false;
+			this._contributorNames.AllowUserToOrderColumns = true;
+			this._contributorNames.AllowUserToResizeRows = false;
+			this._contributorNames.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
+			this._contributorNames.BackgroundColor = System.Drawing.SystemColors.Window;
+			this._contributorNames.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this._contributorNames.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+			dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+			dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
+			dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 9F);
+			dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
+			dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+			dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+			dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+			this._contributorNames.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+			this._contributorNames.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+			this._contributorNames.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.colName});
+			this._contributorNames.Dock = System.Windows.Forms.DockStyle.Fill;
+			this._contributorNames.DrawTextBoxEditControlBorder = false;
+			this._contributorNames.Font = new System.Drawing.Font("Segoe UI", 9F);
+			this._contributorNames.FullRowFocusRectangleColor = System.Drawing.SystemColors.ControlDark;
+			this._contributorNames.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(225)))), ((int)(((byte)(225)))), ((int)(((byte)(225)))));
+			this._contributorNames.Location = new System.Drawing.Point(3, 178);
+			this._contributorNames.MultiSelect = false;
+			this._contributorNames.Name = "_contributorNames";
+			this._contributorNames.PaintHeaderAcrossFullGridWidth = true;
+			this._contributorNames.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+			this._contributorNames.RowHeadersWidth = 22;
+			this._contributorNames.SelectedCellBackColor = System.Drawing.Color.Empty;
+			this._contributorNames.SelectedCellForeColor = System.Drawing.Color.Empty;
+			this._contributorNames.SelectedRowBackColor = System.Drawing.Color.Empty;
+			this._contributorNames.SelectedRowForeColor = System.Drawing.Color.Empty;
+			this._contributorNames.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+			this._contributorNames.ShowWaterMarkWhenDirty = false;
+			this._contributorNames.Size = new System.Drawing.Size(480, 169);
+			this._contributorNames.TabIndex = 1;
+			this._contributorNames.TextBoxEditControlBorderColor = System.Drawing.Color.Silver;
+			this._contributorNames.WaterMark = "!";
+			// 
+			// colName
+			// 
+			this.colName.HeaderText = "Name";
+			this.colName.Name = "colName";
+			// 
+			// btnUpdateContributorNames
+			// 
+			this.btnUpdateContributorNames.Anchor = System.Windows.Forms.AnchorStyles.Right;
+			this.btnUpdateContributorNames.AutoSize = true;
+			this.btnUpdateContributorNames.Location = new System.Drawing.Point(489, 256);
+			this.btnUpdateContributorNames.Name = "btnUpdateContributorNames";
+			this.btnUpdateContributorNames.Size = new System.Drawing.Size(208, 13);
+			this.btnUpdateContributorNames.TabIndex = 2;
+			this.btnUpdateContributorNames.Text = "Hover over this text to Update Contributors";
+			this.btnUpdateContributorNames.MouseHover += new System.EventHandler(this.UpdateNames);
+			// 
+			// timerToTestNonUiThreadAccess
+			// 
+			this.timerToTestNonUiThreadAccess.Tick += new System.EventHandler(this.timerToTestNonUiThreadAccess_Tick);
+			// 
+			// ContributorsForm
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(700, 350);
+			this.Controls.Add(this._tableLayout);
+			this.Name = "ContributorsForm";
+			this.ShowIcon = false;
+			this.Text = "Contributors";
+			this._tableLayout.ResumeLayout(false);
+			this._tableLayout.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)(this._contributorNames)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+		
+		private System.ComponentModel.IContainer components = null;
+		private System.Windows.Forms.TableLayoutPanel _tableLayout;
+		private SIL.Windows.Forms.ClearShare.WinFormsUI.ContributorsListControl _contributorsControl;
+		private SIL.Windows.Forms.Widgets.BetterGrid.BetterGrid _contributorNames;
+		private System.Windows.Forms.Label btnUpdateContributorNames;
+		private System.Windows.Forms.DataGridViewTextBoxColumn colName;
+		private Timer timerToTestNonUiThreadAccess;
+	}
+}

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.cs
@@ -17,7 +17,7 @@ namespace SIL.Windows.Forms.TestApp
 	public partial class ContributorsForm : Form
 	{
 		private ContributorsListControlViewModel _model;
-		private Role _authorRole = new Role("a", "Author", "someone who writes stuff");
+		private readonly Role _authorRole = new Role("a", "Author", "someone who writes stuff");
 		private bool _doneTestingNonUiThreadAccess;
 
 		public ContributorsForm()

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.resx
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.resx
@@ -117,7 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="timerToTestNonUiThreadAccess.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.resx
+++ b/TestApps/SIL.Windows.Forms.TestApp/ContributorsForm.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="timerToTestNonUiThreadAccess.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
Made ContributorsListControl more threadsafe. Possibly fixes crashes like SP-2353 or at least makes them less likely.
Added ContributorsListControl.Initialize method to allow the model to be set later when using the (existing) parameterless constructor in Designer.
Made the TestApp's ContributorsForm able to be edited in Designer and added code to test accessing various methods and properties on ContributorsListControl from a non-UI thread
Also did some minor refactoring, comment/spelling cleanup, etc.
[WIP?] See REVIEW comment at line 259 in ContributorsListControl.cs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1401)
<!-- Reviewable:end -->
