### PR TITLE
Ignore an "invalid ICU DLL" exception when initializing SLDR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.WritingSystems] Handle invalid ICU dlls as well as missing ICU dlls when initializing SLDR.
 - [SIL.Windows.Forms] Made ContributorsListControl.GetCurrentContribution() return null in the case when a valid row is not selected.
 
 ## [16.1.0] - 2025-07-18

--- a/SIL.WritingSystems/Sldr.cs
+++ b/SIL.WritingSystems/Sldr.cs
@@ -162,6 +162,10 @@ namespace SIL.WritingSystems
 			{
 				// The program doesn't have the ICU library available.  We can live with this.
 			}
+			catch (System.BadImageFormatException)
+			{
+				// If the ICU DLLs are invalid, we can't use them.  That's OK.
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
"Missing ICU DLL" exceptions are already ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1466)
<!-- Reviewable:end -->
