### PR TITLE
+semver:major  Made ParseDateTimePermissivelyWithException into an extension method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,15 @@ jobs:
     - name: Test project
       id: test
       run: dotnet test "$TEST_PATH"/SIL*Tests.dll --filter "(TestCategory != SkipOnTeamCity) & (TestCategory != RequiresAudioInputDevice)" --blame-hang-timeout 5m --logger:"trx;LogFilePrefix=results" --results-directory ./test-results
+      
+    - name: Upload hang dump (if any)
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Hang dumps (${{ matrix.framework }})
+        path: |
+          **/testhost_*.dmp
+          **/sequence.xml
 
     - name: Upload test results
       if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Test project
       id: test
       run: dotnet test "$TEST_PATH"/SIL*Tests.dll --filter "(TestCategory != SkipOnTeamCity) & (TestCategory != RequiresAudioInputDevice)" --blame-hang-timeout 5m --logger:"trx;LogFilePrefix=results" --results-directory ./test-results
-      
+
     - name: Upload hang dump (if any)
       if: always()
       uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.DictionaryServices] Added Fields property to LexEntry. Modified LiftWriter.Add(LexEntry entry) to also write the content of entry.Fields.
 - [SIL.Windows.Forms] Added correctly spelled HeaderLabel.ShowWindowBackgroundOnTopAndRightEdge.
 - [SIL.Core] Added correctly spelled XmlUtils.ConvertMultiParagraphToSafeXml.
+- [SIL.Core] Added DateTimeExtensions.ParseModernPastDateTimePermissivelyWithException (as the most probable replacement for the deprecated version of ParseDateTimePermissivelyWithException).
+- [SIL.Core] Added DateTimeExtensions.ParsePastDateTimePermissivelyWithException as a convenience method.
+- [SIL.Core] Added overload of DateTimeExtensions.ParseDateTimePermissivelyWithException that takes parameters `reasonableMin` and `reasonableMax`.
 
 ### Changed
 
@@ -67,8 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] BREAKING CHANGE: Upgraded dependency on L10nSharp. See note regarding creating LocalizationManager before calling localization methods. In tests, it may be expedient to set `LocalizationManager.StrictInitializationMode` to false.
 - [SIL.Core] Improved efficiency in XmlUtils methods: MakeSafeXml and ConvertMultiParagraphToSafeXml (name corrected), and MakeSafeXmlAttribute.
 - [SIL.Core] BREAKING CHANGE (potentially): Made ParseDateTimePermissivelyWithException into an extension method (on string).
-- [SIL.Core] BREAKING CHANGE (potentially): Added optional parameters to DateTimeExtensions.ParseDateTimePermissivelyWithException: `oldestReasonablyExpectedYear` and `numberOfDaysIntoFutureReasonablyExpected`. Also, changed behavior of this method to try to interpret the date according to either the Gregorian calendar or the Buddhist calender in order to get the date to fall within the reasonably expected range. This means that depending on the current culture, dates might be interpreted differently from before.
-
+- [SIL.Core] BREAKING CHANGE (potentially): Changed behavior of DateTimeExtensions.ParseDateTimePermissivelyWithException (now deprecated) to try to interpret the date according to either the Gregorian calendar or the Buddhist calender in order to get the date to fall within a reasonable expected range (from 1/1/1900 through one day in the future). This means that depending on the current culture, dates might be interpreted differently from before. The known places in SIL code where this method is used seems to be for dates in the recent past (modern times); hence the default range. A new overload was added that will allow callers with other needs to specify a different range.
+ 
 ### Fixed
 
 - [SIL.Windows.Forms] Changed build date in SILAboutBox to be computed using the last write time instead of creation time.
@@ -84,6 +87,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Marked the misspelled HeaderLabel.ShowWindowBackgroudOnTopAndRightEdge as [Obsolete] in favor of correctly spelled ShowWindowBackgroundOnTopAndRightEdge.
 - [SIL.Core] Marked the misspelled XmlUtils.ConvertMultiparagraphToSafeXml as [Obsolete] in favor of correctly spelled ConvertMultiParagraphToSafeXml.
 - [SIL.Core] Marked GetAttributeValue as deprecated in favor of GetOptionalAttributeValue. (According to the summary, this has been deprecated for a long time, but it was not officially marked as obsolete.)
