### PR TITLE
Fix date in generated PR commit message

### DIFF
--- a/.github/workflows/update-language-data.yml
+++ b/.github/workflows/update-language-data.yml
@@ -221,6 +221,11 @@ jobs:
         name: updated-changelog
         path: .
 
+    - name: Get current date
+      id: current-date
+      shell: bash
+      run: echo "date=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_OUTPUT"
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
       with:
@@ -232,7 +237,7 @@ jobs:
         commit-message: |
           Update embedded writing system data
 
-          - Updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          - Updated: ${{ steps.current-date.outputs.date }}
           - langtags.json: ${{ needs.check-changes.outputs.has_langtags_changes == 'true' && 'Updated' || 'No changes' }}
           - ianaSubtagRegistry.txt: ${{ needs.check-changes.outputs.has_iana_changes == 'true' && 'Updated' || 'No changes' }}
           - SLDR staging: ${{ github.event.inputs.use_staging }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 - [SIL.Windows.Forms] Prevent ContributorsListControl.GetContributionFromRow from throwing an exception when the DataGridView has no valid rows selected.
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
+- [build] Fixed the update-language-data workflow so the generated pull request commit message shows the actual update date instead of a literal `$(date ...)` string.
 
 ### Changed
 - [SIL.Windows.Forms] PalasoImage robust load/save helpers now accept additional retry exception types without replacing the built-in retry defaults, and the built-in retry lists were expanded for additional read/save exceptions seen in the wild.


### PR DESCRIPTION
Fixes #1448 

The $(date ...) substitution was inside a YAML commit-message value passed to peter-evans/create-pull-request, so it was emitted literally. Compute the date in a separate step and reference its output.

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1508

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1508)
<!-- Reviewable:end -->
