### PR TITLE
Minor fixes and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Scripture] Added VerseControl.TabKeyPressedInVerseField event to VerseControl to support tabbing out of the verse field of a VerseControl into the next control in the tab order rather than cycling back to the book field.
 - [SIL.Windows.Forms] Added OtherKeysToTreatAsInputKeys property to EnterTextBox.
 - [SIL.DictionaryServices] Added Fields property to LexEntry. Modified LiftWriter.Add(LexEntry entry) to also write the content of entry.Fields.
+- [SIL.Windows.Forms] Added correctly spelled HeaderLabel.ShowWindowBackgroundOnTopAndRightEdge.
 
 ### Changed
 
@@ -70,10 +71,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Made FadingMessageWindow implement all UI logic on the main UI thread in a thread-safe way. Fixes crashes like SP-2340.
 - [SIL.Windows.Forms] Made ContributorsListControl more threadsafe. Possibly fixes crashes like SP-2353 or at least makes them less likely.
 - [SIL.WritingSystems] Added check to Subtag.Equals to ensure two subtags being compared are of same derived type. This could potentially be a subtle breaking change in the unlikely event that someone was intentionally relying on the previous errant behavior.
+- [SIL.Core] Changed ReplaceSubstringInAttr.Visit to use StringComparison.Ordinal rather than the default (StringComparison.CurrentCulture), and also made it correctly return true when the replacement was made successfully. Although either of these could potentially be a BREAKING CHANGE, in practice, it seems unlikely that anyone would have been relying on CurrentCulture comparisons, and although the return value is used, it seems to be used merely to set a flag that is returned from the callers, and the callers I could find for those methods all appear to ignore the returned value. In any case, if someone were relying on the return value, it's unlikely they could have found it helpful to have it return false unconditionally.
 
 ### Deprecated
 
 - [SIL.DictionaryServices] Deprecated the second parameter of GetHumanReadableIdWithAnyIllegalUnicodeEscaped: Added GetHumanReadableIdWithAnyIllegalUnicodeEscaped(LexEntry entry) and marked GetHumanReadableIdWithAnyIllegalUnicodeEscaped(LexEntry entry, Dictionary<string, int> idsAndCounts) as [Obsolete].
+- [SIL.Windows.Forms] Marked the misspelled HeaderLabel.ShowWindowBackgroudOnTopAndRightEdge as [Obsolete] in favor of correctly spelled ShowWindowBackgroundOnTopAndRightEdge.
 
 ## [15.0.0] - 2025-01-06
 

--- a/Palaso.sln.DotSettings
+++ b/Palaso.sln.DotSettings
@@ -21,6 +21,7 @@
 	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=81428C0BA0D7D445A698D8CD871CD598/Pattern/@EntryValue">(?&lt;=\W|^)(?&lt;TAG&gt;REVIEW)(\W|$)(.*)</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=81428C0BA0D7D445A698D8CD871CD598/TodoIconStyle/@EntryValue">Normal</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Abbysinica/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Abortable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Abridgement/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=acknowledgements/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=acodec/@EntryIndexedValue">True</s:Boolean>

--- a/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
+++ b/SIL.Archiving/IMDI/Schema/IMDI_3_0.cs
@@ -1580,7 +1580,7 @@ namespace SIL.Archiving.IMDI.Schema
 		public QualityType Quality { get; set; }
 
 		/// <summary>
-		/// Position (start (+end) ) on a old fashioned tape without time indication
+		/// Position (start (+end) ) on an old-fashioned tape without time indication
 		/// </summary>
 		[PublicAPI]
 		public CounterPositionType CounterPosition { get; set; }

--- a/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoHAL.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoHAL.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD
+#if !NETSTANDARD
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -28,7 +28,7 @@ namespace SIL.UsbDrive.Linux
 			{
 				string devicePath = TryGetDevicePropertyString(_volumeDevice, "volume.mount_point");
 				//When a device is present but not mounted. This method will throw an ArgumentException.
-				//In particular this can be the case just after inserting a UsbDevice
+				//In particular this can be the case just after inserting a USB device
 				return new DirectoryInfo(devicePath);
 			}
 		}

--- a/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks.cs
+++ b/SIL.Core.Desktop/UsbDrive/Linux/UsbDriveInfoUDisks.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD
+#if !NETSTANDARD
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -30,7 +30,7 @@ namespace SIL.UsbDrive.Linux
 				{
 					string mountPath = String.Empty;
 					//When a device is present but not mounted, this method will throw an ArgumentException.
-					//In particular this can be the case just after inserting a UsbDevice.
+					//In particular this can be the case just after inserting a USB device.
 					//The loop here tries to mitigate such an occurrence.
 					string[] paths = _device.MountPaths;
 					while (_device.IsMounted && paths == null || paths.Length == 0)
@@ -43,15 +43,9 @@ namespace SIL.UsbDrive.Linux
 			}
 		}
 
-		public override string VolumeLabel
-		{
-			get { return _device.VolumeLabel; }
-		}
+		public override string VolumeLabel => _device.VolumeLabel;
 