+- [SIL.Core] Marked DateTimeExtensions.ParseDateTimePermissivelyWithException as [Obsolete] in favor of ParseModernPastDateTimePermissivelyWithException (or ParsePastDateTimePermissivelyWithException or the new overload of ParseDateTimePermissivelyWithException).
 
 ## [15.0.0] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] BREAKING CHANGE: Upgraded dependency on L10nSharp. See note regarding creating LocalizationManager before calling localization methods. In tests, it may be expedient to set `LocalizationManager.StrictInitializationMode` to false.
 - [SIL.Windows.Forms.Keyboarding] BREAKING CHANGE: Upgraded dependency on L10nSharp. See note regarding creating LocalizationManager before calling localization methods. In tests, it may be expedient to set `LocalizationManager.StrictInitializationMode` to false.
 - [SIL.Core] Improved efficiency in XmlUtils methods: MakeSafeXml and ConvertMultiParagraphToSafeXml (name corrected), and MakeSafeXmlAttribute.
+- [SIL.Core] BREAKING CHANGE (potentially): Made ParseDateTimePermissivelyWithException into an extension method (on string).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] BREAKING CHANGE: Upgraded dependency on L10nSharp. See note regarding creating LocalizationManager before calling localization methods. In tests, it may be expedient to set `LocalizationManager.StrictInitializationMode` to false.
 - [SIL.Core] Improved efficiency in XmlUtils methods: MakeSafeXml and ConvertMultiParagraphToSafeXml (name corrected), and MakeSafeXmlAttribute.
 - [SIL.Core] BREAKING CHANGE (potentially): Made ParseDateTimePermissivelyWithException into an extension method (on string).
+- [SIL.Core] BREAKING CHANGE (potentially): Added optional parameters to DateTimeExtensions.ParseDateTimePermissivelyWithException: `oldestReasonablyExpectedYear` and `numberOfDaysIntoFutureReasonablyExpected`. Also, changed behavior of this method to try to interpret the date according to either the Gregorian calendar or the Buddhist calender in order to get the date to fall within the reasonably expected range. This means that depending on the current culture, dates might be interpreted differently from before.
 
 ### Fixed
 

--- a/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
+++ b/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
@@ -189,7 +189,7 @@ namespace SIL.Tests.Extensions
 		/// </param>
 		/// <param name="expectedResultFormattedAsBuddhistDate"></param>
 		[TestCase("9/3/2025 0:00:00", true, "9/3/2568")]
-		[TestCase("2-2-1920", true, "2/2/2463")] // 
+		[TestCase("2-2-1920", true, "2/2/2463")]
 		[TestCase("14/4/1543", false, "14/4/1543")]
 		[TestCase("3/9/1257 0:01:00", false, "3/9/1257")]
 		[TestCase("9/3/2568 0:01:00", false, "9/3/2568")]
@@ -231,7 +231,7 @@ namespace SIL.Tests.Extensions
 		}
 
 		/// <summary>
-		/// For these test cases, well will supply a future date (beyond reasonableMax) and pass
+		/// For these test cases, we will supply a future date (beyond reasonableMax) and pass
 		/// a reasonableMin that is more than 543 years ago. Thus, we expect the algorithm to guess
 		/// that these are (ancient) Buddhist dates as opposed to future Gregorian dates.
 		/// </summary>
@@ -270,7 +270,7 @@ namespace SIL.Tests.Extensions
 		}
 
 		/// <summary>
-		/// For these test cases, well will supply a future date and pass a reasonableMin that is
+		/// For these test cases, we will supply a future date and pass a reasonableMin that is
 		/// more than 543 years ago. Thus, we expect the algorithm to guess that these are
 		/// (ancient) Buddhist dates as opposed to future Gregorian dates.
 		/// </summary>
@@ -306,7 +306,7 @@ namespace SIL.Tests.Extensions
 		}
 
 		/// <summary>
-		/// For these test cases, well will supply a future date (beyond reasonableMax). However,
+		/// For these test cases, we will supply a future date (beyond reasonableMax). However,
 		/// these are date formats that cannot be parsed in Thai/Buddhist culture, so we expect
 		/// them to be interpreted as Gregorian dates.
 		/// </summary>

--- a/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
+++ b/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
@@ -137,11 +137,11 @@ namespace SIL.Tests.Extensions
 				Is.EqualTo(new DateTime(2012, 02, 29, 12, 30, 45)));
 		}
 
