### PR TITLE
Fix duplicate lines in MetadataCore.GetSummaryParagraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
 
 ### Fixed
+- [SIL.Core.ClearShare] Fixed `MetadataCore.GetSummaryParagraph` appending the Creator line twice and conditionally appending `RightsStatement` twice when using `CustomLicenseInfo`.
 - [SIL.Windows.Forms.WritingSystems] WritingSystemFromWindowsLocaleProvider no longer crashes when an installed input language has a corrupt Windows installation; it now skips languages whose keyboard layout name cannot be read instead of throwing.
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.

--- a/SIL.Core.Tests/ClearShare/MetadataCoreTests.cs
+++ b/SIL.Core.Tests/ClearShare/MetadataCoreTests.cs
@@ -176,8 +176,7 @@ namespace SIL.Tests.ClearShare
 			using (var mediaFile = new Image<Rgba32>(10, 10))
 			{
 				using (var folder =
-				       new TemporaryFolder(
-					       "LibPalaso exiftool Test with non-áscii chárácters"))
+					new TemporaryFolder("LibPalaso exiftool Test with non-áscii chárácters"))
 				{
 					var path = folder.Combine("test.png");
 					mediaFile.Save(path, new PngEncoder());
@@ -543,6 +542,32 @@ namespace SIL.Tests.ClearShare
 			VerifyMetadataUnchangedSavingToTag(meta2, tag, "Verify custom license again: ");
 			VerifyMetadataUnchangedSavingToTag(meta1, tag, "Verify CC license again: ");
 			VerifyMetadataUnchangedSavingToTag(meta3, tag, "Verify null license again: ");
+		}
+
+		[Test]
+		public void GetSummaryParagraph_EachComponentAppearsExactlyOnce()
+		{
+			var m = new MetadataCore
+			{
+				Creator = "Sméagol",
+				CopyrightNotice = "Copyright © 2026 Lex Tools",
+				CollectionName = "My Precious",
+				CollectionUri = "abc://1.2.3",
+				License = new CustomLicenseInfo { RightsStatement = "It's mine!" }
+			};
+			var summary = m.GetSummaryParagraph(new[] { "en" }, out _);
+			foreach (var component in new[]
+			{
+				"Sméagol",
+				"Copyright © 2026 Lex Tools",
+				"My Precious",
+				"abc://1.2.3",
+				"It's mine!"
+			})
+			{
+				var count = summary.Split(new[] { component }, StringSplitOptions.None).Length - 1;
+				Assert.AreEqual(1, count, $"Expected exactly one occurrence of \"{component}\" but found {count}");
+			}
 		}
 
 		private void VerifyMetadataUnchangedSavingToTag(MetadataCore oldMetadata, XmpTag tag, string header)

--- a/SIL.Core/ClearShare/MetadataCore.cs
+++ b/SIL.Core/ClearShare/MetadataCore.cs
@@ -799,7 +799,6 @@ namespace SIL.Core.ClearShare
 		public string GetSummaryParagraph(IEnumerable<string> languagePriorityIds, out string idOfLanguageUsed, string localizedCreatorLabel = "Creator")
 		{
 			var b = new StringBuilder();
-			b.Append(localizedCreatorLabel).Append(": ").AppendLine(Creator);
 			b.AppendLine($"{localizedCreatorLabel}: {Creator}");
 			b.AppendLine(CopyrightNotice);
 			if (!IsNullOrEmpty(CollectionName))
@@ -811,7 +810,8 @@ namespace SIL.Core.ClearShare
 			if (!IsNullOrEmpty(License.Url) && !description.Contains(License.Url))
 				b.AppendLine(License.Url);
 			b.AppendLine(description);
-			if (!IsNullOrWhiteSpace(License.RightsStatement))
+			// CustomLicenseInfo.GetDescription returns RightsStatement, so guard against appending it twice.
+			if (!IsNullOrWhiteSpace(License.RightsStatement) && !description.Contains(License.RightsStatement))
 				b.AppendLine(License.RightsStatement);
 			return b.ToString();
 		}


### PR DESCRIPTION
## Summary
- Remove duplicate Creator line (Append-chain form left alongside interpolated-string form)
- Guard `RightsStatement` against being appended twice when `CustomLicenseInfo.GetDescription` already returns it (mirrors existing `License.Url` guard)
- Add `GetSummaryParagraph_EachComponentAppearsExactlyOnce` test

## Devin review
https://app.devin.ai/review/sillsdev/libpalaso/pull/1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1519)
<!-- Reviewable:end -->
