### PR TITLE
+semver:minor Added PrivacyDlg to allow control over analytics tracking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,12 @@ jobs:
     # WriteVersionInfoToBuildLog=false suppresses the MSBuild task that causes the conflict;
     # assembly versioning is unaffected as it uses a different GitVersion task.
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v3
+      uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
       with:
         versionSpec: '5.x'
 
     - name: Run GitVersion
-      uses: gittools/actions/gitversion/execute@v3
+      uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
 
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release -p:WriteVersionInfoToBuildLog=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - name: Install WiX Toolset v3.14
-      run: choco install wixtoolset --version="[3.14.1,4.0)" -y
+    - name: Ensure WiX Toolset v3.14.(1+)
+      run: choco upgrade wixtoolset --version=3.14.1 -y --no-progress
 
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ jobs:
     # target frameworks building in parallel each try to append to the same GHA environment file.
     # WriteVersionInfoToBuildLog=false suppresses the MSBuild task that causes the conflict;
     # assembly versioning is unaffected as it uses a different GitVersion task.
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v3
+      with:
+        versionSpec: '5.x'
+
     - name: Run GitVersion
       uses: gittools/actions/gitversion/execute@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         fetch-depth: '0'
 
+    - name: Install WiX Toolset v3.14
+      run: choco install wixtoolset --version=3.14.1 -y
+
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ jobs:
       with:
         fetch-depth: '0'
 
-    - name: Ensure WiX Toolset v3.14.(1+)
-      run: choco upgrade wixtoolset --version=3.14.1 -y --no-progress
+    # WiX Toolset v3.14 seems to pre-installed on GH agent. Everything I've tried so far to ensure that with choco fails.
 
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,17 @@ jobs:
       with:
         fetch-depth: '0'
 
-    # WiX Toolset v3.14 seems to pre-installed on GH agent. Everything I've tried so far to ensure that with choco fails.
+    # WiX Toolset v3.14 seems to be pre-installed on GH agent. Everything I've tried so far to ensure that with choco fails.
+
+    # Run GitVersion as a separate step before building to avoid a race condition where multiple
+    # target frameworks building in parallel each try to append to the same GHA environment file.
+    # WriteVersionInfoToBuildLog=false suppresses the MSBuild task that causes the conflict;
+    # assembly versioning is unaffected as it uses a different GitVersion task.
+    - name: Run GitVersion
+      uses: gittools/actions/gitversion/execute@v3
 
     - name: Build project
-      run: dotnet build -bl:build.binlog -c Release
+      run: dotnet build -bl:build.binlog -c Release -p:WriteVersionInfoToBuildLog=false
 
     - name: Get Path to Tests
       run: echo "TEST_PATH=$(dotnet msbuild SIL.Core.Tests/ --getProperty:OutputPath -p:TargetFramework=${{ matrix.framework }} -p:Configuration=Release)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         fetch-depth: '0'
 
     - name: Install WiX Toolset v3.14
-      run: choco install wixtoolset --version=3.14.1 -y
+      run: choco install wixtoolset --version="[3.14.1,4.0)" -y
 
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ icu4c.readme.txt
 /SIL.Windows.Forms/bin-Designer/**
 launchSettings.json
 *.xlf
+/.claude/settings.local.json
+# Normally `.guidsForInstaller.xml` files should be checked into source control, but this is just for the SIL.Windows.Forms.TestApp installer, which we do not deploy, and we don't care about upgrade installs.
+/DistFiles/.guidsForInstaller.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,9 @@ You are an expert C# developer assisting with the `sillsdev/libpalaso` repositor
 ## 1. Code Standards & Quality
 - **Modern C#:** Prefer modern C# syntax (e.g., pattern matching, switch expressions, file-scoped namespaces) unless maintaining legacy consistency.
 - **Null Safety:** Strictly adhere to Nullable Reference Types. Explicitly handle potential nulls; do not suppress warnings with `!` unless absolutely necessary.
-- **Cross-Platform:** Remember that LibPalaso runs on Windows and Linux (Mono/.NET). Avoid Windows-specific APIs (like `Registry` or hardcoded `\` paths) unless wrapped in OS checks.
+- **Cross-Platform:** Cross-Platform: Some libraries are intended to be cross-platform. In those cases, avoid Windows-specific APIs (like `Registry`) and Windows-specific assumptions (such as hardcoded path separators) unless properly guarded or abstracted.
+
+  Projects that explicitly target Windows (e.g., `net*-windows`, WinForms/WPF) may use Windows-specific APIs where appropriate. These are generally projects with names prefixed with `SIL.Windows.Forms`.
 
 ## 2. Testing
 - **Framework:** Use **NUnit** for all unit tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,11 @@ You are an expert C# developer assisting with the `sillsdev/libpalaso` repositor
 - **Null Safety:** Strictly adhere to Nullable Reference Types. Explicitly handle potential nulls; do not suppress warnings with `!` unless absolutely necessary.
 - **Cross-Platform:** Cross-Platform: Some libraries are intended to be cross-platform. In those cases, avoid Windows-specific APIs (like `Registry`) and Windows-specific assumptions (such as hardcoded path separators) unless properly guarded or abstracted.
 
-  Projects that explicitly target Windows (e.g., `net*-windows`, WinForms/WPF) may use Windows-specific APIs where appropriate. These are generally projects with names prefixed with `SIL.Windows.Forms`.
+Projects under `SIL.Windows.Forms` are primarily Windows desktop UI libraries (WinForms). Historically, many of these projects have also been used under Mono, but Mono support is no longer actively maintained and should not be assumed.
+
+Windows-specific APIs may be used in these projects where appropriate. These projects are not required to be cross-platform compatible, and Mono support is not a design goal.
+
+However, existing platform checks (such as `Platform.IsMono` or `#if __MonoCS__`) may still exist in the codebase and should not be removed or broken without a clear understanding of their purpose.
 
 ## 2. Testing
 - **Framework:** Use **NUnit** for all unit tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [SIL.Core.Clearshare] Added new classes MetadataCore, CreativeCommonsLicenseInfo, and CustomLicenseInfo; these are Winforms-free base versions of the classes Metadata, CreativeCommonsLicense, and CustomLicense.
 
-- [SIL.Core.Clearshare and SIL.Windows.Forms.Clearshare] Added LicenseUtils and LicenseWithImageUtils to handle the FromXmp method for creating a license. LicenseUtils constructs a bare license object that is Winforms-independent; LicenseWithImageUtils constructs a Winforms-dependent license object with access to license images. 
+- [SIL.Core.Clearshare and SIL.Windows.Forms.Clearshare] Added LicenseUtils and LicenseWithImageUtils to handle the FromXmp method for creating a license. LicenseUtils constructs a bare license object that is Winforms-independent; LicenseWithImageUtils constructs a Winforms-dependent license object with access to license images.
 - [SIL.Core.Clearshare] New methods "GetIsStringAvailableForLangId" and "GetDynamicStringOrEnglish" were added to Localizer for use in LicenseInfo's "GetBestLicenseTranslation" method, to remove LicenseInfo's L10NSharp dependency.
 - [SIL.Windows.Forms.Clearshare] New ILicenseWithImage interface handles "GetImage" method for Winforms-dependent licenses, implemented in CreativeCommonsLicense and CustomLicense, and formerly included in LicenseInfo.
 - [SIL.Core.Clearshare] New tests MetadataBareTests are based on previous MetadataTests in SIL.Windows.Forms.Clearshare. The tests were updated to use ImageSharp instead of Winforms for handling images.
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core.Desktop] Added IAnalytics interface.
 - [SIL.Windows.Forms.Privacy] Added AnalyticsProxy class, a Winforms/registry-based implementation of IAnalytics.
 - [SIL.Windows.Forms.Privacy] Added PrivacyDlg as a new standard dialog to allow user to control whether analytics tracking is allowed.
+- [SIL.Installer] Added new package for common installer components. Initially, this includes a Privacy dialog and code to access the registry entries so users can opt out of analytics data collection.
+- [SIL.Core] Added PathUtilities.ParentDirectories extension method.
+- [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
 
 ### Fixed
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
@@ -76,7 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms] Made ContributorsListControl.GetCurrentContribution() return null in the case when a valid row is not selected.
-- [SIL.WritingSystems] Make the English names for Chinese (Simplified) and Chinese (Traditional) consistent regardless of differences in Windows CultureInfo 
+- [SIL.WritingSystems] Make the English names for Chinese (Simplified) and Chinese (Traditional) consistent regardless of differences in Windows CultureInfo
 
 ## [16.1.0] - 2025-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added an Exception property to NonFatalErrorReportExpected to return the previous reported non-fatal exception.
 - [SIL.Media] Added a static PlaybackErrorMessage property to AudioFactory and a public const, kDefaultPlaybackErrorMessage, that will be used as the default message if the client does not set PlaybackErrorMessage.
 - [SIL.Windows.Forms] Added KeysExtensions class with the IsNavigationKey extension method.
-- [SIL.Core.Desktop] Added IAnalytics interface.
-- [SIL.Windows.Forms.Privacy] Added AnalyticsProxy class, a Winforms/registry-based implementation of IAnalytics.
+- [SIL.Core.Desktop] Added IAnalyticsConsent interface.
+- [SIL.Windows.Forms.Privacy] Added AnalyticsConsent class, a Registry-based opt-out implementation of IAnalyticsConsent.
 - [SIL.Windows.Forms.Privacy] Added PrivacyDlg as a new standard dialog to allow user to control whether analytics tracking is allowed.
 - [SIL.Installer] Added new package for common installer components. Initially, this includes a Privacy dialog and code to access the registry entries so users can opt out of analytics data collection.
 - [SIL.Core] Added PathUtilities.ParentDirectories extension method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Clearshare] New ILicenseWithImage interface handles "GetImage" method for Winforms-dependent licenses, implemented in CreativeCommonsLicense and CustomLicense, and formerly included in LicenseInfo.
 - [SIL.Core.Clearshare] New tests MetadataBareTests are based on previous MetadataTests in SIL.Windows.Forms.Clearshare. The tests were updated to use ImageSharp instead of Winforms for handling images.
 - [SIL.Core.Desktop] Added a constant (kBrowserCompatibleUserAgent) to RobustNetworkOperation: a browser-like User Agent string that can be used when making HTTP requests to strict servers.
+- [SIL.Core.Desktop] Added IAnalytics interface.
+- [SIL.Windows.Forms.Privacy] Added AnalyticsProxy class, a Winforms/registry-based implementation of IAnalytics.
+- [SIL.Windows.Forms.Privacy] Added PrivacyDlg as a new standard dialog to allow user to control whether analytics tracking is allowed.
 
 ### Fixed
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Company>SIL Global</Company>
     <Authors>SIL Global</Authors>
     <Product>libpalaso</Product>
-    <Copyright>Copyright © 2010-2025 SIL Global</Copyright>
+    <Copyright>Copyright © 2010-2026 SIL Global</Copyright>
     <WarningsAsErrors>NU1605;CS8002</WarningsAsErrors>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Palaso.sln
+++ b/Palaso.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34031.279
@@ -125,6 +125,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SoundFieldControlTestApp", "TestApps\SoundFieldControlTestApp\SoundFieldControlTestApp.csproj", "{184C738D-DFF6-421E-832A-AD7178F166A2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClipboardTestApp", "TestApps\ClipboardTestApp\ClipboardTestApp.csproj", "{9C1E4175-D098-4D9C-AF00-0857B611CEDF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIL.Installer", "SIL.Installer\SIL.Installer.csproj", "{3DCB916C-D4A8-4D6A-A8B8-B7555631E4E1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -320,6 +322,10 @@ Global
 		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C1E4175-D098-4D9C-AF00-0857B611CEDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DCB916C-D4A8-4D6A-A8B8-B7555631E4E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DCB916C-D4A8-4D6A-A8B8-B7555631E4E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DCB916C-D4A8-4D6A-A8B8-B7555631E4E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DCB916C-D4A8-4D6A-A8B8-B7555631E4E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SIL.Core.Desktop/Privacy/AllowTrackingChangedEventArgs.cs
+++ b/SIL.Core.Desktop/Privacy/AllowTrackingChangedEventArgs.cs
@@ -1,0 +1,29 @@
+// --------------------------------------------------------------------------------------------
+#region // Copyright (c) 2026, SIL Global. All Rights Reserved.
+// <copyright from='2026' to='2026' company='SIL Global'>
+//		Copyright (c) 2026, SIL Global. All Rights Reserved.
+//
+//		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
+// </copyright>
+#endregion
+// --------------------------------------------------------------------------------------------
+using System;
+
+namespace SIL.Core.Desktop.Privacy
+{
+	/// <summary>
+	/// Provides data for the AllowTrackingChanged event.
+	/// </summary>
+	public sealed class AllowTrackingChangedEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Gets a value indicating whether analytics tracking is now permitted.
+		/// </summary>
+		public bool IsTrackingAllowed { get; }
+
+		public AllowTrackingChangedEventArgs(bool isTrackingAllowed)
+		{
+			IsTrackingAllowed = isTrackingAllowed;
+		}
+	}
+}

--- a/SIL.Core.Desktop/Privacy/IAnalytics.cs
+++ b/SIL.Core.Desktop/Privacy/IAnalytics.cs
@@ -1,0 +1,75 @@
+// --------------------------------------------------------------------------------------------
+#region // Copyright (c) 2026, SIL Global. All Rights Reserved.
+// <copyright from='2026' to='2026' company='SIL Global'>
+//		Copyright (c) 2026, SIL Global. All Rights Reserved.
+//
+//		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
+// </copyright>
+#endregion
+// --------------------------------------------------------------------------------------------
+
+using System;
+
+namespace SIL.Core.Desktop.Privacy
+{
+	/// <summary>
+	/// Provides configuration and identity information used for analytics tracking.
+	/// </summary>
+	/// <remarks>
+	/// Implementations determine whether analytics events may be sent,
+	/// based on product-level and (optionally) organization-level settings.
+	/// </remarks>
+	public interface IAnalytics
+	{
+		event EventHandler<AllowTrackingChangedEventArgs> AllowTrackingChanged;
+		
+		/// <summary>
+		/// Gets the name of the product (suitable for displaying in the UI) sending analytics
+		/// events.
+		/// </summary>
+		string ProductName { get; }
+
+		/// <summary>
+		/// Gets the name of the organization associated with the product (suitable for displaying
+		/// in the UI).
+		/// </summary>
+		string OrganizationName { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether analytics tracking is currently permitted for this product.
+		/// This is determined as follows:
+		/// 1. If a product-specific setting exists, it takes precedence.
+		/// 2. Otherwise, the global/organization-wide setting is used.
+		/// 3. If neither setting is present, tracking is allowed by default.
+		/// </summary>
+		bool AllowTracking { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether analytics is enabled at the organization level.
+		/// </summary>
+		/// <remarks>
+		/// A value of <c>true</c> tracking is currently permitted at the organization level.
+		/// A value of <c>false</c> tracking is currently disallowed at the organization level.
+		/// A value of <c>null</c> no organization-level preference has been specified.
+		/// </remarks>
+		bool? OrganizationAnalyticsEnabled { get; }
+
+		/// <summary>
+		/// Updates with the specified product-specific tracking permission, applying the setting
+		/// organization-wide if so requested.
+		/// </summary>
+		/// <param name="allowTracking">A value indicating whether analytics tracking is permitted
+		/// for this product.</param>
+		/// <param name="applyOrganizationWide">A value indicating whether the update should apply
+		/// to all desktop programs published the organization.</param>
+		/// <exception cref="T:System.UnauthorizedAccessException">The settings cannot be written
+		/// because the user does not have the necessary access rights.</exception>
+		/// <remarks>
+		/// In practice, this *either* sets the global value (and removes the product-specific
+		/// setting if present) OR it sets only the product-specific setting. This ensures that if
+		/// a later decision is made in a different product to change the global setting, it will
+		/// apply to this product as well (i.e., the product-specific setting won't override it).
+		/// </remarks>
+		void Update(bool allowTracking, bool applyOrganizationWide = false);
+	}
+}

--- a/SIL.Core.Desktop/Privacy/IAnalyticsConsent.cs
+++ b/SIL.Core.Desktop/Privacy/IAnalyticsConsent.cs
@@ -13,13 +13,14 @@ using System;
 namespace SIL.Core.Desktop.Privacy
 {
 	/// <summary>
-	/// Provides configuration and identity information used for analytics tracking.
+	/// Represents the user's consent state for analytics tracking and provides access to the
+	/// effective tracking permission for the current product.
 	/// </summary>
 	/// <remarks>
 	/// Implementations determine whether analytics events may be sent,
 	/// based on product-level and (optionally) organization-level settings.
 	/// </remarks>
-	public interface IAnalytics
+	public interface IAnalyticsConsent
 	{
 		event EventHandler<AllowTrackingChangedEventArgs> AllowTrackingChanged;
 		
@@ -36,11 +37,8 @@ namespace SIL.Core.Desktop.Privacy
 		string OrganizationName { get; }
 
 		/// <summary>
-		/// Gets a value indicating whether analytics tracking is currently permitted for this product.
-		/// This is determined as follows:
-		/// 1. If a product-specific setting exists, it takes precedence.
-		/// 2. Otherwise, the global/organization-wide setting is used.
-		/// 3. If neither setting is present, tracking is allowed by default.
+		/// Gets a value indicating whether analytics tracking is currently permitted for this product
+		/// after applying product and organization preferences.
 		/// </summary>
 		bool AllowTracking { get; }
 

--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -12,6 +12,9 @@ namespace SIL.IO
 {
 	public static class FileLocationUtilities
 	{
+		private static string s_distFilesFolder;
+		private static string s_distFilesFolderCached;
+		
 		/// <summary>
 		/// Gives the directory of either the project folder (if running from visual studio), or
 		/// the installation folder.  Helpful for finding templates and things; by using this,
@@ -113,7 +116,11 @@ namespace SIL.IO
 		/// Added so that test apps that need to use a distinct output folder can indicate where to
 		/// find the files they need without having to copy them into the build directory.
 		/// </summary>
-		public static string DistFilesFolderPath;
+		public static string DistFilesFolderPath
+		{
+			get => s_distFilesFolder ?? s_distFilesFolderCached;
+			set => s_distFilesFolder = value;
+		}
 
 		private static string[] DirectoriesHoldingFiles => new[] {string.Empty, "DistFiles",
 			"common" /*for WeSay*/, "src" /*for Bloom*/};
