### PR TITLE
SP-2356: Fixed flaky DateTimeExtensionTests

### DIFF
--- a/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
+++ b/SIL.Core.Tests/Extensions/DateTimeExtensionTests.cs
@@ -361,15 +361,15 @@ namespace SIL.Tests.Extensions
 		[TestCase("dd/MM/yyyy")] // Thai/European-style numeric date, zero-padded (e.g. 14/05/2025)
 		[TestCase("d/M/yyyy")] // Thai/European-style numeric date (e.g. 14/5/2025)
 		[TestCase("d-M-yyyy")] // Thai/European-style numeric date with dashes (e.g. 14-5-2025)
-		// Commenting out these test cases for now until they can be fixed.
-		//[TestCase("d")] // Short date pattern (e.g. 14/5/2025)
-		//[TestCase("M/d/yyyy")] // US-style numeric date (e.g. 5/14/2025)
-		//[TestCase("M-d-yyyy")] // US-style numeric date with dashes (e.g. 5-14-2025)
-		//[TestCase("MM/dd/yyyy")] // US-style numeric date, zero-padded (e.g. 05/14/2025)
-		//[TestCase("MM-dd-yyyy")] // US-style numeric date with dashes, zero-padded (e.g. 05-14-2025)
+		[TestCase("d")] // Short date pattern (e.g. 14/5/2025)
+		[TestCase("M/d/yyyy")] // US-style numeric date (e.g. 5/14/2025)
+		[TestCase("M-d-yyyy")] // US-style numeric date with dashes (e.g. 5-14-2025)
+		[TestCase("MM/dd/yyyy")] // US-style numeric date, zero-padded (e.g. 05/14/2025)
+		[TestCase("MM-dd-yyyy")] // US-style numeric date with dashes, zero-padded (e.g. 05-14-2025)
 		public void ParseDateTimePermissivelyWithException_NearFutureDatesWithThaiBuddhistCalendar_ReturnsDateWithPastYear(string inputFormat)
 		{
-			var futureDate = DateTime.Today.AddDays(5);
+			var futureDate = GetNextFutureDateWithPotentiallyAmbiguousDay(5);
+			int maxDateOffset = (futureDate - DateTime.Today).Days - 1;
 			string input = futureDate.ToString(inputFormat);
 			int expectedYear = futureDate.Year - 543;
 
@@ -390,7 +390,7 @@ namespace SIL.Tests.Extensions
 					Thread.CurrentThread.CurrentCulture = buddhistCulture;
 
 					var reasonableMin = new DateTime(1481, 1, 1);
-					var reasonableMax = DateTime.Today + TimeSpan.FromDays(4);
+					var reasonableMax = DateTime.Today.AddDays(maxDateOffset);
 					result = input.ParseDateTimePermissivelyWithException(reasonableMin,
 						reasonableMax);
 				}
@@ -418,15 +418,14 @@ namespace SIL.Tests.Extensions
 		[TestCase("dd/MM/yyyy")] // Thai/European-style numeric date, zero-padded (e.g. 14/05/2025)
 		[TestCase("d/M/yyyy")] // Thai/European-style numeric date (e.g. 14/5/2025)
 		[TestCase("d-M-yyyy")] // Thai/European-style numeric date with dashes (e.g. 14-5-2025)
