### PR TITLE
Handle Chinese autonyms explicitly in IetfLanguageTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- [SIL.WritingSystems] Handle Chinese autonyms properly in IetfLanguageTag.GetLocalizedLanguageName().
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 
 ### Changed

--- a/SIL.WritingSystems/IetfLanguageTag.cs
+++ b/SIL.WritingSystems/IetfLanguageTag.cs
@@ -1317,6 +1317,15 @@ namespace SIL.WritingSystems
 			{
 				return kTraditionalChineseNameInEnglish;
 			}
+			else if (generalCode == ChineseSimplifiedTag && uiLanguageTag == ChineseSimplifiedTag)
+			{
+				// Chinese autonyms are also messed up in various ways, so we hard-code them here.
+				return kSimplifiedChineseAutonym;
+			}
+			else if (generalCode == ChineseTraditionalTag && uiLanguageTag == ChineseTraditionalTag)
+			{
+				return kTraditionalChineseAutonym;
+			}
 
 			// Starting some time around Sept 2025, Windows started returning the "fa" culture
 			// for CultureInfo.GetCultureInfo("prs"). We actually want to return Dari in that case.


### PR DESCRIPTION
This fixes a bug reported in Bloom (BL-15436)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1475)
<!-- Reviewable:end -->
