### PR TITLE
SettingsProtectionHelper: support always-hidden controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Change Log
+# Change Log
 
 All notable changes to this project will be documented in this file.
 
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
-- [SIL.WritingSystems] More fixes to consistently use ç¹ä½“ä¸­æ–‡ and ç®€ä½“ä¸­æ–‡ for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
+- [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 - [SIL.Windows.Forms] Prevent ContributorsListControl.GetContributionFromRow from throwing an exception when the DataGridView has no valid rows selected.
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms] In `CustomDropDown.OnOpening`, fixed check that triggers timer to stop.
-- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the systemâ€™s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
+- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the system’s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.Windows.Forms] Fixed SettingsProtectionHelper to support always-hidden controls that remain hidden even under password-override (#1134)
 - [SIL.Core.ClearShare] Fixed `MetadataCore.GetSummaryParagraph` appending the Creator line twice and conditionally appending `RightsStatement` twice when using `CustomLicenseInfo`.
 - [SIL.Core] Fixed FontAnalytics exception handling to preserve original stack traces in debug mode.
 - [SIL.Windows.Forms.WritingSystems] WritingSystemFromWindowsLocaleProvider no longer crashes when an installed input language has a corrupt Windows installation; it now skips languages whose keyboard layout name cannot be read instead of throwing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Change Log
+﻿# Change Log
 
 All notable changes to this project will be documented in this file.
 
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- [SIL.Windows.Forms] Fixed SettingsProtectionHelper to support always-hidden controls that remain hidden even under password-override (#1134)
+- [SIL.Windows.Forms] Fixed SettingsProtectionHelper to support always-hidden controls that remain hidden even under password-override
 - [SIL.Core.ClearShare] Fixed `MetadataCore.GetSummaryParagraph` appending the Creator line twice and conditionally appending `RightsStatement` twice when using `CustomLicenseInfo`.
 - [SIL.Core] Fixed FontAnalytics exception handling to preserve original stack traces in debug mode.
 - [SIL.Windows.Forms.WritingSystems] WritingSystemFromWindowsLocaleProvider no longer crashes when an installed input language has a corrupt Windows installation; it now skips languages whose keyboard layout name cannot be read instead of throwing.
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
-- [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
+- [SIL.WritingSystems] More fixes to consistently use ç¹ä½“ä¸­æ–‡ and ç®€ä½“ä¸­æ–‡ for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.
 - [SIL.Windows.Forms] Prevent ContributorsListControl.GetContributionFromRow from throwing an exception when the DataGridView has no valid rows selected.
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [SIL.Windows.Forms] In `CustomDropDown.OnOpening`, fixed check that triggers timer to stop.
-- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the system’s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
+- [SIL.Windows.Forms] Fixed HtmlBrowserHandled.OnNewWindow to open external URLs (`target="_blank"`) in the systemâ€™s default browser instead of Internet Explorer. This improves behavior in SILAboutBox and other components that use the embedded browser.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Installer] Added new package for common installer components. Initially, this includes a Privacy dialog and code to access the registry entries so users can opt out of analytics data collection.
 - [SIL.Core] Added PathUtilities.ParentDirectories extension method.
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
+- [SIL.Windows.Forms] Added `keepHidden` option to `SetSettingsProtection` so controls can be marked always-hidden, remaining hidden even under password-override.
 
 ### Fixed
 
-- [SIL.Windows.Forms] Fixed SettingsProtectionHelper to support always-hidden controls that remain hidden even under password-override
 - [SIL.Core.ClearShare] Fixed `MetadataCore.GetSummaryParagraph` appending the Creator line twice and conditionally appending `RightsStatement` twice when using `CustomLicenseInfo`.
 - [SIL.Core] Fixed FontAnalytics exception handling to preserve original stack traces in debug mode.
 - [SIL.Windows.Forms.WritingSystems] WritingSystemFromWindowsLocaleProvider no longer crashes when an installed input language has a corrupt Windows installation; it now skips languages whose keyboard layout name cannot be read instead of throwing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
 - [build] Fixed the update-language-data workflow so the generated pull request commit message shows the actual update date instead of a literal `$(date ...)` string.
 - [SIL.Archiving] Fixed ArchiveAccessProtocol.GetDocumentationUri failing to create a missing documentation file because the resource lookup stripped the file extension and no longer matched the embedded resource name.
+- [SIL.Windows.Forms] Fixed `SettingsProtectionHelper.Dispose(bool)` to only touch managed resources when `disposing` is true, and removed a redundant explicit timer disposal.
 - [SIL.Windows.Forms.Archiving] Fixed formatting of message in ArchivingDlg so that the name of the auxiliary archive upload program (e.g., "RAMP") is displayed.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Change Log
+# Change Log
 
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Installer] Added new package for common installer components. Initially, this includes a Privacy dialog and code to access the registry entries so users can opt out of analytics data collection.
 - [SIL.Core] Added PathUtilities.ParentDirectories extension method.
 - [SIL.Core] Added FileLocationUtilities.DistFilesFolderPath property.
-- [SIL.Windows.Forms] Added `keepHidden` option to `SetSettingsProtection` so controls can be marked always-hidden, remaining hidden even under password-override.
+- [SIL.Windows.Forms] Added `SettingsProtectionHelper.SetSettingsProtection` overloads taking a `keepHidden` parameter, so a `Control` or `ToolStripItem` can be marked always-hidden: it stays hidden even while Ctrl+Shift is held to reveal the other protected components. The existing two-parameter overloads are unchanged.
 
 ### Fixed
 
@@ -51,8 +51,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Media] BREAKING CHANGE (subtle and unlikely): WindowsAudioSession.OnPlaybackStopped now passes itself as the sender instead of a private implementation object, making the event arguments correct.
 - [build] Fixed the update-language-data workflow so the generated pull request commit message shows the actual update date instead of a literal `$(date ...)` string.
 - [SIL.Archiving] Fixed ArchiveAccessProtocol.GetDocumentationUri failing to create a missing documentation file because the resource lookup stripped the file extension and no longer matched the embedded resource name.
