### PR TITLE
[SIL.Core] Annotate CLS non-compliance

### DIFF
--- a/SIL.Core/ClearShare/CreativeCommonsLicenseInfo.cs
+++ b/SIL.Core/ClearShare/CreativeCommonsLicenseInfo.cs
@@ -24,6 +24,7 @@ namespace SIL.Core.ClearShare
 			NoDerivatives, DerivativesWithShareAndShareAlike, Derivatives
 		}
 
+		[CLSCompliant(false)]
 		protected bool _attributionRequired;
 		public bool AttributionRequired
 		{
@@ -43,6 +44,7 @@ namespace SIL.Core.ClearShare
 			return Token;  //by-nc-sa
 		}
 
+		[CLSCompliant(false)]
 		protected bool _commercialUseAllowed;
 		public bool CommercialUseAllowed
 		{
@@ -57,6 +59,7 @@ namespace SIL.Core.ClearShare
 			}
 		}
 
+		[CLSCompliant(false)]
 		protected DerivativeRules _derivativeRule;
 		public DerivativeRules DerivativeRule
 		{
@@ -318,6 +321,7 @@ namespace SIL.Core.ClearShare
 			return GetBestLicenseTranslation("CreativeCommons." + idSuffix, englishText, comment, languagePriorityIds, out idOfLanguageUsed);
 		}
 
+		[CLSCompliant(false)]
 		protected string _version;
 		public string Version
 		{
@@ -332,6 +336,7 @@ namespace SIL.Core.ClearShare
 			}
 		}
 
+		[CLSCompliant(false)]
 		protected string _qualifier = null;
 
 		/// <remarks>

--- a/SIL.Core/ClearShare/MetadataCore.cs
+++ b/SIL.Core/ClearShare/MetadataCore.cs
@@ -70,6 +70,7 @@ namespace SIL.Core.ClearShare
 		/// If the MetaData was loaded from a file, this stores all the other metadata from that file,
 		/// which will typically be useful to write to a file derived from it.
 		/// </summary>
+		[CLSCompliant(false)]
 		protected TagLib.Image.File _originalTaglibMetadata;
 
 		// This is called when we got an out of memory exception reading the image itself.
@@ -204,6 +205,7 @@ namespace SIL.Core.ClearShare
 			HasChanges = false;
 		}
 
+		[CLSCompliant(false)]
 		protected LicenseInfo _license;
 
 		///<summary>
@@ -222,6 +224,7 @@ namespace SIL.Core.ClearShare
 			}
 		}
 
+		[CLSCompliant(false)]
 		protected string _copyrightNotice;
 		public string CopyrightNotice
 		{
@@ -256,6 +259,7 @@ namespace SIL.Core.ClearShare
 			return value.Substring(0, startOfProblem);
 		}
 
+		[CLSCompliant(false)]
 		protected string _creator;
 
 		/// <summary>
@@ -424,6 +428,7 @@ namespace SIL.Core.ClearShare
 		/// <inheritdoc/>
 		public override string ToString() => MinimalCredits(new[] { "en" }, out _);
 
+		[CLSCompliant(false)]
 		protected string _path;
 
 		public void Write()
@@ -706,6 +711,7 @@ namespace SIL.Core.ClearShare
 			return qualifier != null && qualifier.Value == lang;
 		}
 
+		[CLSCompliant(false)]
 		protected static string GetRights(XmpTag xmp)
 		{
 			var rightsNode = xmp.FindNode("http://purl.org/dc/elements/1.1/", "rights");

--- a/SIL.Core/Reporting/FontAnalytics.cs
+++ b/SIL.Core/Reporting/FontAnalytics.cs
@@ -125,10 +125,10 @@ namespace SIL.Reporting
 				_currentlyPosting = true;
 				PostAnalytics(content);
 			}
-			catch (Exception)
+			catch (Exception err)
 			{
 #if DEBUG
-				throw;
+				throw err;
 #endif
 				// normally, swallow
 			}
@@ -153,10 +153,10 @@ namespace SIL.Reporting
 					Debug.WriteLine(t.Result);
 				}
 			}
-			catch (Exception)
+			catch (Exception err)
 			{
 #if DEBUG
-				throw;
+				throw err;
 #endif
 				// normally swallow
 			}

--- a/SIL.Core/Reporting/FontAnalytics.cs
+++ b/SIL.Core/Reporting/FontAnalytics.cs
@@ -125,10 +125,10 @@ namespace SIL.Reporting
 				_currentlyPosting = true;
 				PostAnalytics(content);
 			}
-			catch (Exception err)
+			catch (Exception)
 			{
 #if DEBUG
-				throw err;
+				throw;
 #endif
 				// normally, swallow
 			}
@@ -153,10 +153,10 @@ namespace SIL.Reporting
 					Debug.WriteLine(t.Result);
 				}
 			}
-			catch (Exception err)
+			catch (Exception)
 			{
 #if DEBUG
-				throw err;
+				throw;
 #endif
 				// normally swallow
 			}

--- a/SIL.Core/Xml/XmlUtils.cs
+++ b/SIL.Core/Xml/XmlUtils.cs
@@ -826,6 +826,7 @@ namespace SIL.Xml
 		/// XML file.
 		/// </summary>
 		[Obsolete("Use ConvertMultiParagraphToSafeXml")]
+		[CLSCompliant(false)]
 		public static string ConvertMultiparagraphToSafeXml(string sInput) =>
 			ConvertMultiParagraphToSafeXml(sInput);
 


### PR DESCRIPTION
Add [CLSCompliant(false)] to underscore-prefixed protected fields and non-CLS-compliant method parameters.

This addresses `CS300*` build warnings:
```
Warning: D:\a\libpalaso\libpalaso\SIL.Core\Xml\XmlUtils.cs(829,24): warning CS3005: Identifier 'XmlUtils.ConvertMultiparagraphToSafeXml(string)' differing only in case is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(73,31): warning CS3008: Identifier '_originalTaglibMetadata' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(73,31): warning CS3003: Type of 'MetadataCore._originalTaglibMetadata' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(207,25): warning CS3008: Identifier '_license' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(225,20): warning CS3008: Identifier '_copyrightNotice' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(259,20): warning CS3008: Identifier '_creator' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(427,20): warning CS3008: Identifier '_path' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\MetadataCore.cs(709,44): warning CS3001: Argument type 'XmpTag' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\CreativeCommonsLicenseInfo.cs(27,18): warning CS3008: Identifier '_attributionRequired' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\CreativeCommonsLicenseInfo.cs(46,18): warning CS3008: Identifier '_commercialUseAllowed' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\CreativeCommonsLicenseInfo.cs(60,29): warning CS3008: Identifier '_derivativeRule' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\CreativeCommonsLicenseInfo.cs(321,20): warning CS3008: Identifier '_version' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
Warning: D:\a\libpalaso\libpalaso\SIL.Core\ClearShare\CreativeCommonsLicenseInfo.cs(335,20): warning CS3008: Identifier '_qualifier' is not CLS-compliant [D:\a\libpalaso\libpalaso\SIL.Core\SIL.Core.csproj::TargetFramework=netstandard2.0]
```

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1514

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1514)
<!-- Reviewable:end -->
