### PR TITLE
Upgrade SIL.Media (and some SIL.Core) to be compatible with .net 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - [SIL.TestUtilities] Added a Create method to TemporaryFolder that takes a TestContext
+- [SIL.Media] Added .NET 8-Windows target (though it does not support AudioFactory.CreateAudioSession or anything that would require IrrKlang)
+- [SIL.Core] Support for RobustFile.GetAccessControl in all builds
+
 
 ### Fixed
 

--- a/SIL.Core/IO/RobustFile.cs
+++ b/SIL.Core/IO/RobustFile.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.AccessControl;
 using System.Text;
 using JetBrains.Annotations;
 using SIL.Code;
@@ -345,11 +346,13 @@ namespace SIL.IO
 			RetryUtility.Retry(() => File.WriteAllLines(path, contents), memo:$"WriteAllLines {path}");
 		}
 
-#if NET462
-		public static System.Security.AccessControl.FileSecurity GetAccessControl(string filePath)
+		public static FileSecurity GetAccessControl(string filePath)
 		{
+#if NET462
 			return RetryUtility.Retry(() => File.GetAccessControl(filePath), memo: $"GetAccessControl {filePath}");
-		}
+#else
+			return RetryUtility.Retry(() => FileSystemAclExtensions.GetAccessControl(new FileInfo(filePath)), memo: $"GetAccessControl {filePath}");
 #endif
+		}
 	}
 }

--- a/SIL.Core/SIL.Core.csproj
+++ b/SIL.Core/SIL.Core.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="SIL.ReleaseTasks" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>

--- a/SIL.Media.Tests/AudioFactoryTests.cs
+++ b/SIL.Media.Tests/AudioFactoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using NUnit.Framework;
 using SIL.IO;
