### PR TITLE
Fix ImageCropper crash when switching Crop/Choose tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Change Log
+# Change Log
 
 All notable changes to this project will be documented in this file.
 
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal)
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
-- [SIL.WritingSystems] More fixes to consistently use ç¹ä½“ä¸­æ–‡ and ç®€ä½“ä¸­æ–‡ for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
+- [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 - [SIL.Windows.Forms] Prevent ContributorsListControl.GetContributionFromRow from throwing an exception when the DataGridView has no valid rows selected.
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms] In `CustomDropDown.OnOpening`, fixed check that triggers timer to stop.
-- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the systemâ€™s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
+- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the system’s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
-- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal); fixed `Image` setter leaking previous temp file and cropping image on re-set and leaving disposed-but-non-null references on failure; fixed tall images never being downscaled before cropping (Height condition was checking Width)
+- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs: `Application.Idle` handler was never unsubscribed, causing it to fire on a disposed object
+- [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` returning a JPEG-format bitmap backed by a prematurely disposed `MemoryStream`
+- [SIL.Windows.Forms] Fixed ImageCropper `Image` setter leaking the previous temp file and cropping image on re-set; fields are now nulled after disposal so a mid-setter failure does not leave disposed-but-non-null references
+- [SIL.Windows.Forms] Fixed ImageCropper not downscaling tall images before cropping (height condition was checking width)
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
-- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal); also fixed `Image` setter leaking previous temp file and cropping image on re-set
+- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal); fixed `Image` setter leaking previous temp file and cropping image on re-set and leaving disposed-but-non-null references on failure; fixed tall images never being downscaled before cropping (Height condition was checking Width)
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+﻿# Change Log
 
 All notable changes to this project will be documented in this file.
 
@@ -43,9 +43,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
-- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal) (#1275)
+- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal)
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
-- [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
+- [SIL.WritingSystems] More fixes to consistently use ç¹ä½“ä¸­æ–‡ and ç®€ä½“ä¸­æ–‡ for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 - [SIL.Windows.Forms] Prevent ContributorsListControl.GetContributionFromRow from throwing an exception when the DataGridView has no valid rows selected.
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms] In `CustomDropDown.OnOpening`, fixed check that triggers timer to stop.
-- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the system’s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
+- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the systemâ€™s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
+- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal) (#1275)
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
-- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal)
+- [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs (Application.Idle leak + premature MemoryStream disposal); also fixed `Image` setter leaking previous temp file and cropping image on re-set
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` returning a JPEG-format bitmap backed by a prematurely disposed `MemoryStream`
 - [SIL.Windows.Forms] Fixed ImageCropper `Image` setter leaking the previous temp file and cropping image on re-set; fields are now nulled after disposal so a mid-setter failure does not leave disposed-but-non-null references
 - [SIL.Windows.Forms] Fixed ImageCropper not downscaling tall images before cropping (height condition was checking width)
+- [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` throwing `NullReferenceException` when `Image` property is set directly rather than via `SetImage`
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -16,7 +16,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		public void Dispose_CalledTwice_DoesNotThrow()
 		{
 			var cropper = new ImageCropper();
-			cropper.Dispose();
+			Assert.DoesNotThrow(() => cropper.Dispose());
 			Assert.DoesNotThrow(() => cropper.Dispose());
 		}
 
@@ -121,7 +121,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 				{
 					cropper.Size = new Size(400, 300);
 					cropper.SetImage(img1);
-					Assert.DoesNotThrow(() => cropper.SetImage(img2));
+					cropper.SetImage(img2);
 
 					using (var result = cropper.GetCroppedImage())
 					{

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -39,9 +39,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					{
 						Assert.IsNotNull(result);
 						Assert.Greater(result.Width, 0);
-						// Re-encoding forces GDI+ to re-read the pixel data (Width/RawFormat alone
-						// only touch cached metadata); this would throw if the backing store had
-						// been prematurely disposed.
+						// Re-encode to force GDI+ to re-read the pixel data from the backing store.
 						using (var ms = new MemoryStream())
 							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
 					}
@@ -71,9 +69,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					{
 						Assert.IsNotNull(result);
 						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
-						// Re-encode to force GDI+ to re-read pixel data from the backing stream.
-						// Width/RawFormat only touch cached metadata and pass even when the stream
-						// has been disposed, so they cannot confirm the stream is still alive.
+						// Re-encode to force GDI+ to re-read the pixel data from the backing stream.
 						using (var ms = new MemoryStream())
 							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
 					}
@@ -142,11 +138,9 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		[Test]
 		public void SetImage_ReCropPreviouslyCroppedJpeg_DoesNotThrow()
 		{
-			// Regression test for the crash reported in the ImageToolbox (issue #1275) when
-			// switching Get Image <-> Crop with a JPEG. GetImage() returns a Bitmap backed by a
-			// MemoryStream; feeding that result back into a new cropper re-saves it in the Image
-			// setter (value.Image.Save), which threw "A generic error occurred in GDI+" once the
-			// backing stream had been disposed.
+			// GetImage() returns a JPEG Bitmap backed by a MemoryStream; feeding that result
+			// back into a new cropper re-saves it in the Image setter (value.Image.Save), which
+			// crashed once the backing stream had been disposed.
 			using (var tempFile = TempFile.WithExtension(".jpg"))
 			{
 				using (var bmp = new Bitmap(1200, 900))

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -1,0 +1,90 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Threading;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.Windows.Forms.ImageToolbox;
+using SIL.Windows.Forms.ImageToolbox.Cropping;
+
+namespace SIL.Windows.Forms.Tests.ImageToolbox
+{
+	[Apartment(ApartmentState.STA)]
+	[TestFixture]
+	public class ImageCropperTests
+	{
+		[Test]
+		public void Dispose_DoesNotThrow()
+		{
+			var cropper = new ImageCropper();
+			Assert.DoesNotThrow(() => cropper.Dispose());
+		}
+
+		[Test]
+		public void Dispose_CalledTwice_DoesNotThrow()
+		{
+			var cropper = new ImageCropper();
+			cropper.Dispose();
+			Assert.DoesNotThrow(() => cropper.Dispose());
+		}
+
+		[Test]
+		public void GetCroppedImage_PngImage_ReturnsUsableBitmap()
+		{
+			using (var tempFile = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+					bmp.Save(tempFile.Path, ImageFormat.Png);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				using (var cropper = new ImageCropper())
+				{
+					cropper.Size = new Size(400, 300);
+					cropper.SetImage(palasoImage);
+
+					using (var result = cropper.GetCroppedImage())
+					{
+						Assert.IsNotNull(result);
+						// Accessing Width forces GDI+ to decode the image data; this would throw
+						// if the backing stream had been prematurely disposed.
+						Assert.Greater(result.Width, 0);
+						Assert.Greater(result.Height, 0);
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void GetCroppedImage_JpegImage_ReturnsJpegBitmapUsableAfterReturn()
+		{
+			using (var tempFile = TempFile.WithExtension(".jpg"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+					bmp.Save(tempFile.Path, ImageFormat.Jpeg);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				using (var cropper = new ImageCropper())
+				{
+					cropper.Size = new Size(400, 300);
+					cropper.SetImage(palasoImage);
+
+					Image result;
+					// GetCroppedImage returns a Bitmap backed by a MemoryStream for JPEG.
+					// The stream must still be alive after the method returns.
+					result = cropper.GetCroppedImage();
+					try
+					{
+						Assert.IsNotNull(result);
+						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
+						// Force pixel data access to confirm the stream is still alive.
+						Assert.Greater(result.Width, 0);
+						Assert.Greater(result.Height, 0);
+					}
+					finally
+					{
+						result?.Dispose();
+					}
+				}
+			}
+		}
+	}
+}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -13,13 +13,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 	public class ImageCropperTests
 	{
 		[Test]
-		public void Dispose_DoesNotThrow()
-		{
-			var cropper = new ImageCropper();
-			Assert.DoesNotThrow(() => cropper.Dispose());
-		}
-
-		[Test]
 		public void Dispose_CalledTwice_DoesNotThrow()
 		{
 			var cropper = new ImageCropper();
@@ -47,7 +40,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 						// Accessing Width forces GDI+ to decode the image data; this would throw
 						// if the backing stream had been prematurely disposed.
 						Assert.Greater(result.Width, 0);
-						Assert.Greater(result.Height, 0);
 					}
 				}
 			}
@@ -77,7 +69,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
 						// Force pixel data access to confirm the stream is still alive.
 						Assert.Greater(result.Width, 0);
-						Assert.Greater(result.Height, 0);
 					}
 					finally
 					{

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -104,7 +104,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		}
 
 		[Test]
-		public void SetImage_CalledTwice_DoesNotThrow()
+		public void SetImage_Reassign_UpdatesFormatAndDoesNotThrow()
 		{
 			using (var tempFile1 = TempFile.WithExtension(".png"))
 			using (var tempFile2 = TempFile.WithExtension(".jpg"))

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -1,5 +1,6 @@
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using System.Threading;
 using NUnit.Framework;
 using SIL.IO;
@@ -37,9 +38,12 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					using (var result = cropper.GetCroppedImage())
 					{
 						Assert.IsNotNull(result);
-						// Accessing Width forces GDI+ to decode the image data; this would throw
-						// if the backing stream had been prematurely disposed.
 						Assert.Greater(result.Width, 0);
+						// Re-encoding forces GDI+ to re-read the pixel data (Width/RawFormat alone
+						// only touch cached metadata); this would throw if the backing store had
+						// been prematurely disposed.
+						using (var ms = new MemoryStream())
+							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
 					}
 				}
 			}
@@ -67,8 +71,11 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					{
 						Assert.IsNotNull(result);
 						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
-						// Force pixel data access to confirm the stream is still alive.
-						Assert.Greater(result.Width, 0);
+						// Re-encode to force GDI+ to re-read pixel data from the backing stream.
+						// Width/RawFormat only touch cached metadata and pass even when the stream
+						// has been disposed, so they cannot confirm the stream is still alive.
+						using (var ms = new MemoryStream())
+							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
 					}
 					finally
 					{
@@ -127,6 +134,41 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					{
 						Assert.IsNotNull(result);
 						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void SetImage_ReCropPreviouslyCroppedJpeg_DoesNotThrow()
+		{
+			// Regression test for the crash reported in the ImageToolbox (issue #1275) when
+			// switching Get Image <-> Crop with a JPEG. GetImage() returns a Bitmap backed by a
+			// MemoryStream; feeding that result back into a new cropper re-saves it in the Image
+			// setter (value.Image.Save), which threw "A generic error occurred in GDI+" once the
+			// backing stream had been disposed.
+			using (var tempFile = TempFile.WithExtension(".jpg"))
+			{
+				using (var bmp = new Bitmap(1200, 900))
+					bmp.Save(tempFile.Path, ImageFormat.Jpeg);
+
+				// GetImage() returns the same PalasoImage instance, now holding the cropped JPEG,
+				// so the outer using disposes it exactly once.
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				{
+					PalasoImage cropped;
+					using (var cropper1 = new ImageCropper())
+					{
+						cropper1.Size = new Size(400, 300);
+						cropper1.SetImage(palasoImage);
+						cropped = cropper1.GetImage();
+					}
+					Assert.That(cropped, Is.Not.Null);
+
+					using (var cropper2 = new ImageCropper())
+					{
+						cropper2.Size = new Size(400, 300);
+						Assert.DoesNotThrow(() => cropper2.SetImage(cropped));
 					}
 				}
 			}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -86,5 +86,59 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 				}
 			}
 		}
+		[Test]
+		public void GetCroppedImage_JpegImage_SetViaPropertyDirectly_ReturnsJpegBitmap()
+		{
+			// Setting Image directly (not via SetImage) must still initialize _originalFormat so
+			// GetCroppedImage does not throw NullReferenceException on JPEG re-encoding.
+			using (var tempFile = TempFile.WithExtension(".jpg"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+					bmp.Save(tempFile.Path, ImageFormat.Jpeg);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				using (var cropper = new ImageCropper())
+				{
+					cropper.Size = new Size(400, 300);
+					cropper.Image = palasoImage; // bypass SetImage intentionally
+
+					using (var result = cropper.GetCroppedImage())
+					{
+						Assert.IsNotNull(result);
+						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
+						Assert.Greater(result.Width, 0);
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void SetImage_CalledTwice_DoesNotThrow()
+		{
+			using (var tempFile1 = TempFile.WithExtension(".png"))
+			using (var tempFile2 = TempFile.WithExtension(".jpg"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+				{
+					bmp.Save(tempFile1.Path, ImageFormat.Png);
+					bmp.Save(tempFile2.Path, ImageFormat.Jpeg);
+				}
+
+				using (var img1 = PalasoImage.FromFile(tempFile1.Path))
+				using (var img2 = PalasoImage.FromFile(tempFile2.Path))
+				using (var cropper = new ImageCropper())
+				{
+					cropper.Size = new Size(400, 300);
+					cropper.SetImage(img1);
+					Assert.DoesNotThrow(() => cropper.SetImage(img2));
+
+					using (var result = cropper.GetCroppedImage())
+					{
+						Assert.IsNotNull(result);
+						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
+					}
+				}
+			}
+		}
 	}
 }

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -272,6 +272,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 
 		private void CalculateSourceImageArea()
 		{
+			if (_croppingImage == null)
+				return;
 			float imageToCanvaseScaleFactor = GetImageToCanvasScaleFactor(_croppingImage);
 			_sourceImageArea = new Rectangle(GripThickness, GripThickness,
 											 (int)(_croppingImage.Width*imageToCanvaseScaleFactor),

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -443,6 +443,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 						catch
 						{
 							stream.Dispose();
+							cropped.Dispose();
 							throw;
 						}
 						Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -422,13 +422,21 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					{
 						//We've sadly lost our jpeg formatting, so now we encode a new image in jpeg
 						var stream = new MemoryStream();
-						cropped.Save(stream, ImageFormat.Jpeg);
-						var oldCropped = cropped;
-						// Do not dispose stream here: GDI+ bitmaps reference the stream for lazy decoding.
-						// The stream will be collected when the returned Bitmap is no longer referenced.
-						stream.Position = 0;
-						cropped = (Bitmap)System.Drawing.Image.FromStream(stream);
-						oldCropped.Dispose();
+						try
+						{
+							cropped.Save(stream, ImageFormat.Jpeg);
+							stream.Position = 0;
+							// Do not dispose stream on success: GDI+ bitmaps reference the stream for lazy
+							// decoding. The stream is collected when the returned Bitmap is disposed.
+							var oldCropped = cropped;
+							cropped = (Bitmap)System.Drawing.Image.FromStream(stream);
+							oldCropped.Dispose();
+						}
+						catch
+						{
+							stream.Dispose();
+							throw;
+						}
 						Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
 					}
 					return cropped;

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -421,14 +421,15 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					if (_originalFormat.Guid == ImageFormat.Jpeg.Guid)
 					{
 						//We've sadly lost our jpeg formatting, so now we encode a new image in jpeg
-						using (var stream = new MemoryStream())
-						{
-							cropped.Save(stream, ImageFormat.Jpeg);
-							var oldCropped = cropped;
-							cropped = System.Drawing.Image.FromStream(stream) as Bitmap;
-							oldCropped.Dispose();
-							Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
-						}
+						var stream = new MemoryStream();
+						cropped.Save(stream, ImageFormat.Jpeg);
+						var oldCropped = cropped;
+						// Do not dispose stream here: GDI+ bitmaps reference the stream for lazy decoding.
+						// The stream will be collected when the returned Bitmap is no longer referenced.
+						stream.Position = 0;
+						cropped = System.Drawing.Image.FromStream(stream) as Bitmap;
+						oldCropped.Dispose();
+						Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
 					}
 					return cropped;
 				}
@@ -504,6 +505,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				catch (UnauthorizedAccessException)
 				{
 				}
+
+				Application.Idle -= Application_Idle;
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -483,6 +483,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					components = null;
 				}
 
+				Application.Idle -= Application_Idle;
+
 				try
 				{
 					if (_savedOriginalImage != null)
@@ -505,8 +507,6 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				catch (UnauthorizedAccessException)
 				{
 				}
-
-				Application.Idle -= Application_Idle;
 			}
 			base.Dispose(disposing);
 		}

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -149,6 +149,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				_savedOriginalImage = null;
 				_croppingImage?.Dispose();
 				_croppingImage = null;
+				_originalFormat = value.Image.RawFormat;
 
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -427,7 +427,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 						// Do not dispose stream here: GDI+ bitmaps reference the stream for lazy decoding.
 						// The stream will be collected when the returned Bitmap is no longer referenced.
 						stream.Position = 0;
-						cropped = System.Drawing.Image.FromStream(stream) as Bitmap;
+						cropped = (Bitmap)System.Drawing.Image.FromStream(stream);
 						oldCropped.Dispose();
 						Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
 					}

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -466,7 +466,6 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 			}
 			else
 			{
-				_originalFormat = image.Image.RawFormat;
 				Image = image;
 			}
 		}

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -145,6 +145,9 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				if (value == null)
 					return;
 
+				_savedOriginalImage?.Dispose();
+				_croppingImage?.Dispose();
+
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
 

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -146,7 +146,9 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					return;
 
 				_savedOriginalImage?.Dispose();
+				_savedOriginalImage = null;
 				_croppingImage?.Dispose();
+				_croppingImage = null;
 
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
@@ -156,7 +158,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				value.Image.Save(_savedOriginalImage.Path, ImageFormat.Png);
 
 				// make a reasonable sized copy to crop
-				if ((value.Image.Width > 1000) || (value.Image.Width > 1000))
+				if ((value.Image.Width > 1000) || (value.Image.Height > 1000))
 				{
 					_croppingImage = CreateCroppingImage(value.Image.Height, value.Image.Width);
 


### PR DESCRIPTION
## Summary
Fixes several resource-management bugs in `ImageCropper`, most of which could cause crashes in the Image Toolbox: an `Application.Idle` subscription leak that fired on a disposed object when switching tabs; a prematurely disposed `MemoryStream` that broke JPEG bitmaps after `GetCroppedImage` returned; and multiple gaps in the `Image` setter where old resources were leaked or left in a state that could crash a subsequent repaint or resize. Also fixes two other bugs found while reviewing the same code.

### Details
- Fix `Application.Idle` subscription leak in `ImageCropper.Dispose()` — handler was never unsubscribed, firing on a disposed object when the user switched tabs; unsubscription added before the `try`/`catch` so it cannot be skipped
- Fix `GetCroppedImage()` returning a JPEG-format bitmap backed by a prematurely disposed `MemoryStream` — GDI+ bitmaps hold a lazy reference to the source stream; `using` removed so the stream outlives the returned `Bitmap`
- Replace `as Bitmap` with a direct cast so an unexpected non-Bitmap from `Image.FromStream` throws immediately rather than silently propagating `null`
- Fix `Image` setter leaking previous `_savedOriginalImage` (TempFile) and `_croppingImage` on re-set; fields are nulled after disposal so a mid-setter failure does not leave disposed-but-non-null references that pass `OnPaint`'s null guard and crash on repaint
- Fix `CalculateSourceImageArea` not guarding against null `_croppingImage`, which could crash a resize event if the setter threw after disposing the old image
- Fix pre-existing typo: downscale condition checked `Width > 1000` twice instead of `Width || Height`, so tall narrow images were never downscaled before cropping
- Fix `Image` setter not initializing `_originalFormat`, which caused a `NullReferenceException` in `GetCroppedImage` when the property was set directly rather than via `SetImage`

## Test plan
- [x] Manually open ImageToolbox and switch between Crop and Choose tabs — should not crash

Fixes #1275

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1521

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1521)
<!-- Reviewable:end -->