-- [SIL.Windows.Forms] Fixed `SettingsProtectionHelper.Dispose(bool)` to only touch managed resources when `disposing` is true, and removed a redundant explicit timer disposal.
 - [SIL.Windows.Forms.Archiving] Fixed formatting of message in ArchivingDlg so that the name of the auxiliary archive upload program (e.g., "RAMP") is displayed.
+- [SIL.Windows.Forms] Fixed `SettingsProtectionHelper.Dispose` so that it only touches managed resources when disposing, is safe to call more than once, and no longer disposes the Ctrl+Shift timer explicitly (the timer is owned by the component container that disposes it).
 
 ### Changed
 

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
@@ -112,5 +112,14 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 
 			Assert.That(control.Visible, Is.True);
 		}
+
+		[Test]
+		public void GetSettingsProtection_AlwaysHiddenControl_ReturnsTrue()
+		{
+			var control = new Button();
+			_helper.SetSettingsProtection(control, true, keepHidden: true);
+
+			Assert.That(_helper.GetSettingsProtection(control), Is.True);
+		}
 	}
 }

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
@@ -1,0 +1,116 @@
+using System.Reflection;
+using System.Windows.Forms;
+using NUnit.Framework;
+using SIL.Windows.Forms.SettingProtection;
+
+namespace SIL.Windows.Forms.Tests.SettingsProtection
+{
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class SettingsProtectionHelperTests
+	{
+		private SettingsProtectionHelper _helper;
+		private bool _savedNormallyHidden;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_savedNormallyHidden = SettingsProtectionSingleton.Settings.NormallyHidden;
+			_helper = new SettingsProtectionHelper(null);
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = _savedNormallyHidden;
+			_helper.Dispose();
+		}
+
+		private static void CallUpdateDisplay(SettingsProtectionHelper helper)
+		{
+			var method = typeof(SettingsProtectionHelper).GetMethod("UpdateDisplay",
+				BindingFlags.NonPublic | BindingFlags.Instance);
+			method.Invoke(helper, null);
+		}
+
+		[Test]
+		public void UpdateDisplay_NormalProtectedControl_IsVisibleWhenNotNormallyHidden()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = false;
+			var control = new Button { Visible = false };
+			_helper.SetSettingsProtection(control, true);
+
+			CallUpdateDisplay(_helper);
+
+			Assert.That(control.Visible, Is.True);
+		}
+
+		[Test]
+		public void UpdateDisplay_NormalProtectedControl_IsHiddenWhenNormallyHidden()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = true;
+			var control = new Button { Visible = true };
+			_helper.SetSettingsProtection(control, true);
+
+			CallUpdateDisplay(_helper);
+
+			Assert.That(control.Visible, Is.False);
+		}
+
+		[Test]
+		public void UpdateDisplay_AlwaysHiddenControl_RemainsHiddenWhenNotNormallyHidden()
+		{
+			// Even when NormallyHidden=false (i.e., normal controls are visible),
+			// an always-hidden control must stay hidden.
+			SettingsProtectionSingleton.Settings.NormallyHidden = false;
+			var control = new Button { Visible = true };
+			_helper.SetSettingsProtection(control, true, keepHidden: true);
+
+			CallUpdateDisplay(_helper);
+
+			Assert.That(control.Visible, Is.False);
+		}
+
+		[Test]
+		public void UpdateDisplay_AlwaysHiddenControl_RemainsHiddenWhenNormallyHidden()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = true;
+			var control = new Button { Visible = true };
+			_helper.SetSettingsProtection(control, true, keepHidden: true);
+
+			CallUpdateDisplay(_helper);
+
+			Assert.That(control.Visible, Is.False);
+		}
+
+		[Test]
+		public void SetSettingsProtection_SwitchFromAlwaysHiddenToNormal_ControlBecomesNormallyManaged()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = false;
+			var control = new Button { Visible = true };
+			_helper.SetSettingsProtection(control, true, keepHidden: true);
+			CallUpdateDisplay(_helper);
+			Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
+
+			// Re-register without keepHidden — should now follow the normal rule
+			_helper.SetSettingsProtection(control, true, keepHidden: false);
+			CallUpdateDisplay(_helper);
+
+			Assert.That(control.Visible, Is.True);
+		}
+
+		[Test]
+		public void SetSettingsProtection_UnprotectAlwaysHiddenControl_ControlBecomesVisible()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = false;
+			var control = new Button { Visible = true };
+			_helper.SetSettingsProtection(control, true, keepHidden: true);
+			CallUpdateDisplay(_helper);
+			Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
+
+			_helper.SetSettingsProtection(control, false);
+
+			Assert.That(control.Visible, Is.True);
+		}
+	}
+}

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
@@ -93,6 +93,20 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 		}
 
 		[Test]
