### PR TITLE
Updated ImageToolbox UI to consistently use "image" (not "picture")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
 
 ### Fixed
+- [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.

--- a/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/AcquireImageControl.cs
@@ -100,10 +100,10 @@ namespace SIL.Windows.Forms.ImageToolbox
 							dlg.InitialDirectory = ImageToolboxSettings.Default.LastImageFolder; ;
 						}
 
-						dlg.Title = "Choose Picture File".Localize("ImageToolbox.FileChooserTitle", "Title shown for a file chooser dialog brought up by the ImageToolbox");
+						dlg.Title = "Choose Image File".Localize("ImageToolbox.FileChooserTitle", "Title shown for a file chooser dialog brought up by the ImageToolbox");
 
 						//NB: disallowed gif because of a .net crash:  http://jira.palaso.org/issues/browse/BL-85
-						dlg.Filter = "picture files".Localize("ImageToolbox.PictureFiles", "Shown in the file-picking dialog to describe what kind of files the dialog is filtering for") + "(*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp)|*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp;";
+						dlg.Filter = "image files".Localize("ImageToolbox.PictureFiles", "Shown in the file-picking dialog to describe what kind of files the dialog is filtering for") + "(*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp)|*.png;*.tif;*.tiff;*.jpg;*.jpeg;*.bmp;";
 
 						if (DialogResult.OK == dlg.ShowDialog(this.ParentForm))
 						{

--- a/SIL.Windows.Forms/ImageToolbox/ImageToolboxControl.cs
+++ b/SIL.Windows.Forms/ImageToolbox/ImageToolboxControl.cs
@@ -420,7 +420,7 @@ namespace SIL.Windows.Forms.ImageToolbox
 			_editLink.Visible = false;
 			_invitationToMetadataPanel.Visible = false;
 
-			AddControl("Get Picture".Localize("ImageToolbox.GetPicture"), ImageToolboxButtons.browse, "browse", (x) =>
+			AddControl("Get Image".Localize("ImageToolbox.GetPicture"), ImageToolboxButtons.browse, "browse", (x) =>
 			{
 				_acquireImageControl = new AcquireImageControl();
 				_acquireImageControl.ImageLoadingExceptionReporter =


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1501)
<!-- Reviewable:end -->