@@ -9,6 +10,14 @@ namespace SIL.Media.Tests
 	[Category("RequiresAudioOutputDevice")] // These will not work if a speaker is not available.
 	public class AudioFactoryTests
 	{
+		[OneTimeSetUp]
+		public void CheckPlatformSupport()
+		{
+#if NET8_0_OR_GREATER
+			Assert.Ignore("AudioFactory tests are not supported on .NET 8+ because WindowsAudioSession functionality is not available on this platform.");
+#endif
+		}
+
 		[Test]
 		public void Construct_FileDoesNotExist_OK()
 		{

--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -17,6 +17,14 @@ namespace SIL.Media.Tests
 	[NUnit.Framework.Category("AudioTests")]
 	public class AudioSessionTests
 	{
+		[OneTimeSetUp]
+		public void CheckPlatformSupport()
+		{
+#if NET8_0_OR_GREATER
+			Assert.Ignore("AudioSession tests are not supported on .NET 8+ because WindowsAudioSession functionality is not available on this platform.");
+#endif
+		}
+
 		[Test]
 		public void StopRecordingAndSaveAsWav_NotRecording_Throws()
 		{

--- a/SIL.Media.Tests/MediaInfoTests.cs
+++ b/SIL.Media.Tests/MediaInfoTests.cs
@@ -63,7 +63,7 @@ namespace SIL.Media.Tests
 			{
 				var info = MediaInfo.GetInfo(file.Path);
 				Assert.That(info.Video.Duration.TotalMilliseconds, Is.EqualTo(3069).Within(0.1));
-				Assert.That(info.Video.Duration, Is.EqualTo(info.AnalysisData.Duration).Within(0.5).Milliseconds);
+				Assert.That(info.Video.Duration, Is.EqualTo(info.AnalysisData.Duration).Within(1).Milliseconds);
 				Assert.That(info.Audio.Duration.TotalMilliseconds, Is.EqualTo(3029).Within(0.1));
 			}
 		}

--- a/SIL.Media.Tests/SIL.Media.Tests.csproj
+++ b/SIL.Media.Tests/SIL.Media.Tests.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>SIL.Media.Tests</RootNamespace>
     <AssemblyName>SIL.Media.Tests</AssemblyName>
     <Description>Unit tests for SIL.Media</Description>
+    <TargetFrameworks>$(TargetFrameworks);net8.0-windows</TargetFrameworks>
     <SignAssembly>false</SignAssembly>
     <IsPackable>false</IsPackable>
     <UseWindowsForms>true</UseWindowsForms>

--- a/SIL.Media/AlsaAudio/AlsaAudioDevice.cs
+++ b/SIL.Media/AlsaAudio/AlsaAudioDevice.cs
@@ -340,8 +340,6 @@ namespace SIL.Media.AlsaAudio
 				return;
 			_fAsyncQuit = true;
 			_recordingThread.Join(1000);
-			if (_recordingThread.IsAlive)
-				_recordingThread.Abort();
 			_recordingThread = null;
 		}
 
@@ -410,8 +408,6 @@ namespace SIL.Media.AlsaAudio
 				return;
 			_fAsyncQuit = true;
 			_playbackThread.Join(1000);
-			if (_playbackThread.IsAlive)
-				_playbackThread.Abort();
 			_playbackThread = null;
 		}
 
@@ -681,7 +677,7 @@ namespace SIL.Media.AlsaAudio
 				{
 				case SND_PCM_FORMAT_S32_LE:
 					var ints = new int[1024 * _info.channels];
-					while (remaining > 0)
+					while (remaining > 0 && !_fAsyncQuit)
 					{
 						int num = (remaining >= 1024) ? 1024 : remaining;
 						long cf = sf_readf_int(_hsf, ints, num);
@@ -695,7 +691,7 @@ namespace SIL.Media.AlsaAudio
 					break;
 				case SND_PCM_FORMAT_FLOAT_LE:
 					var floats = new float[1024 * _info.channels];
-					while (remaining > 0)
+					while (remaining > 0 && !_fAsyncQuit)
 					{
 						int num = (remaining >= 1024) ? 1024 : remaining;
 						long cf = sf_readf_float(_hsf, floats, num);
@@ -709,7 +705,7 @@ namespace SIL.Media.AlsaAudio
 					break;
 				case SND_PCM_FORMAT_FLOAT64_LE:
 					var doubles = new double[1024 * _info.channels];
-					while (remaining > 0)
+					while (remaining > 0 && !_fAsyncQuit)
 					{
 						int num = (remaining >= 1024) ? 1024 : remaining;
 						long cf = sf_readf_double(_hsf, doubles, num);
@@ -723,7 +719,7 @@ namespace SIL.Media.AlsaAudio
 					break;
 				default:
 					var shorts = new short[1024 * _info.channels];
-					while (remaining > 0)
+					while (remaining > 0 && !_fAsyncQuit)
 					{
 						int num = (remaining >= 1024) ? 1024 : remaining;
 						long cf = sf_readf_short(_hsf, shorts, num);

--- a/SIL.Media/AudioFactory.cs
+++ b/SIL.Media/AudioFactory.cs
@@ -9,19 +9,32 @@ namespace SIL.Media
 {
 	public class AudioFactory
 	{
+		
+		/// <summary>
+		/// Creates an audio session for the given file path.
+		/// On Linux, uses ALSA. On Windows, uses IrrKlang (only supported on .NET Framework 4.6.2/4.8).
+		/// Throws PlatformNotSupportedException on Windows with .NET 8+.
+		/// </summary>
 		public static ISimpleAudioSession CreateAudioSession(string filePath)
 		{
 			if (Platform.IsLinux)
 				return new AudioAlsaSession(filePath);
+#if NET462 || NET48
 			RedirectIrrKlangAssembly();
 			return CreateIrrKlangSession(filePath);
+#else
+			throw new PlatformNotSupportedException("WindowsAudioSession is not supported on .NET 8+");
+#endif
 		}
 
+#if NET462 || NET48
 		private static ISimpleAudioSession CreateIrrKlangSession(string filePath)
 		{
 			return new WindowsAudioSession(filePath);
 		}
+#endif
 
+#if NET462 || NET48
 		///<summary>Adds an AssemblyResolve handler to redirect all attempts to load the
 		/// irrKlang.Net.dll to the architecture specific subdirectory.</summary>
 		private static void RedirectIrrKlangAssembly()
@@ -31,7 +44,8 @@ namespace SIL.Media
 
 			ResolveEventHandler handler = null;
 
-			handler = (sender, args) => {
+			handler = (sender, args) =>
+			{
 				const string irrklangNet4Dll = "irrKlang.NET4";
 
 				var requestedAssembly = new AssemblyName(args.Name);
@@ -62,5 +76,6 @@ namespace SIL.Media
 			};
 			AppDomain.CurrentDomain.AssemblyResolve += handler;
 		}
+#endif
 	}
 }

--- a/SIL.Media/Naudio/AudioRecorder.cs
+++ b/SIL.Media/Naudio/AudioRecorder.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NAudio;
 using NAudio.Mixer;
 using NAudio.Wave;
@@ -102,7 +103,8 @@ namespace SIL.Media.Naudio
 			SampleAggregator.MaximumCalculated += delegate
 			{
 				_peakLevelEventArgs.Level = SampleAggregator.maxValue;
-				PeakLevelChanged?.BeginInvoke(this, _peakLevelEventArgs, null, null);
+			if (PeakLevelChanged != null)
+        		Task.Run(() => PeakLevelChanged(this, _peakLevelEventArgs));
 			};
 
 			RecordingFormat = new WaveFormat(44100, 1);
@@ -651,7 +653,7 @@ namespace SIL.Media.Naudio
 					_prevRecordedTime = currRecordedTime;
 					_recProgressEventArgs.RecordedLength = TimeSpan.FromSeconds(currRecordedTime);
 					if (RecordingProgress != null)
-						RecordingProgress.BeginInvoke(this, _recProgressEventArgs, null, null);
+    					Task.Run(() => RecordingProgress(this, _recProgressEventArgs));
 				}
 
 				if (RecordingState == RecordingState.RequestedStop)

--- a/SIL.Media/SIL.Media.csproj
+++ b/SIL.Media/SIL.Media.csproj
@@ -1,5 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>$(TargetFrameworks);net8.0-windows</TargetFrameworks>
     <RootNamespace>SIL.Media</RootNamespace>
     <AssemblyTitle>SIL.Media</AssemblyTitle>
     <Description>SIL.Media contains Windows Forms UI elements and classes for processing audio on Windows and Linux.</Description>
@@ -28,7 +29,7 @@
     <ProjectReference Include="..\SIL.Core\SIL.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="irrKlang.NET4">
+    <Reference Include="irrKlang.NET4" Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net48' ">
       <Private>false</Private>
     </Reference>
   </ItemGroup>

--- a/SIL.Media/WindowsAudioSession.cs
+++ b/SIL.Media/WindowsAudioSession.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2015-2025 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+/// Not supported in .NET 8+ due to IrrKlang
+#if NET462 || NET48
+
 using System;
 using System.ComponentModel;
 using System.IO;
@@ -287,3 +290,4 @@ namespace SIL.Media
 		}
 	}
 }
+#endif


### PR DESCRIPTION
So we can upgrade Bloom Desktop (https://issues.bloomlibrary.org/youtrack/issue/BL-14973/Upgrade-.net-and-compile-test-in-vscode)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1454)
<!-- Reviewable:end -->
