### PR TITLE
Match AGENTS to CHANGELOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ However, existing platform checks (such as `Platform.IsMono` or `#if __MonoCS__`
         - `### Removed` - for features that have been completely removed
         - `### Security` - for security-related fixes or improvements
     - If the subsections do not exist under `[Unreleased]`, create them as needed.
-    - Format: `- **[Scope]** Description of the change.` (where Scope is the affected library/namespace)
+    - Format: `- [Scope] Description of the change.` (where Scope is the affected library/namespace)
     - For breaking changes, prefix with `BREAKING CHANGE:` in the description.
 
 - **Commit Message Format:** Follow semantic versioning guidelines in commit messages:


### PR DESCRIPTION
On my other prs, Devin keeps commenting that the AGENTS.md file has formatting instructions that don't match our CHANGELOG.md.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1509)
<!-- Reviewable:end -->