@@ -145,7 +152,7 @@ namespace SIL.IO
 				var path = Path.Combine(dir, Path.Combine(partsOfTheSubPath));
 				if (File.Exists(path))
 				{
-					DistFilesFolderPath = dir; // Remember this for next time.
+					s_distFilesFolderCached = dir; // Remember this for next time.
 					return path;
 				}
 			}
@@ -228,7 +235,7 @@ namespace SIL.IO
 				path = Path.Combine(dir, subPath);
 				if (Directory.Exists(path))
 				{
-					DistFilesFolderPath = dir; // Remember this for next time.
+					s_distFilesFolderCached = dir; // Remember this for next time.
 					return path;
 				}
 			}
@@ -371,7 +378,7 @@ namespace SIL.IO
 		/// <summary>
 		/// Returns a list of the possible paths to the program files folder, taking into
 		/// account that 2 often (or always?) exist in a Win64 OS (i.e. "Program Files" and
-		/// "Program Files (x86)"). On Mono we return the folders of the PATH variable.
+		/// "Program Files (x86)"). On Mono, we return the folders of the PATH variable.
 		/// </summary>
 		/// ------------------------------------------------------------------------------------
 		private static IEnumerable<string> GetPossibleProgramFilesFolders()

--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -109,6 +109,12 @@ namespace SIL.IO
 			return LocateExecutable(true, partsOfTheSubPath);
 		}
 
+		/// <summary>
+		/// Added so that test apps that need to use a distinct output folder can indicate where to
+		/// find the files they need without having to copy them into the build directory.
+		/// </summary>
+		public static string DistFilesFolderPath;
+
 		private static string[] DirectoriesHoldingFiles => new[] {string.Empty, "DistFiles",
 			"common" /*for WeSay*/, "src" /*for Bloom*/};
 
@@ -125,12 +131,23 @@ namespace SIL.IO
 		/// <example>GetFileDistributedWithApplication(false, "info", "releaseNotes.htm");</example>
 		public static string GetFileDistributedWithApplication(bool optional, params string[] partsOfTheSubPath)
 		{
-			foreach (var directoryHoldingFiles in DirectoriesHoldingFiles)
+			if (DistFilesFolderPath != null)
 			{
-				var path = Path.Combine(DirectoryOfApplicationOrSolution,
-					directoryHoldingFiles, Path.Combine(partsOfTheSubPath));
+				var path = Path.Combine(DistFilesFolderPath, Path.Combine(partsOfTheSubPath));
 				if (File.Exists(path))
 					return path;
+			}
+
+			foreach (var directoryHoldingFiles in DirectoriesHoldingFiles)
+			{
+				var dir = Path.Combine(DirectoryOfApplicationOrSolution,
+					directoryHoldingFiles);
+				var path = Path.Combine(dir, Path.Combine(partsOfTheSubPath));
+				if (File.Exists(path))
+				{
+					DistFilesFolderPath = dir; // Remember this for next time.
+					return path;
+				}
 			}
 
 			if (optional)
@@ -198,11 +215,22 @@ namespace SIL.IO
 			if (Directory.Exists(path))
 				return path;
 
-			foreach (var directoryHoldingFiles in DirectoriesHoldingFiles)
+			if (DistFilesFolderPath != null)
 			{
-				path = Path.Combine(directory, directoryHoldingFiles, subPath);
+				path = Path.Combine(DistFilesFolderPath, subPath);
 				if (Directory.Exists(path))
 					return path;
+			}
+
+			foreach (var directoryHoldingFiles in DirectoriesHoldingFiles)
+			{
+				var dir = Path.Combine(directory, directoryHoldingFiles);
+				path = Path.Combine(dir, subPath);
+				if (Directory.Exists(path))
+				{
+					DistFilesFolderPath = dir; // Remember this for next time.
+					return path;
+				}
 			}
 
 			return null;

--- a/SIL.Core/IO/PathUtilities.cs
+++ b/SIL.Core/IO/PathUtilities.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 SIL Global
+// Copyright (c) 2025-2026 SIL Global
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 using System;
 using System.Collections.Generic;
@@ -356,6 +356,29 @@ namespace SIL.IO
 					Arguments = arguments,
 					UseShellExecute = false
 				});
+		}
+
+		/// <summary>
+		/// Returns an enumerable of ancestor directory paths for the given path, starting from
+		/// the immediate parent and working up to the root. If the path is rooted, the returned
+		/// paths will also be rooted.
+		/// </summary>
+		/// <param name="path">A file or directory path.</param>
+		/// <returns>
+		/// Parent directory paths ordered from nearest to farthest ancestor. For example,
+		/// <c>"/a/b/c/file.txt"</c> yields <c>"/a/b/c"</c>, <c>"/a/b"</c>, <c>"/a"</c>.
+		/// </returns>
+		public static IEnumerable<string> ParentDirectories(this string path)
+		{
+			var current = Path.GetDirectoryName(path);
+			while (!string.IsNullOrEmpty(current))
+			{
+				yield return current;
+				var parent = Path.GetDirectoryName(current);
+				if (parent == current)
+					break;
+				current = parent;
+			}
 		}
 
 		/// <summary>

--- a/SIL.Installer/Analytics.wxs
+++ b/SIL.Installer/Analytics.wxs
@@ -103,7 +103,7 @@
          to avoid overwriting an existing user preference with a blank value.
        - A value of "0" (explicit opt-out) is still considered "set" in MSI
          conditions, so it will be written correctly. -->
-      <Component Id="ProductAnalyticsSetting" Guid="{490DF2E0-2F29-4F52-9A4D-490F4FD6254F}">
+      <Component Id="$(var.ProductName)AnalyticsSetting" Guid="*">
         <Condition><![CDATA[SIL_ANALYTICS_APPLY_GLOBALLY <> "1" AND PRODUCT_ANALYTICS_ENABLED]]></Condition>
         <RegistryKey Root="HKCU" Key="$(var.ProductAnalyticsRegistryKey)">
           <RegistryValue
@@ -166,24 +166,25 @@
 
     <!-- ═══════════════════════════════════════════════════════
          Run in the UI sequence, these Custom Actions set the three checkbox-backing
-	 properties, following these rules:
-           Case 1 — fresh install (both _SETTING properties empty):
-             PRODUCT_ANALYTICS_ENABLED = "1", SIL_ANALYTICS_ENABLED_GLOBALLY = "1",
-             SIL_ANALYTICS_APPLY_GLOBALLY = "1"
-	     This is the only case where we show the Privacy dialog in the installer;
-	     both checkboxes will be initially checked.
-           Case 2 — only GLOBAL_ANALYTICS_SETTING is set (e.g. another SIL product ran first):
-             PRODUCT_ANALYTICS_ENABLED = normalized(GLOBAL_ANALYTICS_SETTING),
-	     SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
-             SIL_ANALYTICS_APPLY_GLOBALLY = "1" (product always inherits global → they match)
-           Case 3 — only PRODUCT_ANALYTICS_SETTING is set:
-             PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
-	     SIL_ANALYTICS_ENABLED_GLOBALLY = "0",
-             SIL_ANALYTICS_APPLY_GLOBALLY = "1" if PRODUCT = "#0", else "0"
-           Case 4 — both _SETTING properties are set:
-             PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
-	     SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
-             SIL_ANALYTICS_APPLY_GLOBALLY = "1" if equal, else "0"
+	     properties, following these rules:
+         Case 1 — fresh install (both _SETTING properties empty):
+            PRODUCT_ANALYTICS_ENABLED = "1"
+			SIL_ANALYTICS_ENABLED_GLOBALLY = "1",
+            SIL_ANALYTICS_APPLY_GLOBALLY = "1"
+	        This is the only case where we show the Privacy dialog in the installer;
+	        both checkboxes will be initially checked.
+        Case 2 — only GLOBAL_ANALYTICS_SETTING is set (e.g. another SIL product ran first):
+            PRODUCT_ANALYTICS_ENABLED = normalized(GLOBAL_ANALYTICS_SETTING),
+	        SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
+            SIL_ANALYTICS_APPLY_GLOBALLY = "1" (product always inherits global → they match)
+        Case 3 — only PRODUCT_ANALYTICS_SETTING is set:
+            PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
+	        SIL_ANALYTICS_ENABLED_GLOBALLY = "0",
+            SIL_ANALYTICS_APPLY_GLOBALLY = "0" (user previously chose product-level only; respect that)
+        Case 4 — both _SETTING properties are set:
+            PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
+	        SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
+            SIL_ANALYTICS_APPLY_GLOBALLY = "1" if equal, else "0"
 
          "normalized" means: "#1" → "1", "#0" → "0" (stripping the DWORD prefix that
          RegistrySearch Type="raw" adds). The _ENABLED/_GLOBALLY properties therefore
@@ -248,10 +249,6 @@
                   Property="SIL_ANALYTICS_APPLY_GLOBALLY"
                   Value="1"
                   Execute="immediate" />
-    <CustomAction Id="Analytics_SetApplyGlobally_ProductFalseNoGlobal"
-                  Property="SIL_ANALYTICS_APPLY_GLOBALLY"
-                  Value="1"
-                  Execute="immediate" />
     <CustomAction Id="Analytics_SetApplyGlobally_BothMatch"
                   Property="SIL_ANALYTICS_APPLY_GLOBALLY"
                   Value="1"
@@ -294,12 +291,8 @@
       <Custom Action="Analytics_SetApplyGlobally_NoProduct" After="Analytics_SetGlobalEnabled_DefaultFalse">
         NOT PRODUCT_ANALYTICS_SETTING
       </Custom>
-      <!-- Case 3: product="#0", global absent → effective global="0" → match -->
-      <Custom Action="Analytics_SetApplyGlobally_ProductFalseNoGlobal" After="Analytics_SetApplyGlobally_NoProduct">
-        PRODUCT_ANALYTICS_SETTING = "#0" AND NOT GLOBAL_ANALYTICS_SETTING
-      </Custom>
       <!-- Case 4: both set and equal -->
-      <Custom Action="Analytics_SetApplyGlobally_BothMatch" After="Analytics_SetApplyGlobally_ProductFalseNoGlobal">
+      <Custom Action="Analytics_SetApplyGlobally_BothMatch" After="Analytics_SetApplyGlobally_NoProduct">
         GLOBAL_ANALYTICS_SETTING = PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING
       </Custom>
     </InstallUISequence>

