### PR TITLE
[SIL.Core] Fix byte-array strings in FastXmlElementSplitter

### DIFF
--- a/SIL.Core/Xml/FastXmlElementSplitter.cs
+++ b/SIL.Core/Xml/FastXmlElementSplitter.cs
@@ -12,7 +12,6 @@ namespace SIL.Xml
 	/// and return byte arrays of each element for further processing.
 	/// This version works entirely with byte arrays, except for the GetSecondLevelElementStrings
 	/// methods, which should only be used for testing or small files.
-	///
 	///</summary>
 	public class FastXmlElementSplitter : IDisposable
 	{
@@ -172,7 +171,6 @@ namespace SIL.Xml
 			return result;
 		}
 
-
 		/// <summary>
 		/// Return the second level elements that are in the input file, including an optional first element.
 		/// </summary>
@@ -227,8 +225,6 @@ namespace SIL.Xml
 		/// Given that _currentInput is at the first character of the marker of the opening XML tag
 		/// of an element, return the byte array that is the complete element.
 		/// </summary>
-		/// <param name="marker"></param>
-		/// <returns></returns>
 		private byte[] MakeElement(byte[] marker)
 		{
 			int start = _currentOffset - 1; // including the opening angle bracket
@@ -237,7 +233,8 @@ namespace SIL.Xml
 			{
 				bool gotOpenBracket = AdvanceToAngleBracket();
 				if (_currentOffset > _endOfRecordsOffset)
-					throw new ArgumentException("Unmatched opening tag " + marker);
+					throw new ArgumentException(
+						"Unmatched opening tag " + string.Join("", marker));
 				// We have to distinguish these cases:
 				// 1. <x... : depth++ (start of opening marker)
 				// 2: ...> : no change (end of opening or closing marker)
@@ -259,9 +256,7 @@ namespace SIL.Xml
 						continue;
 					}
 					else
-					{
 						depth++; // case 1 (or 6)
-					}
 				}
 				else
 				{
@@ -278,16 +273,20 @@ namespace SIL.Xml
 						// case 3, advance past opening slash
 						_currentOffset++;
 						if (!MatchMarker(marker))
-							throw new ArgumentException("Unmatched opening tag " + marker); // wrong close marker
+							// Wrong close marker.
+							throw new ArgumentException(
+								"Unmatched opening tag " + string.Join("", marker));
 						AdvanceToClosingAngleBracket();
 					}
 					// We matched the marker we started with, output the chunk.
 					if (_input[_currentOffset - 1] != _closingAngleBracket)
-						throw new ArgumentException("Unmatched opening tag " + marker);
+						throw new ArgumentException(
+							"Unmatched opening tag " + string.Join("", marker));
 					return _input.SubArray(start, _currentOffset - start);
 				}
 				if (_currentOffset == _endOfRecordsOffset)
-					throw new ArgumentException("Unmatched opening tag " + marker);
+					throw new ArgumentException(
+						"Unmatched opening tag " + string.Join("", marker));
 			}
 		}
 
@@ -310,19 +309,16 @@ namespace SIL.Xml
 		/// Enhance JohnT: technically I think there could be white space between the opening angle bracket and the
 		/// marker. We can make that enhancement if we need it.
 		/// </summary>
-		/// <param name="marker"></param>
-		/// <returns></returns>
 		bool MatchMarker(byte[] marker)
 		{
-			if (!Match(marker)) return false;
+			if (!Match(marker))
+				return false;
 			return Terminators.Contains(_input[_currentOffset + marker.Length]);
 		}
 
 		/// <summary>
 		/// Return true if the bytes starting at _currentPosition match the specified marker. No termination is required.
 		/// </summary>
-		/// <param name="marker"></param>
-		/// <returns></returns>
 		private bool Match(byte[] marker)
 		{
 			if (_currentOffset + marker.Length >= _endOfRecordsOffset)
@@ -501,8 +497,7 @@ namespace SIL.Xml
 			GC.SuppressFinalize(this);
 		}
 