+		public void SetSettingsProtection_AlwaysHiddenControl_IsHiddenWithoutWaitingForTimer()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = false;
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
+
+				// Deliberately no UpdateDisplay call: an always-hidden control must not stay
+				// visible until the timer next fires.
+				Assert.That(control.Visible, Is.False);
+			}
+		}
+
+		[Test]
 		public void SetSettingsProtection_SwitchFromAlwaysHiddenToNormal_ControlBecomesNormallyManaged()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = false;

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
@@ -125,6 +125,37 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 		}
 
 		[Test]
+		public void SetSettingsProtection_SwitchFromAlwaysHiddenToNormal_IsShownWithoutWaitingForTimer()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = false;
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
+				Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
+
+				_helper.SetSettingsProtection(control, true, keepHidden: false);
+
+				// Deliberately no UpdateDisplay call: registering hid the control, so the normal
+				// rule must be applied without waiting for the timer.
+				Assert.That(control.Visible, Is.True);
+			}
+		}
+
+		[Test]
+		public void SetSettingsProtection_SwitchFromAlwaysHiddenToNormal_StaysHiddenWhenNormallyHidden()
+		{
+			SettingsProtectionSingleton.Settings.NormallyHidden = true;
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
+
+				_helper.SetSettingsProtection(control, true, keepHidden: false);
+
+				Assert.That(control.Visible, Is.False);
+			}
+		}
+
+		[Test]
 		public void SetSettingsProtection_UnprotectAlwaysHiddenControl_ControlBecomesVisible()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = false;

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsProtectionHelperTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Reflection;
 using System.Windows.Forms;
 using NUnit.Framework;
@@ -37,24 +38,28 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 		public void UpdateDisplay_NormalProtectedControl_IsVisibleWhenNotNormallyHidden()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = false;
-			var control = new Button { Visible = false };
-			_helper.SetSettingsProtection(control, true);
+			using (var control = new Button { Visible = false })
+			{
+				_helper.SetSettingsProtection(control, true);
 
-			CallUpdateDisplay(_helper);
+				CallUpdateDisplay(_helper);
 
-			Assert.That(control.Visible, Is.True);
+				Assert.That(control.Visible, Is.True);
+			}
 		}
 
 		[Test]
 		public void UpdateDisplay_NormalProtectedControl_IsHiddenWhenNormallyHidden()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = true;
-			var control = new Button { Visible = true };
-			_helper.SetSettingsProtection(control, true);
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true);
 
-			CallUpdateDisplay(_helper);
+				CallUpdateDisplay(_helper);
 
-			Assert.That(control.Visible, Is.False);
+				Assert.That(control.Visible, Is.False);
+			}
 		}
 
 		[Test]
