### PR TITLE
+semver:minor Explicitly set UseShellExecute, .net core default changed

### DIFF
--- a/SIL.Archiving/ArchivingDlgViewModel.cs
+++ b/SIL.Archiving/ArchivingDlgViewModel.cs
@@ -547,6 +547,10 @@ namespace SIL.Archiving
 				return;
 
 			var prs = new Process();
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			prs.StartInfo.UseShellExecute = true;
 			prs.StartInfo.FileName = PathToProgramToLaunch;
 			if (!IsNullOrEmpty(PackagePath))
 				prs.StartInfo.Arguments = "\"" + PackagePath + "\"";

--- a/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
+++ b/SIL.Archiving/IMDI/IMDIArchivingDlgViewModel.cs
@@ -170,8 +170,10 @@ namespace SIL.Archiving.IMDI
 					Format(ArchivingPrograms.ArbilCommandLineArgs, PathToProgramToLaunch) :
 					PathToProgramToLaunch;
 			}
-
-			var prs = new Process { StartInfo = { FileName = exePath, Arguments = args } };
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			var prs = new Process { StartInfo = { FileName = exePath, Arguments = args, UseShellExecute = true } };
 
 			LaunchArchivingProgram(prs);
 		}

--- a/SIL.Core.Desktop/IO/FileLocator.cs
+++ b/SIL.Core.Desktop/IO/FileLocator.cs
@@ -207,7 +207,10 @@ namespace SIL.IO
 			try
 			{
 				string filePath = $"/tmp/dummy{fileExtension}";
-				Process.Start("touch", filePath)?.WaitForExit();
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				Process.Start(new ProcessStartInfo("touch", filePath) { UseShellExecute = true })?.WaitForExit();
 
 				var process = new Process
 				{

--- a/SIL.Core.Tests/Extensions/ProcessExtensionsTests.cs
+++ b/SIL.Core.Tests/Extensions/ProcessExtensionsTests.cs
@@ -14,6 +14,10 @@ namespace SIL.Extensions
 		{
 			// Setup
 			using var process = new Process();
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			process.StartInfo.UseShellExecute = true;
 			var errorTriggered = false;
 
 			// Execute/Verify
@@ -28,6 +32,10 @@ namespace SIL.Extensions
 		{
 			// Setup
 			using var process = new Process();
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			process.StartInfo.UseShellExecute = true;
 			var errorTriggered = false;
 
 			// Execute/Verify
@@ -42,6 +50,10 @@ namespace SIL.Extensions
 		{
 			// Setup
 			using var process = new Process();
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			process.StartInfo.UseShellExecute = true;
 
 			// Execute/Verify
 			Assert.That(() => process.RunProcess("NonExistingProgram_8473464", "", null),

--- a/SIL.Core/Email/MacOsXEmailProvider.cs
+++ b/SIL.Core/Email/MacOsXEmailProvider.cs
@@ -16,7 +16,10 @@ namespace SIL.Email
 
 		public bool SendMessage(IEmailMessage message)
 		{
-			var startInfo = new ProcessStartInfo { FileName = "osascript" };
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			var startInfo = new ProcessStartInfo { FileName = "osascript", UseShellExecute = true };
 			var bldr = new StringBuilder();
 			bldr.AppendLine("-e 'tell application \"Mail\"");
 			bldr.AppendLine("tell (make new outgoing message)");

--- a/SIL.Core/IO/PathUtilities.cs
+++ b/SIL.Core/IO/PathUtilities.cs
@@ -321,7 +321,10 @@ namespace SIL.IO
 						arguments = $"\"{Path.GetDirectoryName(path)}\"";
 						break;
 				}
-				Process.Start(fileManager, arguments);
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				Process.Start(new ProcessStartInfo(fileManager, arguments) { UseShellExecute = true });
 			}
 		}
 
@@ -361,7 +364,10 @@ namespace SIL.IO
 		/// <param name="filePath">Full path to the file</param>
 		public static void OpenFileInApplication(string filePath)
 		{
-			Process.Start(filePath);
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			Process.Start(new ProcessStartInfo(filePath) { UseShellExecute = true });
 		}
 
 		private static string GetDefaultFileManager()
@@ -372,6 +378,10 @@ namespace SIL.IO
 			const string fallbackFileManager = "xdg-open";
 
 			using var xdgmime = new Process();
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			xdgmime.StartInfo.UseShellExecute = true;
 			bool processError = false;
 			xdgmime.RunProcess("xdg-mime", "query default inode/directory", exception =>  {
 				processError = true;

--- a/SIL.Core/Program/Process.cs
+++ b/SIL.Core/Program/Process.cs
@@ -30,8 +30,10 @@ namespace SIL.Program
 			var libpath = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");
 			if (!String.IsNullOrEmpty(libpath))
 				Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", null);
-
-			System.Diagnostics.Process.Start(urlOrCmd);
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(urlOrCmd) { UseShellExecute = true });
 
 			if (!String.IsNullOrEmpty(libpath))
 				Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", libpath);
@@ -47,7 +49,10 @@ namespace SIL.Program
 			if (!String.IsNullOrEmpty(libpath))
 				Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", null);
 
-			System.Diagnostics.Process.Start(command, arguments);
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(command, arguments) { UseShellExecute = true });
 
 			if (!String.IsNullOrEmpty(libpath))
 				Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", libpath);

--- a/SIL.Core/Reporting/Logger.cs
+++ b/SIL.Core/Reporting/Logger.cs
@@ -519,7 +519,10 @@ namespace SIL.Reporting
 		public static void ShowUserTheLogFile()
 		{
 			Singleton.m_out.Flush();
-			Process.Start(LogPath);
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			Process.Start(new ProcessStartInfo(LogPath) { UseShellExecute = true });
 		}
 
 		/// <summary>
@@ -547,7 +550,10 @@ namespace SIL.Reporting
 				writer.Flush();
 				writer.Close();
 			}
-			Process.Start(tempFileName);
+			// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+			// We are explicitly setting it to true for consistency with the old behavior
+			// but have not checked if it is necessary here.
+			Process.Start(new ProcessStartInfo(tempFileName) { UseShellExecute = true });
 		}
 	}
 }

