### PR TITLE
+semver:minor Add FileLocationUtilities.AdditionalSearchDirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Installer] Added new package for common installer components. Initially, this includes a Privacy dialog and code to access the registry entries so users can opt out of analytics data collection.
 - [SIL.Core] Added PathUtilities.ParentDirectories extension method.
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
+- [SIL.Core] Added FileLocationUtilities.AdditionalSearchDirectories property, allowing apps to register extra directories searched as a fallback by GetFileDistributedWithApplication.
 
 ### Fixed
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").

--- a/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
+++ b/SIL.Core.Tests/IO/FileLocationUtilitiesTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using SIL.IO;
 using SIL.PlatformUtilities;
 using static SIL.IO.FileLocationUtilities;
 
@@ -190,6 +191,28 @@ namespace SIL.Tests.IO
 		}
 
 		//TODO: this could use lots more tests
+
+		[Test]
+		public void GetFileDistributedWithApplication_FileOnlyInAdditionalDirectory_FindsCorrectly()
+		{
+			const string fileName = "TestFileInAdditionalDir.txt";
+			using (var tempFile = TempFile.WithFilenameInTempFolder(fileName))
+			{
+				File.WriteAllText(tempFile.Path, "test content");
+				var tempDir = Path.GetDirectoryName(tempFile.Path);
+				AdditionalSearchDirectories.Add(tempDir);
+				try
+				{
+					var result = GetFileDistributedWithApplication(true, fileName);
+					Assert.That(result, Is.Not.Null);
+					Assert.That(File.Exists(result));
+				}
+				finally
+				{
+					AdditionalSearchDirectories.Remove(tempDir);
+				}
+			}
+		}
 
 		[Test]
 		public void LocateExecutable_DistFiles()

--- a/SIL.Core/IO/FileLocationUtilities.cs
+++ b/SIL.Core/IO/FileLocationUtilities.cs
@@ -126,6 +126,13 @@ namespace SIL.IO
 			"common" /*for WeSay*/, "src" /*for Bloom*/};
 
 		/// <summary>
+		/// Additional directories to search after the built-in ones in
+		/// <see cref="GetFileDistributedWithApplication(bool, string[])"/>. Useful for apps that
+		/// install files outside the standard locations (e.g., a git submodule during development).
+		/// </summary>
+		public static IList<string> AdditionalSearchDirectories { get; } = new List<string>();
+
+		/// <summary>
 		/// Find a file which, on a development machine, lives in [solution]/[distFileFolderName]/[subPath],
 		/// and when installed, lives in
 		/// [applicationFolder]/[distFileFolderName]/[subPath1]/[subPathN]  or
@@ -155,6 +162,13 @@ namespace SIL.IO
 					s_distFilesFolderCached = dir; // Remember this for next time.
 					return path;
 				}
+			}
+
+			foreach (var additionalDir in AdditionalSearchDirectories)
+			{
+				var path = Path.Combine(additionalDir, Path.Combine(partsOfTheSubPath));
+				if (File.Exists(path))
+					return path;
 			}
 
 			if (optional)


### PR DESCRIPTION
## Summary

- Added `FileLocationUtilities.AdditionalSearchDirectories` (`IList<string>`) — a public static property, defaulting to an empty list, that apps can populate at startup with full directory paths.
- `GetFileDistributedWithApplication` now iterates those directories after all built-in search locations (`DistFilesFolderPath`, `DirectoriesHoldingFiles`), so they only fire as a fallback and existing behavior is unchanged when the list is empty.
- Added a NUnit test (`GetFileDistributedWithApplication_FileOnlyInAdditionalDirectory_FindsCorrectly`) that places a file exclusively in a temp directory registered via `AdditionalSearchDirectories` and asserts it is found.

**Typical usage at app startup:**
```csharp
FileLocationUtilities.AdditionalSearchDirectories.Add(
    FileLocationUtilities.GetDirectoryDistributedWithApplication("docs"));
```

## Test plan

- [x] New test passes on all three target frameworks (net48, net462, net8.0)
- [x] All existing `FileLocationUtilitiesTests` still pass
- [x] No regressions in `SIL.Core.Tests` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1518)
<!-- Reviewable:end -->