@@ -63,63 +68,86 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 			// Even when NormallyHidden=false (i.e., normal controls are visible),
 			// an always-hidden control must stay hidden.
 			SettingsProtectionSingleton.Settings.NormallyHidden = false;
-			var control = new Button { Visible = true };
-			_helper.SetSettingsProtection(control, true, keepHidden: true);
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
 
-			CallUpdateDisplay(_helper);
+				CallUpdateDisplay(_helper);
 
-			Assert.That(control.Visible, Is.False);
+				Assert.That(control.Visible, Is.False);
+			}
 		}
 
 		[Test]
 		public void UpdateDisplay_AlwaysHiddenControl_RemainsHiddenWhenNormallyHidden()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = true;
-			var control = new Button { Visible = true };
-			_helper.SetSettingsProtection(control, true, keepHidden: true);
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
 
-			CallUpdateDisplay(_helper);
+				CallUpdateDisplay(_helper);
 
-			Assert.That(control.Visible, Is.False);
+				Assert.That(control.Visible, Is.False);
+			}
 		}
 
 		[Test]
 		public void SetSettingsProtection_SwitchFromAlwaysHiddenToNormal_ControlBecomesNormallyManaged()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = false;
-			var control = new Button { Visible = true };
-			_helper.SetSettingsProtection(control, true, keepHidden: true);
-			CallUpdateDisplay(_helper);
-			Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
+				CallUpdateDisplay(_helper);
+				Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
 
-			// Re-register without keepHidden — should now follow the normal rule
-			_helper.SetSettingsProtection(control, true, keepHidden: false);
-			CallUpdateDisplay(_helper);
+				// Re-register without keepHidden — should now follow the normal rule
+				_helper.SetSettingsProtection(control, true, keepHidden: false);
+				CallUpdateDisplay(_helper);
 
-			Assert.That(control.Visible, Is.True);
+				Assert.That(control.Visible, Is.True);
+			}
 		}
 
 		[Test]
 		public void SetSettingsProtection_UnprotectAlwaysHiddenControl_ControlBecomesVisible()
 		{
 			SettingsProtectionSingleton.Settings.NormallyHidden = false;
-			var control = new Button { Visible = true };
-			_helper.SetSettingsProtection(control, true, keepHidden: true);
-			CallUpdateDisplay(_helper);
-			Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
+			using (var control = new Button { Visible = true })
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
+				CallUpdateDisplay(_helper);
+				Assert.That(control.Visible, Is.False, "Precondition: always-hidden should be hidden");
 
-			_helper.SetSettingsProtection(control, false);
+				_helper.SetSettingsProtection(control, false);
 
-			Assert.That(control.Visible, Is.True);
+				Assert.That(control.Visible, Is.True);
+			}
 		}
 
 		[Test]
 		public void GetSettingsProtection_AlwaysHiddenControl_ReturnsTrue()
 		{
-			var control = new Button();
-			_helper.SetSettingsProtection(control, true, keepHidden: true);
+			using (var control = new Button())
+			{
+				_helper.SetSettingsProtection(control, true, keepHidden: true);
 
-			Assert.That(_helper.GetSettingsProtection(control), Is.True);
+				Assert.That(_helper.GetSettingsProtection(control), Is.True);
+			}
+		}
+
+		[Test]
+		public void Dispose_WhileStillSitedInContainer_DoesNotThrow()
+		{
+			// Disposing removes the component from its container, which reads Site, and the Site
+			// override throws once disposed; so _isDisposed must not be set until that is done.
+			using (var container = new Container())
+			{
+				var helper = new SettingsProtectionHelper(container);
+
+				Assert.That(() => helper.Dispose(), Throws.Nothing);
+			}
 		}
 	}
 }

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
@@ -15,18 +15,19 @@ namespace SIL.Windows.Forms.SettingProtection
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && (components != null))
+			if (disposing)
 			{
-				components.Dispose();
+				if (components != null)
+					components.Dispose();
+				_checkForCtrlKeyTimer.Dispose();
+				if (!_isDisposed)
+				{
+					_isDisposed = true;
+					_componentsUnderSettingsProtection.Clear();
+					_alwaysHiddenComponents.Clear();
+				}
 			}
 			base.Dispose(disposing);
