### PR TITLE
Fix BadImageFormatException loading Interop.WIA.dll in 64-bit apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [SIL.Windows.Forms] Fixed `Interop.WIA.dll` deployment to provide the AnyCPU build to 64-bit (x64/AnyCPU) consumers instead of the 32-bit-only build.
 - [SIL.Core.ClearShare] Fixed `MetadataCore.GetSummaryParagraph` appending the Creator line twice and conditionally appending `RightsStatement` twice when using `CustomLicenseInfo`.
 - [SIL.Core] Fixed FontAnalytics exception handling to preserve original stack traces in debug mode.
 - [SIL.Windows.Forms.WritingSystems] WritingSystemFromWindowsLocaleProvider no longer crashes when an installed input language has a corrupt Windows installation; it now skips languages whose keyboard layout name cannot be read instead of throwing.

--- a/SIL.Windows.Forms/SIL.Windows.Forms.csproj
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.csproj
@@ -49,12 +49,12 @@
 
   <ItemGroup>
     <None Include="../lib/Interop.WIA.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Pack>true</Pack>
       <PackagePath>build</PackagePath>
     </None>
     <None Include="../lib/x64/Interop.WIA.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Link>Interop.WIA.dll</Link>
       <Pack>true</Pack>
       <PackagePath>build/x64</PackagePath>
     </None>

--- a/SIL.Windows.Forms/SIL.Windows.Forms.targets
+++ b/SIL.Windows.Forms/SIL.Windows.Forms.targets
@@ -1,7 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition="'$(Platform)' == 'x86'">
     <None Include="$(MSBuildThisFileDirectory)**\*.dll"
           Exclude="$(MSBuildThisFileDirectory)x64\**\*.dll">
+      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Platform)' != 'x86'">
+    <None Include="$(MSBuildThisFileDirectory)x64\**\*.dll">
       <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Problem

`build/SIL.Windows.Forms.targets` (shipped in the package's `build/` folder and
auto-imported by consumers) unconditionally copied the 32-bit
`build/Interop.WIA.dll` to every consumer's output directory and explicitly
excluded the AnyCPU `build/x64/` variant.

The 32-bit interop is built with the CorFlags `32BITREQUIRED` bit, so it cannot
load in a 64-bit process. Any 64-bit consumer that exercised the ImageToolbox
scanner/camera support (`AcquireImageControl.GetFromDevice`) crashed with
`System.BadImageFormatException` ("An attempt was made to load a program with an
incorrect format").

## Fix

Make the copy platform-aware:

- **x86** builds get the 32-bit interop from `build/`.
- **x64 / AnyCPU / unspecified** builds get the AnyCPU interop from `build/x64/`.

The AnyCPU assembly loads correctly in both 32- and 64-bit processes.

## Testing

- Verified the deployed `Interop.WIA.dll` is the AnyCPU build (CorFlags `0x09`,
  no `32BITREQUIRED`) in a 64-bit consumer's output.
- Confirmed in a downstream 64-bit application (FieldWorks) that the scanner/camera
  buttons in the ImageToolbox no longer throw `BadImageFormatException`.

## Notes

- Found via FieldWorks LT-22458 (crash clicking Camera/Scanner in the Picture
  Properties dialog of the 64-bit FieldWorks build).
- CHANGELOG.md updated under `[Unreleased]` → `Fixed`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1524)
<!-- Reviewable:end -->
