### PR TITLE
+semver:patch [SIL.WIndows.Forms] In CustomDropDown, fixed timer check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- [SIL.Windows.Forms] In `CustomDropDown.OnOpening`, fixed check that triggers timer to stop.
+
 ## [16.0.0] - 2025-05-20
 
 ### Added

--- a/SIL.Windows.Forms/Widgets/CustomDropDown.cs
+++ b/SIL.Windows.Forms/Widgets/CustomDropDown.cs
@@ -184,7 +184,7 @@ namespace SIL.Windows.Forms.Widgets
 			timer.Tick += delegate
 			{
 				Opacity += 0.1;
-				if (Opacity == 1f)
+				if (Opacity >= .99)
 					timer.Stop();
 			};
 


### PR DESCRIPTION
If you start with `double` 0 and add .1 ten times, you can end up with (e.g.) 0.9999999999999999 instead of `1f`.

This fixes https://github.com/sillsdev/libpalaso/security/code-scanning/2627

Of the other 15 warnings for "Equality check on floating point values" (https://github.com/sillsdev/libpalaso/security/code-scanning?query=is%3Aopen+branch%3Amaster+rule%3Acs%2Fequality-on-floats), three involve screen DPI ([2624](https://github.com/sillsdev/libpalaso/security/code-scanning/2624), [2625](https://github.com/sillsdev/libpalaso/security/code-scanning/2625), [2626](https://github.com/sillsdev/libpalaso/security/code-scanning/2626)), and the rest involve font size.