-			_checkForCtrlKeyTimer.Dispose();
-			if(!_isDisposed)
-			{
-				_isDisposed = true;
-				_componentsUnderSettingsProtection.Clear();
-				_alwaysHiddenComponents.Clear();
-			}
 		}
 
 		#region Component Designer generated code

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
@@ -19,7 +19,6 @@ namespace SIL.Windows.Forms.SettingProtection
 			{
 				if (components != null)
 					components.Dispose();
-				_checkForCtrlKeyTimer.Dispose();
 				if (!_isDisposed)
 				{
 					_isDisposed = true;

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
@@ -25,6 +25,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			{
 				_isDisposed = true;
 				_componentsUnderSettingsProtection.Clear();
+				_alwaysHiddenComponents.Clear();
 			}
 		}
 

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.Designer.cs
@@ -15,18 +15,21 @@ namespace SIL.Windows.Forms.SettingProtection
 		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
 		protected override void Dispose(bool disposing)
 		{
+			System.Diagnostics.Debug.WriteLineIf(!disposing, "****** Missing Dispose() call for " + GetType().Name + ". ****** ");
+			if (_isDisposed)
+				return;
 			if (disposing)
 			{
 				if (components != null)
 					components.Dispose();
-				if (!_isDisposed)
-				{
-					_isDisposed = true;
-					_componentsUnderSettingsProtection.Clear();
-					_alwaysHiddenComponents.Clear();
-				}
+				_componentsUnderSettingsProtection.Clear();
+				_alwaysHiddenComponents.Clear();
 			}
+			// Must run before _isDisposed is set: the base implementation removes this component
+			// from its container, which reads the Site property, and our override of Site throws
+			// once disposed.
 			base.Dispose(disposing);
+			_isDisposed = true;
 		}
 
 		#region Component Designer generated code

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -22,6 +22,7 @@ namespace SIL.Windows.Forms.SettingProtection
 	public partial class SettingsProtectionHelper : Component, IExtenderProvider
 	{
 		private readonly HashSet<Component> _componentsUnderSettingsProtection;
+		private readonly HashSet<Component> _alwaysHiddenComponents;
 		private bool _isDisposed;
 
 		public bool CanExtend(object extendee)
@@ -35,6 +36,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			InitializeComponent();
 
 			_componentsUnderSettingsProtection = new HashSet<Component>();
+			_alwaysHiddenComponents = new HashSet<Component>();
 
 			if (LicenseManager.UsageMode != LicenseUsageMode.Designtime)
 			{
@@ -76,6 +78,11 @@ namespace SIL.Windows.Forms.SettingProtection
 
 				ShowOrHideComponent(component, visible);
 			}
+
+			foreach (var component in _alwaysHiddenComponents)
+			{
+				ShowOrHideComponent(component, false);
+			}
 		}
 
 		private static void ShowOrHideComponent(Component component, bool visible)
@@ -89,7 +96,8 @@ namespace SIL.Windows.Forms.SettingProtection
 					"Only components which are Controls or ToolStripItems can be under settings protection.");
 		}
 
-		private void SetSettingsProtectionInternal(Component controlOrToolStripItem, bool isProtected)
+		private void SetSettingsProtectionInternal(Component controlOrToolStripItem, bool isProtected,
+			bool keepHidden = false)
 		{
 			if (controlOrToolStripItem == null)
 				throw new ArgumentNullException();
@@ -100,13 +108,23 @@ namespace SIL.Windows.Forms.SettingProtection
 
 			if (isProtected)
 			{
-				_componentsUnderSettingsProtection.Add(controlOrToolStripItem);
+				if (keepHidden)
+				{
+					_alwaysHiddenComponents.Add(controlOrToolStripItem);
+					_componentsUnderSettingsProtection.Remove(controlOrToolStripItem);
+				}
+				else
+				{
+					_componentsUnderSettingsProtection.Add(controlOrToolStripItem);
+					_alwaysHiddenComponents.Remove(controlOrToolStripItem);
+				}
 				// No need to call ShowOrHideComponent explicitly. It will get called when the
 				// timer fires.
 			}
 			else
 			{
 				_componentsUnderSettingsProtection.Remove(controlOrToolStripItem);
+				_alwaysHiddenComponents.Remove(controlOrToolStripItem);
 				ShowOrHideComponent(controlOrToolStripItem, true);
 			}
 		}
@@ -128,8 +146,8 @@ namespace SIL.Windows.Forms.SettingProtection
 		}
 
 		[PublicAPI]
-		public void SetSettingsProtection(Control c, bool isProtected) =>
-			SetSettingsProtectionInternal(c, isProtected);
+		public void SetSettingsProtection(Control c, bool isProtected, bool keepHidden = false) =>
+			SetSettingsProtectionInternal(c, isProtected, keepHidden);
 		#endregion
 
 		#region IComponent Members