--- a/SIL.Media/AlsaAudio/AudioAlsaSession.cs
+++ b/SIL.Media/AlsaAudio/AudioAlsaSession.cs
@@ -115,7 +115,10 @@ namespace SIL.Media.AlsaAudio
 			if(!_device.StartPlaying(FilePath))
 			{
 				// If the Alsa device can't play the file, it's probably a format we don't recognize. See if the OS knows how to play it.
-				Process.Start(FilePath);
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				Process.Start(new ProcessStartInfo(FilePath) { UseShellExecute = true });
 			}
 		}
 

--- a/SIL.Media/Naudio/UI/RecordingDeviceIndicator.cs
+++ b/SIL.Media/Naudio/UI/RecordingDeviceIndicator.cs
@@ -225,7 +225,10 @@ namespace SIL.Media.Naudio.UI
 			try
 			{
 				// launch the control panel that shows the user all their recording device options
-				System.Diagnostics.Process.Start("control", "mmsys.cpl,,1");
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("control", "mmsys.cpl,,1") { UseShellExecute = true });
 			}
 			catch(Exception)
 			{

--- a/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
+++ b/SIL.Windows.Forms.Keyboarding.Tests/XkbKeyboardAdapterTests.cs
@@ -204,6 +204,10 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 				{
 					process.StartInfo.FileName = "/bin/grep";
 					process.StartInfo.Arguments = "-q Belgian /usr/share/X11/xkb/rules/evdev.xml";
+					// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+					// We are explicitly setting it to true for consistency with the old behavior
+					// but have not checked if it is necessary here.
+					process.StartInfo.UseShellExecute = true;
 					process.Start();
 					process.WaitForExit();
 					if (process.ExitCode != 0)
@@ -216,6 +220,10 @@ namespace SIL.Windows.Forms.Keyboarding.Tests
 				{
 					process.StartInfo.FileName = "/bin/grep";
 					process.StartInfo.Arguments = "-q 'French (no dead keys)' /usr/share/X11/xkb/rules/evdev.xml";
+					// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+					// We are explicitly setting it to true for consistency with the old behavior
+					// but have not checked if it is necessary here.
+					process.StartInfo.UseShellExecute = true;
 					process.Start();
 					process.WaitForExit();
 					if (process.ExitCode != 0)

--- a/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/IbusKeyboardRetrievingAdaptor.cs
@@ -159,7 +159,10 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 			}
 			return () =>
 			{
-				using (Process.Start(setupApp, args)) { }
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				using (Process.Start(new ProcessStartInfo(setupApp, args) { UseShellExecute = true })) { }
 			};
 		}
 
@@ -170,7 +173,10 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 
 			return () =>
 			{
-				using (Process.Start(KeymanConfigApp)) { }
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				using (Process.Start(new ProcessStartInfo(KeymanConfigApp) { UseShellExecute = true })) { }
 			};
 		}
 

--- a/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Linux/XkbKeyboardRetrievingAdaptor.cs
@@ -197,7 +197,10 @@ namespace SIL.Windows.Forms.Keyboarding.Linux
 				return null;
 			}
 			return () => {
-				using (Process.Start(setupApp, args)) { }
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				using (Process.Start(new ProcessStartInfo(setupApp, args) { UseShellExecute = true })) { }
 			};
 		}
 

--- a/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/KeymanKeyboardAdaptor.cs
@@ -281,7 +281,10 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 					return () =>
 					{
 						var setupApp = GetKeyboardSetupApplication(out var args);
-						Process.Start(setupApp, args);
+						// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+						// We are explicitly setting it to true for consistency with the old behavior
+						// but have not checked if it is necessary here.
+						Process.Start(new ProcessStartInfo(setupApp, args) { UseShellExecute = true });
 					};
 				default:
 					throw new NotSupportedException($"No keyboard setup action defined for keyman version {InstalledKeymanVersion}");

--- a/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
+++ b/SIL.Windows.Forms.Keyboarding/Windows/WinKeyboardAdaptor.cs
@@ -280,8 +280,12 @@ namespace SIL.Windows.Forms.Keyboarding.Windows
 		{
 			return () =>
 			{
-				using (Process.Start(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "control.exe"),
-					"input.dll")) {}
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				using (Process.Start(new ProcessStartInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "control.exe"),
+					"input.dll")
+				{ UseShellExecute = true })) { }
 			};
 		}
 

--- a/SIL.Windows.Forms/FlexibleMessageBox.cs
+++ b/SIL.Windows.Forms/FlexibleMessageBox.cs
@@ -180,7 +180,10 @@ namespace SIL.Windows.Forms
 			try
 			{
 				Cursor.Current = Cursors.WaitCursor;
-				Process.Start(e.LinkText);
+				// UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8)
+				// We are explicitly setting it to true for consistency with the old behavior
+				// but have not checked if it is necessary here.
+				Process.Start(new ProcessStartInfo(e.LinkText) { UseShellExecute = true });
 			}
 			finally
 			{


### PR DESCRIPTION
UseShellExecute defaults to true in .net framework (including .net 4) and to false in .net core (including .net 8). Set it explicitly for consistency