-		// Commenting out these test cases for now until they can be fixed.
-		//[TestCase("d")] // Short date pattern (e.g. 14/5/2025)
-		//[TestCase("M/d/yyyy")] // US-style numeric date (e.g. 5/14/2025)
-		//[TestCase("M-d-yyyy")] // US-style numeric date with dashes (e.g. 5-14-2025)
-		//[TestCase("MM/dd/yyyy")] // US-style numeric date, zero-padded (e.g. 05/14/2025)
-		//[TestCase("MM-dd-yyyy")] // US-style numeric date with dashes, zero-padded (e.g. 05-14-2025)
+		[TestCase("d")] // Short date pattern (e.g. 14/5/2025)
+		[TestCase("M/d/yyyy")] // US-style numeric date (e.g. 5/14/2025)
+		[TestCase("M-d-yyyy")] // US-style numeric date with dashes (e.g. 5-14-2025)
+		[TestCase("MM/dd/yyyy")] // US-style numeric date, zero-padded (e.g. 05/14/2025)
+		[TestCase("MM-dd-yyyy")] // US-style numeric date with dashes, zero-padded (e.g. 05-14-2025)
 		public void ParsePastDateTimePermissivelyWithException_NearFutureDatesWithThaiBuddhistCalendar_ReturnsDateWithPastYear(string inputFormat)
 		{
-			var futureDate = DateTime.Today.AddDays(2);
+			var futureDate = GetNextFutureDateWithPotentiallyAmbiguousDay();
 			var input = futureDate.ToString(inputFormat);
 			var expectedYear = futureDate.Year - 543;
 			
@@ -469,7 +468,8 @@ namespace SIL.Tests.Extensions
 		[TestCase("dddd, dd MMMM yyyy")] // Full long format (e.g. Wednesday, 14 May 2025)
 		public void ParseDateTimePermissivelyWithException_NearFutureUSDatesWithThaiBuddhistCalendar_ReturnsDateWithFutureYear(string inputFormat)
 		{
-			var futureDate = DateTime.Today.AddDays(5);
+			var futureDate = GetNextFutureDateWithPotentiallyAmbiguousDay(5);
+			int maxDateOffset = (futureDate - DateTime.Today).Days - 1;
 			string input = futureDate.ToString(inputFormat);
 			int expectedYear = futureDate.Year;
 
@@ -490,7 +490,7 @@ namespace SIL.Tests.Extensions
 					Thread.CurrentThread.CurrentCulture = buddhistCulture;
 
 					var reasonableMin = new DateTime(1900, 1, 1);
-					var reasonableMax = DateTime.Today + TimeSpan.FromDays(4);
+					var reasonableMax = DateTime.Today.AddDays(maxDateOffset);
 					result = input.ParseDateTimePermissivelyWithException(reasonableMin,
 						reasonableMax);
 				}
@@ -516,7 +516,7 @@ namespace SIL.Tests.Extensions
 		[TestCase("dddd, dd MMMM yyyy")] // Full long format (e.g. Wednesday, 14 May 2025)
 		public void ParsePastDateTimePermissivelyWithException_NearFutureUSDatesWithThaiBuddhistCalendar_ReturnsDateWithFutureYear(string inputFormat)
 		{
-			var futureDate = DateTime.Today.AddDays(2);
+			var futureDate = GetNextFutureDateWithPotentiallyAmbiguousDay();
 			string input = futureDate.ToString(inputFormat);
 			int expectedYear = futureDate.Year;
 			
@@ -550,6 +550,22 @@ namespace SIL.Tests.Extensions
 			Assert.That(result?.Year, Is.EqualTo(expectedYear));
 		}
 
+		/// <summary>
+		/// Helper method to find the next "near" future date with a day number less than or equal
+		/// to 12, such that it that could potentially be mistaken for a month number if the date
+		/// format is ambiguous.
+		/// </summary>
+		/// <param name="minDaysIntoFuture">Number of days in the future to start looking for a
+		/// "near" date. Pass 2 or greater to avoid possible edge cases related to time zones.
+		/// </param>
+		private static DateTime GetNextFutureDateWithPotentiallyAmbiguousDay(int minDaysIntoFuture = 2)
+		{
+			var date = DateTime.Today.AddDays(minDaysIntoFuture);
+			while (date.Day > 12)
+				date = date.AddDays(1);
+			return date;
+		}
+		
 		[TestCase("19/10/2025 0:00:00", ExpectedResult = "2025-10-19")]
 		[TestCase("14/4/1482", ExpectedResult = "1482-04-14")]
 		[TestCase("13/3/1800 0:01:00", ExpectedResult = "1800-03-13")]

--- a/SIL.Core/Extensions/DateTimeExtensions.cs
+++ b/SIL.Core/Extensions/DateTimeExtensions.cs
@@ -203,7 +203,9 @@ namespace SIL.Extensions
 						return true;
 					}
 
-					// Try switching calendar
+					// Try switching to Thai/Buddhist calendar. Note that other calendars (Hijri,
+					// Hebrew, etc.) could also be tried, in order of likelihood, but we have never
+					// seen evidence of data suggesting that it is necessary.
 					var altCulture = (CultureInfo)cultureInfo.Clone();
 					var originalCalendar = altCulture.DateTimeFormat.Calendar;
 					try


### PR DESCRIPTION
The tests that were previously commented out because of their dependency on certain current dates should now be reliable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1461)
<!-- Reviewable:end -->
