### PR TITLE
Bump and pin GHA workflow deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,12 @@ jobs:
     # WriteVersionInfoToBuildLog=false suppresses the MSBuild task that causes the conflict;
     # assembly versioning is unaffected as it uses a different GitVersion task.
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
+      uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
       with:
         versionSpec: '5.x'
 
     - name: Run GitVersion
-      uses: gittools/actions/gitversion/execute@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
+      uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
 
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release -p:WriteVersionInfoToBuildLog=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: '0'
 
@@ -38,12 +38,12 @@ jobs:
     # WriteVersionInfoToBuildLog=false suppresses the MSBuild task that causes the conflict;
     # assembly versioning is unaffected as it uses a different GitVersion task.
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
+      uses: gittools/actions/gitversion/setup@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
       with:
         versionSpec: '5.x'
 
     - name: Run GitVersion
-      uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
+      uses: gittools/actions/gitversion/execute@bc6623af8fc07d5a8903052dd46da33403eec8e8 # v4.5.0
 
     - name: Build project
       run: dotnet build -bl:build.binlog -c Release -p:WriteVersionInfoToBuildLog=false
@@ -53,7 +53,7 @@ jobs:
 
     # Several steps to set up FFmpeg and Scream and start Audio Service so that audio tests can run
     - name: Install FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v3
+      uses: FedericoCarboni/setup-ffmpeg@37062fbf7149fc5578d6c57e08aed62458b375d6 # v3.1
       id: setup-ffmpeg
       with:
         ffmpeg-version: release
@@ -73,7 +73,7 @@ jobs:
         openssl pkcs12 -export -nodes -in ScreamCertificate.cer -inkey ScreamCertificate.pvk -out ScreamCertificate.pfx -passout pass:
 
     - name: Setup MSVC Dev Cmd
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
     - name: Sign and Install Scream Driver - allows unit tests that require an audio output device
       shell: powershell
@@ -100,7 +100,7 @@ jobs:
 
     - name: Upload hang dump (if any)
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Hang dumps (${{ matrix.framework }})
         path: |
@@ -109,7 +109,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Test results (${{ matrix.framework }})
         path: ./test-results
@@ -124,7 +124,7 @@ jobs:
     # You might want to test out the PR packages, but the release should be pulled from nuget
     - name: Upload Nuget Packages
       id: nuget-temp
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Nuget Packages
         path: |
@@ -140,7 +140,7 @@ jobs:
 
     - name: Publish logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: binary-logs (${{ matrix.framework }})
         path: build.binlog
@@ -155,12 +155,12 @@ jobs:
     if: always()
     steps:
       - name: Download test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: Test results *
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@8885e273a4343cd7b48eaa72428dea0c3067ea98 # v2.14.0
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           check_name: Palaso Tests
           files: artifacts/**/*.trx

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: "0"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -48,10 +48,10 @@ jobs:
         if: ${{ matrix.language == 'csharp' }}
 
       - name: Autobuild everything else
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: ${{ matrix.language != 'csharp' }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/l10n-packaging.yml
+++ b/.github/workflows/l10n-packaging.yml
@@ -21,19 +21,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: 8.x
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe (Windows OS)
-      uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # v1.3.1
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true # So the PATH can be set by this step
 

--- a/.github/workflows/l10n-source.yml
+++ b/.github/workflows/l10n-source.yml
@@ -21,19 +21,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
 
       # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: 8.x
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe (Windows OS)
-      uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # v1.3.1
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true # So the PATH can be set by this step
 

--- a/.github/workflows/update-language-data.yml
+++ b/.github/workflows/update-language-data.yml
@@ -36,7 +36,7 @@ jobs:
       langtags_url: ${{ steps.changes.outputs.langtags_url }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
     if: needs.check-changes.outputs.has_changes == 'true'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
@@ -120,20 +120,20 @@ jobs:
 
     - name: Add langtags entry to CHANGELOG.md
       if: needs.check-changes.outputs.has_langtags_changes
-      uses: claudiodekker/changelog-updater@6d9e21971591cfd515ef8cc71b721b767794afd4
+      uses: claudiodekker/changelog-updater@965b63190529191a495923ef184fb3090784ea1e # v1.2.0
       with:
         section: "Changed"
         entry-text: "[SIL.WritingSystems] Updated embedded langtags.json"
 
     - name: Add iana subtags entry to CHANGELOG.md
       if: needs.check-changes.outputs.has_iana_changes
-      uses: claudiodekker/changelog-updater@6d9e21971591cfd515ef8cc71b721b767794afd4
+      uses: claudiodekker/changelog-updater@965b63190529191a495923ef184fb3090784ea1e # v1.2.0
       with:
         section: "Changed"
         entry-text: "[SIL.WritingSystems] Updated embedded ianaSubtagRegistry.txt"
 
     - name: Upload updated changelog
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: updated-changelog
         path: CHANGELOG.md
@@ -145,13 +145,13 @@ jobs:
     if: needs.check-changes.outputs.has_changes == 'true'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '8.0.x'
 
@@ -216,13 +216,13 @@ jobs:
         fi
 
     - name: Download updated changelog
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: updated-changelog
         path: .
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         add-paths: |


### PR DESCRIPTION
We had a mix of pinned and unpinned actions, and some of the workflow jobs have deprecation warnings;
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: [...]

Keeping `gittools/actions/gitversion/` back at v3, because v4 requires upgrading the GitVersion spec from `5.x` to `6.x`, which has breaking changes that affect this repo. That's it's own migration task for another day.

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1513

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1513)
<!-- Reviewable:end -->
