### PR TITLE
+semver:minor Added PortableClipboard.CanGetImage()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+    - [SIL.Windows.Forms] Added PortableClipboard.CanGetImage()
+    - [ClipboardTestApp] Restored this test program and added tests for PortableClipboard.CanGetImage() and GetImageFromClipboard()
+
 ### Fixed
 
 - [SIL.Windows.Forms] In `CustomDropDown.OnOpening`, fixed check that triggers timer to stop.

--- a/Palaso.sln
+++ b/Palaso.sln
@@ -120,9 +120,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.Archiving", "SIL.Archiv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.Archiving.Tests", "SIL.Archiving.Tests\SIL.Archiving.Tests.csproj", "{698FDB66-0ACE-46E0-843C-3AB70DC7B055}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchivingTestApp", "TestApps\ArchivingTestApp\ArchivingTestApp.csproj", "{321BB622-8185-4173-8770-742CD620BC18}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArchivingTestApp", "TestApps\ArchivingTestApp\ArchivingTestApp.csproj", "{321BB622-8185-4173-8770-742CD620BC18}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SoundFieldControlTestApp", "TestApps\SoundFieldControlTestApp\SoundFieldControlTestApp.csproj", "{184C738D-DFF6-421E-832A-AD7178F166A2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoundFieldControlTestApp", "TestApps\SoundFieldControlTestApp\SoundFieldControlTestApp.csproj", "{184C738D-DFF6-421E-832A-AD7178F166A2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClipboardTestApp", "TestApps\ClipboardTestApp\ClipboardTestApp.csproj", "{9C1E4175-D098-4D9C-AF00-0857B611CEDF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -314,6 +316,10 @@ Global
 		{184C738D-DFF6-421E-832A-AD7178F166A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{184C738D-DFF6-421E-832A-AD7178F166A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{184C738D-DFF6-421E-832A-AD7178F166A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -327,6 +333,7 @@ Global
 		{6407C2F9-F62D-4568-B694-7A79C72582C9} = {3C695301-9C39-4715-8EDD-817C63EF81E7}
 		{321BB622-8185-4173-8770-742CD620BC18} = {3C695301-9C39-4715-8EDD-817C63EF81E7}
 		{184C738D-DFF6-421E-832A-AD7178F166A2} = {3C695301-9C39-4715-8EDD-817C63EF81E7}
+		{9C1E4175-D098-4D9C-AF00-0857B611CEDF} = {3C695301-9C39-4715-8EDD-817C63EF81E7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0915B762-D4AE-4892-BF4F-AC428A687B02}

--- a/SIL.Windows.Forms/Clipboarding/IClipboard.cs
+++ b/SIL.Windows.Forms/Clipboarding/IClipboard.cs
@@ -15,6 +15,8 @@ namespace SIL.Windows.Forms.Clipboarding
 		void SetText(string text);
 		void SetText(string text, TextDataFormat format);
 		bool ContainsImage();
+
+		bool CanGetImage();
 		Image GetImage();
 		void CopyImageToClipboard(PalasoImage image);
 		PalasoImage GetImageFromClipboard();

--- a/SIL.Windows.Forms/Clipboarding/LinuxClipboard.cs
+++ b/SIL.Windows.Forms/Clipboarding/LinuxClipboard.cs
@@ -32,6 +32,11 @@ namespace SIL.Windows.Forms.Clipboarding
 			return gtk_clipboard_wait_is_image_available(Clipboard);
 		}
 
+		public bool CanGetImage()
+		{
+			throw new NotImplementedException();
+		}
+
 		public Image GetImage()
 		{
 			var pixBuf = gtk_clipboard_wait_for_image(Clipboard);

--- a/SIL.Windows.Forms/Miscellaneous/PortableClipboard.cs
+++ b/SIL.Windows.Forms/Miscellaneous/PortableClipboard.cs
@@ -25,6 +25,8 @@ namespace SIL.Windows.Forms.Miscellaneous
 		public static void SetText(string text) => _Clipboard.SetText(text);
 		public static void SetText(string text, TextDataFormat format) => _Clipboard.SetText(text, format);
 		public static bool ContainsImage() => _Clipboard.ContainsImage();
+
+		public static bool CanGetImage() => _Clipboard.CanGetImage();
 		public static Image GetImage() => _Clipboard.GetImage();
 		public static void CopyImageToClipboard(PalasoImage image) => _Clipboard.CopyImageToClipboard(image);
 

--- a/TestApps/ClipboardTestApp/ClipboardTestApp.csproj
+++ b/TestApps/ClipboardTestApp/ClipboardTestApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <SignAssembly>false</SignAssembly>
+    <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\SIL.Windows.Forms\SIL.Windows.Forms.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestApps/ClipboardTestApp/Form1.Designer.cs
+++ b/TestApps/ClipboardTestApp/Form1.Designer.cs
@@ -1,0 +1,251 @@
+namespace ClipboardTestApp
+{
+	partial class Form1
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+            this.btnCopyText = new System.Windows.Forms.Button();
+            this.btnPasteText = new System.Windows.Forms.Button();
+            this.btnCopyImage = new System.Windows.Forms.Button();
+            this.btnPasteImage = new System.Windows.Forms.Button();
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.labelContainsText = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.labelContainsImage = new System.Windows.Forms.Label();
+            this.btnClose = new System.Windows.Forms.Button();
+            this.btnPasteAnyImage = new System.Windows.Forms.Button();
+            this.label5 = new System.Windows.Forms.Label();
+            this.labelContainsAnyImage = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // btnCopyText
+            // 
+            this.btnCopyText.Location = new System.Drawing.Point(13, 11);
+            this.btnCopyText.Name = "btnCopyText";
+            this.btnCopyText.Size = new System.Drawing.Size(75, 23);
+            this.btnCopyText.TabIndex = 0;
+            this.btnCopyText.Text = "Copy Text";
+            this.btnCopyText.UseVisualStyleBackColor = true;
+            this.btnCopyText.Click += new System.EventHandler(this.OnCopyText);
+            // 
+            // btnPasteText
+            // 
+            this.btnPasteText.Location = new System.Drawing.Point(94, 11);
+            this.btnPasteText.Name = "btnPasteText";
+            this.btnPasteText.Size = new System.Drawing.Size(75, 23);
+            this.btnPasteText.TabIndex = 1;
+            this.btnPasteText.Text = "Paste Text";
+            this.btnPasteText.UseVisualStyleBackColor = true;
+            this.btnPasteText.Click += new System.EventHandler(this.OnPasteText);
+            // 
+            // btnCopyImage
+            // 
+            this.btnCopyImage.Location = new System.Drawing.Point(175, 11);
+            this.btnCopyImage.Name = "btnCopyImage";
+            this.btnCopyImage.Size = new System.Drawing.Size(75, 23);
+            this.btnCopyImage.TabIndex = 2;
+            this.btnCopyImage.Text = "Copy Image";
+            this.btnCopyImage.UseVisualStyleBackColor = true;
+            this.btnCopyImage.Click += new System.EventHandler(this.OnCopyImage);
+            // 
+            // btnPasteImage
+            // 
+            this.btnPasteImage.Location = new System.Drawing.Point(256, 11);
+            this.btnPasteImage.Name = "btnPasteImage";
+            this.btnPasteImage.Size = new System.Drawing.Size(75, 23);
+            this.btnPasteImage.TabIndex = 1;
+            this.btnPasteImage.Text = "Paste Image";
+            this.btnPasteImage.UseVisualStyleBackColor = true;
+            this.btnPasteImage.Click += new System.EventHandler(this.OnPasteImage);
+            // 
+            // textBox1
+            // 
+            this.textBox1.Location = new System.Drawing.Point(16, 57);
+            this.textBox1.Multiline = true;
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(223, 100);
+            this.textBox1.TabIndex = 3;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(13, 41);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(31, 13);
+            this.label1.TabIndex = 4;
+            this.label1.Text = "Text:";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Location = new System.Drawing.Point(19, 180);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(220, 135);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox1.TabIndex = 5;
+            this.pictureBox1.TabStop = false;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(16, 164);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(39, 13);
+            this.label2.TabIndex = 6;
+            this.label2.Text = "Image:";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(253, 41);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(117, 13);
+            this.label3.TabIndex = 7;
+            this.label3.Text = "Clipboard contains text:";
+            // 
+            // labelContainsText
+            // 
+            this.labelContainsText.AutoSize = true;
+            this.labelContainsText.Location = new System.Drawing.Point(256, 58);
+            this.labelContainsText.Name = "labelContainsText";
+            this.labelContainsText.Size = new System.Drawing.Size(25, 13);
+            this.labelContainsText.TabIndex = 8;
+            this.labelContainsText.Text = "???";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(256, 180);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(129, 13);
+            this.label4.TabIndex = 9;
+            this.label4.Text = "Clipboard contains Image:";
+            // 
+            // labelContainsImage
+            // 
+            this.labelContainsImage.AutoSize = true;
+            this.labelContainsImage.Location = new System.Drawing.Point(256, 197);
+            this.labelContainsImage.Name = "labelContainsImage";
+            this.labelContainsImage.Size = new System.Drawing.Size(25, 13);
+            this.labelContainsImage.TabIndex = 10;
+            this.labelContainsImage.Text = "???";
+            // 
+            // btnClose
+            // 
+            this.btnClose.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btnClose.Location = new System.Drawing.Point(322, 335);
+            this.btnClose.Name = "btnClose";
+            this.btnClose.Size = new System.Drawing.Size(75, 23);
+            this.btnClose.TabIndex = 11;
+            this.btnClose.Text = "Close";
+            this.btnClose.UseVisualStyleBackColor = true;
+            this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
+            // 
+            // btnPasteAnyImage
+            // 
+            this.btnPasteAnyImage.Location = new System.Drawing.Point(348, 11);
+            this.btnPasteAnyImage.Name = "btnPasteAnyImage";
+            this.btnPasteAnyImage.Size = new System.Drawing.Size(108, 23);
+            this.btnPasteAnyImage.TabIndex = 12;
+            this.btnPasteAnyImage.Text = "Paste Any Image";
+            this.btnPasteAnyImage.UseVisualStyleBackColor = true;
+            this.btnPasteAnyImage.Click += new System.EventHandler(this.OnPasteAnyImage);
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(256, 230);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(149, 13);
+            this.label5.TabIndex = 13;
+            this.label5.Text = "Clipboard contains any Image:";
+            // 
+            // labelContainsAnyImage
+            // 
+            this.labelContainsAnyImage.AutoSize = true;
+            this.labelContainsAnyImage.Location = new System.Drawing.Point(256, 252);
+            this.labelContainsAnyImage.Name = "labelContainsAnyImage";
+            this.labelContainsAnyImage.Size = new System.Drawing.Size(25, 13);
+            this.labelContainsAnyImage.TabIndex = 14;
+            this.labelContainsAnyImage.Text = "???";
+            // 
+            // Form1
+            // 
+            this.AcceptButton = this.btnClose;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(465, 370);
+            this.Controls.Add(this.btnClose);
+            this.Controls.Add(this.labelContainsImage);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.labelContainsText);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.btnCopyImage);
+            this.Controls.Add(this.btnPasteImage);
+            this.Controls.Add(this.btnPasteText);
+            this.Controls.Add(this.btnCopyText);
+            this.Controls.Add(this.labelContainsAnyImage);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.btnPasteAnyImage);
+            this.Name = "Form1";
+            this.Text = "Clipboard Test App";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+		}
+
+		private System.Windows.Forms.Button btnCopyText;
+
+		#endregion
+
+		private System.Windows.Forms.Button btnPasteText;
+		private System.Windows.Forms.Button btnCopyImage;
+		private System.Windows.Forms.Button btnPasteImage;
+		private System.Windows.Forms.Button btnPasteAnyImage;
+		private System.Windows.Forms.TextBox textBox1;
+		private System.Windows.Forms.Label label1;
+		private System.Windows.Forms.PictureBox pictureBox1;
+		private System.Windows.Forms.Label label2;
+		private System.Windows.Forms.Label label3;
+		private System.Windows.Forms.Label labelContainsText;
+		private System.Windows.Forms.Label label4;
+		private System.Windows.Forms.Label label5;
+		private System.Windows.Forms.Label labelContainsAnyImage;
+		private System.Windows.Forms.Label labelContainsImage;
+		private System.Windows.Forms.Button btnClose;
+	}
+}

--- a/TestApps/ClipboardTestApp/Form1.cs
+++ b/TestApps/ClipboardTestApp/Form1.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using SIL.PlatformUtilities;
+using SIL.Windows.Forms.ImageToolbox;
+using SIL.Windows.Forms.Miscellaneous;
+
+namespace ClipboardTestApp
+{
+	public partial class Form1 : Form
+	{
+		public Form1()
+		{
+			InitializeComponent();
+		}
+
+		private void OnCopyText(object sender, EventArgs e)
+		{
+			PortableClipboard.SetText(textBox1.Text);
+			UpdateLabels();
+		}
+
+		private void OnPasteText(object sender, EventArgs e)
+		{
+			textBox1.Text = PortableClipboard.GetText();
+		}
+
+		private void OnCopyImage(object sender, EventArgs e)
+		{
+			try
+			{
+				using var openFileDialog =
+					new OpenFileDialogWithViews(OpenFileDialogWithViews.DialogViewTypes.Details);
+				if (openFileDialog.ShowDialog(this) != DialogResult.OK)
+					return;
+
+				using var image = PalasoImage.FromFile(openFileDialog.FileName);
+				PortableClipboard.CopyImageToClipboard(image);
+				UpdateLabels();
+			}
+			catch (NotImplementedException)
+			{
+				if (Platform.IsWindows)
+					throw;
+				// ignore on Linux - currently not yet implemented
+			}
+		}
+
+		private void OnPasteImage(object sender, EventArgs e)
+		{
+			pictureBox1.Image = PortableClipboard.GetImage();
+		}
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			UpdateLabels();
+		}
+
+		protected override void OnActivated(EventArgs e)
+		{
+			base.OnActivated(e);
+			UpdateLabels();
+		}
+
+		private void UpdateLabels()
+		{
+			labelContainsText.Text = PortableClipboard.ContainsText() ? "true" : "false";
+			labelContainsImage.Text = PortableClipboard.ContainsImage() ? "true" : "false";
+			labelContainsAnyImage.Text = PortableClipboard.CanGetImage() ? "true" : "false";
+		}
+
+		private void OnClose(object sender, EventArgs e)
+		{
+			Close();
+		}
+		private void OnPasteAnyImage(object sender, EventArgs e)
+		{
+			var imageFromClipboard = PortableClipboard.GetImageFromClipboard();
+			if (imageFromClipboard == null)
+			{
+				MessageBox.Show("No image found in clipboard.");
+				return;
+			}
+			pictureBox1.Image = imageFromClipboard.Image;
+		}
+
+		private void btnClose_Click(object sender, EventArgs e)
+		{
+			Close();
+		}
+	}
+}

--- a/TestApps/ClipboardTestApp/Form1.resx
+++ b/TestApps/ClipboardTestApp/Form1.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/TestApps/ClipboardTestApp/Program.cs
+++ b/TestApps/ClipboardTestApp/Program.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ClipboardTestApp
+{
+	static class Program
+	{
+		/// <summary>
+		///  The main entry point for the application.
+		/// </summary>
+		[STAThread]
+		static void Main()
+		{
+			Application.EnableVisualStyles();
+			Application.SetCompatibleTextRenderingDefault(false);
+			Application.Run(new Form1());
+		}
+	}
+}


### PR DESCRIPTION
Also restores and enhances the ClipboardTestApp. Most of it is restored after e3f8d8da748bed3a436f3c095b6d86d9dd52f526. I added the button and label for "paste any image" and "contains any image" which use the newer functions, and tweaked to show the whole image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1438)
<!-- Reviewable:end -->