-		[TestCase("9/3/2025 0:00:00", ExpectedResult = "1482-03-09")]
-		[TestCase("14/4/1482", ExpectedResult = "0939-04-14")]
-		[TestCase("9/3/1800 0:01:00", ExpectedResult = "1257-03-09")]
-		[NonParallelizable]
-		public string ParseDateTimePermissivelyWithException_WithThaiBuddhistCalendar_ReturnsDateWithCorrectYear(string input)
+		[TestCase("2025-05-12")]
+		[TestCase("1482-04-14")]
+		[TestCase("2033-01-02")]
+		public void ParseDateTimePermissivelyWithException_GregorianISO8601WithThaiBuddhistCalendar_ReturnsDateWithCorrectYear(
+			string inputGregorian)
 		{
 			var originalCulture = Thread.CurrentThread.CurrentCulture;
 			try
@@ -151,8 +151,166 @@ namespace SIL.Tests.Extensions
 				buddhistCulture.DateTimeFormat.Calendar = new ThaiBuddhistCalendar();
 				Thread.CurrentThread.CurrentCulture = buddhistCulture;
 
-				return input.ParseDateTimePermissivelyWithException()
-					.ToISO8601TimeFormatDateOnlyString();
+				var result = inputGregorian.ParseDateTimePermissivelyWithException();
+				var inputDateOnly = inputGregorian.Split(' ')[0];
+				var inputDateParts = inputDateOnly.Split('-');
+				Assert.That(inputDateParts.Length, Is.EqualTo(3), "Sanity check");
+				// Note that even when the current culture is Thai/Buddhist, the year,
+				// month and day values in the DateTime object are still Gregorian.
+				Assert.That(result.Year.ToString(), Is.EqualTo(inputDateParts[0]));
+				Assert.That(result.Month, Is.EqualTo(int.Parse(inputDateParts[1])));
+				Assert.That(result.Day, Is.EqualTo(int.Parse(inputDateParts[2])));
+				Assert.That(result.ToISO8601TimeFormatDateOnlyString(),
+					Is.EqualTo(inputDateOnly));
+
+				var expectedResultFormattedAsBuddhistDate =
+					$"{result.Day}/{result.Month}/{result.Year + 543}";
+				Assert.That(result.ToShortDateString(),
+					Is.EqualTo(expectedResultFormattedAsBuddhistDate));
+			}
+			finally
+			{
+				// Reset system locale to the original culture
+				Thread.CurrentThread.CurrentCulture = originalCulture;
+			}
+		}
+
+		/// <summary>
+		/// Input dates are not formatted as valid ISO8601 dates. Method should guess which
+		/// calendar to use based on year and current culture. If year is in the "modern" range
+		/// for the Gregorian calendar, it should be treated as a Gregorian date. If year is
+		/// older or way in the future, it should be treated as a Buddhist date. Thai culture
+		/// normally formats dates as dd/MM/yyyy, so that is how these dates should be
+		/// interpreted.
+		/// </summary>
+		/// <param name="input">The ambiguous input date, not formatted as ISO 8601</param>
+		/// <param name="expectedToInterpretAsGregorianYear">Flag indicating whether algorithm is
+		/// expected to guess that the input date represents a year in the Gregorian calendar
+		/// </param>
+		/// <param name="expectedResultFormattedAsBuddhistDate"></param>
+		[TestCase("9/3/2025 0:00:00", true, "9/3/2568")]
+		[TestCase("2-2-1920", true, "2/2/2463")] // 
+		[TestCase("14/4/1543", false, "14/4/1543")]
+		[TestCase("3/9/1257 0:01:00", false, "3/9/1257")]
+		[TestCase("9/3/2568 0:01:00", false, "9/3/2568")]
+		[NonParallelizable]
+		public void ParseDateTimePermissivelyWithException_WithThaiBuddhistCalendar_ReturnsDateWithCorrectYear(
+			string input, bool expectedToInterpretAsGregorianYear,
+			string expectedResultFormattedAsBuddhistDate)
+		{
+			var originalCulture = Thread.CurrentThread.CurrentCulture;
+			try
+			{
+				// Temporarily set system locale to use Buddhist date system
+				var buddhistCulture = new CultureInfo("th-TH");
+				buddhistCulture.DateTimeFormat.Calendar = new ThaiBuddhistCalendar();
+				Thread.CurrentThread.CurrentCulture = buddhistCulture;
+
+				var result = input.ParseDateTimePermissivelyWithException();
+				Assert.That(result.ToShortDateString(),
+					Is.EqualTo(expectedResultFormattedAsBuddhistDate));
+				var inputDateOnly = input.Split(' ')[0];
+				var inputDateParts = inputDateOnly.Split('/', '-');
+				Assert.That(inputDateParts.Length, Is.EqualTo(3), "Sanity check");
+				// Note that even when the current culture is Thai/Buddhist, the unformatted year,
+				// month and day stored in the DateTime object are still Gregorian.
+				var expectedGregorianYear = expectedToInterpretAsGregorianYear
+					? inputDateParts[2]
+					: (int.Parse(inputDateParts[2]) - 543).ToString();
+				Assert.That(result.Year.ToString(), Is.EqualTo(expectedGregorianYear));
+				Assert.That(result.Month.ToString(), Is.EqualTo(inputDateParts[1]));
+				Assert.That(result.Day.ToString(), Is.EqualTo(inputDateParts[0]));
+				Assert.That(result.ToISO8601TimeFormatDateOnlyString(), Is.EqualTo(
+					$"{int.Parse(expectedGregorianYear):D4}-{int.Parse(inputDateParts[1]):D2}-{int.Parse(inputDateParts[0]):D2}"));
+			}
+			finally
+			{
+				// Reset system locale to the original culture
+				Thread.CurrentThread.CurrentCulture = originalCulture;
+			}
+		}
+
+		/// <summary>
+		/// For these test cases, well will generate a future date (beyond the
+		/// numberOfDaysIntoFutureReasonablyExpected) and pass a value of
+		/// oldestReasonablyExpectedYear that is more than 543 years ago. Thus, we
+		/// expect the algorithm to guess that these are (ancient) Buddhist dates as
+		/// opposed to future Gregorian dates.
+		/// </summary>
+		/// <remarks>Given the non-Thai (probably usually English) month name when using the
+		/// "dd MMM yyyy" format, it's slightly surprising that the Thai/Buddhist locale can parse
+		/// it, but apparently it can.</remarks>
+		[TestCase("dd MMM yyyy")] // Medium pattern (e.g. 14 May 2025)
+		[TestCase("dd/MM/yyyy")] // Thai/European-style numeric date, zero-padded (e.g. 14/05/2025)
+		[TestCase("d/M/yyyy")] // Thai/European-style numeric date (e.g. 14/5/2025)
+		[TestCase("d-M-yyyy")] // Thai/European-style numeric date with dashes (e.g. 14-5-2025)
+		[NonParallelizable]
+		public void ParseDateTimePermissivelyWithException_NearFutureDatesWithThaiBuddhistCalendar_ReturnsDateWithPastYear(string inputFormat)
+		{
+			var futureDateA = DateTime.Today.AddDays(2);
+			var futureDateB = DateTime.Today.AddDays(5);
+			string inputA = futureDateA.ToString(inputFormat);
+			string inputB = futureDateB.ToString(inputFormat);
+			int expectedYearA = futureDateA.Year - 543;
+			int expectedYearB = futureDateB.Year - 543;
+			var originalCulture = Thread.CurrentThread.CurrentCulture;
+			try
+			{
+				// Temporarily set system locale to use Buddhist date system
+				var buddhistCulture = new CultureInfo("th-TH");
+				buddhistCulture.DateTimeFormat.Calendar = new ThaiBuddhistCalendar();
+				Thread.CurrentThread.CurrentCulture = buddhistCulture;
+
+				var result = inputA.ParseDateTimePermissivelyWithException(
+					oldestReasonablyExpectedYear: 1481);
+				Assert.That(result.Year, Is.EqualTo(expectedYearA));
+				result = inputB.ParseDateTimePermissivelyWithException(
+					oldestReasonablyExpectedYear: 1481,
+					numberOfDaysIntoFutureReasonablyExpected: 4);
+				Assert.That(result.Year, Is.EqualTo(expectedYearB));
+			}
+			finally
+			{
+				// Reset system locale to the original culture
+				Thread.CurrentThread.CurrentCulture = originalCulture;
+			}
+		}
+
+		/// <summary>
+		/// For these test cases, well will generate a future date (beyond the
+		/// numberOfDaysIntoFutureReasonablyExpected). However, these are date formats that cannot
+		/// be parsed in Thai/Buddhist culture, so we expect them to be interpreted as Gregorian
+		/// dates.
+		/// </summary>
+		[TestCase("d")] // Short date pattern (e.g. 14/5/2025)
+		[TestCase("D")] // Long date pattern (e.g. Wednesday, 14 May 2025)
+		[TestCase("dddd, dd MMMM yyyy")] // Full long format (e.g. Wednesday, 14 May 2025)
+		[TestCase("M/d/yyyy")] // US-style numeric date (e.g. 5/14/2025)
+		[TestCase("M-d-yyyy")] // US-style numeric date with dashes (e.g. 5-14-2025)
+		[TestCase("MM/dd/yyyy")] // US-style numeric date, zero-padded (e.g. 05/14/2025)
+		[TestCase("MM-dd-yyyy")] // US-style numeric date with dashes, zero-padded (e.g. 05-14-2025)
+		[NonParallelizable]
+		public void ParseDateTimePermissivelyWithException_NearFutureUSDatesWithThaiBuddhistCalendar_ReturnsDateWithPastYear(string inputFormat)
+		{
+			var futureDateA = DateTime.Today.AddDays(2);
+			var futureDateB = DateTime.Today.AddDays(5);
+			string inputA = futureDateA.ToString(inputFormat);
+			string inputB = futureDateB.ToString(inputFormat);
+			int expectedYearA = futureDateA.Year;
+			int expectedYearB = futureDateB.Year;
+			var originalCulture = Thread.CurrentThread.CurrentCulture;
+			try
+			{
+				// Temporarily set system locale to use Buddhist date system
+				var buddhistCulture = new CultureInfo("th-TH");
+				buddhistCulture.DateTimeFormat.Calendar = new ThaiBuddhistCalendar();
+				Thread.CurrentThread.CurrentCulture = buddhistCulture;
+
+				var result = inputA.ParseDateTimePermissivelyWithException();
+				Assert.That(result.Year, Is.EqualTo(expectedYearA));
+				result = inputB.ParseDateTimePermissivelyWithException(
+					numberOfDaysIntoFutureReasonablyExpected: 4);
+				Assert.That(result.Year, Is.EqualTo(expectedYearB));
 			}
 			finally
 			{
@@ -179,7 +337,7 @@ namespace SIL.Tests.Extensions
 		[TestCase("@13:00.T")]
 		public void ParseDateTimePermissivelyWithException_UnknownFormat_ThrowsApplicationException(string input)
 		{
-			Assert.That(input.ParseDateTimePermissivelyWithException,
+			Assert.That(() => input.ParseDateTimePermissivelyWithException(),
 				Throws.TypeOf<ApplicationException>().With.InnerException.TypeOf<FormatException>());
 		}
 	}

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -111,7 +111,7 @@ namespace SIL.Tests.IO
 		}
 
 		[Test]
-		public void LocateInProgramFiles_SendInValidSubFolder_DoesNotThrow()
+		public void LocateInProgramFiles_SendInvalidSubFolder_DoesNotThrow()
 		{
 			Assert.DoesNotThrow(() => LocateInProgramFiles(SystemProgramFileThatShouldExist,
 				true, "!~@blah"));
@@ -233,7 +233,7 @@ namespace SIL.Tests.IO
 		}
 
 		[Test]
-		public void LocateExecutable_NonexistentFileFileThrows()
+		public void LocateExecutable_NonexistentFileThrows()
 		{
 			Assert.That(() => LocateExecutable("dummy", "__nonexistent.exe"),
 				Throws.Exception.TypeOf<ApplicationException>());

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -89,7 +89,7 @@ namespace SIL.Tests.IO
 				Assert.IsNotNull(LocateInProgramFiles(findFile, true));
 		}
 
-		[Test] // On CI build (GHA) this can time out
+		[Test]
 		public void LocateInProgramFiles_SendValidProgramDeepSearch_SubFolderSpecified_ReturnsProgramPath()
 		{
 			// This should work on Mono because it ignores the subFoldersToSearch parameter.

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -1,24 +1,33 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using NUnit.Framework;
-using SIL.IO;
 using SIL.PlatformUtilities;
+using static SIL.IO.FileLocationUtilities;
 
 namespace SIL.Tests.IO
 {
 	[TestFixture]
 	class FileLocationUtilitiesTests
 	{
+		private const int ciDeepSearchTimeoutInSeconds = 15;
+
+		private string WindowsProgramFileThatShouldExist => "msinfo32.exe";
+
+		private string SystemProgramFileThatShouldExist =>
+			Platform.IsMono ? "bash" : WindowsProgramFileThatShouldExist;
+
 		[Test]
 		public void GetFileDistributedWithApplication_MultipleParts_FindsCorrectly()
 		{
-			var path = FileLocationUtilities.GetFileDistributedWithApplication("DirectoryForTests", "SampleFileForTests.txt");
+			var path = GetFileDistributedWithApplication("DirectoryForTests", "SampleFileForTests.txt");
 			Assert.That(File.Exists(path));
 		}
+		
 		[Test]
 		public void GetDirectoryDistributedWithApplication_MultipleParts_FindsCorrectly()
 		{
-			var path = FileLocationUtilities.GetDirectoryDistributedWithApplication("DirectoryForTests");
+			var path = GetDirectoryDistributedWithApplication("DirectoryForTests");
 			Assert.That(Directory.Exists(path));
 		}
 
@@ -27,12 +36,12 @@ namespace SIL.Tests.IO
 		{
 			try
 			{
-				FileLocationUtilities.GetDirectoryDistributedWithApplication("LookHere", "ThisWillNotExist");
+				GetDirectoryDistributedWithApplication("LookHere", "ThisWillNotExist");
 			}
 			catch (ArgumentException ex)
 			{
 				Assert.That(ex.Message, Does.Contain(Path.Combine("LookHere", "ThisWillNotExist")));
-				Assert.That(ex.Message, Does.Contain(FileLocationUtilities.DirectoryOfApplicationOrSolution));
+				Assert.That(ex.Message, Does.Contain(DirectoryOfApplicationOrSolution));
 				Assert.That(ex.Message, Does.Contain("DistFiles"));
 				Assert.That(ex.Message, Does.Contain("src"));
 			}
@@ -41,7 +50,7 @@ namespace SIL.Tests.IO
 		[Test]
 		public void DirectoryOfApplicationOrSolution_OnDevMachine_FindsOutputDirectory()
 		{
-			var path = FileLocationUtilities.DirectoryOfTheApplicationExecutable;
+			var path = DirectoryOfTheApplicationExecutable;
 			Assert.That(Directory.Exists(path));
 			Assert.That(path.Contains("output"));
 		}
@@ -49,7 +58,7 @@ namespace SIL.Tests.IO
 		[Test]
 		public void LocateInProgramFiles_SendInvalidProgramNoDeepSearch_ReturnsNull()
 		{
-			Assert.IsNull(FileLocationUtilities.LocateInProgramFiles("blah.exe", false));
+			Assert.IsNull(LocateInProgramFiles("blah.exe", false));
 		}
 
 		// 12 SEP 2013, Phil Hopper: This test not valid on Mono.
@@ -58,35 +67,59 @@ namespace SIL.Tests.IO
 		[Category("SkipOnTeamCity;KnownMonoIssue")]
 		public void LocateInProgramFiles_SendValidProgramNoDeepSearch_ReturnsNull()
 		{
-			Assert.IsNull(FileLocationUtilities.LocateInProgramFiles("msinfo32.exe", false));
+			Assert.IsNull(LocateInProgramFiles(WindowsProgramFileThatShouldExist, false));
 		}
 
-		[Test, Timeout(10000)] // On CI build (GHA) this can time out
+		[Test]
 		public void LocateInProgramFiles_SendValidProgramDeepSearch_ReturnsProgramPath()
 		{
-			var findFile = Platform.IsMono ? "bash" : "msinfo32.exe";
-			Assert.IsNotNull(FileLocationUtilities.LocateInProgramFiles(findFile, true));
+			var findFile = SystemProgramFileThatShouldExist;
+
+			// On CI build (GHA) this can time out
+			if (Environment.GetEnvironmentVariable("CI") == "true")
+			{
+				var task = Task.Run(() => LocateInProgramFiles(findFile, true));
+
+				if (!task.Wait(TimeSpan.FromSeconds(ciDeepSearchTimeoutInSeconds)))
+					Assert.Inconclusive("Test timed out on CI build.");
+
+				Assert.IsNotNull(task.Result);
+			}
+			else
+				Assert.IsNotNull(LocateInProgramFiles(findFile, true));
 		}
 
-		[Test, Timeout(10000)] // On CI build (GHA) this can time out
+		[Test] // On CI build (GHA) this can time out
 		public void LocateInProgramFiles_SendValidProgramDeepSearch_SubFolderSpecified_ReturnsProgramPath()
 		{
-			var findFile = Platform.IsMono ? "bash" : "msinfo32.exe";
+			// This should work on Mono because it ignores the subFoldersToSearch parameter.
 
-			// this will work on Mono because it ignores the subFoldersToSearch parameter
-			Assert.IsNotNull(FileLocationUtilities.LocateInProgramFiles(findFile, true, "Common Files"));
+			var findFile = SystemProgramFileThatShouldExist;
+
+			// On CI build (GHA) this can time out
+			if (Environment.GetEnvironmentVariable("CI") == "true")
+			{
+				var task = Task.Run(() => LocateInProgramFiles(findFile, true, "Common Files"));
+
+				if (!task.Wait(TimeSpan.FromSeconds(ciDeepSearchTimeoutInSeconds)))
+					Assert.Inconclusive("Test timed out on CI build.");
+
+				Assert.IsNotNull(task.Result);
+			}
+			else
+				Assert.IsNotNull(LocateInProgramFiles(findFile, true, "Common Files"));
 		}
 
 		[Test]
 		public void LocateInProgramFiles_SendInValidSubFolder_DoesNotThrow()
 		{
-			var findFile = Platform.IsMono ? "bash" : "msinfo32.exe";
-			Assert.DoesNotThrow(() => FileLocationUtilities.LocateInProgramFiles(findFile, true, "!~@blah"));
+			Assert.DoesNotThrow(() => LocateInProgramFiles(SystemProgramFileThatShouldExist,
+				true, "!~@blah"));
 		}
 
 		[Test]
 		[Platform(Include = "Linux")]
-		public void LocateInProgramFiles_DeepSearch_FindsFileInSubdir()
+		public void LocateInProgramFiles_DeepSearch_FindsFileInSubDir()
 		{
 			// This simulates finding RAMP which is installed as /opt/RAMP/ramp. We can't put
 			// anything in /opt for testing, so we add our tmp directory to the path.
@@ -103,7 +136,7 @@ namespace SIL.Tests.IO
 				Environment.SetEnvironmentVariable("PATH", $"{simulatedOptDir}{Path.PathSeparator}{pathVariable}");
 
 				// Exercise/Verify
-				Assert.That(FileLocationUtilities.LocateInProgramFiles("ramp", true),
+				Assert.That(LocateInProgramFiles("ramp", true),
 					Is.EqualTo(file));
 			}
 			finally
@@ -139,7 +172,7 @@ namespace SIL.Tests.IO
 				Environment.SetEnvironmentVariable("PATH", $"{simulatedOptDir}{Path.PathSeparator}{pathVariable}");
 
 				// Exercise/Verify
-				Assert.That(FileLocationUtilities.LocateInProgramFiles("ramp", false),
+				Assert.That(LocateInProgramFiles("ramp", false),
 					Is.Null);
 			}
 			finally
@@ -161,7 +194,7 @@ namespace SIL.Tests.IO
 		[Test]
 		public void LocateExecutable_DistFiles()
 		{
-			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "SampleExecutable.exe"),
+			Assert.That(LocateExecutable("DirectoryForTests", "SampleExecutable.exe"),
 				Does.EndWith(string.Format("DistFiles{0}DirectoryForTests{0}SampleExecutable.exe",
 					Path.DirectorySeparatorChar)));
 		}
@@ -170,7 +203,7 @@ namespace SIL.Tests.IO
 		[Platform(Exclude = "Linux")]
 		public void LocateExecutable_PlatformSpecificInDistFiles_Windows()
 		{
-			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "dummy.exe"),
+			Assert.That(LocateExecutable("DirectoryForTests", "dummy.exe"),
 				Does.EndWith(string.Format("DistFiles{0}Windows{0}DirectoryForTests{0}dummy.exe",
 				Path.DirectorySeparatorChar)));
 		}
@@ -179,7 +212,7 @@ namespace SIL.Tests.IO
 		[Platform(Include = "Linux")]
 		public void LocateExecutable_PlatformSpecificInDistFiles_LinuxWithoutExtension()
 		{
-			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "dummy.exe"),
+			Assert.That(LocateExecutable("DirectoryForTests", "dummy.exe"),
 				Does.EndWith(string.Format("DistFiles{0}Linux{0}DirectoryForTests{0}dummy",
 				Path.DirectorySeparatorChar)));
 		}
@@ -188,21 +221,21 @@ namespace SIL.Tests.IO
 		[Platform(Include = "Linux")]
 		public void LocateExecutable_PlatformSpecificInDistFiles_Linux()
 		{
-			Assert.That(FileLocationUtilities.LocateExecutable("DirectoryForTests", "dummy2.exe"),
+			Assert.That(LocateExecutable("DirectoryForTests", "dummy2.exe"),
 				Does.EndWith(string.Format("DistFiles{0}Linux{0}DirectoryForTests{0}dummy2.exe",
 				Path.DirectorySeparatorChar)));
 		}
 
 		[Test]
-		public void LocateExecutable_NonexistingFile()
+		public void LocateExecutable_NonexistentFile()
 		{
-			Assert.That(FileLocationUtilities.LocateExecutable(false, "dummy", "__nonexisting.exe"), Is.Null);
+			Assert.That(LocateExecutable(false, "dummy", "__nonexistent.exe"), Is.Null);
 		}
 
 		[Test]
-		public void LocateExecutable_NonexistingFileThrows()
+		public void LocateExecutable_NonexistentFileFileThrows()
 		{
-			Assert.That(() => FileLocationUtilities.LocateExecutable("dummy", "__nonexisting.exe"),
+			Assert.That(() => LocateExecutable("dummy", "__nonexistent.exe"),
 				Throws.Exception.TypeOf<ApplicationException>());
 		}
 	}

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -61,17 +61,17 @@ namespace SIL.Tests.IO
 			Assert.IsNull(FileLocationUtilities.LocateInProgramFiles("msinfo32.exe", false));
 		}
 
-		[Test]
+		[Test, Timeout(10000)] // On CI build (GHA) this can time out
 		public void LocateInProgramFiles_SendValidProgramDeepSearch_ReturnsProgramPath()
 		{
-			var findFile = (Platform.IsMono ? "bash" : "msinfo32.exe");
+			var findFile = Platform.IsMono ? "bash" : "msinfo32.exe";
 			Assert.IsNotNull(FileLocationUtilities.LocateInProgramFiles(findFile, true));
 		}
 
-		[Test]
+		[Test, Timeout(10000)] // On CI build (GHA) this can time out
 		public void LocateInProgramFiles_SendValidProgramDeepSearch_SubFolderSpecified_ReturnsProgramPath()
 		{
-			var findFile = (Platform.IsMono ? "bash" : "msinfo32.exe");
+			var findFile = Platform.IsMono ? "bash" : "msinfo32.exe";
 
 			// this will work on Mono because it ignores the subFoldersToSearch parameter
 			Assert.IsNotNull(FileLocationUtilities.LocateInProgramFiles(findFile, true, "Common Files"));
@@ -80,7 +80,7 @@ namespace SIL.Tests.IO
 		[Test]
 		public void LocateInProgramFiles_SendInValidSubFolder_DoesNotThrow()
 		{
-			var findFile = (Platform.IsMono ? "bash" : "msinfo32.exe");
+			var findFile = Platform.IsMono ? "bash" : "msinfo32.exe";
 			Assert.DoesNotThrow(() => FileLocationUtilities.LocateInProgramFiles(findFile, true, "!~@blah"));
 		}
 

--- a/SIL.Core/Extensions/DateTimeExtensions.cs
+++ b/SIL.Core/Extensions/DateTimeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -44,7 +44,7 @@ namespace SIL.Extensions
 
 		public static DateTime ParseISO8601DateTime(string when)
 		{
-			var formats = new string[]
+			var formats = new []
 								  {
 									  ISO8601TimeFormatNoTimeZone,
 									  ISO8601TimeFormatWithTimeZone,
@@ -102,7 +102,7 @@ namespace SIL.Extensions
 		/// We have this permissive business because we released versions of SayMore which used the local
 		/// format, rather than a universal one.
 		/// </summary>
-		public static DateTime ParseDateTimePermissivelyWithException(string when)
+		public static DateTime ParseDateTimePermissivelyWithException(this string when)
 		{
 			try
 			{
@@ -113,16 +113,15 @@ namespace SIL.Extensions
 				// Up-until mid-version 1.1, we were accidentally saving locale-specific dates
 
 				// First try a few common cultures
-				DateTime date;
-				List<CultureInfo> culturesToTry = new List<CultureInfo>(new[]
-																			{
-																				Thread.CurrentThread.CurrentCulture,
-																				CultureInfo.CurrentCulture,
-																				CultureInfo.CreateSpecificCulture("en-US"),
-																				CultureInfo.CreateSpecificCulture("en-GB"),
-																				CultureInfo.CreateSpecificCulture("ru")
-																			});
-				if (TryParseWithTheseCultures(when, out date, culturesToTry))
+				var culturesToTry = new List<CultureInfo>(new[]
+					{
+						Thread.CurrentThread.CurrentCulture,
+						CultureInfo.CurrentCulture,
+						CultureInfo.CreateSpecificCulture("en-US"),
+						CultureInfo.CreateSpecificCulture("en-GB"),
+						CultureInfo.CreateSpecificCulture("ru")
+					});
+				if (TryParseWithTheseCultures(when, out var date, culturesToTry))
 					return date;
 
 				// If not found, try more
@@ -158,8 +157,7 @@ namespace SIL.Extensions
 
 			if (!m.Success) return false;
 
-			DateTime testDate;
-			return (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out testDate));
+			return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
 		}
 
 		/// <summary>
@@ -179,8 +177,7 @@ namespace SIL.Extensions
 				!Regex.IsMatch(value, @"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:?\d{2}$"))
 				return false;
 
-			DateTime testDate;
-			return (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out testDate));
+			return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
 		}
 	}
 }

--- a/TestApps/CommandLineRunnerTestApp/CommandLineRunnerTestApp.csproj
+++ b/TestApps/CommandLineRunnerTestApp/CommandLineRunnerTestApp.csproj
@@ -7,5 +7,6 @@
     <IsPackable>false</IsPackable>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is kind of related to SP-2356, though it's not yet clear whether any actual logic changes will be needed in these date-handling methods.

Added test cases for ToISO8601TimeFormatWithUTCString and some unit tests for Made ParseDateTimePermissivelyWithException

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1422)
<!-- Reviewable:end -->
