### PR TITLE
Exclude all CodeQL code-scanning queries of "Note" severity

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,18 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          config: |
+            query-filters:
+              - exclude:
+                  id: cs/call-to-unmanaged-code
+              - exclude:
+                  id: cs/catch-of-all-exceptions
+              - exclude:
+                  id: cs/missed-readonly-modifier
+              - exclude:
+                  id: cs/unmanaged-code
+              - exclude:
+                  id: cs/xmldoc/missing-summary
 
       - name: Build C#
         run: dotnet build -bl:build.binlog -c Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,11 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: +security-extended
+          queries: +security-and-quality
+          config: |
+            query-filters:
+              - exclude:
+                  problem.severity: recommendation
 
       - name: Build C#
         run: dotnet build -bl:build.binlog -c Release

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,11 @@ jobs:
               - exclude:
                   id: cs/catch-of-all-exceptions
               - exclude:
+                  id: cs/empty-catch-block
+              - exclude:
                   id: cs/missed-readonly-modifier
+              - exclude:
+                  id: cs/string-concatenation-in-loop
               - exclude:
                   id: cs/unmanaged-code
               - exclude:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,23 +37,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: +security-and-quality
-          config: |
-            query-filters:
-              - exclude:
-                  id: cs/call-to-unmanaged-code
-              - exclude:
-                  id: cs/catch-of-all-exceptions
-              - exclude:
-                  id: cs/empty-catch-block
-              - exclude:
-                  id: cs/missed-readonly-modifier
-              - exclude:
-                  id: cs/string-concatenation-in-loop
-              - exclude:
-                  id: cs/unmanaged-code
-              - exclude:
-                  id: cs/xmldoc/missing-summary
+          queries: +security-extended
 
       - name: Build C#
         run: dotnet build -bl:build.binlog -c Release


### PR DESCRIPTION
To make the code-scanning more useful and less annoying, we can exclude all "note" severity queries. Drops us from ~2700 to 725 alerts: https://github.com/sillsdev/libpalaso/security/code-scanning?query=pr%3A1402+tool%3ACodeQL+is%3Aopen

Using documentation from:

- https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#example-configuration
- https://codeql.github.com/docs/writing-codeql-queries/metadata-for-codeql-queries/
- https://colinsalmcorner.com/fine-tuning-codeql-scans/#widening-the-filter

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1402)
<!-- Reviewable:end -->