@@ -180,7 +198,8 @@ namespace SIL.Windows.Forms.SettingProtection
 		/// </summary>
 		/// <exception cref="ArgumentNullException">toolStripItem was null</exception>
 		[PublicAPI]
-		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected) =>
-			SetSettingsProtectionInternal(toolStripItem, isProtected);
+		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected,
+			bool keepHidden = false) =>
+			SetSettingsProtectionInternal(toolStripItem, isProtected, keepHidden);
 	}
 }

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -202,8 +202,11 @@ namespace SIL.Windows.Forms.SettingProtection
 		/// </summary>
 		/// <exception cref="ArgumentNullException">toolStripItem was null</exception>
 		[PublicAPI]
-		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected,
-			bool keepHidden = false) =>
+		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected) =>
+			SetSettingsProtectionInternal(toolStripItem, isProtected);
+
+		[PublicAPI]
+		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected, bool keepHidden) =>
 			SetSettingsProtectionInternal(toolStripItem, isProtected, keepHidden);
 	}
 }

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -146,7 +146,11 @@ namespace SIL.Windows.Forms.SettingProtection
 		}
 
 		[PublicAPI]
-		public void SetSettingsProtection(Control c, bool isProtected, bool keepHidden = false) =>
+		public void SetSettingsProtection(Control c, bool isProtected) =>
+			SetSettingsProtectionInternal(c, isProtected);
+
+		[PublicAPI]
+		public void SetSettingsProtection(Control c, bool isProtected, bool keepHidden) =>
 			SetSettingsProtectionInternal(c, isProtected, keepHidden);
 		#endregion
 

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -142,7 +142,7 @@ namespace SIL.Windows.Forms.SettingProtection
 			if (c == null)
 				throw new ArgumentNullException();
 
-			return _componentsUnderSettingsProtection.Contains(c);
+			return _componentsUnderSettingsProtection.Contains(c) || _alwaysHiddenComponents.Contains(c);
 		}
 
 		[PublicAPI]

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -149,6 +149,10 @@ namespace SIL.Windows.Forms.SettingProtection
 		public void SetSettingsProtection(Control c, bool isProtected) =>
 			SetSettingsProtectionInternal(c, isProtected);
 
+		/// <param name="keepHidden">When <c>true</c> and <paramref name="isProtected"/> is <c>true</c>,
+		/// the control is always hidden regardless of password override. Has no effect when
+		/// <paramref name="isProtected"/> is <c>false</c> — the component is shown and removed from
+		/// all tracking sets.</param>
 		[PublicAPI]
 		public void SetSettingsProtection(Control c, bool isProtected, bool keepHidden) =>
 			SetSettingsProtectionInternal(c, isProtected, keepHidden);
@@ -205,6 +209,10 @@ namespace SIL.Windows.Forms.SettingProtection
 		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected) =>
 			SetSettingsProtectionInternal(toolStripItem, isProtected);
 
