### PR TITLE
Prevent crash in InitializeGrid if model does not have contributions set

### DIFF
--- a/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
+++ b/SIL.Windows.Forms/ClearShare/WinFormsUI/ContributorsListControl.cs
@@ -142,7 +142,7 @@ namespace SIL.Windows.Forms.ClearShare.WinFormsUI
 
 			_model.ContributorsGridSettings?.InitializeGrid(_grid);
 
-			if (_model.Contributions.Any())
+			if (_model.Contributions != null && _model.Contributions.Any())
 				HandleNewContributionListAvailable(_model, EventArgs.Empty);
 		}
 


### PR DESCRIPTION
This was inspired by a crash I ran into while fixing SP-2353 in SayMore, though it is not technically required as part of the fix for that issue.