### PR TITLE
Now that L10nsharp 8.0.0 is released, removed beta

### DIFF
--- a/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
+++ b/SIL.Windows.Forms.Keyboarding.Tests/SIL.Windows.Forms.Keyboarding.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="L10NSharp" Version="8.0.0-beta*" />
+    <PackageReference Include="L10NSharp" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="ibusdotnet" Version="2.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
+++ b/SIL.Windows.Forms.Keyboarding/SIL.Windows.Forms.Keyboarding.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="L10NSharp" Version="8.0.0-beta*" />
+    <PackageReference Include="L10NSharp" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="2.5.0" PrivateAssets="All" />

--- a/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests.csproj
+++ b/SIL.Windows.Forms.Tests/SIL.Windows.Forms.Tests.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="L10NSharp" Version="8.0.0-beta*" />
+    <PackageReference Include="L10NSharp" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Moq" Version="4.18.2" />

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Enchant.Net" Version="1.4.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" PrivateAssets="All" />
-    <PackageReference Include="L10NSharp" Version="8.0.0-beta*" />
+    <PackageReference Include="L10NSharp" Version="8.0.0" />
     <PackageReference Include="Markdig.Signed" Version="0.30.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />


### PR DESCRIPTION
This is a test to see if it passes tests on Appveyor build

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1410)
<!-- Reviewable:end -->