-		private bool IsDisposed
-		{ get; set; }
+		private bool IsDisposed { get; set; }
 
 		private void Dispose(bool disposing)
 		{
@@ -511,8 +506,7 @@ namespace SIL.Xml
 
 			if (disposing)
 			{
-				if (_input != null)
-					_input.Close();
+				_input?.Close();
 				_input = null;
 			}
 
@@ -622,8 +616,6 @@ namespace SIL.Xml
 		/// <summary>
 		/// This makes the class function like a byte array, allowing [n] to get the nth byte.
 		/// </summary>
-		/// <param name="n"></param>
-		/// <returns></returns>
 		public byte this[int n]
 		{
 			get
@@ -714,15 +706,9 @@ namespace SIL.Xml
 			// nothing to do
 		}
 
-		public byte this[int index]
-		{
-			get { return _bytes[index]; }
-		}
+		public byte this[int index] => _bytes[index];
 
-		public int Length
-		{
-			get { return _bytes.Length; }
-		}
+		public int Length => _bytes.Length;
 
 		public byte[] SubArray(int start, int count)
 		{
@@ -746,9 +732,6 @@ namespace SIL.Xml
 			Bytes = bytes;
 		}
 
-		public string BytesAsString
-		{
-			get { return Encoding.UTF8.GetString(Bytes); }
-		}
+		public string BytesAsString => Encoding.UTF8.GetString(Bytes);
 	}
 }