--- a/SIL.Installer/Analytics.wxs
+++ b/SIL.Installer/Analytics.wxs
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SIL.Installer Analytics Fragment
+
+  Provides reusable WiX 3 components for the SIL analytics opt-in/opt-out installer experience.
+
+  Preprocessor variables (define these via DefineConstants in the consuming installer's
+  .wixproj — WiX 3 preprocessor variables are file-scoped, so <?define?> in one .wxs
+  file is NOT visible to other compiled files):
+    $(var.ProductName)                  — Display name of the product, e.g. "SayMore"
+    $(var.ProductAnalyticsRegistryKey)  — Optional. Product-specific registry key under HKCU.
+                                          Defaults to "Software\SIL\$(var.ProductName)\Analytics"
+                                          if not defined by the consuming installer.
+
+  The consuming installer is responsible for:
+    - Adding a ComponentGroupRef to its Feature:
+        <ComponentGroupRef Id="SilAnalyticsComponents" />
+    - Wiring dialog navigation (or include AnalyticsNavigation.wxs for the standard flow):
+        LicenseAgreementDlg -> PrivacyDlg -> VerifyReadyDlg
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+
+    <!-- Default ProductAnalyticsRegistryKey to the conventional SIL path derived from ProductName.
+         Consuming installers that need a different key can define the variable before this
+         fragment is compiled (e.g. in their own .wxs) to override this default. -->
+    <?define GlobalAnalyticsRegistryKey = "Software\SIL\Analytics" ?>
+
+    <?ifdef var.ProductAnalyticsRegistryKey ?>
+    <?else?>
+      <?define ProductAnalyticsRegistryKey = "Software\SIL\$(var.ProductName)\Analytics" ?>
+    <?endif?>
+
+    <!-- ═══════════════════════════════════════════════════════
+         MSI Properties
+    ════════════════════════════════════════════════════════════ -->
+
+    <!-- Presence-detection properties: populated by RegistrySearch, no defaults.
+         Used by AnalyticsNavigation.wxs to decide whether to show the Privacy dialog.
+         Empty = no prior choice recorded; non-empty = user has already made a choice.
+         Note: Type="raw" is the only WiX 3 option that reads a registry value; it returns
+         DWORD values with a "#" prefix (e.g. "#0", "#1"). Conditions below use that format. -->
+    <Property Id="PRODUCT_ANALYTICS_SETTING" Secure="yes">
+      <RegistrySearch Id="ProductAnalyticsSearch"
+                      Root="HKCU"
+                      Key="$(var.ProductAnalyticsRegistryKey)"
+                      Name="Enabled"
+                      Type="raw"
+                      Win64="yes" />
+    </Property>
+
+    <Property Id="GLOBAL_ANALYTICS_SETTING" Secure="yes">
+      <RegistrySearch Id="GlobalAnalyticsSearch"
+                      Root="HKCU"
+                      Key="$(var.GlobalAnalyticsRegistryKey)"
+                      Name="Enabled"
+                      Type="raw"
+                      Win64="yes" />
+    </Property>
+
+    <!-- Normalized checkbox-backing properties: no defaults, no RegistrySearch.
+         Set exclusively by the normalization custom actions below (reads from the _SETTING
+         properties above to derive correct initial values). -->
+    <Property Id="PRODUCT_ANALYTICS_ENABLED" Secure="yes" />
+    <Property Id="SIL_ANALYTICS_ENABLED_GLOBALLY" Secure="yes" />
+
+    <!-- Set by the normalization custom actions when product and global values agree.
+         Must be Secure so it survives the UI->execute session handoff in per-machine installs;
+         component conditions depend on it. -->
+    <Property Id="SIL_ANALYTICS_APPLY_GLOBALLY" Secure="yes" />
+
+    <!-- ═══════════════════════════════════════════════════════
+         Analytics registry components
+         Wrapped in a ComponentGroup so the consuming installer
+         only needs: <ComponentGroupRef Id="SilAnalyticsComponents" />
+    ════════════════════════════════════════════════════════════ -->
+    <ComponentGroup Id="SilAnalyticsComponents" Directory="TARGETDIR">
+
+      <!-- Writes the shared SIL-wide analytics preference.
+           GUID is fixed across all SIL products — they all share ownership of this key. -->
+      <Component Id="GlobalAnalyticsSetting" Guid="{5D729D52-F0E1-443F-AA40-664AA754F1C1}">
+        <Condition><![CDATA[SIL_ANALYTICS_APPLY_GLOBALLY = "1"]]></Condition>
+        <RegistryKey Root="HKCU" Key="$(var.GlobalAnalyticsRegistryKey)">
+          <RegistryValue
+            Name="Enabled"
+            Type="integer"
+            Value="[SIL_ANALYTICS_ENABLED_GLOBALLY]"
+            KeyPath="yes" />
+        </RegistryKey>
+      </Component>
+
+<!-- Writes the per-product analytics setting (HKCU).
+
+     This component is installed only when:
+       - the user is NOT applying the setting globally, and
+       - a product-level value is actually set.
+
+     Behavior:
+       - If the user switches to a global setting, this condition becomes false
+         and MSI removes the per-product registry value.
+       - During silent installs or repairs (when the UI is skipped),
+         PRODUCT_ANALYTICS_ENABLED will be empty; we skip writing
+         to avoid overwriting an existing user preference with a blank value.
+       - A value of "0" (explicit opt-out) is still considered "set" in MSI
+         conditions, so it will be written correctly. -->
+      <Component Id="ProductAnalyticsSetting" Guid="{490DF2E0-2F29-4F52-9A4D-490F4FD6254F}">
+        <Condition><![CDATA[SIL_ANALYTICS_APPLY_GLOBALLY <> "1" AND PRODUCT_ANALYTICS_ENABLED]]></Condition>
+        <RegistryKey Root="HKCU" Key="$(var.ProductAnalyticsRegistryKey)">
+          <RegistryValue
+            Name="Enabled"
+            Type="integer"
+            Value="[PRODUCT_ANALYTICS_ENABLED]"
+            KeyPath="yes" />
+        </RegistryKey>
+      </Component>
+
+    </ComponentGroup>
+
+    <!-- Pull in the navigation fragment. Without this UIRef the linker drops
+         AnalyticsNavigation.wxs because its fragment defines no referenced symbol.
+         Omitted when the consuming installer sets SilAnalyticsSkipNavigation=1. -->
+    <?ifdef var.SilAnalyticsSkipNavigation ?>
+    <?else?>
+      <UIRef Id="SilAnalyticsNavigation" />
+    <?endif?>
+
+    <!-- ═══════════════════════════════════════════════════════
+         Privacy dialog
+    ════════════════════════════════════════════════════════════ -->
+    <UI>
+      <Dialog Id="PrivacyDlg" Width="370" Height="270" Title="Privacy Settings">
+        <!-- NOTE: These three strings must be kept in sync with PrivacyDlg.cs/.resx in
+             SIL.Windows.Forms (the C# dialog shown at runtime). The C# version is
+             localizable via L10NSharp; this installer version is English-only.
+             Known discrepancy: the "apply globally" checkbox below reads "Use this setting
+             for other SIL Global desktop software" here, but "Apply this change to other
+             {0} desktop software" in the C# dialog — resolve before next sync. -->
+        <Control Id="Description" Type="Text" X="20" Y="10" Width="330" Height="100"
+                 Text="$(var.ProductName) collects a small amount of usage data to help SIL Global improve the software. This data is intended to be anonymous and does not include personal information. However, given the small number of users and the types of data collected, we cannot strictly guarantee that individuals or language communities could never be identified. You may opt out below." />
+        <Control Id="ProductAnalyticsCheckbox" Type="CheckBox"
+                 X="20" Y="120" Width="330" Height="18"
+                 Property="PRODUCT_ANALYTICS_ENABLED"
+                 CheckBoxValue="1"
+                 Text="Share anonymous $(var.ProductName) usage data" />
+        <Control Id="GlobalAnalyticsCheckbox" Type="CheckBox"
+                 X="20" Y="145" Width="330" Height="18"
+                 Property="SIL_ANALYTICS_APPLY_GLOBALLY"
+                 CheckBoxValue="1"
+                 Text="Use this setting for other SIL Global desktop software" />
+        <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="&lt; Back">
+          <Publish Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+        </Control>
+        <Control Id="Next" Type="PushButton" X="240" Y="243" Width="56" Height="17" Default="yes" Text="Next >">
+          <!-- Normalize unchecked product-specific value to "0" only when global is NOT applied -->
+          <Publish Property="PRODUCT_ANALYTICS_ENABLED" Value="0">NOT PRODUCT_ANALYTICS_ENABLED AND NOT SIL_ANALYTICS_APPLY_GLOBALLY</Publish>
+          <!-- Set global value to match product-specific value when global IS applied; don't touch it otherwise -->
+          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY" Value="1">PRODUCT_ANALYTICS_ENABLED = "1" AND SIL_ANALYTICS_APPLY_GLOBALLY = "1"</Publish>
+          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY" Value="0">NOT PRODUCT_ANALYTICS_ENABLED AND SIL_ANALYTICS_APPLY_GLOBALLY = "1"</Publish>
+          <Publish Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+        </Control>
+        <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="Cancel">
+          <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+        </Control>
+      </Dialog>
+    </UI>
+
+    <!-- ═══════════════════════════════════════════════════════
+         Run in the UI sequence, these Custom Actions set the three checkbox-backing
+	 properties, following these rules:
+           Case 1 — fresh install (both _SETTING properties empty):
+             PRODUCT_ANALYTICS_ENABLED = "1", SIL_ANALYTICS_ENABLED_GLOBALLY = "1",
+             SIL_ANALYTICS_APPLY_GLOBALLY = "1"
+	     This is the only case where we show the Privacy dialog in the installer;
+	     both checkboxes will be initially checked.
+           Case 2 — only GLOBAL_ANALYTICS_SETTING is set (e.g. another SIL product ran first):
+             PRODUCT_ANALYTICS_ENABLED = normalized(GLOBAL_ANALYTICS_SETTING),
+	     SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
+             SIL_ANALYTICS_APPLY_GLOBALLY = "1" (product always inherits global → they match)
+           Case 3 — only PRODUCT_ANALYTICS_SETTING is set:
+             PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
+	     SIL_ANALYTICS_ENABLED_GLOBALLY = "0",
+             SIL_ANALYTICS_APPLY_GLOBALLY = "1" if PRODUCT = "#0", else "0"
+           Case 4 — both _SETTING properties are set:
+             PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
+	     SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
+             SIL_ANALYTICS_APPLY_GLOBALLY = "1" if equal, else "0"
+
+         "normalized" means: "#1" → "1", "#0" → "0" (stripping the DWORD prefix that
+         RegistrySearch Type="raw" adds). The _ENABLED/_GLOBALLY properties therefore
+         always hold "0" or "1", never "#0"/"#1", so CheckBoxValue="1" and Type="integer"
+         registry writes work correctly.
+
+         PRODUCT_ANALYTICS_SETTING and GLOBAL_ANALYTICS_SETTING are read-only here:
+         they are populated by RegistrySearch and are used by AnalyticsNavigation.wxs
+         to decide whether to show the Privacy dialog. These CAs must never write to them.
+
+		 Note that originally this was implemented with a much simpler CA in C#, but since
+		 it needs to run in the UI sequence and it was trying to create a temp folder (and
+		 (failing because it needed UAC elevation that isn't available in the UI sequence),
+		 we use multiple WiX CAs with conditions to cover all the cases even though it's
+		 a bit more verbose.
+
+		 See AnalyticsNormalizationTests.wixproj for tests that verify this logic.
+    ════════════════════════════════════════════════════════════ -->
+
+    <!-- PRODUCT_ANALYTICS_ENABLED -->
+    <CustomAction Id="Analytics_SetProductEnabled_Fresh"
+                  Property="PRODUCT_ANALYTICS_ENABLED"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetProductEnabled_FromGlobal_True"
+                  Property="PRODUCT_ANALYTICS_ENABLED"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetProductEnabled_FromGlobal_False"
+                  Property="PRODUCT_ANALYTICS_ENABLED"
+                  Value="0"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetProductEnabled_FromProduct_True"
+                  Property="PRODUCT_ANALYTICS_ENABLED"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetProductEnabled_FromProduct_False"
+                  Property="PRODUCT_ANALYTICS_ENABLED"
+                  Value="0"
+                  Execute="immediate" />
+
+    <!-- SIL_ANALYTICS_ENABLED_GLOBALLY -->
+    <CustomAction Id="Analytics_SetGlobalEnabled_Fresh"
+                  Property="SIL_ANALYTICS_ENABLED_GLOBALLY"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetGlobalEnabled_FromGlobal_True"
+                  Property="SIL_ANALYTICS_ENABLED_GLOBALLY"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetGlobalEnabled_FromGlobal_False"
+                  Property="SIL_ANALYTICS_ENABLED_GLOBALLY"
+                  Value="0"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetGlobalEnabled_DefaultFalse"
+                  Property="SIL_ANALYTICS_ENABLED_GLOBALLY"
+                  Value="0"
+                  Execute="immediate" />
+
+    <!-- SIL_ANALYTICS_APPLY_GLOBALLY — left unset (≡ "0") when no "1" CA fires -->
+    <CustomAction Id="Analytics_SetApplyGlobally_NoProduct"
+                  Property="SIL_ANALYTICS_APPLY_GLOBALLY"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetApplyGlobally_ProductFalseNoGlobal"
+                  Property="SIL_ANALYTICS_APPLY_GLOBALLY"
+                  Value="1"
+                  Execute="immediate" />
+    <CustomAction Id="Analytics_SetApplyGlobally_BothMatch"
+                  Property="SIL_ANALYTICS_APPLY_GLOBALLY"
+                  Value="1"
+                  Execute="immediate" />
+
+    <InstallUISequence>
+      <!-- PRODUCT_ANALYTICS_ENABLED: exactly one of these five fires -->
+      <Custom Action="Analytics_SetProductEnabled_Fresh" Before="CostFinalize">
+        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromGlobal_True" After="Analytics_SetProductEnabled_Fresh">
+        NOT PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING = "#1"
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromGlobal_False" After="Analytics_SetProductEnabled_FromGlobal_True">
+        NOT PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING = "#0"
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromProduct_True" After="Analytics_SetProductEnabled_FromGlobal_False">
+        PRODUCT_ANALYTICS_SETTING = "#1"
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromProduct_False" After="Analytics_SetProductEnabled_FromProduct_True">
+        PRODUCT_ANALYTICS_SETTING = "#0"
+      </Custom>
+
+      <!-- SIL_ANALYTICS_ENABLED_GLOBALLY: exactly one of these four fires -->
+      <Custom Action="Analytics_SetGlobalEnabled_Fresh" After="Analytics_SetProductEnabled_FromProduct_False">
+        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
+      </Custom>
+      <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_True" After="Analytics_SetGlobalEnabled_Fresh">
+        GLOBAL_ANALYTICS_SETTING = "#1"
+      </Custom>
+      <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_False" After="Analytics_SetGlobalEnabled_FromGlobal_True">
+        GLOBAL_ANALYTICS_SETTING = "#0"
+      </Custom>
+      <Custom Action="Analytics_SetGlobalEnabled_DefaultFalse" After="Analytics_SetGlobalEnabled_FromGlobal_False">
+        PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
+      </Custom>
+
+      <!-- SIL_ANALYTICS_APPLY_GLOBALLY: "1" when effective values match, unset (≡ "0") otherwise -->
+      <!-- Cases 1+2: product absent → inherits global → always matches -->
+      <Custom Action="Analytics_SetApplyGlobally_NoProduct" After="Analytics_SetGlobalEnabled_DefaultFalse">
+        NOT PRODUCT_ANALYTICS_SETTING
+      </Custom>
+      <!-- Case 3: product="#0", global absent → effective global="0" → match -->
+      <Custom Action="Analytics_SetApplyGlobally_ProductFalseNoGlobal" After="Analytics_SetApplyGlobally_NoProduct">
+        PRODUCT_ANALYTICS_SETTING = "#0" AND NOT GLOBAL_ANALYTICS_SETTING
+      </Custom>
+      <!-- Case 4: both set and equal -->
+      <Custom Action="Analytics_SetApplyGlobally_BothMatch" After="Analytics_SetApplyGlobally_ProductFalseNoGlobal">
+        GLOBAL_ANALYTICS_SETTING = PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING
+      </Custom>
+    </InstallUISequence>
+
+  </Fragment>
+</Wix>

--- a/SIL.Installer/Analytics.wxs
+++ b/SIL.Installer/Analytics.wxs
@@ -26,9 +26,16 @@
          fragment is compiled (e.g. in their own .wxs) to override this default. -->
     <?define GlobalAnalyticsRegistryKey = "Software\SIL\Analytics" ?>
 
-    <?ifdef var.ProductAnalyticsRegistryKey ?>
-    <?else?>
+    <?ifndef var.ProductAnalyticsRegistryKey ?>
       <?define ProductAnalyticsRegistryKey = "Software\SIL\$(var.ProductName)\Analytics" ?>
+    <?endif?>
+
+    <?ifndef var.AnalyticsComponentDirectory ?>
+      <?define AnalyticsComponentDirectory = ProgramDir ?>
+    <?endif?>
+
+    <?ifndef var.AnalyticsComponentWin64 ?>
+      <?define AnalyticsComponentWin64 = "yes" ?>
     <?endif?>
 
     <!-- ═══════════════════════════════════════════════════════
@@ -46,7 +53,7 @@
                       Key="$(var.ProductAnalyticsRegistryKey)"
                       Name="Enabled"
                       Type="raw"
-                      Win64="yes" />
+                      Win64="$(var.AnalyticsComponentWin64)" />
     </Property>
 
     <Property Id="GLOBAL_ANALYTICS_SETTING" Secure="yes">
@@ -55,31 +62,42 @@
                       Key="$(var.GlobalAnalyticsRegistryKey)"
                       Name="Enabled"
                       Type="raw"
-                      Win64="yes" />
+                      Win64="$(var.AnalyticsComponentWin64)" />
     </Property>
 
+	<!-- UI property for the privacy dialog checkboxes. These are *not* secure since they are
+		used only in the UI. This allows the UI to display the correct state for the checkboxes
+		even if the user clicks Back to revisit the dialog (because MSI may treat any non-empty
+		value (including "0") as "truthy" when displaying the checkbox). Since the privacy
+		 dialog only ever displays when no prior choice is recorded, we can safely initialize both
+		to "1" unconditionally. -->
+    <Property Id="PRODUCT_ANALYTICS_ENABLED_UI" Value="1" />
+    <Property Id="SIL_ANALYTICS_APPLY_GLOBALLY_UI" Value="1" />
+
     <!-- Normalized checkbox-backing properties: no defaults, no RegistrySearch.
-         Set exclusively by the normalization custom actions below (reads from the _SETTING
-         properties above to derive correct initial values). -->
+         Initialized by the normalization custom actions below (reads from the _SETTING
+         properties above to derive correct initial values) and updated by Publish actions
+		 in the UI based on user choices in the Privacy Settings dialog box. -->
     <Property Id="PRODUCT_ANALYTICS_ENABLED" Secure="yes" />
     <Property Id="SIL_ANALYTICS_ENABLED_GLOBALLY" Secure="yes" />
 
-    <!-- Set by the normalization custom actions when product and global values agree.
-         Must be Secure so it survives the UI->execute session handoff in per-machine installs;
-         component conditions depend on it. -->
-    <Property Id="SIL_ANALYTICS_APPLY_GLOBALLY" Secure="yes" />
+    <!-- Sentinel: set by Analytics_SetUiRan in InstallUISequence so InstallExecuteSequence
+         CAs can detect that the UI ran. Must be Secure to survive the UI→execute handoff.
+         When this is set, the ExecuteSequence normalization CAs are skipped — the user's
+         dialog choices (already stored in the other Secure properties) take precedence. -->
+    <Property Id="ANALYTICS_UI_RAN" Secure="yes" />
 
     <!-- ═══════════════════════════════════════════════════════
          Analytics registry components
          Wrapped in a ComponentGroup so the consuming installer
          only needs: <ComponentGroupRef Id="SilAnalyticsComponents" />
     ════════════════════════════════════════════════════════════ -->
-    <ComponentGroup Id="SilAnalyticsComponents" Directory="TARGETDIR">
+    <ComponentGroup Id="SilAnalyticsComponents" Directory="$(var.AnalyticsComponentDirectory)">
 
       <!-- Writes the shared SIL-wide analytics preference.
            GUID is fixed across all SIL products — they all share ownership of this key. -->
-      <Component Id="GlobalAnalyticsSetting" Guid="{5D729D52-F0E1-443F-AA40-664AA754F1C1}">
-        <Condition><![CDATA[SIL_ANALYTICS_APPLY_GLOBALLY = "1"]]></Condition>
+      <Component Id="GlobalAnalyticsSetting" Guid="{5D729D52-F0E1-443F-AA40-664AA754F1C1}" Win64="$(var.AnalyticsComponentWin64)" Transitive="yes">
+        <Condition><![CDATA[SIL_ANALYTICS_ENABLED_GLOBALLY]]></Condition>
         <RegistryKey Root="HKCU" Key="$(var.GlobalAnalyticsRegistryKey)">
           <RegistryValue
             Name="Enabled"
@@ -91,20 +109,13 @@
 
       <!-- Writes the per-product analytics setting (HKCU).
 
-      This component is installed only when:
-       - the user is NOT applying the setting globally, and
-       - a product-level value is actually set.
-
-      Behavior:
-       - If the user switches to a global setting, this condition becomes false
-         and MSI removes the per-product registry value.
-       - During silent installs or repairs/upgrades (when the Privacy dialog is usually skipped),
-         PRODUCT_ANALYTICS_ENABLED will be empty; we skip writing
-         to avoid overwriting an existing user preference with a blank value.
-       - A value of "0" (explicit opt-out) is still considered "set" in MSI
-         conditions, so it will be written correctly. -->
-      <Component Id="$(var.ProductName)AnalyticsSetting" Guid="*">
-        <Condition><![CDATA[SIL_ANALYTICS_APPLY_GLOBALLY <> "1" AND PRODUCT_ANALYTICS_ENABLED]]></Condition>
+      This component is installed whenever the user has made a choice (PRODUCT_ANALYTICS_ENABLED is
+      set to "0" or "1"), including when the global checkbox is also checked. This ensures the
+      per-product registry value is always authoritative for this product (matching the application's
+      AllowTracking logic, which reads the per-product key first). It also ensures that a MSI repair
+      that force-reinstalls this component (due to a missing KeyPath) always writes a consistent value. -->
+      <Component Id="$(var.ProductName)AnalyticsSetting" Guid="*" Win64="$(var.AnalyticsComponentWin64)" Transitive="yes">
+        <Condition>PRODUCT_ANALYTICS_ENABLED</Condition>
         <RegistryKey Root="HKCU" Key="$(var.ProductAnalyticsRegistryKey)">
           <RegistryValue
             Name="Enabled"
@@ -137,25 +148,39 @@
              {0} desktop software" in the C# dialog — resolve before next sync. -->
         <Control Id="Description" Type="Text" X="20" Y="10" Width="330" Height="100"
                  Text="$(var.ProductName) collects a small amount of usage data to help SIL Global improve the software. This data is intended to be anonymous and does not include personal information. However, given the small number of users and the types of data collected, we cannot strictly guarantee that individuals or language communities could never be identified. You may opt out below." />
+		<!-- CheckBoxValue="1" indicates the *output* value of PRODUCT_ANALYTICS_ENABLED_UI when checked -->
         <Control Id="ProductAnalyticsCheckbox" Type="CheckBox"
                  X="20" Y="120" Width="330" Height="18"
-                 Property="PRODUCT_ANALYTICS_ENABLED"
+                 Property="PRODUCT_ANALYTICS_ENABLED_UI"
                  CheckBoxValue="1"
                  Text="Share anonymous $(var.ProductName) usage data" />
+		<!-- CheckBoxValue="1" indicates the value of SIL_ANALYTICS_APPLY_GLOBALLY_UI when checked.
+             Hidden during repair: the global setting is shared across SIL products and should not
+             be changed during a repair; only the per-product setting may be adjusted. -->
         <Control Id="GlobalAnalyticsCheckbox" Type="CheckBox"
                  X="20" Y="145" Width="330" Height="18"
-                 Property="SIL_ANALYTICS_APPLY_GLOBALLY"
+                 Property="SIL_ANALYTICS_APPLY_GLOBALLY_UI"
                  CheckBoxValue="1"
-                 Text="Use this setting for other SIL Global desktop software" />
+                 Text="Use this setting for other SIL Global desktop software">
+          <Condition Action="hide">Installed</Condition>
+        </Control>
         <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="&lt; Back">
           <Publish Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
         </Control>
         <Control Id="Next" Type="PushButton" X="240" Y="243" Width="56" Height="17" Default="yes" Text="Next >">
-          <!-- Normalize unchecked product-specific value to "0" only when global is NOT applied -->
-          <Publish Property="PRODUCT_ANALYTICS_ENABLED" Value="0">NOT PRODUCT_ANALYTICS_ENABLED AND NOT SIL_ANALYTICS_APPLY_GLOBALLY</Publish>
-          <!-- Set global value to match product-specific value when global IS applied; don't touch it otherwise -->
-          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY" Value="1">PRODUCT_ANALYTICS_ENABLED = "1" AND SIL_ANALYTICS_APPLY_GLOBALLY = "1"</Publish>
-          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY" Value="0">NOT PRODUCT_ANALYTICS_ENABLED AND SIL_ANALYTICS_APPLY_GLOBALLY = "1"</Publish>
+          <!-- Set product-specific value according to the UI selection. -->
+          <Publish Property="PRODUCT_ANALYTICS_ENABLED" Value="0">NOT PRODUCT_ANALYTICS_ENABLED_UI OR PRODUCT_ANALYTICS_ENABLED_UI = "0"</Publish>
+          <Publish Property="PRODUCT_ANALYTICS_ENABLED" Value="1">PRODUCT_ANALYTICS_ENABLED_UI = "1"</Publish>
+          <!-- Set global value to match product-specific value when global IS applied; clear it otherwise.
+               All three are suppressed during repair (Installed is set): the GlobalAnalyticsCheckbox is
+               hidden then and SIL_ANALYTICS_APPLY_GLOBALLY_UI defaults to "1", which would otherwise
+               incorrectly trigger the "set" actions. The global registry value is intentionally left
+               untouched during repair regardless of its current state.
+               The clear only fires when GLOBAL_ANALYTICS_SETTING is null (i.e. no pre-existing global
+               registry value), which is the only case where the Privacy dialog is shown at all. -->
+          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY">NOT SIL_ANALYTICS_APPLY_GLOBALLY_UI AND NOT GLOBAL_ANALYTICS_SETTING AND NOT Installed</Publish>
+          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY" Value="0">PRODUCT_ANALYTICS_ENABLED = "0" AND SIL_ANALYTICS_APPLY_GLOBALLY_UI = "1" AND NOT Installed</Publish>
+          <Publish Property="SIL_ANALYTICS_ENABLED_GLOBALLY" Value="1">PRODUCT_ANALYTICS_ENABLED = "1" AND SIL_ANALYTICS_APPLY_GLOBALLY_UI = "1" AND NOT Installed</Publish>
           <Publish Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
         </Control>
         <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="Cancel">
@@ -165,26 +190,22 @@
     </UI>
 
     <!-- ═══════════════════════════════════════════════════════
-         Run in the UI sequence, these Custom Actions set the three checkbox-backing
-	     properties, following these rules:
-         Case 1 — fresh install (both _SETTING properties empty):
-            PRODUCT_ANALYTICS_ENABLED = "1"
-			SIL_ANALYTICS_ENABLED_GLOBALLY = "1",
-            SIL_ANALYTICS_APPLY_GLOBALLY = "1"
-	        This is the only case where we show the Privacy dialog in the installer;
-	        both checkboxes will be initially checked.
+        Run in the UI sequence, these Custom Actions set the three checkbox-backing
+	    properties, following these rules:
+        Case 1 — fresh install (both _SETTING properties empty):
+	    	This is the only case where we show the Privacy dialog in the installer;
+	    	both checkboxes will be initially checked, but we don't want to set any defaults
+			for the registry values until the user clicks Next, so *none* of the CAs below
+			fire in this case.
         Case 2 — only GLOBAL_ANALYTICS_SETTING is set (e.g. another SIL product ran first):
             PRODUCT_ANALYTICS_ENABLED = normalized(GLOBAL_ANALYTICS_SETTING),
-	        SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
-            SIL_ANALYTICS_APPLY_GLOBALLY = "1" (product always inherits global → they match)
+	        SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING)
         Case 3 — only PRODUCT_ANALYTICS_SETTING is set:
             PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
-	        SIL_ANALYTICS_ENABLED_GLOBALLY = "0",
-            SIL_ANALYTICS_APPLY_GLOBALLY = "0" (user previously chose product-level only; respect that)
+	        SIL_ANALYTICS_ENABLED_GLOBALLY = "0"
         Case 4 — both _SETTING properties are set:
             PRODUCT_ANALYTICS_ENABLED = normalized(PRODUCT_ANALYTICS_SETTING),
-	        SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING),
-            SIL_ANALYTICS_APPLY_GLOBALLY = "1" if equal, else "0"
+	        SIL_ANALYTICS_ENABLED_GLOBALLY = normalized(GLOBAL_ANALYTICS_SETTING)
 
          "normalized" means: "#1" → "1", "#0" → "0" (stripping the DWORD prefix that
          RegistrySearch Type="raw" adds). The _ENABLED/_GLOBALLY properties therefore
@@ -200,15 +221,9 @@
 		 (failing because it needed UAC elevation that isn't available in the UI sequence),
 		 we use multiple WiX CAs with conditions to cover all the cases even though it's
 		 a bit more verbose.
-
-		 See AnalyticsNormalizationTests.wixproj for tests that verify this logic.
     ════════════════════════════════════════════════════════════ -->
 
     <!-- PRODUCT_ANALYTICS_ENABLED -->
-    <CustomAction Id="Analytics_SetProductEnabled_Fresh"
-                  Property="PRODUCT_ANALYTICS_ENABLED"
-                  Value="1"
-                  Execute="immediate" />
     <CustomAction Id="Analytics_SetProductEnabled_FromGlobal_True"
                   Property="PRODUCT_ANALYTICS_ENABLED"
                   Value="1"
@@ -227,10 +242,6 @@
                   Execute="immediate" />
 
     <!-- SIL_ANALYTICS_ENABLED_GLOBALLY -->
-    <CustomAction Id="Analytics_SetGlobalEnabled_Fresh"
-                  Property="SIL_ANALYTICS_ENABLED_GLOBALLY"
-                  Value="1"
-                  Execute="immediate" />
     <CustomAction Id="Analytics_SetGlobalEnabled_FromGlobal_True"
                   Property="SIL_ANALYTICS_ENABLED_GLOBALLY"
                   Value="1"
@@ -244,22 +255,18 @@
                   Value="0"
                   Execute="immediate" />
 
-    <!-- SIL_ANALYTICS_APPLY_GLOBALLY — left unset (≡ "0") when no "1" CA fires -->
-    <CustomAction Id="Analytics_SetApplyGlobally_NoProduct"
-                  Property="SIL_ANALYTICS_APPLY_GLOBALLY"
-                  Value="1"
-                  Execute="immediate" />
-    <CustomAction Id="Analytics_SetApplyGlobally_BothMatch"
-                  Property="SIL_ANALYTICS_APPLY_GLOBALLY"
+    <!-- Sentinel: marks that InstallUISequence ran, so ExecuteSequence CAs are suppressed -->
+    <CustomAction Id="Analytics_SetUiRan"
+                  Property="ANALYTICS_UI_RAN"
                   Value="1"
                   Execute="immediate" />
 
     <InstallUISequence>
-      <!-- PRODUCT_ANALYTICS_ENABLED: exactly one of these five fires -->
-      <Custom Action="Analytics_SetProductEnabled_Fresh" Before="CostFinalize">
-        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
-      </Custom>
-      <Custom Action="Analytics_SetProductEnabled_FromGlobal_True" After="Analytics_SetProductEnabled_Fresh">
+      <!-- Sentinel: fires unconditionally so ExecuteSequence CAs know the UI ran -->
+      <Custom Action="Analytics_SetUiRan" Before="Analytics_SetProductEnabled_FromGlobal_True">1</Custom>
+
+      <!-- PRODUCT_ANALYTICS_ENABLED: no more than one of these four fires -->
+      <Custom Action="Analytics_SetProductEnabled_FromGlobal_True" Before="CostFinalize">
         NOT PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING = "#1"
       </Custom>
       <Custom Action="Analytics_SetProductEnabled_FromGlobal_False" After="Analytics_SetProductEnabled_FromGlobal_True">
@@ -272,11 +279,8 @@
         PRODUCT_ANALYTICS_SETTING = "#0"
       </Custom>
 
-      <!-- SIL_ANALYTICS_ENABLED_GLOBALLY: exactly one of these four fires -->
-      <Custom Action="Analytics_SetGlobalEnabled_Fresh" After="Analytics_SetProductEnabled_FromProduct_False">
-        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
-      </Custom>
-      <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_True" After="Analytics_SetGlobalEnabled_Fresh">
+      <!-- SIL_ANALYTICS_ENABLED_GLOBALLY: no more than one of these three fires -->
+      <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_True" After="Analytics_SetProductEnabled_FromProduct_False">
         GLOBAL_ANALYTICS_SETTING = "#1"
       </Custom>
       <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_False" After="Analytics_SetGlobalEnabled_FromGlobal_True">
@@ -285,17 +289,44 @@
       <Custom Action="Analytics_SetGlobalEnabled_DefaultFalse" After="Analytics_SetGlobalEnabled_FromGlobal_False">
         PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
       </Custom>
-
-      <!-- SIL_ANALYTICS_APPLY_GLOBALLY: "1" when effective values match, unset (≡ "0") otherwise -->
-      <!-- Cases 1+2: product absent → inherits global → always matches -->
-      <Custom Action="Analytics_SetApplyGlobally_NoProduct" After="Analytics_SetGlobalEnabled_DefaultFalse">
-        NOT PRODUCT_ANALYTICS_SETTING
-      </Custom>
-      <!-- Case 4: both set and equal -->
-      <Custom Action="Analytics_SetApplyGlobally_BothMatch" After="Analytics_SetApplyGlobally_NoProduct">
-        GLOBAL_ANALYTICS_SETTING = PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING
-      </Custom>
     </InstallUISequence>
+
+    <!-- Run the normalization CAs in InstallExecuteSequence so that in silent/minimal-UI
+		 installs, if prior settings exist the relevant CAs fire, the component conditions
+         evaluate correctly, and existing registry values are preserved rather than
+         deleted by a false component condition. -->
+    <InstallExecuteSequence>
+
+      <!-- All CAs in this sequence are gated on NOT ANALYTICS_UI_RAN.
+           When the installer runs interactively, InstallUISequence sets ANALYTICS_UI_RAN = "1"
+           and that value is passed (as a Secure property) to the execute session, so none of
+           these CAs fire — the user's choices from the Privacy dialog take precedence.
+           Only during a silent install (UISequence skipped) do these CAs fire. -->
+
+      <!-- PRODUCT_ANALYTICS_ENABLED (cases 2-4) -->
+      <Custom Action="Analytics_SetProductEnabled_FromGlobal_True" After="AppSearch">
+        NOT ANALYTICS_UI_RAN AND NOT PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING = "#1"
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromGlobal_False" After="Analytics_SetProductEnabled_FromGlobal_True">
+        NOT ANALYTICS_UI_RAN AND NOT PRODUCT_ANALYTICS_SETTING AND GLOBAL_ANALYTICS_SETTING = "#0"
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromProduct_True" After="Analytics_SetProductEnabled_FromGlobal_False">
+        NOT ANALYTICS_UI_RAN AND PRODUCT_ANALYTICS_SETTING = "#1"
+      </Custom>
+      <Custom Action="Analytics_SetProductEnabled_FromProduct_False" After="Analytics_SetProductEnabled_FromProduct_True">
+        NOT ANALYTICS_UI_RAN AND PRODUCT_ANALYTICS_SETTING = "#0"
+      </Custom>
+
+      <!-- SIL_ANALYTICS_ENABLED_GLOBALLY (cases 2/4 — needed so GlobalAnalyticsSetting
+           writes the correct value) -->
+      <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_True" After="Analytics_SetProductEnabled_FromProduct_False">
+        NOT ANALYTICS_UI_RAN AND GLOBAL_ANALYTICS_SETTING = "#1"
+      </Custom>
+      <Custom Action="Analytics_SetGlobalEnabled_FromGlobal_False" After="Analytics_SetGlobalEnabled_FromGlobal_True">
+        NOT ANALYTICS_UI_RAN AND GLOBAL_ANALYTICS_SETTING = "#0"
+      </Custom>
+
+    </InstallExecuteSequence>
 
   </Fragment>
 </Wix>

--- a/SIL.Installer/Analytics.wxs
+++ b/SIL.Installer/Analytics.wxs
@@ -89,16 +89,16 @@
         </RegistryKey>
       </Component>
 
-<!-- Writes the per-product analytics setting (HKCU).
+      <!-- Writes the per-product analytics setting (HKCU).
 
-     This component is installed only when:
+      This component is installed only when:
        - the user is NOT applying the setting globally, and
        - a product-level value is actually set.
 
-     Behavior:
+      Behavior:
        - If the user switches to a global setting, this condition becomes false
          and MSI removes the per-product registry value.
-       - During silent installs or repairs (when the UI is skipped),
+       - During silent installs or repairs/upgrades (when the Privacy dialog is usually skipped),
          PRODUCT_ANALYTICS_ENABLED will be empty; we skip writing
          to avoid overwriting an existing user preference with a blank value.
        - A value of "0" (explicit opt-out) is still considered "set" in MSI

--- a/SIL.Installer/AnalyticsNavigation.wxs
+++ b/SIL.Installer/AnalyticsNavigation.wxs
@@ -3,8 +3,12 @@
   SIL.Installer Analytics Navigation Fragment (optional)
 
   Wires dialog navigation for the analytics privacy dialog:
-    LicenseAgreementDlg -> PrivacyDlg -> VerifyReadyDlg  (no prior analytics preference)
-    LicenseAgreementDlg -> VerifyReadyDlg                 (preference already recorded)
+    Fresh install / upgrade (via LicenseAgreementDlg):
+      LicenseAgreementDlg -> PrivacyDlg -> VerifyReadyDlg  (no prior analytics preference)
+      LicenseAgreementDlg -> VerifyReadyDlg                 (preference already recorded)
+    Repair / modify (via MaintenanceTypeDlg):
+      MaintenanceTypeDlg  -> PrivacyDlg -> VerifyReadyDlg  (no prior analytics preference)
+      MaintenanceTypeDlg  -> VerifyReadyDlg                 (preference already recorded)
 
   The privacy dialog is skipped when either a product-specific or a global SIL analytics
   preference already exists in the registry — e.g. on reinstall/repair, or when another
@@ -69,6 +73,68 @@
                Value="LicenseAgreementDlg"
                Order="3">
         PRODUCT_ANALYTICS_SETTING OR GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+      <!-- ── Repair flow: MaintenanceTypeDlg forward navigation ─────────────
+           During repair the flow bypasses LicenseAgreementDlg and routes through
+           MaintenanceTypeDlg instead. We override ChangeButton (standard Order=1
+           wires it to CustomizeDlg) and RepairButton (standard Order=1 wires it
+           directly to VerifyReadyDlg) so both follow the same logic as the
+           fresh-install path: show PrivacyDlg if no prior preference exists,
+           skip straight to VerifyReadyDlg otherwise. -->
+
+      <!-- No prior preference: show the privacy dialog (Change path) -->
+      <Publish Dialog="MaintenanceTypeDlg"
+               Control="ChangeButton"
+               Event="NewDialog"
+               Value="PrivacyDlg"
+               Order="2">
+        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+      <!-- Prior preference exists: skip the privacy dialog (Change path) -->
+      <Publish Dialog="MaintenanceTypeDlg"
+               Control="ChangeButton"
+               Event="NewDialog"
+               Value="VerifyReadyDlg"
+               Order="3">
+        PRODUCT_ANALYTICS_SETTING OR GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+      <!-- No prior preference: show the privacy dialog (Repair path).
+           Standard wires RepairButton → VerifyReadyDlg at Order=1; we fire at
+           Order=2 to intercept only when analytics has not been configured yet. -->
+      <Publish Dialog="MaintenanceTypeDlg"
+               Control="RepairButton"
+               Event="NewDialog"
+               Value="PrivacyDlg"
+               Order="2">
+        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+      <!-- ── Repair flow: PrivacyDlg Back ─────────────────────────────────────
+           When PrivacyDlg is reached from MaintenanceTypeDlg (repair path),
+           Back should return to MaintenanceTypeDlg rather than LicenseAgreementDlg.
+           Order=2 overrides the hardcoded Order=1 target in Analytics.wxs when
+           the product is already installed. -->
+      <Publish Dialog="PrivacyDlg"
+               Control="Back"
+               Event="NewDialog"
+               Value="MaintenanceTypeDlg"
+               Order="2">
+        Installed
+      </Publish>
+
+      <!-- ── Repair flow: VerifyReadyDlg Back ──────────────────────────────────
+           During repair with a prior analytics preference, Back should return to
+           MaintenanceTypeDlg rather than LicenseAgreementDlg. Order=4 overrides
+           the fresh-install Order=3 override above when the product is installed. -->
+      <Publish Dialog="VerifyReadyDlg"
+               Control="Back"
+               Event="NewDialog"
+               Value="MaintenanceTypeDlg"
+               Order="4">
+        Installed AND (PRODUCT_ANALYTICS_SETTING OR GLOBAL_ANALYTICS_SETTING)
       </Publish>
 
     </UI>

--- a/SIL.Installer/AnalyticsNavigation.wxs
+++ b/SIL.Installer/AnalyticsNavigation.wxs
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SIL.Installer Analytics Navigation Fragment (optional)
+
+  Wires dialog navigation for the analytics privacy dialog:
+    LicenseAgreementDlg -> PrivacyDlg -> VerifyReadyDlg  (no prior analytics preference)
+    LicenseAgreementDlg -> VerifyReadyDlg                 (preference already recorded)
+
+  The privacy dialog is skipped when either a product-specific or a global SIL analytics
+  preference already exists in the registry — e.g. on reinstall/repair, or when another
+  SIL product has already set the global preference.
+
+  Compatible with any WiX 3 UI set that includes LicenseAgreementDlg in its navigation
+  flow: WixUI_FeatureTree, WixUI_InstallDir, WixUI_Mondo, WixUI_Advanced.
+  Not compatible with WixUI_Minimal (which does not route through LicenseAgreementDlg).
+
+  This file is included automatically when the SIL.Installer NuGet package is referenced.
+  To wire navigation manually instead, set in your .wixproj before importing the package:
+    <SilAnalyticsIncludeNavigation>false</SilAnalyticsIncludeNavigation>
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <UI Id="SilAnalyticsNavigation">
+
+      <!-- ── Forward: LicenseAgreementDlg Next ───────────────────────────────────
+           Standard WiX UI sets wire LicenseAgreementDlg Next at Order=2 (to their
+           intermediate dialog, e.g. CustomizeDlg). We fire at Order=3 and 4 so our
+           events run last and take precedence (last NewDialog fired wins). -->
+
+      <!-- No prior preference: show the privacy dialog -->
+      <Publish Dialog="LicenseAgreementDlg"
+               Control="Next"
+               Event="NewDialog"
+               Value="PrivacyDlg"
+               Order="3">
+        LicenseAccepted = "1"
+        AND NOT PRODUCT_ANALYTICS_SETTING
+        AND NOT GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+      <!-- Prior preference exists: skip the privacy dialog -->
+      <Publish Dialog="LicenseAgreementDlg"
+               Control="Next"
+               Event="NewDialog"
+               Value="VerifyReadyDlg"
+               Order="4">
+        LicenseAccepted = "1"
+        AND (PRODUCT_ANALYTICS_SETTING OR GLOBAL_ANALYTICS_SETTING)
+      </Publish>
+
+      <!-- ── Back: VerifyReadyDlg Back ────────────────────────────────────────────
+           Standard WiX UI sets wire VerifyReadyDlg Back to their intermediate dialog
+           (e.g. CustomizeDlg) at Order=1. We fire at Order=2 and 3 to override that,
+           returning to whichever dialog the user actually came from. -->
+
+      <!-- No prior preference: privacy dialog was shown → return to it -->
+      <Publish Dialog="VerifyReadyDlg"
+               Control="Back"
+               Event="NewDialog"
+               Value="PrivacyDlg"
+               Order="2">
+        NOT PRODUCT_ANALYTICS_SETTING AND NOT GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+      <!-- Prior preference exists: privacy dialog was skipped → return to LicenseAgreementDlg -->
+      <Publish Dialog="VerifyReadyDlg"
+               Control="Back"
+               Event="NewDialog"
+               Value="LicenseAgreementDlg"
+               Order="3">
+        PRODUCT_ANALYTICS_SETTING OR GLOBAL_ANALYTICS_SETTING
+      </Publish>
+
+    </UI>
+  </Fragment>
+</Wix>

--- a/SIL.Installer/SIL.Installer.csproj
+++ b/SIL.Installer/SIL.Installer.csproj
@@ -26,4 +26,24 @@
     <None Include="build/README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
+
+  <!-- Compile the WiX fragments with candle.exe to catch syntax and schema errors early.
+       Skipped silently when WiX 3.14 is not installed (e.g. on machines that only build
+       the NuGet package and never build a consuming installer). -->
+  <PropertyGroup>
+    <WixToolsPath Condition="'$(WixToolsPath)' == ''">$(ProgramFiles(x86))\WiX Toolset v3.14\bin\</WixToolsPath>
+    <WixValidationOutDir>$(IntermediateOutputPath)wix-validate\</WixValidationOutDir>
+  </PropertyGroup>
+
+  <Target Name="ValidateWixFragments" AfterTargets="Build"
+          Condition="Exists('$(WixToolsPath)candle.exe')">
+    <MakeDir Directories="$(WixValidationOutDir)" />
+    <Exec Command="&quot;$(WixToolsPath)candle.exe&quot; -nologo -arch x64 -dProductName=SILInstallerValidation -out &quot;$(WixValidationOutDir)&quot; Analytics.wxs AnalyticsNavigation.wxs"
+          WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
+  <Target Name="CleanWixValidation" AfterTargets="Clean">
+    <RemoveDir Directories="$(WixValidationOutDir)" />
+  </Target>
+
 </Project>

--- a/SIL.Installer/SIL.Installer.csproj
+++ b/SIL.Installer/SIL.Installer.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- This project exists solely to pack the WiX fragments and targets file as a NuGet
+         package. The compiled (empty) DLL is included in the package to satisfy NuGet's
+         NU5017 requirement that a package have content or dependencies. -->
+    <TargetFrameworks></TargetFrameworks><!-- override Directory.Build.props multi-targeting -->
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>SIL.Installer</AssemblyName>
+    <RootNamespace>SIL.Installer</RootNamespace>
+    <Description>Reusable WiX 3 installer components for SIL applications: analytics WiX fragment.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- WiX source fragments — explicit PackagePath including filename to avoid ambiguity -->
+    <None Include="Analytics.wxs" Pack="true" PackagePath="build/Analytics.wxs" />
+    <None Include="AnalyticsNavigation.wxs" Pack="true" PackagePath="build/AnalyticsNavigation.wxs" />
+    <!-- Auto-wire targets: NuGet auto-imports build\<PackageId>.targets for PackageReference consumers -->
+    <None Include="build/SIL.Installer.targets" Pack="true" PackagePath="build/SIL.Installer.targets" />
+    <!-- Usage README at package root -->
+    <None Include="build/README.md" Pack="true" PackagePath="README.md" />
+  </ItemGroup>
+
+</Project>

--- a/SIL.Installer/build/README.md
+++ b/SIL.Installer/build/README.md
@@ -25,13 +25,26 @@ The `SIL.Installer.targets` file is imported automatically. It:
 - Adds `Analytics.wxs` to the WiX compiler's `Compile` items.
 - Adds `AnalyticsNavigation.wxs` to `Compile` items (opt out with `SilAnalyticsIncludeNavigation=false`).
 
-### 2. Define required preprocessor variables
+### 2. Define preprocessor variables
 
 In your installer's `.wxs` file (or via `DefineConstants` in the `.wixproj`):
 
 ```xml
+<!-- Required -->
 <?define ProductName = "YourProduct" ?>
+
+<!-- Optional: defaults to "Software\SIL\$(var.ProductName)\Analytics" -->
 <?define ProductAnalyticsRegistryKey = "Software\SIL\YourProduct\Analytics" ?>
+
+<!-- Optional: WiX directory ID to anchor the analytics ComponentGroup.
+     Must be a directory ID defined in your installer's <Directory> tree.
+     No files are written here; MSI requires a directory anchor even for
+     registry-only components. Override only if your installer does not
+     define 'ProgramDir'. -->
+<?define AnalyticsComponentDirectory = ProgramDir ?>
+
+<!-- Optional: set to "no" for a 32-bit installer. Defaults to "yes". -->
+<?define AnalyticsComponentWin64 = "yes" ?>
 ```
 
 ### 3. Reference the component group

--- a/SIL.Installer/build/README.md
+++ b/SIL.Installer/build/README.md
@@ -1,0 +1,71 @@
+# SIL.Installer
+
+Reusable WiX 3 installer components for SIL Windows applications.
+
+## Package Contents
+
+| Package path | Description |
+|---|---|
+| `build/Analytics.wxs` | WiX fragment: analytics properties, registry components, privacy dialog, property-set custom actions |
+| `build/AnalyticsNavigation.wxs` | Optional WiX fragment: standard LicenseAgreementDlg → PrivacyDlg → VerifyReadyDlg navigation |
+| `build/SIL.Installer.targets` | Auto-imported MSBuild targets file |
+| `lib/net48/SIL.Installer.dll` | Empty placeholder DLL (satisfies NuGet NU5017; not referenced by your project) |
+
+## Usage
+
+### 1. Reference the package
+
+Add a `PackageReference` to your `.wixproj`:
+
+```xml
+<PackageReference Include="SIL.Installer" Version="..." />
+```
+
+The `SIL.Installer.targets` file is imported automatically. It:
+- Adds `Analytics.wxs` to the WiX compiler's `Compile` items.
+- Adds `AnalyticsNavigation.wxs` to `Compile` items (opt out with `SilAnalyticsIncludeNavigation=false`).
+
+### 2. Define required preprocessor variables
+
+In your installer's `.wxs` file (or via `DefineConstants` in the `.wixproj`):
+
+```xml
+<?define ProductName = "YourProduct" ?>
+<?define ProductAnalyticsRegistryKey = "Software\SIL\YourProduct\Analytics" ?>
+```
+
+### 3. Reference the component group
+
+In your product's `Feature` element:
+
+```xml
+<Feature Id="ProductFeature" ...>
+    <ComponentGroupRef Id="SilAnalyticsComponents" />
+    <!-- ... other ComponentRef elements ... -->
+</Feature>
+```
+
+### 4. Choose a compatible WiX UI set
+
+`AnalyticsNavigation.wxs` is included automatically and wires `LicenseAgreementDlg →
+[PrivacyDlg →] VerifyReadyDlg`. It requires a UI set that routes through
+`LicenseAgreementDlg`; `WixUI_Minimal` is not supported.
+
+### 5. Customize dialog navigation (optional)
+
+The built-in navigation intentionally bypasses any intermediate dialog the UI set normally
+shows between `LicenseAgreementDlg` and `VerifyReadyDlg` (e.g. `CustomizeDlg` in
+`WixUI_FeatureTree`, `InstallDirDlg` in `WixUI_InstallDir`). If you need those dialogs to
+appear, or if you are wiring navigation yourself for any other reason, disable the built-in
+navigation and add your own `<Publish>` elements connecting to `PrivacyDlg`:
+
+```xml
+<!-- in your .wixproj -->
+<SilAnalyticsIncludeNavigation>false</SilAnalyticsIncludeNavigation>
+```
+
+## Build Requirements
+
+- **WiX Toolset v3.14** must be installed on the build machine.
+  - Default path: `%ProgramFiles(x86)%\WiX Toolset v3.14\SDK\`
+- CI: install via `choco install wixtoolset --version=3.14.1 -y`

--- a/SIL.Installer/build/SIL.Installer.targets
+++ b/SIL.Installer/build/SIL.Installer.targets
@@ -1,0 +1,27 @@
+<Project>
+  <!--
+    Auto-imported by NuGet for projects that reference SIL.Installer via PackageReference.
+
+    This file:
+      1. Adds Analytics.wxs to the WiX compiler's Compile item group.
+      2. Optionally adds AnalyticsNavigation.wxs (enabled by default; set
+         SilAnalyticsIncludeNavigation=false to wire dialog navigation manually).
+  -->
+  <PropertyGroup>
+    <!-- Set to false to suppress automatic inclusion of AnalyticsNavigation.wxs -->
+    <SilAnalyticsIncludeNavigation Condition="'$(SilAnalyticsIncludeNavigation)' == ''">true</SilAnalyticsIncludeNavigation>
+
+    <!-- When navigation is disabled, pass a WiX preprocessor variable so Analytics.wxs
+         can suppress the UIRef that would otherwise pull in the missing fragment. -->
+    <DefineConstants Condition="'$(SilAnalyticsIncludeNavigation)' != 'true'">$(DefineConstants);SilAnalyticsSkipNavigation=1</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Automatically compile the shared analytics WiX fragment -->
+    <Compile Include="$(MSBuildThisFileDirectory)Analytics.wxs" />
+
+    <!-- Automatically compile the standard dialog navigation fragment (opt-out if needed) -->
+    <Compile Include="$(MSBuildThisFileDirectory)AnalyticsNavigation.wxs"
+             Condition="'$(SilAnalyticsIncludeNavigation)' == 'true'" />
+  </ItemGroup>
+</Project>

--- a/SIL.Windows.Forms/Privacy/AnalyticsConsent.cs
+++ b/SIL.Windows.Forms/Privacy/AnalyticsConsent.cs
@@ -7,10 +7,13 @@ using SIL.Core.Desktop.Privacy;
 namespace SIL.Windows.Forms.Privacy
 {
 	/// <summary>
-	/// An analytics implementation that saves settings in the Windows registry.
+	/// An analytics consent implementation backed by settings stored in the Windows registry. In
+	/// this implementation, product-specific settings take precedence over global/organization-wide
+	/// settings if both are present. Also, consent follows an opt-out model, so if neither setting
+	/// is present, tracking is allowed.
 	/// </summary>
 	[PublicAPI]
-	public class AnalyticsProxy : IAnalytics
+	public class AnalyticsConsent : IAnalyticsConsent
 	{
 		private const string kRegistryValueName = "Enabled";
 
@@ -19,7 +22,8 @@ namespace SIL.Windows.Forms.Privacy
 		public string ProductName { get; }
 
 		/// <summary>
-		/// Constructs an instance of the AnalyticsProxy class with the specified product name.
+		/// Constructs an instance of the <see cref="AnalyticsConsent"/> class for the specified
+		/// product.
 		/// </summary>
 		/// <param name="productName">
 		/// The name of the product (suitable for displaying in the UI). This will be also be used
@@ -29,7 +33,7 @@ namespace SIL.Windows.Forms.Privacy
 		/// <exception cref="ArgumentNullException">
 		/// The <paramref name="productName"/> was null
 		/// </exception>
-		public AnalyticsProxy(string productName)
+		public AnalyticsConsent(string productName)
 		{
 			ProductName = productName ?? throw new ArgumentNullException(nameof(productName));
 		}

--- a/SIL.Windows.Forms/Privacy/AnalyticsProxy.cs
+++ b/SIL.Windows.Forms/Privacy/AnalyticsProxy.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Win32;
+using SIL.Core.Desktop.Privacy;
+
+namespace SIL.Windows.Forms.Privacy
+{
+	/// <summary>
+	/// An analytics implementation that saves settings in the Windows registry.
+	/// </summary>
+	[PublicAPI]
+	public class AnalyticsProxy : IAnalytics
+	{
+		private const string kRegistryValueName = "Enabled";
+
+		public event EventHandler<AllowTrackingChangedEventArgs> AllowTrackingChanged;
+
+		private string _productRegistryKeyId;
+		public string ProductName { get; }
+
+		/// <summary>
+		/// Constructs an instance of the AnalyticsProxy class with the specified product name.
+		/// </summary>
+		/// <param name="productName">
+		/// The name of the product (suitable for displaying in the UI). This will be also be used
+		/// as part of the registry key path for storing the product-specific analytics-enabled
+		/// setting, unless <see cref="ProductRegistryKeyId"/> is overridden.
+		/// </param>
+		/// <exception cref="ArgumentNullException">
+		/// The <paramref name="productName"/> was null
+		/// </exception>
+		public AnalyticsProxy(string productName)
+		{
+			ProductName = productName ?? throw new ArgumentNullException(nameof(productName));
+		}
+
+		/// <summary>
+		/// If <see cref="ProductName"/> (the UI name of the product) is not suitable to be used
+		/// as part of a registry key path, this property can be overridden to provide an alternate
+		/// identifier. This should be unique across products published by the organization.
+		/// </summary>
+		public virtual string ProductRegistryKeyId => _productRegistryKeyId ?? ProductName;
+
+		public virtual string OrganizationName { get; } = "SIL Global";
+		
+		public virtual string OrganizationRegistryKeyId { get; } = "SIL";
+
+		private string OrganizationRegistryKeyPath => $@"Software\{OrganizationRegistryKeyId}";
+
+		private string GetKeyPath(string productKeyId)
+		{
+			var productPart = productKeyId != null ? $@"\{productKeyId}" : string.Empty;
+			return $@"{OrganizationRegistryKeyPath}{productPart}\Analytics";
+		}
+
+		public bool AllowTracking =>
+			ReadAnalyticsEnabledState(ProductRegistryKeyId)  // product-specific
+			?? (OrganizationAnalyticsEnabled ?? true); // fall back to global, then default to true
+
+		public bool? OrganizationAnalyticsEnabled => ReadAnalyticsEnabledState(null);
+
+		public void Update(bool allowTracking, bool applyOrganizationWide = false)
+		{
+			if (applyOrganizationWide)
+			{
+				WriteAnalyticsEnabledState(null, allowTracking);
+				// Since the global value is being set, we must remove the product-specific setting, so that
+				// if a *later* decision is made in a different product to change the global setting, it
+				// will apply to this product as well (i.e., the product-specific setting won't override it).
+				RemoveProductAnalyticsEnabledSetting();
+			}
+			else
+			{
+				// The global value is *not* being set. If it was previously set in some other product, it
+				// will remain in effect, but the product-specific value will override it for this product.
+				WriteAnalyticsEnabledState(ProductRegistryKeyId, allowTracking);
+			}
+
+			AllowTrackingChanged?.Invoke(this, new AllowTrackingChangedEventArgs(allowTracking));
+		}
+
+		private bool? ReadAnalyticsEnabledState(string productKeyId)
+		{
+			try
+			{
+				using var key = Registry.CurrentUser.OpenSubKey(GetKeyPath(productKeyId));
+
+				var value = key?.GetValue(kRegistryValueName);
+				if (value == null)
+					return null;
+				return Convert.ToInt32(value) != 0;
+			}
+			catch
+			{
+				return null;
+			}
+		}
+
+		private void WriteAnalyticsEnabledState(string productKeyId, bool value)
+		{
+			using var key = Registry.CurrentUser.CreateSubKey(GetKeyPath(productKeyId));
+			key?.SetValue(kRegistryValueName, value ? 1 : 0, RegistryValueKind.DWord);
+		}
+
+		private void RemoveProductAnalyticsEnabledSetting()
+		{
+			using var key =
+				Registry.CurrentUser.OpenSubKey(GetKeyPath(ProductRegistryKeyId), true);
+			if (key != null && key.GetValueNames().Contains(kRegistryValueName))
+				key.DeleteValue(kRegistryValueName);
+		}
+	}
+}

--- a/SIL.Windows.Forms/Privacy/AnalyticsProxy.cs
+++ b/SIL.Windows.Forms/Privacy/AnalyticsProxy.cs
@@ -42,7 +42,7 @@ namespace SIL.Windows.Forms.Privacy
 		public virtual string ProductRegistryKeyId => ProductName;
 
 		public virtual string OrganizationName { get; } = "SIL Global";
-		
+
 		public virtual string OrganizationRegistryKeyId { get; } = "SIL";
 
 		private string OrganizationRegistryKeyPath => $@"Software\{OrganizationRegistryKeyId}";

--- a/SIL.Windows.Forms/Privacy/AnalyticsProxy.cs
+++ b/SIL.Windows.Forms/Privacy/AnalyticsProxy.cs
@@ -16,7 +16,6 @@ namespace SIL.Windows.Forms.Privacy
 
 		public event EventHandler<AllowTrackingChangedEventArgs> AllowTrackingChanged;
 
-		private string _productRegistryKeyId;
 		public string ProductName { get; }
 
 		/// <summary>
@@ -40,7 +39,7 @@ namespace SIL.Windows.Forms.Privacy
 		/// as part of a registry key path, this property can be overridden to provide an alternate
 		/// identifier. This should be unique across products published by the organization.
 		/// </summary>
-		public virtual string ProductRegistryKeyId => _productRegistryKeyId ?? ProductName;
+		public virtual string ProductRegistryKeyId => ProductName;
 
 		public virtual string OrganizationName { get; } = "SIL Global";
 		

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
@@ -29,6 +29,7 @@ namespace SIL.Windows.Forms.Privacy
 		private void InitializeComponent()
 		{
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PrivacyDlg));
             this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this._labelDescription = new System.Windows.Forms.Label();
             this._chkProductAnalytics = new System.Windows.Forms.CheckBox();
@@ -63,7 +64,7 @@ namespace SIL.Windows.Forms.Privacy
             this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this._tableLayoutPanel.Size = new System.Drawing.Size(413, 190);
+            this._tableLayoutPanel.Size = new System.Drawing.Size(392, 218);
             this._tableLayoutPanel.TabIndex = 0;
             // 
             // _labelDescription
@@ -77,11 +78,9 @@ namespace SIL.Windows.Forms.Privacy
             this._labelDescription.Margin = new System.Windows.Forms.Padding(0, 0, 0, 10);
             this._labelDescription.MaximumSize = new System.Drawing.Size(380, 0);
             this._labelDescription.Name = "_labelDescription";
-            this._labelDescription.Size = new System.Drawing.Size(377, 39);
+            this._labelDescription.Size = new System.Drawing.Size(380, 65);
             this._labelDescription.TabIndex = 0;
-            this._labelDescription.Text = "{0} normally reports a small amount of anonymous analytics data to {1} in order t" +
-    "o enable the developers to make continued improvements to the software. You can " +
-    "opt out of analytics reporting below.";
+            this._labelDescription.Text = resources.GetString("_labelDescription.Text");
             // 
             // _chkProductAnalytics
             // 
@@ -90,7 +89,7 @@ namespace SIL.Windows.Forms.Privacy
             this.locExtender.SetLocalizableToolTip(this._chkProductAnalytics, null);
             this.locExtender.SetLocalizationComment(this._chkProductAnalytics, "Param 0: product name");
             this.locExtender.SetLocalizingId(this._chkProductAnalytics, "DialogBoxes.PrivacyDlg.ShareProductAnalyticsCheckbox");
-            this._chkProductAnalytics.Location = new System.Drawing.Point(0, 59);
+            this._chkProductAnalytics.Location = new System.Drawing.Point(0, 85);
             this._chkProductAnalytics.Margin = new System.Windows.Forms.Padding(0, 10, 0, 5);
             this._chkProductAnalytics.Name = "_chkProductAnalytics";
             this._chkProductAnalytics.Size = new System.Drawing.Size(184, 17);
@@ -106,7 +105,7 @@ namespace SIL.Windows.Forms.Privacy
             this.locExtender.SetLocalizableToolTip(this._chkPropagateDecisionGlobally, null);
             this.locExtender.SetLocalizationComment(this._chkPropagateDecisionGlobally, "Param 0: \"SIL Global\"");
             this.locExtender.SetLocalizingId(this._chkPropagateDecisionGlobally, "DialogBoxes.PrivacyDlg.ApplyGloballyCheckbox");
-            this._chkPropagateDecisionGlobally.Location = new System.Drawing.Point(0, 86);
+            this._chkPropagateDecisionGlobally.Location = new System.Drawing.Point(0, 112);
             this._chkPropagateDecisionGlobally.Margin = new System.Windows.Forms.Padding(0, 5, 0, 0);
             this._chkPropagateDecisionGlobally.Name = "_chkPropagateDecisionGlobally";
             this._chkPropagateDecisionGlobally.Padding = new System.Windows.Forms.Padding(14, 0, 0, 0);
@@ -124,7 +123,7 @@ namespace SIL.Windows.Forms.Privacy
             this.locExtender.SetLocalizableToolTip(this._labelRestartNote, null);
             this.locExtender.SetLocalizationComment(this._labelRestartNote, "");
             this.locExtender.SetLocalizingId(this._labelRestartNote, "DialogBoxes.PrivacyDlg.RestartNoteLabel");
-            this._labelRestartNote.Location = new System.Drawing.Point(0, 113);
+            this._labelRestartNote.Location = new System.Drawing.Point(0, 139);
             this._labelRestartNote.Margin = new System.Windows.Forms.Padding(0, 10, 0, 0);
             this._labelRestartNote.MaximumSize = new System.Drawing.Size(380, 0);
             this._labelRestartNote.Name = "_labelRestartNote";
@@ -141,7 +140,7 @@ namespace SIL.Windows.Forms.Privacy
             this.locExtender.SetLocalizableToolTip(this._buttonOK, null);
             this.locExtender.SetLocalizationComment(this._buttonOK, null);
             this.locExtender.SetLocalizingId(this._buttonOK, "Common.OK");
-            this._buttonOK.Location = new System.Drawing.Point(255, 164);
+            this._buttonOK.Location = new System.Drawing.Point(234, 192);
             this._buttonOK.Margin = new System.Windows.Forms.Padding(0);
             this._buttonOK.MinimumSize = new System.Drawing.Size(75, 26);
             this._buttonOK.Name = "_buttonOK";
@@ -159,7 +158,7 @@ namespace SIL.Windows.Forms.Privacy
             this.locExtender.SetLocalizableToolTip(this._buttonCancel, null);
             this.locExtender.SetLocalizationComment(this._buttonCancel, null);
             this.locExtender.SetLocalizingId(this._buttonCancel, "Common.Cancel");
-            this._buttonCancel.Location = new System.Drawing.Point(338, 164);
+            this._buttonCancel.Location = new System.Drawing.Point(317, 192);
             this._buttonCancel.Margin = new System.Windows.Forms.Padding(8, 0, 0, 0);
             this._buttonCancel.MinimumSize = new System.Drawing.Size(75, 26);
             this._buttonCancel.Name = "_buttonCancel";
@@ -180,14 +179,14 @@ namespace SIL.Windows.Forms.Privacy
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this._buttonCancel;
-            this.ClientSize = new System.Drawing.Size(453, 230);
+            this.ClientSize = new System.Drawing.Size(432, 258);
             this.Controls.Add(this._tableLayoutPanel);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.locExtender.SetLocalizableToolTip(this, null);
             this.locExtender.SetLocalizationComment(this, null);
             this.locExtender.SetLocalizingId(this, "DialogBoxes.PrivacyDlg.WindowTitle");
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(444, 268);
             this.Name = "PrivacyDlg";
             this.Padding = new System.Windows.Forms.Padding(20);
             this.ShowIcon = false;

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
@@ -1,0 +1,216 @@
+namespace SIL.Windows.Forms.Privacy
+{
+	partial class PrivacyDlg
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+            this.components = new System.ComponentModel.Container();
+            this._tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this._labelDescription = new System.Windows.Forms.Label();
+            this._chkProductAnalytics = new System.Windows.Forms.CheckBox();
+            this._chkPropagateDecisionGlobally = new System.Windows.Forms.CheckBox();
+            this._labelRestartNote = new System.Windows.Forms.Label();
+            this._buttonOK = new System.Windows.Forms.Button();
+            this._buttonCancel = new System.Windows.Forms.Button();
+            this.locExtender = new L10NSharp.Windows.Forms.L10NSharpExtender(this.components);
+            this._tableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.locExtender)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // _tableLayoutPanel
+            // 
+            this._tableLayoutPanel.AutoSize = true;
+            this._tableLayoutPanel.ColumnCount = 3;
+            this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this._tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this._tableLayoutPanel.Controls.Add(this._labelDescription, 0, 0);
+            this._tableLayoutPanel.Controls.Add(this._chkProductAnalytics, 0, 1);
+            this._tableLayoutPanel.Controls.Add(this._chkPropagateDecisionGlobally, 0, 2);
+            this._tableLayoutPanel.Controls.Add(this._labelRestartNote, 0, 3);
+            this._tableLayoutPanel.Controls.Add(this._buttonOK, 1, 4);
+            this._tableLayoutPanel.Controls.Add(this._buttonCancel, 2, 4);
+            this._tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this._tableLayoutPanel.Location = new System.Drawing.Point(20, 20);
+            this._tableLayoutPanel.Name = "_tableLayoutPanel";
+            this._tableLayoutPanel.RowCount = 5;
+            this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this._tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this._tableLayoutPanel.Size = new System.Drawing.Size(413, 190);
+            this._tableLayoutPanel.TabIndex = 0;
+            // 
+            // _labelDescription
+            // 
+            this._labelDescription.AutoSize = true;
+            this._tableLayoutPanel.SetColumnSpan(this._labelDescription, 3);
+            this.locExtender.SetLocalizableToolTip(this._labelDescription, null);
+            this.locExtender.SetLocalizationComment(this._labelDescription, "Param 0: product name; Param 1: Organization name (e.g., \"SIL Global\")");
+            this.locExtender.SetLocalizingId(this._labelDescription, "DialogBoxes.PrivacyDlg.DescriptionLabel");
+            this._labelDescription.Location = new System.Drawing.Point(0, 0);
+            this._labelDescription.Margin = new System.Windows.Forms.Padding(0, 0, 0, 10);
+            this._labelDescription.MaximumSize = new System.Drawing.Size(380, 0);
+            this._labelDescription.Name = "_labelDescription";
+            this._labelDescription.Size = new System.Drawing.Size(377, 39);
+            this._labelDescription.TabIndex = 0;
+            this._labelDescription.Text = "{0} normally reports a small amount of anonymous analytics data to {1} in order t" +
+    "o enable the developers to make continued improvements to the software. You can " +
+    "opt out of analytics reporting below.";
+            // 
+            // _chkProductAnalytics
+            // 
+            this._chkProductAnalytics.AutoSize = true;
+            this._tableLayoutPanel.SetColumnSpan(this._chkProductAnalytics, 3);
+            this.locExtender.SetLocalizableToolTip(this._chkProductAnalytics, null);
+            this.locExtender.SetLocalizationComment(this._chkProductAnalytics, "Param 0: product name");
+            this.locExtender.SetLocalizingId(this._chkProductAnalytics, "DialogBoxes.PrivacyDlg.ShareProductAnalyticsCheckbox");
+            this._chkProductAnalytics.Location = new System.Drawing.Point(0, 59);
+            this._chkProductAnalytics.Margin = new System.Windows.Forms.Padding(0, 10, 0, 5);
+            this._chkProductAnalytics.Name = "_chkProductAnalytics";
+            this._chkProductAnalytics.Size = new System.Drawing.Size(184, 17);
+            this._chkProductAnalytics.TabIndex = 1;
+            this._chkProductAnalytics.Text = "Share anonymous {0} usage data";
+            this._chkProductAnalytics.UseVisualStyleBackColor = true;
+            // 
+            // _checkBoxGlobalAnalytics
+            // 
+            this._chkPropagateDecisionGlobally.AutoSize = true;
+            this._tableLayoutPanel.SetColumnSpan(this._chkPropagateDecisionGlobally, 3);
+            this._chkPropagateDecisionGlobally.Enabled = false;
+            this.locExtender.SetLocalizableToolTip(this._chkPropagateDecisionGlobally, null);
+            this.locExtender.SetLocalizationComment(this._chkPropagateDecisionGlobally, "Param 0: \"SIL Global\"");
+            this.locExtender.SetLocalizingId(this._chkPropagateDecisionGlobally, "DialogBoxes.PrivacyDlg.ApplyGloballyCheckbox");
+            this._chkPropagateDecisionGlobally.Location = new System.Drawing.Point(0, 86);
+            this._chkPropagateDecisionGlobally.Margin = new System.Windows.Forms.Padding(0, 5, 0, 0);
+            this._chkPropagateDecisionGlobally.Name = "_chkPropagateDecisionGlobally";
+            this._chkPropagateDecisionGlobally.Padding = new System.Windows.Forms.Padding(14, 0, 0, 0);
+            this._chkPropagateDecisionGlobally.Size = new System.Drawing.Size(264, 17);
+            this._chkPropagateDecisionGlobally.TabIndex = 2;
+            this._chkPropagateDecisionGlobally.Text = "Apply this change to other {0} desktop software";
+            this._chkPropagateDecisionGlobally.UseVisualStyleBackColor = true;
+            // 
+            // _labelRestartNote
+            // 
+            this._labelRestartNote.AutoSize = true;
+            this._tableLayoutPanel.SetColumnSpan(this._labelRestartNote, 3);
+            this._labelRestartNote.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this._labelRestartNote.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.locExtender.SetLocalizableToolTip(this._labelRestartNote, null);
+            this.locExtender.SetLocalizationComment(this._labelRestartNote, "");
+            this.locExtender.SetLocalizingId(this._labelRestartNote, "DialogBoxes.PrivacyDlg.RestartNoteLabel");
+            this._labelRestartNote.Location = new System.Drawing.Point(0, 113);
+            this._labelRestartNote.Margin = new System.Windows.Forms.Padding(0, 10, 0, 0);
+            this._labelRestartNote.MaximumSize = new System.Drawing.Size(380, 0);
+            this._labelRestartNote.Name = "_labelRestartNote";
+            this._labelRestartNote.Padding = new System.Windows.Forms.Padding(14, 0, 0, 8);
+            this._labelRestartNote.Size = new System.Drawing.Size(335, 21);
+            this._labelRestartNote.TabIndex = 5;
+            this._labelRestartNote.Text = "Changes will take effect in other programs when they are restarted.";
+            this._labelRestartNote.Visible = false;
+            // 
+            // _buttonOK
+            // 
+            this._buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this._buttonOK.AutoSize = true;
+            this._buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.locExtender.SetLocalizableToolTip(this._buttonOK, null);
+            this.locExtender.SetLocalizationComment(this._buttonOK, null);
+            this.locExtender.SetLocalizingId(this._buttonOK, "Common.OK");
+            this._buttonOK.Location = new System.Drawing.Point(255, 164);
+            this._buttonOK.Margin = new System.Windows.Forms.Padding(0);
+            this._buttonOK.MinimumSize = new System.Drawing.Size(75, 26);
+            this._buttonOK.Name = "_buttonOK";
+            this._buttonOK.Size = new System.Drawing.Size(75, 26);
+            this._buttonOK.TabIndex = 3;
+            this._buttonOK.Text = "OK";
+            this._buttonOK.UseVisualStyleBackColor = true;
+            // 
+            // _buttonCancel
+            // 
+            this._buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this._buttonCancel.AutoSize = true;
+            this._buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.locExtender.SetLocalizableToolTip(this._buttonCancel, null);
+            this.locExtender.SetLocalizationComment(this._buttonCancel, null);
+            this.locExtender.SetLocalizingId(this._buttonCancel, "Common.Cancel");
+            this._buttonCancel.Location = new System.Drawing.Point(338, 164);
+            this._buttonCancel.Margin = new System.Windows.Forms.Padding(8, 0, 0, 0);
+            this._buttonCancel.MinimumSize = new System.Drawing.Size(75, 26);
+            this._buttonCancel.Name = "_buttonCancel";
+            this._buttonCancel.Size = new System.Drawing.Size(75, 26);
+            this._buttonCancel.TabIndex = 4;
+            this._buttonCancel.Text = "Cancel";
+            this._buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // locExtender
+            // 
+            this.locExtender.LocalizationManagerId = "SIL.Windows.Forms.Privacy";
+            this.locExtender.PrefixForNewItems = null;
+            // 
+            // PrivacyDlg
+            // 
+            this.AcceptButton = this._buttonOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
+            this.CancelButton = this._buttonCancel;
+            this.ClientSize = new System.Drawing.Size(453, 230);
+            this.Controls.Add(this._tableLayoutPanel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.locExtender.SetLocalizableToolTip(this, null);
+            this.locExtender.SetLocalizationComment(this, null);
+            this.locExtender.SetLocalizingId(this, "DialogBoxes.PrivacyDlg.WindowTitle");
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "PrivacyDlg";
+            this.Padding = new System.Windows.Forms.Padding(20);
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Privacy Settings";
+            this._tableLayoutPanel.ResumeLayout(false);
+            this._tableLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.locExtender)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.TableLayoutPanel _tableLayoutPanel;
+		private System.Windows.Forms.Label _labelDescription;
+		private System.Windows.Forms.CheckBox _chkProductAnalytics;
+		private System.Windows.Forms.CheckBox _chkPropagateDecisionGlobally;
+		private System.Windows.Forms.Button _buttonOK;
+		private System.Windows.Forms.Button _buttonCancel;
+		private System.Windows.Forms.Label _labelRestartNote;
+		private L10NSharp.Windows.Forms.L10NSharpExtender locExtender;
+	}
+}

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
@@ -170,7 +170,7 @@ namespace SIL.Windows.Forms.Privacy
             // 
             // locExtender
             // 
-            this.locExtender.LocalizationManagerId = "SIL.Windows.Forms.Privacy";
+            this.locExtender.LocalizationManagerId = "Palaso";
             this.locExtender.PrefixForNewItems = null;
             // 
             // PrivacyDlg

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.Designer.cs
@@ -98,7 +98,7 @@ namespace SIL.Windows.Forms.Privacy
             this._chkProductAnalytics.Text = "Share anonymous {0} usage data";
             this._chkProductAnalytics.UseVisualStyleBackColor = true;
             // 
-            // _checkBoxGlobalAnalytics
+            // _chkPropagateDecisionGlobally
             // 
             this._chkPropagateDecisionGlobally.AutoSize = true;
             this._tableLayoutPanel.SetColumnSpan(this._chkPropagateDecisionGlobally, 3);
@@ -138,7 +138,6 @@ namespace SIL.Windows.Forms.Privacy
             // 
             this._buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this._buttonOK.AutoSize = true;
-            this._buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.locExtender.SetLocalizableToolTip(this._buttonOK, null);
             this.locExtender.SetLocalizationComment(this._buttonOK, null);
             this.locExtender.SetLocalizingId(this._buttonOK, "Common.OK");
@@ -150,6 +149,7 @@ namespace SIL.Windows.Forms.Privacy
             this._buttonOK.TabIndex = 3;
             this._buttonOK.Text = "OK";
             this._buttonOK.UseVisualStyleBackColor = true;
+            this._buttonOK.Click += new System.EventHandler(this.HandleOkButtonClick);
             // 
             // _buttonCancel
             // 

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
@@ -1,0 +1,118 @@
+// --------------------------------------------------------------------------------------------
+#region // Copyright (c) 2026, SIL Global. All Rights Reserved.
+// <copyright from='2026' to='2026' company='SIL Global'>
+//		Copyright (c) 2026, SIL Global. All Rights Reserved.
+//
+//		Distributable under the terms of the MIT License (https://sil.mit-license.org/)
+// </copyright>
+#endregion
+// --------------------------------------------------------------------------------------------
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using L10NSharp;
+using SIL.Core.Desktop.Privacy;
+using static System.Environment;
+using static System.Windows.Forms.MessageBoxIcon;
+
+namespace SIL.Windows.Forms.Privacy
+{
+	public partial class PrivacyDlg : Form
+	{
+		private readonly bool _initialAnalyticsEnabledValue;
+		private readonly bool _initialGlobalInSync;
+		private readonly IAnalytics _analyticsImpl;
+		private readonly string _fmtDescription;
+		private readonly string _fmtProductCheckboxLabel;
+		private readonly string _fmtOrganizationCheckboxLabel;
+
+		public Color RestartLabelColor
+		{
+			get => _labelRestartNote.ForeColor;
+			set => _labelRestartNote.ForeColor = value;
+		}
+		
+		public PrivacyDlg(IAnalytics analyticsImpl)
+		{
+			InitializeComponent();
+
+			_analyticsImpl = analyticsImpl;
+
+			// Substitute product/brand names into the localizable format strings.
+			_fmtDescription = _labelDescription.Text;
+			_fmtProductCheckboxLabel = _chkProductAnalytics.Text;
+			_fmtOrganizationCheckboxLabel = _chkPropagateDecisionGlobally.Text;
+
+			_initialAnalyticsEnabledValue = _analyticsImpl?.AllowTracking ?? true;
+			// Global checkbox: show as checked when the global setting is set and its value
+			// matches the current product setting (i.e., they are in sync). Once the user
+			// has selected this
+			var globalValue = _analyticsImpl?.OrganizationAnalyticsEnabled;
+			_initialGlobalInSync = globalValue == _initialAnalyticsEnabledValue;
+
+			// Populate checkboxes from current runtime state.
+			_chkProductAnalytics.Checked = _initialAnalyticsEnabledValue;
+			SetInitialGlobalCheckboxState();
+
+			_chkProductAnalytics.CheckedChanged += HandleCheckboxChanged;
+			_chkPropagateDecisionGlobally.CheckedChanged += HandleCheckboxChanged;
+		}
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+
+			_labelDescription.Text = string.Format(_fmtDescription,
+				_analyticsImpl.ProductName, _analyticsImpl.OrganizationName);
+			_chkProductAnalytics.Text = string.Format(_fmtProductCheckboxLabel,
+				_analyticsImpl.ProductName);
+			_chkPropagateDecisionGlobally.Text = string.Format(_fmtOrganizationCheckboxLabel,
+				_analyticsImpl.OrganizationName);
+		}
+
+		private void HandleCheckboxChanged(object sender, EventArgs e)
+		{
+			if (_chkProductAnalytics.Checked == _initialAnalyticsEnabledValue)
+				SetInitialGlobalCheckboxState();
+			else
+				_chkPropagateDecisionGlobally.Enabled = true;
+
+			// Show the restart note whenever the global checkbox is checked and clicking OK
+			// would write a new or changed value to the shared SIL analytics registry key.
+			var globalWillChange = _chkPropagateDecisionGlobally.Checked &&
+				(_chkProductAnalytics.Checked != _initialAnalyticsEnabledValue || !_initialGlobalInSync);
+			_labelRestartNote.Visible = globalWillChange;
+		}
+		private void SetInitialGlobalCheckboxState()
+		{
+			_chkPropagateDecisionGlobally.Checked = false;
+			_chkPropagateDecisionGlobally.Enabled = false;
+		}
+
+		protected override void OnFormClosing(FormClosingEventArgs e)
+		{
+			base.OnFormClosing(e);
+
+			if (DialogResult != DialogResult.OK)
+				return;
+
+			if (_chkProductAnalytics.Checked != _initialAnalyticsEnabledValue)
+			{
+				try
+				{
+					_analyticsImpl.Update(_chkProductAnalytics.Checked,
+						_chkPropagateDecisionGlobally.Checked);
+				}
+				catch (UnauthorizedAccessException exception)
+				{
+					MessageBox.Show(LocalizationManager.GetString(
+							"PrivacyDialog.UnauthorizedAccess",
+							"Sorry. Your preferences could not be saved.") +
+					                NewLine + NewLine + exception.Message,
+						$"{_analyticsImpl.ProductName} - {Text}", MessageBoxButtons.OK,
+						Warning);
+				}
+			}
+		}
+	}
+}

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
@@ -44,10 +44,15 @@ namespace SIL.Windows.Forms.Privacy
 			_fmtOrganizationCheckboxLabel = _chkPropagateDecisionGlobally.Text;
 
 			_initialAnalyticsEnabledValue = _analyticsImpl.AllowTracking;
-			// Global checkbox: show as checked when the global setting is set and its value
-			// matches the current product setting (i.e., they are in sync). Once the user
-			// has selected this
-			var globalValue = _analyticsImpl?.OrganizationAnalyticsEnabled;
+
+			// The Global checkbox is initially unchecked and disabled. 
+			// It asks whether the product-level decision should be applied globally, but at
+			// startup no new decision has been made yet. 
+			// If a global decision already exists, the product checkbox reflects either that
+			// global value or a product-specific override. 
+			// Regardless, the Global checkbox remains unchecked and disabled until the user
+			// changes the product-level checkbox.
+			var globalValue = _analyticsImpl.OrganizationAnalyticsEnabled;
 			_initialGlobalInSync = globalValue == _initialAnalyticsEnabledValue;
 
 			// Populate checkboxes from current runtime state.
@@ -89,12 +94,9 @@ namespace SIL.Windows.Forms.Privacy
 			_chkPropagateDecisionGlobally.Enabled = false;
 		}
 
-		protected override void OnFormClosing(FormClosingEventArgs e)
+		private void HandleOkButtonClick(object sender, EventArgs e)
 		{
-			base.OnFormClosing(e);
-
-			if (DialogResult != DialogResult.OK)
-				return;
+			DialogResult = DialogResult.OK;
 
 			if (_chkProductAnalytics.Checked != _initialAnalyticsEnabledValue)
 			{
@@ -111,8 +113,12 @@ namespace SIL.Windows.Forms.Privacy
 					                NewLine + NewLine + exception.Message,
 						$"{_analyticsImpl.ProductName} - {Text}", MessageBoxButtons.OK,
 						Warning);
+
+					DialogResult = DialogResult.Cancel;
 				}
 			}
+
+			Close();
 		}
 	}
 }

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
@@ -21,7 +21,7 @@ namespace SIL.Windows.Forms.Privacy
 	{
 		private readonly bool _initialAnalyticsEnabledValue;
 		private readonly bool _initialGlobalInSync;
-		private readonly IAnalytics _analyticsImpl;
+		private readonly IAnalyticsConsent _analyticsImpl;
 		private readonly string _fmtDescription;
 		private readonly string _fmtProductCheckboxLabel;
 		private readonly string _fmtOrganizationCheckboxLabel;
@@ -32,7 +32,7 @@ namespace SIL.Windows.Forms.Privacy
 			set => _labelRestartNote.ForeColor = value;
 		}
 
-		public PrivacyDlg(IAnalytics analyticsImpl)
+		public PrivacyDlg(IAnalyticsConsent analyticsImpl)
 		{
 			_analyticsImpl = analyticsImpl ?? throw new ArgumentNullException(nameof(analyticsImpl));
 

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
@@ -31,7 +31,7 @@ namespace SIL.Windows.Forms.Privacy
 			get => _labelRestartNote.ForeColor;
 			set => _labelRestartNote.ForeColor = value;
 		}
-		
+
 		public PrivacyDlg(IAnalytics analyticsImpl)
 		{
 			_analyticsImpl = analyticsImpl ?? throw new ArgumentNullException(nameof(analyticsImpl));
@@ -39,17 +39,20 @@ namespace SIL.Windows.Forms.Privacy
 			InitializeComponent();
 
 			// Substitute product/brand names into the localizable format strings.
+			// NOTE: The installer privacy dialog (Analytics.wxs in SIL.Installer) contains
+			// equivalent text that must be kept in sync manually if any of these strings change.
+			// The "apply globally" checkbox label intentionally differs from the WiX version.
 			_fmtDescription = _labelDescription.Text;
 			_fmtProductCheckboxLabel = _chkProductAnalytics.Text;
 			_fmtOrganizationCheckboxLabel = _chkPropagateDecisionGlobally.Text;
 
 			_initialAnalyticsEnabledValue = _analyticsImpl.AllowTracking;
 
-			// The Global checkbox is initially unchecked and disabled. 
+			// The Global checkbox is initially unchecked and disabled.
 			// It asks whether the product-level decision should be applied globally, but at
-			// startup no new decision has been made yet. 
+			// startup no new decision has been made yet.
 			// If a global decision already exists, the product checkbox reflects either that
-			// global value or a product-specific override. 
+			// global value or a product-specific override.
 			// Regardless, the Global checkbox remains unchecked and disabled until the user
 			// changes the product-level checkbox.
 			var globalValue = _analyticsImpl.OrganizationAnalyticsEnabled;

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.cs
@@ -34,16 +34,16 @@ namespace SIL.Windows.Forms.Privacy
 		
 		public PrivacyDlg(IAnalytics analyticsImpl)
 		{
-			InitializeComponent();
+			_analyticsImpl = analyticsImpl ?? throw new ArgumentNullException(nameof(analyticsImpl));
 
-			_analyticsImpl = analyticsImpl;
+			InitializeComponent();
 
 			// Substitute product/brand names into the localizable format strings.
 			_fmtDescription = _labelDescription.Text;
 			_fmtProductCheckboxLabel = _chkProductAnalytics.Text;
 			_fmtOrganizationCheckboxLabel = _chkPropagateDecisionGlobally.Text;
 
-			_initialAnalyticsEnabledValue = _analyticsImpl?.AllowTracking ?? true;
+			_initialAnalyticsEnabledValue = _analyticsImpl.AllowTracking;
 			// Global checkbox: show as checked when the global setting is set and its value
 			// matches the current product setting (i.e., they are in sync). Once the user
 			// has selected this

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.resx
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.resx
@@ -120,7 +120,4 @@
   <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.resx
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.resx
@@ -117,19 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>275, 17</value>
-  </metadata>
-  <metadata name="superToolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>146, 17</value>
-  </metadata>
-  <metadata name="superToolTip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <data name="superToolTipInfo2.BodyText" xml:space="preserve">
-    <value>Spare ribs chicken shoulder flank, meatball sausage corned beef turducken doner bacon jowl fatback kielbasa. Shankle cow ground round buffalo ham shank. Meatball ribeye cow chuck. Doner sirloin cupim ground round rump turkey tail flank. Jerky meatball boudin biltong shankle filet mignon burgdoggen.</value>
-  </data>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>34</value>
+  <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/SIL.Windows.Forms/Privacy/PrivacyDlg.resx
+++ b/SIL.Windows.Forms/Privacy/PrivacyDlg.resx
@@ -120,4 +120,7 @@
   <metadata name="locExtender.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="_labelDescription.Text" xml:space="preserve">
+    <value>{0} collects a small amount of usage data to help {1} improve the software. This data is intended to be anonymous and does not include personal information. However, given the small number of users and the types of data collected, we cannot strictly guarantee that individuals or language communities could never be identified. You may opt out below.</value>
+  </data>
 </root>

--- a/TestApps/Directory.Build.props
+++ b/TestApps/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+  
+  <PropertyGroup>
+    <Product>$(AssemblyName)</Product>
+  </PropertyGroup>
+</Project>

--- a/TestApps/SIL.Windows.Forms.TestApp.Installer/Installer.sln
+++ b/TestApps/SIL.Windows.Forms.TestApp.Installer/Installer.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.37027.9 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "SIL.Windows.Forms.TestAppInstaller", "SIL.Windows.Forms.TestAppInstaller.wixproj", "{2A256529-31BF-49DC-9F67-B069C6986228}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2A256529-31BF-49DC-9F67-B069C6986228}.Debug|x86.ActiveCfg = Debug|x86
+		{2A256529-31BF-49DC-9F67-B069C6986228}.Debug|x86.Build.0 = Debug|x86
+		{2A256529-31BF-49DC-9F67-B069C6986228}.Release|x86.ActiveCfg = Release|x86
+		{2A256529-31BF-49DC-9F67-B069C6986228}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C412BFA9-FE9F-4436-A51D-6F6A6B21C1FC}
+	EndGlobalSection
+EndGlobal

--- a/TestApps/SIL.Windows.Forms.TestApp.Installer/Installer.wxs
+++ b/TestApps/SIL.Windows.Forms.TestApp.Installer/Installer.wxs
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Bare-bones installer for SIL.Windows.Forms.TestApp.
+  Purpose: dog-food the SIL.Installer NuGet package (analytics dialog, custom action, registry
+  components) before the package is published.
+
+  Analytics.wxs and AnalyticsNavigation.wxs are referenced directly from the SIL.Installer
+  source tree (see Installer.wixproj). Real consumers reference the SIL.Installer NuGet package
+  instead, which delivers these files automatically via its build\SIL.Installer.targets file.
+
+  Only ProductName is required; no need to override default ProductAnalyticsRegistryKey.
+-->
+<?define ProductVersion = "1.0.0" ?>
+<?define UpgradeCode = "{A0F64E48-E75C-4AE3-89DE-7E0E953BB7A3}" ?>
+<?ifdef var.ProductName ?>
+<?else?>
+  <?define ProductName = "SIL.Windows.Forms.TestApp" ?>
+<?endif?>
+<?define OutputDir = "$(var.ProjectDir)..\SIL.Windows.Forms.TestApp\output\$(var.Configuration)\net48\" ?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*"
+           Name="$(var.ProductName) $(var.ProductVersion)"
+           Language="1033"
+           Version="$(var.ProductVersion)"
+           Manufacturer="SIL Global"
+           UpgradeCode="$(var.UpgradeCode)">
+
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" Platform="x64" />
+
+    <MajorUpgrade Schedule="afterInstallInitialize"
+                  DowngradeErrorMessage="A later version of $(var.ProductName) is already installed." />
+
+    <!-- WixUI_FeatureTree provides LicenseAgreementDlg, which AnalyticsNavigation.wxs hooks into
+         to insert the PrivacyDlg between License acceptance and the final confirmation. -->
+    <UIRef Id="WixUI_FeatureTree" />
+    <WixVariable Id="WixUILicenseRtf" Value="License.rtf" />
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFiles64Folder">
+        <Directory Id="ProgramDir" Name="$(var.ProductName)">
+
+          <Component Id="TestApp.exe" Guid="{77E6C2A9-CE5B-42F6-B2C5-9B477D3E5062}" Win64="yes">
+            <File Id="TestApp.exe"
+                  Name="SIL.Windows.Forms.TestApp.exe"
+                  Source="$(var.OutputDir)SIL.Windows.Forms.TestApp.exe"
+                  KeyPath="yes" />
+          </Component>
+
+          <Component Id="TestApp.exe.config" Guid="{86606984-EFEF-48DE-84F3-D14C707B9458}" Win64="yes">
+            <File Id="TestApp.exe.config"
+                  Name="SIL.Windows.Forms.TestApp.exe.config"
+                  Source="$(var.OutputDir)SIL.Windows.Forms.TestApp.exe.config"
+                  KeyPath="yes" />
+          </Component>
+
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id="ProductFeature" Level="1" Title="$(var.ProductName)">
+      <ComponentRef Id="TestApp.exe" />
+      <ComponentRef Id="TestApp.exe.config" />
+	  <ComponentGroupRef Id="DistFiles" />
+	  <ComponentGroupRef Id="DllDependencies" />
+      <!-- GlobalAnalyticsSetting + ProductAnalyticsSetting, both from Analytics.wxs -->
+      <ComponentGroupRef Id="SilAnalyticsComponents" />
+    </Feature>
+
+    <Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
+    <Icon Id="AppIcon.exe" SourceFile="$(var.OutputDir)SIL.Windows.Forms.TestApp.exe" />
+    <Property Id="ARPPRODUCTICON" Value="AppIcon.exe" />
+
+  </Product>
+</Wix>

--- a/TestApps/SIL.Windows.Forms.TestApp.Installer/License.rtf
+++ b/TestApps/SIL.Windows.Forms.TestApp.Installer/License.rtf
@@ -1,0 +1,21 @@
+{\rtf1\ansi\deff0
+{\fonttbl{\f0\froman\fcharset0 Times New Roman;}}
+\f0\fs20
+MIT License\par
+\par
+Copyright (c) 2026 SIL Global\par
+\par
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:\par
+\par
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.\par
+\par
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\par
+}

--- a/TestApps/SIL.Windows.Forms.TestApp.Installer/SIL.Windows.Forms.TestAppInstaller.wixproj
+++ b/TestApps/SIL.Windows.Forms.TestApp.Installer/SIL.Windows.Forms.TestAppInstaller.wixproj
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Dog-food test installer for SIL.Windows.Forms.TestApp.
+  References SIL.Installer source files directly from this repo rather than through the
+  NuGet package — NuGet PackageReference restore is not supported for old-style .wixproj
+  without nuget.exe. Real consumers use the SIL.Installer NuGet package instead.
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="..\..\packages\SIL.BuildTasks.3.2.0\build\SIL.BuildTasks.props" Condition="Exists('..\..\packages\SIL.BuildTasks.3.2.0\build\SIL.BuildTasks.props')" />
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
+    <ProductVersion>3.0</ProductVersion>
+    <ProjectGuid>{2A256529-31BF-49DC-9F67-B069C6986228}</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>SIL.Windows.Forms.TestAppInstaller</OutputName>
+    <OutputType>Package</OutputType>
+    <OutputPath>output\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
+    <!-- ProductName must be in DefineConstants (not just <?define?> in Installer.wxs) so that
+         Analytics.wxs can see it — WiX 3 preprocessor variables are file-scoped. -->
+    <DefineConstants>ProductName=SIL.Windows.Forms.TestApp</DefineConstants>
+    <Name>SIL.Windows.Forms.TestAppInstaller</Name>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+	<GeneratedDllsDependencies>$(IntermediateOutputPath)GeneratedDllsDependencies.wxs</GeneratedDllsDependencies>
+	<GeneratedDistFiles>$(IntermediateOutputPath)GeneratedDistFiles.wxs</GeneratedDistFiles>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Installer.wxs" />
+	<Compile Include="$(GeneratedDllsDependencies)" />
+	<Compile Include="$(GeneratedDistFiles)" />
+    <!-- Include the WiX fragments directly from the SIL.Installer source tree,
+         mirroring what SIL.Installer.targets does for real NuGet consumers. -->
+    <Compile Include="..\..\SIL.Installer\Analytics.wxs">
+      <Link>Analytics.wxs</Link>
+    </Compile>
+    <Compile Include="..\..\SIL.Installer\AnalyticsNavigation.wxs">
+      <Link>AnalyticsNavigation.wxs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <WixExtension Include="WixUIExtension">
+      <HintPath>$(WixExtDir)WixUIExtension.dll</HintPath>
+      <Name>WixUIExtension</Name>
+    </WixExtension>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SilBuildTasksFile)')"
+    Text="$([System.String]::Format('$(ErrorText)', '$(SilBuildTasksFile)'))" />
+  </Target>
+  
+  <UsingTask
+	TaskName="SIL.BuildTasks.MakeWixForDirTree.MakeWixForDirTree"
+	AssemblyFile="$(SilBuildTasksFile)" />
+	
+  <Target Name="GenerateWixFiles"
+        BeforeTargets="Compile">
+
+  <MakeWixForDirTree
+      DirectoryReferenceId="ProgramDir"
+      ComponentGroupId="DllDependencies"
+      RootDirectory="$(MSBuildProjectDirectory)\..\SIL.Windows.Forms.TestApp\output\$(Configuration)\net48\"
+      OutputFilePath="$(GeneratedDllsDependencies)"
+      InstallerSourceDirectory="$(MSBuildProjectDirectory)"
+      MatchRegExPattern=".+\.dll"
+      SetWin64="true" />
+
+  <MakeWixForDirTree
+      DirectoryReferenceId="ProgramDir"
+      ComponentGroupId="DistFiles"
+      RootDirectory="$(MSBuildProjectDirectory)\..\..\DistFiles\"
+      OutputFilePath="$(GeneratedDistFiles)"
+      InstallerSourceDirectory="$(MSBuildProjectDirectory)"
+      MatchRegExPattern=".*\.xlf"
+      SetWin64="true" />
+
+  </Target>
+</Project>

--- a/TestApps/SIL.Windows.Forms.TestApp.Installer/SIL.Windows.Forms.TestAppInstaller.wixproj
+++ b/TestApps/SIL.Windows.Forms.TestApp.Installer/SIL.Windows.Forms.TestAppInstaller.wixproj
@@ -6,7 +6,7 @@
   without nuget.exe. Real consumers use the SIL.Installer NuGet package instead.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <Import Project="..\..\packages\SIL.BuildTasks.3.2.0\build\SIL.BuildTasks.props" Condition="Exists('..\..\packages\SIL.BuildTasks.3.2.0\build\SIL.BuildTasks.props')" />
+  <Import Project=".\packages\SIL.BuildTasks.3.2.0\build\SIL.BuildTasks.props" Condition="Exists('.\packages\SIL.BuildTasks.3.2.0\build\SIL.BuildTasks.props')" />
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>

--- a/TestApps/SIL.Windows.Forms.TestApp.Installer/packages.config
+++ b/TestApps/SIL.Windows.Forms.TestApp.Installer/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SIL.BuildTasks" version="3.2.0" />
+</packages>

--- a/TestApps/SIL.Windows.Forms.TestApp/Program.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Program.cs
@@ -9,6 +9,7 @@ using SIL.Reporting;
 using SIL.Windows.Forms.Privacy;
 using SIL.Windows.Forms.Reporting;
 using SIL.WritingSystems;
+using static System.Reflection.Assembly;
 
 namespace SIL.Windows.Forms.TestApp
 {
@@ -30,6 +31,18 @@ namespace SIL.Windows.Forms.TestApp
 
 			Sldr.Initialize();
 			Icu.Wrapper.Init();
+
+			foreach (var path in GetEntryAssembly().Location.ParentDirectories())
+			{
+				if (path.EndsWith("TestApps"))
+				{
+					FileLocationUtilities.DistFilesFolderPath = Path.Combine(
+						Path.GetDirectoryName(path),
+						"DistFiles"
+					);
+					break;
+				}
+			}
 
 			var preferredUILocale = "fr";
 			if (args.Length > 0)
@@ -56,7 +69,7 @@ namespace SIL.Windows.Forms.TestApp
 
 		private static void SetUpAnalytics()
 		{
-			AnalyticsImpl = new AnalyticsProxy("TestApp");
+			AnalyticsImpl = new AnalyticsProxy(Application.ProductName);
 		}
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/Program.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Program.cs
@@ -3,8 +3,10 @@ using System.IO;
 using System.Windows.Forms;
 using L10NSharp;
 using L10NSharp.Windows.Forms;
+using SIL.Core.Desktop.Privacy;
 using SIL.IO;
 using SIL.Reporting;
+using SIL.Windows.Forms.Privacy;
 using SIL.Windows.Forms.Reporting;
 using SIL.WritingSystems;
 
@@ -15,6 +17,8 @@ namespace SIL.Windows.Forms.TestApp
 		internal const string kSupportEmailAddress = "bogus_test_app_email_addr@sil.org";
 		internal static ILocalizationManager PrimaryL10NManager;
 
+		internal static IAnalytics AnalyticsImpl;
+
 		[STAThread]
 		public static void Main(string[] args)
 		{
@@ -22,6 +26,7 @@ namespace SIL.Windows.Forms.TestApp
 			Application.SetCompatibleTextRenderingDefault(false);
 
 			SetUpErrorHandling();
+			SetUpAnalytics();
 
 			Sldr.Initialize();
 			Icu.Wrapper.Init();
@@ -47,6 +52,11 @@ namespace SIL.Windows.Forms.TestApp
 			ErrorReport.EmailAddress = kSupportEmailAddress;
 			ErrorReport.AddStandardProperties();
 			ExceptionHandler.Init(new WinFormsExceptionHandler());
+		}
+
+		private static void SetUpAnalytics()
+		{
+			AnalyticsImpl = new AnalyticsProxy("TestApp");
 		}
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/Program.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/Program.cs
@@ -18,7 +18,7 @@ namespace SIL.Windows.Forms.TestApp
 		internal const string kSupportEmailAddress = "bogus_test_app_email_addr@sil.org";
 		internal static ILocalizationManager PrimaryL10NManager;
 
-		internal static IAnalytics AnalyticsImpl;
+		internal static IAnalyticsConsent AnalyticsImpl;
 
 		[STAThread]
 		public static void Main(string[] args)
@@ -69,7 +69,7 @@ namespace SIL.Windows.Forms.TestApp
 
 		private static void SetUpAnalytics()
 		{
-			AnalyticsImpl = new AnalyticsProxy(Application.ProductName);
+			AnalyticsImpl = new AnalyticsConsent(Application.ProductName);
 		}
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
+++ b/TestApps/SIL.Windows.Forms.TestApp/SIL.Windows.Forms.TestApp.csproj
@@ -4,8 +4,8 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>SIL.Windows.Forms.TestApp</RootNamespace>
     <AssemblyName>SIL.Windows.Forms.TestApp</AssemblyName>
-    <Description>SIL.Windows.Forms.TestApp test app</Description>
-    <OutputPath>../../output/$(Configuration)</OutputPath>
+    <Description>SIL.Windows.Forms test app</Description>
+    <OutputPath>output/$(Configuration)</OutputPath>
     <!-- Unsigned because we reference SIL.Media which itself is unsigned because it depends on
     irrKlang.NET4.dll which is a mixed-mode assembly -->
     <SignAssembly>false</SignAssembly>

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.Designer.cs
@@ -56,10 +56,10 @@ namespace SIL.Windows.Forms.TestApp
 		private void InitializeComponent()
 		{
             this.components = new System.ComponentModel.Container();
-            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper superToolTipInfoWrapper3 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper();
-            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo superToolTipInfo3 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo();
-            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper superToolTipInfoWrapper4 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper();
-            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo superToolTipInfo4 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo();
+            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper superToolTipInfoWrapper1 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper();
+            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo superToolTipInfo1 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo();
+            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper superToolTipInfoWrapper2 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfoWrapper();
+            SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo superToolTipInfo2 = new SIL.Windows.Forms.SuperToolTip.SuperToolTipInfo();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TestAppForm));
             this._cboAboutHTML = new System.Windows.Forms.ComboBox();
             this.btnRefRange = new System.Windows.Forms.Button();
@@ -88,6 +88,7 @@ namespace SIL.Windows.Forms.TestApp
             this.btnFolderBrowserControl = new System.Windows.Forms.Button();
             this.superToolTip1 = new SIL.Windows.Forms.SuperToolTip.SuperToolTip(this.components);
             this.superToolTip2 = new SIL.Windows.Forms.SuperToolTip.SuperToolTip(this.components);
+            this._btnShowPrivacyDlg = new System.Windows.Forms.Button();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -187,23 +188,23 @@ namespace SIL.Windows.Forms.TestApp
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 583);
+            this.label1.Location = new System.Drawing.Point(12, 606);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(149, 13);
-            superToolTipInfo3.BackgroundGradientBegin = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(0)))));
-            superToolTipInfo3.BackgroundGradientEnd = System.Drawing.Color.Blue;
-            superToolTipInfo3.BackgroundGradientMiddle = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(246)))), ((int)(((byte)(251)))));
-            superToolTipInfo3.BodyText = "This is the body text";
-            superToolTipInfo3.FooterForeColor = System.Drawing.Color.Lime;
-            superToolTipInfo3.FooterText = "And this is the footer";
-            superToolTipInfo3.HeaderForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            superToolTipInfo3.HeaderText = "The header can serve as a title";
-            superToolTipInfo3.OffsetForWhereToDisplay = new System.Drawing.Point(0, 0);
-            superToolTipInfo3.ShowFooter = true;
-            superToolTipInfo3.ShowFooterSeparator = true;
-            superToolTipInfoWrapper3.SuperToolTipInfo = superToolTipInfo3;
-            superToolTipInfoWrapper3.UseSuperToolTip = true;
-            this.superToolTip1.SetSuperStuff(this.label1, superToolTipInfoWrapper3);
+            superToolTipInfo1.BackgroundGradientBegin = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(128)))), ((int)(((byte)(0)))));
+            superToolTipInfo1.BackgroundGradientEnd = System.Drawing.Color.Blue;
+            superToolTipInfo1.BackgroundGradientMiddle = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(246)))), ((int)(((byte)(251)))));
+            superToolTipInfo1.BodyText = "This is the body text";
+            superToolTipInfo1.FooterForeColor = System.Drawing.Color.Lime;
+            superToolTipInfo1.FooterText = "And this is the footer";
+            superToolTipInfo1.HeaderForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            superToolTipInfo1.HeaderText = "The header can serve as a title";
+            superToolTipInfo1.OffsetForWhereToDisplay = new System.Drawing.Point(0, 0);
+            superToolTipInfo1.ShowFooter = true;
+            superToolTipInfo1.ShowFooterSeparator = true;
+            superToolTipInfoWrapper1.SuperToolTipInfo = superToolTipInfo1;
+            superToolTipInfoWrapper1.UseSuperToolTip = true;
+            this.superToolTip1.SetSuperStuff(this.label1, superToolTipInfoWrapper1);
             this.label1.TabIndex = 1;
             this.label1.Text = "Hover over me to see a tooltip";
             // 
@@ -211,18 +212,18 @@ namespace SIL.Windows.Forms.TestApp
             // 
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(12, 603);
+            this.label2.Location = new System.Drawing.Point(12, 626);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(140, 13);
-            superToolTipInfo4.BackgroundGradientBegin = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            superToolTipInfo4.BackgroundGradientEnd = System.Drawing.Color.FromArgb(((int)(((byte)(202)))), ((int)(((byte)(218)))), ((int)(((byte)(239)))));
-            superToolTipInfo4.BackgroundGradientMiddle = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(246)))), ((int)(((byte)(251)))));
-            superToolTipInfo4.BodyText = resources.GetString("superToolTipInfo4.BodyText");
-            superToolTipInfo4.OffsetForWhereToDisplay = new System.Drawing.Point(0, 0);
-            superToolTipInfo4.ShowHeader = false;
-            superToolTipInfoWrapper4.SuperToolTipInfo = superToolTipInfo4;
-            superToolTipInfoWrapper4.UseSuperToolTip = true;
-            this.superToolTip2.SetSuperStuff(this.label2, superToolTipInfoWrapper4);
+            superToolTipInfo2.BackgroundGradientBegin = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
+            superToolTipInfo2.BackgroundGradientEnd = System.Drawing.Color.FromArgb(((int)(((byte)(202)))), ((int)(((byte)(218)))), ((int)(((byte)(239)))));
+            superToolTipInfo2.BackgroundGradientMiddle = System.Drawing.Color.FromArgb(((int)(((byte)(242)))), ((int)(((byte)(246)))), ((int)(((byte)(251)))));
+            superToolTipInfo2.BodyText = resources.GetString("superToolTipInfo2.BodyText");
+            superToolTipInfo2.OffsetForWhereToDisplay = new System.Drawing.Point(0, 0);
+            superToolTipInfo2.ShowHeader = false;
+            superToolTipInfoWrapper2.SuperToolTipInfo = superToolTipInfo2;
+            superToolTipInfoWrapper2.UseSuperToolTip = true;
+            this.superToolTip2.SetSuperStuff(this.label2, superToolTipInfoWrapper2);
             this.label2.TabIndex = 1;
             this.label2.Text = "Hover for simple, long tooltip";
             // 
@@ -383,11 +384,23 @@ namespace SIL.Windows.Forms.TestApp
             // 
             this.superToolTip2.FadingInterval = 10;
             // 
+            // _btnShowPrivacyDlg
+            // 
+            this._btnShowPrivacyDlg.Location = new System.Drawing.Point(12, 577);
+            this._btnShowPrivacyDlg.Margin = new System.Windows.Forms.Padding(2);
+            this._btnShowPrivacyDlg.Name = "_btnShowPrivacyDlg";
+            this._btnShowPrivacyDlg.Size = new System.Drawing.Size(157, 23);
+            this._btnShowPrivacyDlg.TabIndex = 17;
+            this._btnShowPrivacyDlg.Text = "Privacy Dialog";
+            this._btnShowPrivacyDlg.UseVisualStyleBackColor = true;
+            this._btnShowPrivacyDlg.Click += new System.EventHandler(this._btnShowPrivacyDlg_Click);
+            // 
             // TestAppForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(187, 627);
+            this.ClientSize = new System.Drawing.Size(187, 650);
+            this.Controls.Add(this._btnShowPrivacyDlg);
             this.Controls.Add(this._cboAboutHTML);
             this.Controls.Add(this.btnRefRange);
             this.Controls.Add(this._btnShowFadingMessage);
@@ -450,5 +463,6 @@ namespace SIL.Windows.Forms.TestApp
 		private System.Windows.Forms.Button _btnShowFadingMessage;
 		private System.Windows.Forms.Button btnRefRange;
 		private System.Windows.Forms.ComboBox _cboAboutHTML;
+		private System.Windows.Forms.Button _btnShowPrivacyDlg;
 	}
 }

--- a/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
+++ b/TestApps/SIL.Windows.Forms.TestApp/TestAppForm.cs
@@ -28,6 +28,7 @@ using SIL.Media;
 using SIL.Windows.Forms.Extensions;
 using SIL.Windows.Forms.FileSystem;
 using SIL.Windows.Forms.LocalizationIncompleteDlg;
+using SIL.Windows.Forms.Privacy;
 using static System.Windows.Forms.MessageBoxButtons;
 
 namespace SIL.Windows.Forms.TestApp
@@ -58,6 +59,18 @@ namespace SIL.Windows.Forms.TestApp
 				_localizationIncompleteViewModel, additionalNamedLocales:new Dictionary<string, string> {
 					{ "Some untranslated language", WellKnownSubtags.UnlistedLanguage } });
 			_cboAboutHTML.SelectedIndex = 0;
+
+			SetPrivacyDlgButtonColor(Program.AnalyticsImpl.AllowTracking);
+			
+			Program.AnalyticsImpl.AllowTrackingChanged += (sender, args) =>
+			{
+				SetPrivacyDlgButtonColor(args.IsTrackingAllowed);
+			};
+		}
+
+		void SetPrivacyDlgButtonColor(bool allowed)
+		{
+			_btnShowPrivacyDlg.BackColor = allowed ? Color.LightGreen : Color.LightPink;
 		}
 
 		private void IssueAnalyticsRequest()
@@ -673,6 +686,13 @@ and displays it as HTML.
 		{
 			using (var dlg = new ScrReferenceFilterDlg())
 				dlg.ShowDialog();
+		}
+
+		private void _btnShowPrivacyDlg_Click(object sender, EventArgs e)
+		{
+			using var dlg = new PrivacyDlg(Program.AnalyticsImpl);
+			dlg.RestartLabelColor = Color.Red;
+			dlg.ShowDialog(this);
 		}
 	}
 }


### PR DESCRIPTION
Added new `SIL.Installer` package for common installer components. Includes a Privacy dialog to enable users to opt out of analytics reporting.
Added two public members currently just used in Test App but potentially useful elsewhere:

- PathUtilities.ParentDirectories extension method.
- FileLocationUtilities.DistFilesFolderPath property.

Added elements to TestApp to exercise the new Privacy dialog

Added installer for SIL.Windows.Forms.TestApp - not intended for deployment, just a testbed for the wxs files in SIL.Installer

Added elements to TestApp to exercise the new Privacy dialog

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sillsdev/libpalaso/pull/1493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1493)
<!-- Reviewable:end -->