-		public override ulong TotalSize
-		{
-			get { return _device.TotalSize; }
-		}
+		public override ulong TotalSize => _device.TotalSize;
 
 		public override ulong AvailableFreeSpace
 		{

--- a/SIL.Core/Reflection/ReflectionHelper.cs
+++ b/SIL.Core/Reflection/ReflectionHelper.cs
@@ -112,7 +112,7 @@ namespace SIL.Reflection
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Returns a integer value returned from a call to a private method.
+		/// Returns an integer value returned from a call to a private method.
 		/// </summary>
 		/// <param name="binding">This is either the Type of the object on which the method
 		/// is called or an instance of that type of object. When the method being called
@@ -127,7 +127,7 @@ namespace SIL.Reflection
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Returns a integer value returned from a call to a private method.
+		/// Returns an integer value returned from a call to a private method.
 		/// </summary>
 		/// <param name="binding">This is either the Type of the object on which the method
 		/// is called or an instance of that type of object. When the method being called

--- a/SIL.Core/Xml/XmlUtils.cs
+++ b/SIL.Core/Xml/XmlUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -7,6 +8,7 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
+using JetBrains.Annotations;
 using SIL.Linq;
 
 namespace SIL.Xml
@@ -22,6 +24,7 @@ namespace SIL.Xml
 		/// <param name="node">The XmlNode to look in.</param>
 		/// <param name="attrName">The optional attribute to find.</param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static bool GetBooleanAttributeValue(XmlNode node, string attrName)
 		{
 			return GetBooleanAttributeValue(GetOptionalAttributeValue(node, attrName));
@@ -39,9 +42,9 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Given bytes that represent an xml element, return the values of requested attributes (if they exist).
+		/// Given bytes that represent an XML element, return the values of requested attributes (if they exist).
 		/// </summary>
-		/// <param name="data">Data that is expected to an xml element.</param>
+		/// <param name="data">Data that is expected to an XML element.</param>
 		/// <param name="attributes">A set of attributes, the values of which are to be returned.</param>
 		/// <returns>A dictionary </returns>
 		public static Dictionary<string, string> GetAttributes(byte[] data, HashSet<string> attributes)
@@ -63,9 +66,9 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Given a string that represents an xml element, return the values of requested attributes (if they exist).
+		/// Given a string that represents an XML element, return the values of requested attributes (if they exist).
 		/// </summary>
-		/// <param name="data">Data that is expected to an xml element.</param>
+		/// <param name="data">Data that is expected to an XML element.</param>
 		/// <param name="attributes">A set of attributes, the values of which are to be returned.</param>
 		/// <returns>A dictionary </returns>
 		public static Dictionary<string, string> GetAttributes(string data, HashSet<string> attributes)
@@ -92,6 +95,7 @@ namespace SIL.Xml
 		/// <param name="node">The XmlNode to look in.</param>
 		/// <param name="attrName">The optional attribute to find.</param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static bool GetBooleanAttributeValue(XPathNavigator node, string attrName)
 		{
 			return GetBooleanAttributeValue(GetOptionalAttributeValue(node, attrName));
@@ -107,18 +111,19 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Returns a integer obtained from the (mandatory) attribute named.
+		/// Returns an integer obtained from the (mandatory) attribute named.
 		/// </summary>
 		/// <param name="node">The XmlNode to look in.</param>
 		/// <param name="attrName">The mandatory attribute to find.</param>
 		/// <returns>The value, or 0 if attr is missing.</returns>
+		[PublicAPI]
 		public static int GetMandatoryIntegerAttributeValue(XmlNode node, string attrName)
 		{
-			return Int32.Parse(GetMandatoryAttributeValue(node, attrName));
+			return int.Parse(GetMandatoryAttributeValue(node, attrName));
 		}
 
 		/// <summary>
-		/// Returns a integer obtained from the (mandatory) attribute named.
+		/// Returns an integer obtained from the (mandatory) attribute named.
 		/// </summary>
 		/// <param name="element">The XmlNode to look in.</param>
 		/// <param name="attrName">The mandatory attribute to find.</param>
@@ -137,6 +142,7 @@ namespace SIL.Xml
 		/// <param name="attrName"></param>
 		/// <param name="defaultVal"></param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static int GetOptionalIntegerValue(XmlNode node, string attrName, int defaultVal)
 		{
 			string val = GetOptionalAttributeValue(node, attrName);
@@ -144,7 +150,7 @@ namespace SIL.Xml
 			{
 				return defaultVal;
 			}
-			return Int32.Parse(val);
+			return int.Parse(val);
 		}
 
 		/// <summary>
@@ -163,6 +169,7 @@ namespace SIL.Xml
 		/// <param name="node"></param>
 		/// <param name="attrName"></param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static int[] GetMandatoryIntegerListAttributeValue(XmlNode node, string attrName)
 		{
 			string input = GetMandatoryAttributeValue(node, attrName);
@@ -170,7 +177,7 @@ namespace SIL.Xml
 			int[] result = new int[vals.Length];
 			for (int i = 0;i < vals.Length;i++)
 			{
-				result[i] = Int32.Parse(vals[i]);
+				result[i] = int.Parse(vals[i]);
 			}
 			return result;
 		}
@@ -198,6 +205,7 @@ namespace SIL.Xml
 		/// <param name="attrName"></param>
 		/// <returns></returns>
 		[CLSCompliant(false)]
+		[PublicAPI]
 		public static uint[] GetMandatoryUIntegerListAttributeValue(XmlNode node, string attrName)
 		{
 			var input = GetMandatoryAttributeValue(node, attrName);
@@ -240,6 +248,7 @@ namespace SIL.Xml
 		/// </summary>
 		/// <param name="vals"></param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static string MakeIntegerListValue(int[] vals)
 		{
 			return MakeStringFromEnum(vals, vals.Length);
@@ -273,6 +282,7 @@ namespace SIL.Xml
 		/// <param name="attrName">The attribute to find.</param>
 		/// <param name="defaultValue"></param>
 		/// <returns>The value of the attribute, or the default value, if the attribute dismissing</returns>
+		[PublicAPI]
 		public static bool GetOptionalBooleanAttributeValue(XmlNode node, string attrName,
 			bool defaultValue)
 		{
@@ -336,7 +346,7 @@ namespace SIL.Xml
 		public static string GetOptionalAttributeValue(XmlNode node, string attrName,
 			string defaultString)
 		{
-			if (node != null && node.Attributes != null)
+			if (node is { Attributes: { } })
 			{
 				XmlAttribute xa = node.Attributes[attrName];
 				if (xa != null)
@@ -358,9 +368,7 @@ namespace SIL.Xml
 			string defaultString)
 		{
 			if (element == null || !element.Attributes().Any())
-			{
 				return defaultString;
-			}
 			var attribute = element.Attribute(attrName);
 			return attribute != null ? attribute.Value : defaultString;
 		}
@@ -375,13 +383,11 @@ namespace SIL.Xml
 		public static string GetOptionalAttributeValue(XPathNavigator node, string attrName,
 			string defaultString)
 		{
-			if (node != null && node.HasAttributes)
+			if (node is { HasAttributes: true })
 			{
 				string s = node.GetAttribute(attrName, string.Empty);
 				if (!string.IsNullOrEmpty(s))
-				{
 					return s;
-				}
 			}
 			return defaultString;
 		}
@@ -395,20 +401,16 @@ namespace SIL.Xml
 		public static XmlNode FindNode(XmlNode node, string name)
 		{
 			if (node.Name == name)
-			{
 				return node;
-			}
+
 			foreach (XmlNode childNode in node.ChildNodes)
 			{
 				if (childNode.Name == name)
-				{
 					return childNode;
-				}
+
 				XmlNode n = FindNode(childNode, name);
 				if (n != null)
-				{
 					return n;
-				}
 			}
 			return null;
 		}
@@ -489,6 +491,7 @@ namespace SIL.Xml
 			return retval;
 		}
 
+		[PublicAPI]
 		public static string GetMandatoryAttributeValue(XPathNavigator node, string attrName)
 		{
 			string retval = GetOptionalAttributeValue(node, attrName, null);
@@ -499,7 +502,7 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Append an child node with the specified name and value to <paramref name="node"/>.
+		/// Append a child node with the specified name and value to <paramref name="node"/>.
 		/// </summary>
 		/// <param name="node"></param>
 		/// <param name="elementName"></param>
@@ -556,35 +559,28 @@ namespace SIL.Xml
 		public static bool NodesMatch(XmlNode node1, XmlNode node2)
 		{
 			if (node1 == null && node2 == null)
-			{
 				return true;
-			}
+
 			if (node1 == null || node2 == null)
-			{
 				return false;
-			}
+
 			if (node1.Name != node2.Name)
-			{
 				return false;
-			}
+
 			if (node1.InnerText != node2.InnerText)
-			{
 				return false;
-			}
+
 			if (node1.Attributes == null && node2.Attributes != null)
-			{
 				return false;
-			}
-			if (node1.Attributes != null && node2.Attributes == null)
-			{
-				return false;
-			}
+
 			if (node1.Attributes != null)
 			{
-				if (node1.Attributes.Count != node2.Attributes.Count)
-				{
+				if (node2.Attributes == null)
 					return false;
-				}
+
+				if (node1.Attributes.Count != node2.Attributes.Count)
+					return false;
+
 				for (int i = 0;i < node1.Attributes.Count;i++)
 				{
 					XmlAttribute xa1 = node1.Attributes[i];
@@ -595,53 +591,41 @@ namespace SIL.Xml
 					}
 				}
 			}
-			if (node1.ChildNodes == null && node2.ChildNodes != null)
+
+			int iChild1 = 0; // index node1.ChildNodes
+			int iChild2 = 0; // index node2.ChildNodes
+			while (iChild1 < node1.ChildNodes.Count && iChild2 < node1.ChildNodes.Count)
 			{
-				return false;
-			}
-			if (node1.ChildNodes != null && node2.ChildNodes == null)
-			{
-				return false;
-			}
-			if (node1.ChildNodes != null)
-			{
-				int ichild1 = 0; // index node1.ChildNodes
-				int ichild2 = 0; // index node2.ChildNodes
-				while (ichild1 < node1.ChildNodes.Count && ichild2 < node1.ChildNodes.Count)
+				XmlNode child1 = node1.ChildNodes[iChild1];
+
+				// Note that we must defer doing the 'continue' until after we have checked to see if both children are comments
+				// If we continue immediately and the last node of both elements is a comment, the second node will not have
+				// iChild2 incremented and the final test will fail.
+				bool foundComment = false;
+
+				if (child1 is XmlComment)
 				{
-					XmlNode child1 = node1.ChildNodes[ichild1];
-
-					// Note that we must defer doing the 'continue' until after we have checked to see if both children are comments
-					// If we continue immediately and the last node of both elements is a comment, the second node will not have
-					// ichild2 incremented and the final test will fail.
-					bool foundComment = false;
-
-					if (child1 is XmlComment)
-					{
-						ichild1++;
-						foundComment = true;
-					}
-					XmlNode child2 = node2.ChildNodes[ichild2];
-					if (child2 is XmlComment)
-					{
-						ichild2++;
-						foundComment = true;
-					}
-
-					if (foundComment)
-					{
-						continue;
-					}
-
-					if (!NodesMatch(child1, child2))
-					{
-						return false;
-					}
-					ichild1++;
-					ichild2++;
+					iChild1++;
+					foundComment = true;
 				}
+				XmlNode child2 = node2.ChildNodes[iChild2];
+				if (child2 is XmlComment)
+				{
+					iChild2++;
+					foundComment = true;
+				}
+
+				if (foundComment)
+					continue;
+
+				if (!NodesMatch(child1, child2))
+					return false;
+
+				iChild1++;
+				iChild2++;
+				
 				// If we finished both lists we got a match.
-				return ichild1 == node1.ChildNodes.Count && ichild2 == node2.ChildNodes.Count;
+				return iChild1 == node1.ChildNodes.Count && iChild2 == node2.ChildNodes.Count;
 			}
 			// both lists are null
 			return true;
@@ -683,20 +667,20 @@ namespace SIL.Xml
 				return false;
 			if (element1.HasElements)
 			{
-				int ichild1 = 0; // index node1.Elements()
-				int ichild2 = 0; // index node2.Elements()
-				while (ichild1 < element1.Elements().Count() && ichild2 < element1.Elements().Count())
+				int iChild1 = 0; // index node1.Elements()
+				int iChild2 = 0; // index node2.Elements()
+				while (iChild1 < element1.Elements().Count() && iChild2 < element1.Elements().Count())
 				{
-					var child1 = element1.Elements().ToList()[ichild1];
-					var child2 = element2.Elements().ToList()[ichild2];
+					var child1 = element1.Elements().ToList()[iChild1];
+					var child2 = element2.Elements().ToList()[iChild2];
 
 					if (!NodesMatch(child1, child2))
 						return false;
-					ichild1++;
-					ichild2++;
+					iChild1++;
+					iChild2++;
 				}
 				// If we finished both lists we got a match.
-				return (ichild1 == element1.Elements().Count()) && (ichild2 == element2.Elements().Count());
+				return iChild1 == element1.Elements().Count() && iChild2 == element2.Elements().Count();
 			}
 
 			// both lists are null
@@ -707,7 +691,7 @@ namespace SIL.Xml
 		/// Return the first child of the node that is not a comment (or null).
 		/// </summary>
 		/// <param name="node"></param>
-		/// <returns></returns>
+		[PublicAPI]
 		public static XmlNode GetFirstNonCommentChild(XmlNode node)
 		{
 			if (node == null)
@@ -729,9 +713,10 @@ namespace SIL.Xml
 		/// </summary>
 		/// <param name="element"></param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static XElement GetFirstNonCommentChild(XElement element)
 		{
-			return (element == null) ? null : element.Elements().FirstOrDefault();
+			return element?.Elements().FirstOrDefault();
 		}
 
 		/// <summary>
@@ -753,8 +738,9 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Convert a possibly multiparagraph string to a form that is safe to store both in an XML file.
+		/// Convert a possibly multi-paragraph string to a form that is safe to store both in an XML file.
 		/// </summary>
+		[PublicAPI]
 		public static string ConvertMultiparagraphToSafeXml(string sInput)
 		{
 			var sOutput = sInput;
@@ -774,6 +760,7 @@ namespace SIL.Xml
 		/// </summary>
 		/// <param name="sInput"></param>
 		/// <returns></returns>
+		[PublicAPI]
 		public static string MakeSafeXmlAttribute(string sInput)
 		{
 			string sOutput = sInput;
@@ -793,11 +780,12 @@ namespace SIL.Xml
 		/// Convert an encoded attribute string into plain text.
 		/// </summary>
 		/// <param name="sInput"></param>
-		/// <returns></returns>
+		/// <returns>The plain text representation, with all the XML codes replaced by their normal
+		/// (single-character) textual representations</returns>
 		public static string DecodeXmlAttribute(string sInput)
 		{
 			string sOutput = sInput;
-			if (!String.IsNullOrEmpty(sOutput) && sOutput.Contains("&"))
+			if (!string.IsNullOrEmpty(sOutput) && sOutput.Contains("&"))
 			{
 				sOutput = sOutput.Replace("&gt;", ">");
 				sOutput = sOutput.Replace("&lt;", "<");
@@ -805,6 +793,7 @@ namespace SIL.Xml
 				sOutput = sOutput.Replace("&quot;", "\"");
 				sOutput = sOutput.Replace("&amp;", "&");
 			}
+
 			for (int idx = sOutput.IndexOf("&#"); idx >= 0; idx = sOutput.IndexOf("&#"))
 			{
 				int idxEnd = sOutput.IndexOf(';', idx);
@@ -813,19 +802,17 @@ namespace SIL.Xml
 				string sOrig = sOutput.Substring(idx, (idxEnd - idx) + 1);
 				string sNum = sOutput.Substring(idx + 2, idxEnd - (idx + 2));
 				string sReplace = null;
-				int chNum = 0;
 				if (sNum[0] == 'x' || sNum[0] == 'X')
 				{
-					if (Int32.TryParse(sNum.Substring(1), NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo, out chNum))
-						sReplace = Char.ConvertFromUtf32(chNum);
+					if (int.TryParse(sNum.Substring(1), NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo, out var chNum))
+						sReplace = char.ConvertFromUtf32(chNum);
 				}
 				else
 				{
-					if (Int32.TryParse(sNum, out chNum))
-						sReplace = Char.ConvertFromUtf32(chNum);
+					if (int.TryParse(sNum, out var chNum))
+						sReplace = char.ConvertFromUtf32(chNum);
 				}
-				if (sReplace == null)
-					sReplace = sNum;
+				sReplace ??= sNum;
 				sOutput = sOutput.Replace(sOrig, sReplace);
 			}
 			return sOutput;
@@ -837,13 +824,13 @@ namespace SIL.Xml
 		/// <param name="xml"></param>
 		/// <returns></returns>
 		public static string GetIndentedXml(string xml)
-	  {
-		 string outXml = string.Empty;
-		 using(MemoryStream ms = new MemoryStream())
-		 // Create a XMLTextWriter that will send its output to a memory stream (file)
-		 using (XmlTextWriter xtw = new XmlTextWriter(ms, Encoding.Unicode))
-		 {
-			 XmlDocument doc = new XmlDocument();
+		{
+			string outXml = string.Empty;
+			using(MemoryStream ms = new MemoryStream())
+			// Create a XMLTextWriter that will send its output to a memory stream (file)
+			using (XmlTextWriter xtw = new XmlTextWriter(ms, Encoding.Unicode))
+			{
+				XmlDocument doc = new XmlDocument();
 
 //             try
 //             {
@@ -851,7 +838,7 @@ namespace SIL.Xml
 				 // of the XML Document Object Model (DOM)
 				 doc.LoadXml(xml);
 
-				 // Set the formatting property of the XML Text Writer to indented
+				 // Set the formatting property of the XML Text Writer to be indented
 				 // the text writer is where the indenting will be performed
 				 xtw.Formatting = Formatting.Indented;
 
@@ -873,11 +860,11 @@ namespace SIL.Xml
 //             {
 //                 return ex.Message;
 //             }
-		 }
-	  }
+			}
+		}
 
-		//todo: what's the diff between this one and the next?
-		static public XmlElement GetOrCreateElementPredicate(XmlDocument dom, XmlElement parent, string predicate, string name)
+		[PublicAPI]
+		public static XmlElement GetOrCreateElementPredicate(XmlDocument dom, XmlElement parent, string predicate, string name)
 		{
 			XmlElement element = (XmlElement)parent.SelectSingleNodeHonoringDefaultNS("/" + predicate);
 			if (element == null)
@@ -888,7 +875,7 @@ namespace SIL.Xml
 			return element;
 		}
 
-		static public XmlElement GetOrCreateElement(XmlDocument dom, string parentPath, string name)
+		public static XmlElement GetOrCreateElement(XmlDocument dom, string parentPath, string name)
 		{
 			XmlElement element = (XmlElement)dom.SelectSingleNodeHonoringDefaultNS(parentPath + "/" + name);
 			if (element == null)
@@ -910,29 +897,27 @@ namespace SIL.Xml
 			}
 			catch (NullReferenceException)
 			{
-				throw new XmlFormatException(string.Format("Expected a {0} attribute on {1}.", attr, form.OuterXml));
+				throw new XmlFormatException($"Expected a {attr} attribute on {form.OuterXml}.");
 			}
 		}
 
 		public static string GetOptionalAttributeString(XmlNode xmlNode, string attributeName)
 		{
-			XmlAttribute attr = xmlNode.Attributes[attributeName];
-			if (attr == null)
-				return null;
-			return attr.Value;
+			return xmlNode.Attributes[attributeName]?.Value;
 		}
 
+		[PublicAPI]
 		public static XmlNode GetDocumentNodeFromRawXml(string outerXml, XmlNode nodeMaker)
 		{
 			if (string.IsNullOrEmpty(outerXml))
-			{
 				throw new ArgumentException();
-			}
-			XmlDocument doc = nodeMaker as XmlDocument;
-			if (doc == null)
+
+			if (!(nodeMaker is XmlDocument doc))
 			{
 				doc = nodeMaker.OwnerDocument;
+				Debug.Assert(doc != null);
 			}
+
 			using (StringReader sr = new StringReader(outerXml))
 			{
 				using (XmlReader r = XmlReader.Create(sr))
@@ -943,15 +928,16 @@ namespace SIL.Xml
 			}
 		}
 
+		[PublicAPI]
 		public static string GetXmlForShowingInHtml(string xml)
 		{
-			var s = XmlUtils.GetIndentedXml(xml).Replace("<", "&lt;");
+			var s = GetIndentedXml(xml).Replace("<", "&lt;");
 			s = s.Replace("\r\n", "<br/>");
 			s = s.Replace("  ", "&nbsp;&nbsp;");
 			return s;
 		}
 
-
+		[PublicAPI]
 		public static string GetTitleOfHtml(XmlDocument dom, string defaultIfMissing)
 		{
 			var title = dom.SelectSingleNode("//head/title");
@@ -1040,8 +1026,7 @@ namespace SIL.Xml
 				writer.WriteString("");
 			foreach (var child in element.Nodes())
 			{
-				var xElement = child as XElement;
-				if (xElement != null)
+				if (child is XElement xElement)
 					WriteElementTo(writer, xElement, suppressIndentingChildren, preserveNamespaces);
 				else
 					child.WriteTo(writer); // defaults are fine for everything else.
@@ -1066,15 +1051,15 @@ namespace SIL.Xml
 				int code;
 				try
 				{
-					code = Char.ConvertToUtf32(s, i);
+					code = char.ConvertToUtf32(s, i);
 				}
 				catch (ArgumentException)
 				{
 					continue;
 				}
 				if (IsLegalXmlChar(code))
-					buffer.Append(Char.ConvertFromUtf32(code));
-				if (Char.IsSurrogatePair(s, i))
+					buffer.Append(char.ConvertFromUtf32(code));
+				if (char.IsSurrogatePair(s, i))
 					i++;
 			}
 
@@ -1139,13 +1124,11 @@ namespace SIL.Xml
 						fSuccessfulVisit = true;
 				}
 			}
-			if (input.ChildNodes != null) // not sure whether this can happen.
+
+			foreach (XmlNode child in input.ChildNodes)
 			{
-				foreach (XmlNode child in input.ChildNodes)
-				{
-					if (VisitAttributes(child, visitor))
-						fSuccessfulVisit = true;
-				}
+				if (VisitAttributes(child, visitor))
+					fSuccessfulVisit = true;
 			}
 			return fSuccessfulVisit;
 		}
@@ -1187,23 +1170,39 @@ namespace SIL.Xml
 		bool Visit(XAttribute xa);
 	}
 
+	/// <summary>
+	/// "Visitor" that replaces a substring in the value of an attribute.
+	/// </summary>
 	public class ReplaceSubstringInAttr : IAttributeVisitor
 	{
 		readonly string _pattern;
 		readonly string _replacement;
+
+		/// <summary>
+		/// Sets up an object that can be used to replace a particular substring in the value of an
+		/// attribute.
+		/// </summary>
+		/// <param name="pattern">The text of the substring to search for (using case-sensitive,
+		/// ordinal comparison)</param>
+		/// <param name="replacement">The replacement text</param>
 		public ReplaceSubstringInAttr(string pattern, string replacement)
 		{
 			_pattern = pattern;
 			_replacement = replacement;
 		}
+
+		/// <summary>
+		/// Actually performs the replacement in the given attribute.
+		/// </summary>
+		/// <returns>Whether the pattern was found and the replacement made</returns>
 		public virtual bool Visit(XAttribute xa)
 		{
 			string old = xa.Value;
-			int index = old.IndexOf(_pattern);
+			int index = old.IndexOf(_pattern, StringComparison.Ordinal);
 			if (index < 0)
 				return false;
 			xa.Value = old.Replace(_pattern, _replacement);
-			return false;
+			return true;
 		}
 	}
 }

--- a/SIL.Lift/Options/Option.cs
+++ b/SIL.Lift/Options/Option.cs
@@ -12,23 +12,19 @@ namespace SIL.Lift.Options
 		private MultiText _abbreviation;
 		private MultiText _description;
 		private string _humanReadableKey;
-		private MultiText _name;
 
 		public Option(): this(string.Empty, new MultiText()) {}
 
 		public Option(string humanReadableKey, MultiText name) //, Guid guid)
 		{
 			_humanReadableKey = humanReadableKey;
-			_name = name;
+			Name = name;
 			//SearchKeys = new List<string>();
 		}
 
 		#region IChoice Members
 
-		public string Label
-		{
-			get { return _name.GetFirstAlternative(); }
-		}
+		public string Label => Name.GetFirstAlternative();
 
 		#endregion
 
@@ -38,14 +34,9 @@ namespace SIL.Lift.Options
 			get
 			{
 				if (String.IsNullOrEmpty(_humanReadableKey))
-				{
 					return GetDefaultKey(); //don't actually save it yet
-				}
 
-				else
-				{
-					return _humanReadableKey;
-				}
+				return _humanReadableKey;
 			}
 
 			set
@@ -54,8 +45,9 @@ namespace SIL.Lift.Options
 				{
 					_humanReadableKey = GetDefaultKey();
 				}
-						//the idea here is, we're delaying setting the key in concrete for as long as possible
-						//this allows the ui to continue to auto-create the key during a ui session.
+
+				// The idea here is, we're delaying setting the key in concrete for as long as
+				// possible to allow the UI to continue to auto-create the key during a UI session.
 				else if (value != GetDefaultKey())
 				{
 					_humanReadableKey = value.Trim();
@@ -66,26 +58,15 @@ namespace SIL.Lift.Options
 		//        [ReflectorProperty("name", typeof (MultiTextSerializorFactory),
 		//            Required = true)]
 		[XmlElement("name")]
-		public MultiText Name
-		{
-			get { return _name; }
-			set { _name = value; }
-		}
+		public MultiText Name { get; set; }
 
 		//        [ReflectorProperty("abbreviation", typeof (MultiTextSerializorFactory),
 		//            Required = false)]
 		[XmlElement("abbreviation")]
 		public MultiText Abbreviation
 		{
-			get
-			{
-				if (_abbreviation == null)
-				{
-					return Name;
-				}
-				return _abbreviation;
-			}
-			set { _abbreviation = value; }
+			get => _abbreviation ?? Name;
+			set => _abbreviation = value;
 		}
 
 		//
@@ -97,12 +78,11 @@ namespace SIL.Lift.Options
 			get
 			{
 				if (_description == null)
-				{
 					_description = new MultiText();
-				}
+
 				return _description;
 			}
-			set { _description = value; }
+			set => _description = value;
 		}
 
 		[XmlElement("searchKeys")]
@@ -135,7 +115,7 @@ namespace SIL.Lift.Options
 
 		public override string ToString()
 		{
-			return _name.GetFirstAlternative();
+			return Name.GetFirstAlternative();
 		}
 
 		public object GetDisplayProxy(string writingSystemId)
@@ -181,10 +161,10 @@ namespace SIL.Lift.Options
 		public IList<string> GetSearchKeys(string writingSystemId)
 		{
 			var keys = SearchKeys;
-			if(keys==null)
+			if (keys == null)
 				return new List<string>();
 			var alt = SearchKeys.GetExactAlternative(writingSystemId);
-			if(alt==null)
+			if (alt == null)
 				return new List<string>();
 
 			return alt.SplitTrimmed(',');

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBase.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/GeckoBase.cs
@@ -278,8 +278,8 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		}
 		public virtual bool InFocus
 		{
-			get { return _inFocus; }
-			set { _inFocus = value; }
+			get => _inFocus;
+			set => _inFocus = value;
 		}
 
 		public virtual bool Bold { get; set; }
@@ -299,10 +299,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			if (_inFocus)
 			{
 				_inFocus = false;
-				if (UserLostFocus != null)
-				{
-					UserLostFocus.Invoke(this, null);
-				}
+				UserLostFocus?.Invoke(this, null);
 			}
 		}
 		protected virtual void OnDomFocus(object sender, EventArgs ea)
@@ -313,30 +310,24 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 				return;
 			}
 
-			// Only handle DomFocus that occurs on a Element.
-			// This is Important or it will mess with IME keyboard focus.
+			// Only handle DomFocus that occurs on an Element.
+			// This is important, or it will mess with IME keyboard focus.
 			if (e == null || e.Target == null || e.Target.CastToGeckoElement () == null)
 			{
 				return;
 			}
 
 			var content = _browser.Document.GetElementById("main");
-			if (content != null)
+			if (content is GeckoHtmlElement geckoHtmlElement && !_inFocus)
 			{
-				if ((content is GeckoHtmlElement) && (!_inFocus))
-				{
-					// The following is required because we get two in focus events every time this
-					// is entered.  This is normal for Gecko.  But I don't want to be constantly
-					// refocussing.
-					_inFocus = true;
-					EnsureFocusedGeckoControlHasInputFocus();
-					if (_browser != null)
-					{
-						_browser.SetInputFocus();
-					}
-					_focusElement = (GeckoHtmlElement)content;
-					ChangeFocus();
-				}
+				// The following is required because we get two in focus events every time this
+				// is entered. This is normal for Gecko. But I don't want to be constantly
+				// refocusing.
+				_inFocus = true;
+				EnsureFocusedGeckoControlHasInputFocus();
+				_browser?.SetInputFocus();
+				_focusElement = geckoHtmlElement;
+				ChangeFocus();
 			}
 		}
 		protected virtual void OnDomDocumentCompleted(object sender, EventArgs ea)
@@ -350,7 +341,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 
 				IContainerControl containerControl = GetContainerControl();
 
-				if ((containerControl != null) && (containerControl != this) && (containerControl.ActiveControl != this))
+				if (containerControl != null && containerControl != this && containerControl.ActiveControl != this)
 					containerControl.ActiveControl = this;
 
 				_browser.WebBrowserFocus.Activate();
@@ -392,7 +383,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 				// and the mouse is over a gecko control.
 				Form.ActiveForm.ActiveControl = control;
 				EventHandler focusEvent = null;
-				// Attach a execute once only focus handler to the Non GeckoWebBrowser control focus is moving too...
+				// Attach an execute-once only focus handler to the Non GeckoWebBrowser control focus is moving too...
 				focusEvent = (object sender, EventArgs eventArg) =>
 				{
 					control.GotFocus -= focusEvent;

--- a/SIL.Windows.Forms.GeckoBrowserAdapter/ProgressUtils.cs
+++ b/SIL.Windows.Forms.GeckoBrowserAdapter/ProgressUtils.cs
@@ -104,14 +104,14 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		static bool runningInvokeLaterOnUIThreadAction;
 
 		/// <summary>
-		/// If Reentry occurs while processing a InvokeLaterOnUIThread action, then the second action gets moved
+		/// If Reentry occurs while processing an InvokeLaterOnUIThread action, then the second action gets moved
 		/// into this List. When the original action is finished then the saved actions are reposted to the
 		/// synchronization context, and this list is cleared.
 		/// </summary>
 		static List<ThreadStart> postponedInvokeLaterOnUIThreadActions = new List<ThreadStart>();
 
 		/// <summary>
-		/// Check whether or not we have a UI Synchronization Context, and if so whether or not the current
+		/// Check whether we have a UI Synchronization Context, and if so whether the current
 		/// thread is the main UI thread.
 		/// </summary>
 		/// <returns>
@@ -208,7 +208,7 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 			if (caughtException == null)
 				return;
 
-			// FB25127 - if a UnhandledThreadException handler is present use that rather than
+			// FB25127 - if an UnhandledThreadException handler is present use that rather than
 			// rethrowing the exception.
 			if (UnhandledThreadException != null)
 				UnhandledThreadException(caughtException);
@@ -309,8 +309,6 @@ namespace SIL.Windows.Forms.GeckoBrowserAdapter
 		}
 
 		public delegate void ExceptionHandlerDelegate(Exception exception);
-
-
 
 		/// <summary>
 		/// Saves stack trace in the Data property of the exception.

--- a/SIL.Windows.Forms/FileDialogExtender/FileDialogControlBase.cs
+++ b/SIL.Windows.Forms/FileDialogExtender/FileDialogControlBase.cs
@@ -1,5 +1,5 @@
 //  Copyright (c) 2006, Gustavo Franco
-//  Copyright © Decebal Mihailescu 2007-2010
+//  Copyright Â© Decebal Mihailescu 2007-2010
 
 //  Email:  gustavo_franco@hotmail.com
 //  All rights reserved.
@@ -60,18 +60,14 @@ namespace SIL.Windows.Forms.FileDialogExtender
 		#endregion
 
 		#region Variables Declaration
-		System.Windows.Forms.FileDialog _MSdialog;
+		FileDialog _MSdialog;
 		NativeWindow _dlgWrapper;
 		private AddonWindowLocation _StartLocation = AddonWindowLocation.Right;
-		private FolderViewMode _DefaultViewMode = FolderViewMode.Default;
 		IntPtr _hFileDialogHandle = IntPtr.Zero;
-		FileDialogType _FileDlgType;
 		string _InitialDirectory = string.Empty;
 		string _Filter = "All files (*.*)|*.*";
 		string _DefaultExt = "jpg";
 		string _FileName = string.Empty;
-		string _Caption = "Save";
-		string _OKCaption = "&Open";
 		int _FilterIndex = 1;
 		bool _AddExtension = true;
 		bool _CheckFileExists = true;
@@ -98,14 +94,14 @@ namespace SIL.Windows.Forms.FileDialogExtender
 
 		internal static uint OriginalDlgWidth
 		{
-			get { return FileDialogControlBase._originalDlgWidth; }
-			set { FileDialogControlBase._originalDlgWidth = value; }
+			get { return _originalDlgWidth; }
+			set { _originalDlgWidth = value; }
 		}
 
 		internal static uint OriginalDlgHeight
 		{
-			get { return FileDialogControlBase._originalDlgHeight; }
-			set { FileDialogControlBase._originalDlgHeight = value; }
+			get { return _originalDlgHeight; }
+			set { _originalDlgHeight = value; }
 		}
 
 		[Browsable(false)]
@@ -131,42 +127,26 @@ namespace SIL.Windows.Forms.FileDialogExtender
 				_StartLocation = value;
 				if (DesignMode)
 				{
-					this.Refresh();
+					Refresh();
 				}
 			}
 		}
 
-		Size _OriginalCtrlSize;
-		internal Size OriginalCtrlSize
-		{
-			get { return _OriginalCtrlSize; }
-			set
-			{
-				_OriginalCtrlSize = value;
-			}
-		}
+		internal Size OriginalCtrlSize { get; set; }
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(FolderViewMode.Default)]
-		public FolderViewMode FileDlgDefaultViewMode
-		{
-			get { return _DefaultViewMode; }
-			set { _DefaultViewMode = value; }
-		}
+		public FolderViewMode FileDlgDefaultViewMode { get; set; } = FolderViewMode.Default;
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(FileDialogType.OpenFileDlg)]
-		public FileDialogType FileDlgType
-		{
-			get { return _FileDlgType; }
-			set { _FileDlgType = value; }
-		}
+		public FileDialogType FileDlgType { get; set; }
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue("")]
 		public string FileDlgInitialDirectory
 		{
-			get { return DesignMode ? _InitialDirectory : MSDialog.InitialDirectory; }
+			get => DesignMode ? _InitialDirectory : MSDialog.InitialDirectory;
 			set
 			{
 				_InitialDirectory = value;
@@ -179,63 +159,55 @@ namespace SIL.Windows.Forms.FileDialogExtender
 		[DefaultValue("")]
 		public string FileDlgFileName
 		{
-			get { return DesignMode ? _FileName : MSDialog.FileName; }
-			set { _FileName = value; }
+			get => DesignMode ? _FileName : MSDialog.FileName;
+			set => _FileName = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue("")]
-		public string FileDlgCaption
-		{
-			get { return _Caption; }
-			set { _Caption = value; }
-		}
+		public string FileDlgCaption { get; set; } = "Save";
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue("&Open")]
-		public string FileDlgOkCaption
-		{
-			get { return _OKCaption; }
-			set { _OKCaption = value; }
-		}
+		public string FileDlgOkCaption { get; set; } = "&Open";
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue("jpg")]
 		public string FileDlgDefaultExt
 		{
-			get { return DesignMode ? _DefaultExt : MSDialog.DefaultExt; }
-			set { _DefaultExt = value; }
+			get => DesignMode ? _DefaultExt : MSDialog.DefaultExt;
+			set => _DefaultExt = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue("All files (*.*)|*.*")]
 		public string FileDlgFilter
 		{
-			get { return DesignMode ? _Filter : MSDialog.Filter; }
-			set { _Filter = value; }
+			get => DesignMode ? _Filter : MSDialog.Filter;
+			set => _Filter = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(1)]
 		public int FileDlgFilterIndex
 		{
-			get { return DesignMode ? _FilterIndex : MSDialog.FilterIndex; }
-			set { _FilterIndex = value; }
+			get => DesignMode ? _FilterIndex : MSDialog.FilterIndex;
+			set => _FilterIndex = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(true)]
 		public bool FileDlgAddExtension
 		{
-			get { return DesignMode ? _AddExtension : MSDialog.AddExtension; }
-			set { _AddExtension = value; }
+			get => DesignMode ? _AddExtension : MSDialog.AddExtension;
+			set => _AddExtension = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(true)]
 		public bool FileDlgEnableOkBtn
 		{
-			get { return _EnableOkBtn; }
+			get => _EnableOkBtn;
 			set
 			{
 				_EnableOkBtn = value;
@@ -248,25 +220,24 @@ namespace SIL.Windows.Forms.FileDialogExtender
 		[DefaultValue(true)]
 		public bool FileDlgCheckFileExists
 		{
-			get { return DesignMode ? _CheckFileExists : MSDialog.CheckFileExists; }
-			set
-			{ _CheckFileExists = value; }
+			get => DesignMode ? _CheckFileExists : MSDialog.CheckFileExists;
+			set => _CheckFileExists = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(false)]
 		public bool FileDlgShowHelp
 		{
-			get { return DesignMode ? _ShowHelp : MSDialog.ShowHelp; }
-			set { _ShowHelp = value; }
+			get => DesignMode ? _ShowHelp : MSDialog.ShowHelp;
+			set => _ShowHelp = value;
 		}
 
 		[Category("FileDialogExtenders")]
 		[DefaultValue(true)]
 		public bool FileDlgDereferenceLinks
 		{
-			get { return DesignMode ? _DereferenceLinks : MSDialog.DereferenceLinks; }
-			set { _DereferenceLinks = value; }
+			get => DesignMode ? _DereferenceLinks : MSDialog.DereferenceLinks;
+			set => _DereferenceLinks = value;
 		}
 		#endregion
 
@@ -280,13 +251,13 @@ namespace SIL.Windows.Forms.FileDialogExtender
 			{
 				if (MSDialog != null)
 				{
-					MSDialog.FileOk += new CancelEventHandler(FileDialogControlBase_ClosingDialog);
-					MSDialog.Disposed += new EventHandler(FileDialogControlBase_DialogDisposed);
-					MSDialog.HelpRequest += new EventHandler(FileDialogControlBase_HelpRequest);
+					MSDialog.FileOk += FileDialogControlBase_ClosingDialog;
+					MSDialog.Disposed += FileDialogControlBase_DialogDisposed;
+					MSDialog.HelpRequest += FileDialogControlBase_HelpRequest;
 					FileDlgEnableOkBtn = _EnableOkBtn;//that's designed time value
-					NativeMethods.SetWindowText(new HandleRef(_dlgWrapper,_dlgWrapper.Handle), _Caption);
+					NativeMethods.SetWindowText(new HandleRef(_dlgWrapper,_dlgWrapper.Handle), FileDlgCaption);
 					//will work only for open dialog, save dialog will be overriden internally by windows
-					NativeMethods.SetWindowText(new HandleRef(this,_hOKButton), _OKCaption);//SetDlgItemText fails too
+					NativeMethods.SetWindowText(new HandleRef(this,_hOKButton), FileDlgOkCaption);//SetDlgItemText fails too
 					//bool res = NativeMethods.SetDlgItemText(NativeMethods.GetParent(Handle), (int)ControlsId.ButtonOk, FileDlgOkCaption);
 				}
 			}
@@ -302,9 +273,9 @@ namespace SIL.Windows.Forms.FileDialogExtender
 				return;
 			if (MSDialog != null)
 			{
-				MSDialog.FileOk -= new CancelEventHandler(FileDialogControlBase_ClosingDialog);
-				MSDialog.Disposed -= new EventHandler(FileDialogControlBase_DialogDisposed);
-				MSDialog.HelpRequest -= new EventHandler(FileDialogControlBase_HelpRequest);
+				MSDialog.FileOk -= FileDialogControlBase_ClosingDialog;
+				MSDialog.Disposed -= FileDialogControlBase_DialogDisposed;
+				MSDialog.HelpRequest -= FileDialogControlBase_HelpRequest;
 				MSDialog.Dispose();
 				MSDialog = null;
 			}
@@ -351,21 +322,21 @@ namespace SIL.Windows.Forms.FileDialogExtender
 					Pen p = null;
 					try
 					{
-						switch (this.FileDlgStartLocation)
+						switch (FileDlgStartLocation)
 						{
 							case AddonWindowLocation.Right:
-								hb = new System.Drawing.Drawing2D.HatchBrush(HatchStyle.NarrowHorizontal, Color.Black, Color.Red);
+								hb = new HatchBrush(HatchStyle.NarrowHorizontal, Color.Black, Color.Red);
 								p = new Pen(hb, 5);
-								gr.DrawLine(p, 0, 0, 0, this.Height);
+								gr.DrawLine(p, 0, 0, 0, Height);
 								break;
 							case AddonWindowLocation.Bottom:
-								hb = new System.Drawing.Drawing2D.HatchBrush(HatchStyle.NarrowVertical, Color.Black, Color.Red);
+								hb = new HatchBrush(HatchStyle.NarrowVertical, Color.Black, Color.Red);
 								p = new Pen(hb, 5);
-								gr.DrawLine(p, 0, 0, this.Width, 0);
+								gr.DrawLine(p, 0, 0, Width, 0);
 								break;
 							case AddonWindowLocation.BottomRight:
 							default:
-								hb = new System.Drawing.Drawing2D.HatchBrush(HatchStyle.Sphere, Color.Black, Color.Red);
+								hb = new HatchBrush(HatchStyle.Sphere, Color.Black, Color.Red);
 								p = new Pen(hb, 5);
 								gr.DrawLine(p, 0, 0, 4, 4);
 								break;
@@ -373,10 +344,8 @@ namespace SIL.Windows.Forms.FileDialogExtender
 					}
 					finally
 					{
-						if (p != null)
-							p.Dispose();
-						if (hb != null)
-							hb.Dispose();
+						p?.Dispose();
+						hb?.Dispose();
 					}
 				}
 			}
@@ -412,15 +381,15 @@ namespace SIL.Windows.Forms.FileDialogExtender
 		public DialogResult ShowDialog(IWin32Window owner)
 		{
 			DialogResult returnDialogResult = DialogResult.Cancel;
-			if (this.IsDisposed)
+			if (IsDisposed)
 				return returnDialogResult;
 			if (owner == null || owner.Handle == IntPtr.Zero)
 			{
 				WindowWrapper wr = new WindowWrapper(System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle);
 				owner = wr;
 			}
-			OriginalCtrlSize = this.Size;
-			_MSdialog = (FileDlgType == FileDialogType.OpenFileDlg)?new OpenFileDialog()as FileDialog:new SaveFileDialog() as FileDialog;
+			OriginalCtrlSize = Size;
+			_MSdialog = FileDlgType == FileDialogType.OpenFileDlg ? new OpenFileDialog() : new SaveFileDialog() as FileDialog;
 			_dlgWrapper = new WholeDialogWrapper(this);
 			OnPrepareMSDialog();
 			if (!_hasRunInitMSDialog)
@@ -432,8 +401,8 @@ namespace SIL.Windows.Forms.FileDialogExtender
 					AutoUpgradeInfo.SetValue(MSDialog, false, null);
 				returnDialogResult = _MSdialog.ShowDialog(owner);
 			}
-			// Sometimes if you open a animated .gif on the preview and the Form is closed, .Net class throw an exception
-			// Lets ignore this exception and keep closing the form.
+			// Sometimes if you open an animated .gif on the preview and the Form is closed, an
+			// exception is thrown. Let's ignore this exception and keep closing the form.
 			catch (ObjectDisposedException)
 			{
 			}
@@ -447,26 +416,26 @@ namespace SIL.Windows.Forms.FileDialogExtender
 		internal DialogResult ShowDialogExt(FileDialog fdlg,IWin32Window owner)
 		{
 			DialogResult returnDialogResult = DialogResult.Cancel;
-			if (this.IsDisposed)
+			if (IsDisposed)
 				return returnDialogResult;
 			if (owner == null || owner.Handle == IntPtr.Zero)
 			{
 				WindowWrapper wr = new WindowWrapper(System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle);
 				owner = wr;
 			}
-			OriginalCtrlSize = this.Size;
+			OriginalCtrlSize = Size;
 			MSDialog = fdlg;
 			_dlgWrapper = new WholeDialogWrapper(this);
 
 			try
 			{
-				System.Reflection.PropertyInfo AutoUpgradeInfo = MSDialog.GetType().GetProperty("AutoUpgradeEnabled");
-				if (AutoUpgradeInfo != null)
-					AutoUpgradeInfo.SetValue(MSDialog, false, null);
+				var autoUpgradeInfo = MSDialog.GetType().GetProperty("AutoUpgradeEnabled");
+				if (autoUpgradeInfo != null)
+					autoUpgradeInfo.SetValue(MSDialog, false, null);
 				returnDialogResult = _MSdialog.ShowDialog(owner);
 			}
-			// Sometimes if you open a animated .gif on the preview and the Form is closed, .Net class throw an exception
-			// Lets ignore this exception and keep closing the form.
+			// Sometimes if you open an animated .gif on the preview and the Form is closed, an
+			// exception is thrown. Let's ignore this exception and keep closing the form.
 			catch (ObjectDisposedException)
 			{
 			}
@@ -503,7 +472,7 @@ namespace SIL.Windows.Forms.FileDialogExtender
 		#endregion
 		#region helper types
 
-		public class WindowWrapper : System.Windows.Forms.IWin32Window
+		public class WindowWrapper : IWin32Window
 		{
 			public WindowWrapper(IntPtr handle)
 			{

--- a/SIL.Windows.Forms/Reporting/WinFormsExceptionHandler.cs
+++ b/SIL.Windows.Forms/Reporting/WinFormsExceptionHandler.cs
@@ -49,7 +49,7 @@ namespace SIL.Windows.Forms.Reporting
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Catches and displays a otherwise unhandled exception.
+		/// Catches and displays an otherwise unhandled exception.
 		/// </summary>
 		/// <param name="sender">sender</param>
 		/// <param name="e">Exception</param>
@@ -64,7 +64,7 @@ namespace SIL.Windows.Forms.Reporting
 
 			if (DisplayError(e.Exception))
 			{
-				//Are we inside a Application.Run() statement?
+				// Are we inside an Application.Run() statement?
 				if (Application.MessageLoop)
 					Application.Exit();
 				else

--- a/SIL.Windows.Forms/Widgets/HeaderLabel.cs
+++ b/SIL.Windows.Forms/Widgets/HeaderLabel.cs
@@ -1,19 +1,25 @@
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
+using JetBrains.Annotations;
 
 namespace SIL.Windows.Forms.Widgets
 {
+	[PublicAPI]
 	public class HeaderLabel : EnhancedPanel
 	{
+		[Obsolete("Replace with correctly spelled ShowWindowBackgroundOnTopAndRightEdge")]
+		public bool ShowWindowBackgroudOnTopAndRightEdge { get; set; }
+
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
-		/// Gets or sets a value indicating whether or not a one pixel line on the top and
-		/// right edge of the panel is painted the window background color. This is they
+		/// Gets or sets a value indicating whether a one-pixel line on the top and
+		/// right edge of the panel is painted the window background color. This is the
 		/// way a list view header is drawn... believe it or not.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
-		public bool ShowWindowBackgroudOnTopAndRightEdge { get; set; }
+		public bool ShowWindowBackgroundOnTopAndRightEdge { get; set; }
 
 		/// ------------------------------------------------------------------------------------
 		/// <summary>
@@ -22,20 +28,20 @@ namespace SIL.Windows.Forms.Widgets
 		/// ------------------------------------------------------------------------------------
 		protected override void OnPaintBackground(PaintEventArgs e)
 		{
-			Rectangle rc = ClientRectangle;
+			var rc = ClientRectangle;
 			e.Graphics.FillRectangle(SystemBrushes.Window, rc);
 			VisualStyleElement element = VisualStyleElement.Header.Item.Normal;
 
-			// Draw the background, preferrably using visual styles.
+			// Draw the background, preferably using visual styles.
 			if (!PaintingHelper.CanPaintVisualStyle(element))
 				ControlPaint.DrawButton(e.Graphics, rc, ButtonState.Normal);
 			else
 			{
-				// Add 2 so the separator that's drawn at the right
+				// Add 2 so the separator that's drawn on the right
 				// side of normal list resultView header isn't visible.
 				rc.Width += 2;
 
-				if (ShowWindowBackgroudOnTopAndRightEdge)
+				if (ShowWindowBackgroundOnTopAndRightEdge)
 				{
 					// Shrink the rectangle so the top and left
 					// edge window background don't get clobbered.
@@ -47,7 +53,7 @@ namespace SIL.Windows.Forms.Widgets
 				VisualStyleRenderer renderer = new VisualStyleRenderer(element);
 				renderer.DrawBackground(e.Graphics, rc);
 
-				if (ShowWindowBackgroudOnTopAndRightEdge)
+				if (ShowWindowBackgroundOnTopAndRightEdge)
 				{
 					// Draw a window background color line down the right edge.
 					rc = ClientRectangle;

--- a/SIL.WritingSystems.Tests/SortingTests.cs
+++ b/SIL.WritingSystems.Tests/SortingTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -10,10 +10,7 @@ namespace SIL.WritingSystems.Tests
 		[Test]
 		public void IcuCollator_CBA_ABC()
 		{
-			var list = new List<string>();
-			list.Add("c");
-			list.Add("b");
-			list.Add("a");
+			var list = new List<string> {"c", "b", "a" };
 			list.Sort(new IcuRulesCollator(String.Empty));
 			Assert.That(list[0], Is.EqualTo("a"));
 			Assert.That(list[1], Is.EqualTo("b"));
@@ -23,10 +20,7 @@ namespace SIL.WritingSystems.Tests
 		[Test]
 		public void System_CBA_ABC()
 		{
-			var list = new List<string>();
-			list.Add("c");
-			list.Add("b");
-			list.Add("a");
+			var list = new List<string> { "c", "b", "a" };
 			list.Sort(new SystemCollator(null));
 			Assert.That(list[0], Is.EqualTo("a"));
 			Assert.That(list[1], Is.EqualTo("b"));
@@ -38,11 +32,7 @@ namespace SIL.WritingSystems.Tests
 		{
 //            string rules = String.Empty; // This will fail
 			string rules = "&[last primary ignorable] <<< '-' <<< ' '";
-			var list = new List<string>();
-			list.Add("-c");
-			list.Add("c");
-			list.Add("b");
-			list.Add("a");
+			var list = new List<string> { "-c", "c", "b", "a" };
 			list.Sort(new IcuRulesCollator(rules));
 			Assert.That(list[0], Is.EqualTo("a"));
 			Assert.That(list[1], Is.EqualTo("b"));
@@ -53,11 +43,8 @@ namespace SIL.WritingSystems.Tests
 		[Test]
 		public void ICUCollator_WithUnicodeEscapes()
 		{
-			string rules = "&b<\\u0061"; //b comes before 'a' where 'a' is a unicode escape
-			var list = new List<string>();
-			list.Add("a");
-			list.Add("c");
-			list.Add("b");
+			string rules = "&b<\\u0061"; //b comes before 'a' where 'a' is a Unicode escape
+			var list = new List<string> { "a", "c", "b" };
 			list.Sort(new IcuRulesCollator(rules));
 			Assert.That(list[0], Is.EqualTo("b"));
 			Assert.That(list[1], Is.EqualTo("a"));
@@ -67,11 +54,7 @@ namespace SIL.WritingSystems.Tests
 		[Test]
 		public void System_WithDashCBA_ABCDash()
 		{
-			var list = new List<string>();
-			list.Add("-c");
-			list.Add("c");
-			list.Add("b");
-			list.Add("a");
+			var list = new List<string> { "-c", "c", "b", "a" };
 			list.Sort(new SystemCollator(null));
 			Assert.That(list[0], Is.EqualTo("a"));
 			Assert.That(list[1], Is.EqualTo("b"));


### PR DESCRIPTION
Replaced HeaderLabel.ShowWindowBackgroudOnTopAndRightEdge (deprecated) with a correctly spelled version: ShowWindowBackgroundOnTopAndRightEdge
Fixed minor behavior flaws in ReplaceSubstringInAttr
Fixed some spelling/grammar/formatting errors in comments
Added PublicAPI attribute to some public things not used internally.
Minor misc refactoring, including removing unreachable code