### PR TITLE
Fix GetDocumentationUri resource lookup for missing doc file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 - [SIL.Windows.Forms] Prevent ContributorsListControl.GetContributionFromRow from throwing an exception when the DataGridView has no valid rows selected.
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
+- [SIL.Archiving] Fixed ArchiveAccessProtocol.GetDocumentationUri failing to create a missing documentation file because the resource lookup stripped the file extension and no longer matched the embedded resource name.
 
 ### Changed
 - [SIL.Windows.Forms] PalasoImage robust load/save helpers now accept additional retry exception types without replacing the built-in retry defaults, and the built-in retry lists were expanded for additional read/save exceptions seen in the wild.

--- a/SIL.Archiving/Generic/AccessProtocol/AccessProtocolList.cs
+++ b/SIL.Archiving/Generic/AccessProtocol/AccessProtocolList.cs
@@ -204,9 +204,7 @@ namespace SIL.Archiving.Generic.AccessProtocol
 			// try to create the file if it is not there
 			if (!File.Exists(fileName))
 			{
-				var pos = DocumentationFile.LastIndexOf('.');
-				var resourceName = pos > -1 ? DocumentationFile.Substring(0, pos) : DocumentationFile;
-				var resourceString = GetResource(resourceName);
+				var resourceString = GetResource(DocumentationFile);
 				if (!string.IsNullOrEmpty(resourceString))
 					File.WriteAllText(fileName, resourceString);
 			}


### PR DESCRIPTION
Fixes #1392

`ArchiveAccessProtocol.GetDocumentationUri` stripped the extension from `DocumentationFile` before calling `GetResource` (e.g. `"ailca.html"` → `"ailca"`), so the lookup no longer matched the embedded resource manifest name `SIL.Archiving.Resources.ailca.html` and the missing documentation file could not be created from the resource.

The fix passes the full filename to `GetResource`.

### Where the bug was introduced
PR #1317 ("Renamed project to SIL.Windows.Forms.Archiving", merge commit `0dfeebe3`) rewrote the resource accessor so `GetResource` prepends `SIL.Archiving.Resources.` and requires the full filename *including* the extension. The extension-stripping logic in `GetDocumentationUri` was carried over against this new accessor, producing the mismatch.


### Testing
The covering test is in a fixture categorized `SkipOnTeamCity`, so it does **not** run on CI and must be run by hand:

`SIL.Archiving.Tests.AccessProtocolListTests.GetDocumentationUri_ProgramDirectoryNotSpecified_ReturnsRootedPathToExistingFile`

```
dotnet test SIL.Archiving.Tests/SIL.Archiving.Tests.csproj --filter "FullyQualifiedName~GetDocumentationUri_ProgramDirectoryNotSpecified_ReturnsRootedPathToExistingFile"
```

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1510)
<!-- Reviewable:end -->