+		/// <param name="keepHidden">When <c>true</c> and <paramref name="isProtected"/> is <c>true</c>,
+		/// the item is always hidden regardless of password override. Has no effect when
+		/// <paramref name="isProtected"/> is <c>false</c> — the component is shown and removed from
+		/// all tracking sets.</param>
 		[PublicAPI]
 		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected, bool keepHidden) =>
 			SetSettingsProtectionInternal(toolStripItem, isProtected, keepHidden);

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -23,6 +23,7 @@ namespace SIL.Windows.Forms.SettingProtection
 	{
 		private readonly HashSet<Component> _componentsUnderSettingsProtection = new HashSet<Component>();
 		private readonly HashSet<Component> _alwaysHiddenComponents = new HashSet<Component>();
+		private readonly bool _isRuntime;
 		private bool _isDisposed;
 
 		public bool CanExtend(object extendee)
@@ -35,7 +36,8 @@ namespace SIL.Windows.Forms.SettingProtection
 		{
 			InitializeComponent();
 
-			if (LicenseManager.UsageMode != LicenseUsageMode.Designtime)
+			_isRuntime = LicenseManager.UsageMode != LicenseUsageMode.Designtime;
+			if (_isRuntime)
 			{
 				container?.Add(this);
 				_checkForCtrlKeyTimer.Enabled = true;
@@ -109,14 +111,18 @@ namespace SIL.Windows.Forms.SettingProtection
 				{
 					_alwaysHiddenComponents.Add(controlOrToolStripItem);
 					_componentsUnderSettingsProtection.Remove(controlOrToolStripItem);
+					// Hide now rather than on the next tick, except at design time, where the
+					// component must stay visible on the design surface.
+					if (_isRuntime)
+						ShowOrHideComponent(controlOrToolStripItem, false);
 				}
 				else
 				{
 					_componentsUnderSettingsProtection.Add(controlOrToolStripItem);
 					_alwaysHiddenComponents.Remove(controlOrToolStripItem);
+					// No need to call ShowOrHideComponent explicitly. It will get called when the
+					// timer fires.
 				}
-				// No need to call ShowOrHideComponent explicitly. It will get called when the
-				// timer fires.
 			}
 			else
 			{
@@ -146,10 +152,17 @@ namespace SIL.Windows.Forms.SettingProtection
 		public void SetSettingsProtection(Control c, bool isProtected) =>
 			SetSettingsProtectionInternal(c, isProtected);
 
-		/// <param name="keepHidden">When <c>true</c> and <paramref name="isProtected"/> is <c>true</c>,
-		/// the control is always hidden regardless of password override. Has no effect when
-		/// <paramref name="isProtected"/> is <c>false</c> — the component is shown and removed from
-		/// all tracking sets.</param>
+		/// <summary>
+		/// Makes a control protected (i.e., managed) or not, optionally keeping it hidden even
+		/// when the other protected controls are revealed.
+		/// </summary>
+		/// <param name="c">The control to protect or stop protecting</param>
+		/// <param name="isProtected">Whether the control is under settings protection</param>
+		/// <param name="keepHidden">When <c>true</c> and <paramref name="isProtected"/> is
+		/// <c>true</c>, the control is hidden and stays hidden even while the user holds down
+		/// Ctrl+Shift to reveal the other protected controls. This has no effect when
+		/// <paramref name="isProtected"/> is <c>false</c>.</param>
+		/// <exception cref="ArgumentNullException">c was null</exception>
 		[PublicAPI]
 		public void SetSettingsProtection(Control c, bool isProtected, bool keepHidden) =>
 			SetSettingsProtectionInternal(c, isProtected, keepHidden);
@@ -206,10 +219,17 @@ namespace SIL.Windows.Forms.SettingProtection
 		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected) =>
 			SetSettingsProtectionInternal(toolStripItem, isProtected);
 
-		/// <param name="keepHidden">When <c>true</c> and <paramref name="isProtected"/> is <c>true</c>,
-		/// the item is always hidden regardless of password override. Has no effect when
-		/// <paramref name="isProtected"/> is <c>false</c> — the component is shown and removed from
-		/// all tracking sets.</param>
+		/// <summary>
+		/// Allows you to dynamically make a ToolStripItem protected (i.e., managed) or not,
+		/// optionally keeping it hidden even when the other protected items are revealed
+		/// </summary>
+		/// <param name="toolStripItem">The item to protect or stop protecting</param>
+		/// <param name="isProtected">Whether the item is under settings protection</param>
+		/// <param name="keepHidden">When <c>true</c> and <paramref name="isProtected"/> is
+		/// <c>true</c>, the item is hidden and stays hidden even while the user holds down
+		/// Ctrl+Shift to reveal the other protected items. This has no effect when
+		/// <paramref name="isProtected"/> is <c>false</c>.</param>
+		/// <exception cref="ArgumentNullException">toolStripItem was null</exception>
 		[PublicAPI]
 		public void SetSettingsProtection(ToolStripItem toolStripItem, bool isProtected, bool keepHidden) =>
 			SetSettingsProtectionInternal(toolStripItem, isProtected, keepHidden);

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -21,8 +21,8 @@ namespace SIL.Windows.Forms.SettingProtection
 	[ProvideProperty("SettingsProtection", typeof(Control))]
 	public partial class SettingsProtectionHelper : Component, IExtenderProvider
 	{
-		private readonly HashSet<Component> _componentsUnderSettingsProtection;
-		private readonly HashSet<Component> _alwaysHiddenComponents;
+		private readonly HashSet<Component> _componentsUnderSettingsProtection = new HashSet<Component>();
+		private readonly HashSet<Component> _alwaysHiddenComponents = new HashSet<Component>();
 		private bool _isDisposed;
 
 		public bool CanExtend(object extendee)
@@ -34,9 +34,6 @@ namespace SIL.Windows.Forms.SettingProtection
 		public SettingsProtectionHelper(IContainer container)
 		{
 			InitializeComponent();
-
-			_componentsUnderSettingsProtection = new HashSet<Component>();
-			_alwaysHiddenComponents = new HashSet<Component>();
 
 			if (LicenseManager.UsageMode != LicenseUsageMode.Designtime)
 			{

--- a/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsProtectionHelper.cs
@@ -64,17 +64,25 @@ namespace SIL.Windows.Forms.SettingProtection
 			return result;
 		}
 
+		private static bool ProtectedComponentsAreVisible
+		{
+			get
+			{
+				var keys = Keys.Control | Keys.Shift;
+				return !SettingsProtectionSingleton.Settings.NormallyHidden ||
+					((Control.ModifierKeys & keys) == keys);
+			}
+		}
+
 		private void UpdateDisplay()
 		{
 			if (_componentsUnderSettingsProtection == null)//sometimes get a tick before this has been set
 				return;
 
-			var keys = Keys.Control | Keys.Shift;
+			var visible = ProtectedComponentsAreVisible;
 
 			foreach (var component in _componentsUnderSettingsProtection)
 			{
-				bool visible = !SettingsProtectionSingleton.Settings.NormallyHidden || ((Control.ModifierKeys & keys) == keys);
-
 				ShowOrHideComponent(component, visible);
 			}
 
@@ -119,9 +127,11 @@ namespace SIL.Windows.Forms.SettingProtection
 				else
 				{
 					_componentsUnderSettingsProtection.Add(controlOrToolStripItem);
-					_alwaysHiddenComponents.Remove(controlOrToolStripItem);
-					// No need to call ShowOrHideComponent explicitly. It will get called when the
-					// timer fires.
+					var wasAlwaysHidden = _alwaysHiddenComponents.Remove(controlOrToolStripItem);
+					// If it was always-hidden then it is hidden now, so apply the normal rule
+					// instead of leaving it hidden until the timer fires.
+					if (wasAlwaysHidden && _isRuntime)
+						ShowOrHideComponent(controlOrToolStripItem, ProtectedComponentsAreVisible);
 				}
 			}
 			else


### PR DESCRIPTION
## Summary

- Add `SetSettingsProtection(Control, bool, bool keepHidden)` and `SetSettingsProtection(ToolStripItem, bool, bool keepHidden)` overloads so a control or ToolStripItem can be marked always-hidden, staying hidden even while Ctrl+Shift reveals the other protected components. The original 2-parameter overloads are preserved for WinForms designer extender-property discovery and binary compatibility.
- Track always-hidden components in a separate `_alwaysHiddenComponents` set, which `UpdateDisplay()` hides unconditionally after the normal pass. `GetSettingsProtection` reports `true` for them too.
- Apply always-hidden registration immediately at run time instead of leaving the component visible until the next (~100 ms) timer tick. Design time is deliberately excluded: the extender property setter runs there as well, where the timer is off and the component must stay visible on the design surface.
- Apply the normal visibility rule immediately when a component leaves always-hidden, so the two directions are symmetric. The `!NormallyHidden || Ctrl+Shift` rule moved into a property shared with `UpdateDisplay()`, which had been recomputing it once per component.
- Rework `Dispose(bool)` into the standard form used elsewhere in the repo — the missing-Dispose debug warning, an early return that makes it idempotent, managed cleanup only when `disposing`, and `_isDisposed` set *after* `base.Dispose(disposing)`. That ordering matters: `Component.Dispose` removes itself from its container, which reads the `Site` property, and this class overrides `Site` to throw once disposed. The explicit `_checkForCtrlKeyTimer.Dispose()` is gone, since the timer is owned by the `components` container that disposes it.
- Give both new overloads full XML documentation (summary plus a tag for every parameter).
- Add `SettingsProtectionHelperTests` — 11 tests covering normal vs. always-hidden visibility, both transition directions and their immediacy, unprotecting, `GetSettingsProtection`, and disposing while still sited in a container.
- Add CHANGELOG entries under Added and Fixed.

## Scope note on #1134

`keepHidden` is a "never show this" primitive: an always-hidden component is not revealed by Ctrl+Shift, and it is not revealed by entering the settings password either — nothing records that the password was entered, and `UpdateDisplay()` re-hides these components on every tick.

#1134 asks for components that remain hidden *unless the password is entered*. A client can build that on top of this: mark the components `keepHidden: true`, then re-register them with `keepHidden: false` after a successful challenge. This PR does not add that behavior to the library itself.

Fixes #1134

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1522

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1522)
<!-- Reviewable:end -->
