### PR TITLE
Fix FontAnalytics exception handling to preserve stack traces in debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
 
 ### Fixed
+- [SIL.Core] Fixed FontAnalytics exception handling to preserve original stack traces in debug mode.
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter

--- a/SIL.Core/Reporting/FontAnalytics.cs
+++ b/SIL.Core/Reporting/FontAnalytics.cs
@@ -125,10 +125,10 @@ namespace SIL.Reporting
 				_currentlyPosting = true;
 				PostAnalytics(content);
 			}
-			catch (Exception err)
+			catch (Exception)
 			{
 #if DEBUG
-				throw err;
+				throw;
 #endif
 				// normally, swallow
 			}
@@ -153,10 +153,10 @@ namespace SIL.Reporting
 					Debug.WriteLine(t.Result);
 				}
 			}
-			catch (Exception err)
+			catch (Exception)
 			{
 #if DEBUG
-				throw err;
+				throw;
 #endif
 				// normally swallow
 			}


### PR DESCRIPTION
Using `throw err` re-throws with a new stack trace; `throw` (bare rethrow) preserves the original. Also removes the unused `err` variable in release builds (CS0168).

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1515

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1515)
<!-- Reviewable:end -->