--- a/SIL.Core/Xml/FastXmlElementSplitter.cs
+++ b/SIL.Core/Xml/FastXmlElementSplitter.cs
@@ -222,8 +222,8 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Given that _currentInput is at the first character of the marker of the opening XML tag
-		/// of an element, return the byte array that is the complete element.
+		/// Since <see cref="_currentOffset"/> is at the first character of the marker of the
+		/// opening XML tag of an element, return the byte array that is the complete element.
 		/// </summary>
 		private byte[] MakeElement(byte[] marker)
 		{
@@ -441,7 +441,7 @@ namespace SIL.Xml
 		/// </summary>
 		private void AdvanceToOpenAngleBracket()
 		{
-			for (; _currentOffset < _endOfRecordsOffset;_currentOffset++)
+			for (; _currentOffset < _endOfRecordsOffset; _currentOffset++)
 			{
 				if (_input[_currentOffset] == _openingAngleBracket)
 				{
@@ -566,7 +566,7 @@ namespace SIL.Xml
 			Length = (int)new FileInfo(_pathname).Length;
 			// Setting a high offset ensures that no byte we want will be in any buffer's range.
 			for (int i = 0; i < kBufferCount; i++)
-				buffers[i] = new Buffer() {Data = new byte[kbufLen], Offset = Length};
+				buffers[i] = new Buffer() { Data = new byte[kbufLen], Offset = Length };
 			_currentBuffer = -1; // no buffer is loaded
 			m_reader = new FileStream(_pathname, FileMode.Open, FileAccess.Read, FileShare.None, 4096, true);
 			// Read a block at the end of the file, which we happen to know we will want first.

--- a/SIL.Core/Xml/FastXmlElementSplitter.cs
+++ b/SIL.Core/Xml/FastXmlElementSplitter.cs
@@ -15,11 +15,11 @@ namespace SIL.Xml
 	///</summary>
 	public class FastXmlElementSplitter : IDisposable
 	{
-		private readonly static Encoding EncUtf8 = Encoding.UTF8;
-		private readonly static byte _openingAngleBracket = EncUtf8.GetBytes("<")[0];
-		private readonly static byte _closingAngleBracket = EncUtf8.GetBytes(">")[0];
-		private readonly static byte _slash = EncUtf8.GetBytes("/")[0];
-		private readonly static byte _hyphen = EncUtf8.GetBytes("-")[0];
+		private static readonly Encoding EncUtf8 = Encoding.UTF8;
+		private static readonly byte _openingAngleBracket = EncUtf8.GetBytes("<")[0];
+		private static readonly byte _closingAngleBracket = EncUtf8.GetBytes(">")[0];
+		private static readonly byte _slash = EncUtf8.GetBytes("/")[0];
+		private static readonly byte _hyphen = EncUtf8.GetBytes("-")[0];
 		private static byte[] cdataStart = EncUtf8.GetBytes("![CDATA[");
 		private static byte[] cdataEnd = EncUtf8.GetBytes("]]>");
 		private static byte[] startComment = EncUtf8.GetBytes("!--");
@@ -303,11 +303,11 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Return true if the bytes starting at _currentPosition match the specified marker.
-		/// The following character must not be part of a marker name.
+		/// Return true if the bytes starting at <see cref="_currentOffset"/> match the specified
+		/// marker. The following character must not be part of a marker name.
 		///
-		/// Enhance JohnT: technically I think there could be white space between the opening angle bracket and the
-		/// marker. We can make that enhancement if we need it.
+		/// Enhance JohnT: technically I think there could be white space between the opening
+		/// angle bracket and the marker. We can make that enhancement if we need it.
 		/// </summary>
 		bool MatchMarker(byte[] marker)
 		{
@@ -317,7 +317,8 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Return true if the bytes starting at _currentPosition match the specified marker. No termination is required.
+		/// Return true if the bytes starting at <see cref="_currentOffset"/> match the specified
+		/// marker. No termination is required.
 		/// </summary>
 		private bool Match(byte[] marker)
 		{
@@ -343,10 +344,10 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// This method adjusts _currentPosition to the offset of the first record,
+		/// This method adjusts <see cref="_currentOffset"/> to the offset of the first record,
 		/// and adjusts _endOfRecordsOffset to the end of the last record.
-		/// If there are no records they will end up equal, at the index of the last open angle bracket
-		/// in the file. Throws exception if there is no top-level element in the file.
+		/// If there are no records they will end up equal, at the index of the last open angle
+		/// bracket in the file. Throws exception if there is no top-level element in the file.
 		/// </summary>
 		private void InitializeOffsets()
 		{
@@ -413,7 +414,8 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Move _currentOffset to the character following the next angle bracket of either type, or to _endOfRecordOffset if that comes first.
+		/// Move <see cref="_currentOffset"/> to the character following the next angle bracket of
+		/// either type, or to <see cref="_endOfRecordsOffset"/> if that comes first.
 		/// Answer true if what we got was an opening bracket
 		/// </summary>
 		private bool AdvanceToAngleBracket()
@@ -436,8 +438,8 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Move _currentOffset to the character following the next angle bracket, or to _endOfRecordOffset if that comes first.
-		/// Skip comments.
+		/// Move <see cref="_currentOffset"/> to the character following the next angle bracket, or
+		/// to <see cref="_endOfRecordOffset"/> if that comes first. Skip comments.
 		/// </summary>
 		private void AdvanceToOpenAngleBracket()
 		{
@@ -459,7 +461,8 @@ namespace SIL.Xml
 		}
 
 		/// <summary>
-		/// Move _currentOffset to the character following the next closing angle bracket, or to _endOfRecordOffset if that comes first.
+		/// Move <see cref="_currentOffset"/> to the character following the next closing angle
+		/// bracket, or to <see cref="_endOfRecordOffset"/> if that comes first.
 		/// </summary>
 		private void AdvanceToClosingAngleBracket()
 		{


### PR DESCRIPTION
Fixes https://github.com/sillsdev/libpalaso/security/code-scanning/2305, https://github.com/sillsdev/libpalaso/security/code-scanning/2306, https://github.com/sillsdev/libpalaso/security/code-scanning/2307, https://github.com/sillsdev/libpalaso/security/code-scanning/2308

These 4 instances of `throw new ArgumentException("Unmatched opening tag " + marker);` will throw with string `"Unmatched opening tag System.Byte[]"`, which isn't very helpful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1419)
<!-- Reviewable:end -->
