### PR TITLE
Fix crash on corrupt Windows language installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
 
 ### Fixed
+- [SIL.Windows.Forms.WritingSystems] WritingSystemFromWindowsLocaleProvider no longer crashes when an installed input language has a corrupt Windows installation; it now skips languages whose keyboard layout name cannot be read instead of throwing.
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter

--- a/SIL.Windows.Forms.WritingSystems/WritingSystemFromWindowsLocaleProvider.cs
+++ b/SIL.Windows.Forms.WritingSystems/WritingSystemFromWindowsLocaleProvider.cs
@@ -117,7 +117,21 @@ namespace SIL.Windows.Forms.WritingSystems
 				var cleaner = new IetfLanguageTagCleaner(culture.TwoLetterISOLanguageName, "", region, "", "");
 				cleaner.Clean();
 
-				yield return Tuple.Create(cleaner.GetCompleteTag(), language.LayoutName);
+				string layoutName;
+				try
+				{
+					// InputLanguage.LayoutName can throw (e.g. a NullReferenceException from
+					// System.Windows.Forms) when the user's Windows language installation is
+					// corrupt. Skip the offending language rather than crashing the whole enumeration.
+					layoutName = language.LayoutName;
+				}
+				catch (Exception e)
+				{
+					Debug.WriteLine($"Skipping input language '{culture.EnglishName}' because its keyboard layout name could not be read (the Windows language installation may be corrupt): {e.Message}");
+					continue;
+				}
+
+				yield return Tuple.Create(cleaner.GetCompleteTag(), layoutName);
 			}
 		}
 


### PR DESCRIPTION
Fixes #761 

WritingSystemFromWindowsLocaleProvider.GetLanguageAndKeyboardCombinations accessed InputLanguage.LayoutName unguarded, which can throw a NullReferenceException from System.Windows.Forms when a user has a corrupt Windows language installation. Read the layout name inside a try/catch and skip the offending language instead of crashing the whole enumeration.

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1507

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1507)
<!-- Reviewable:end -->
