### PR TITLE
Dispose the ImageCropper JPEG re-encode MemoryStream (restore using)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs: `Application.Idle` handler was never unsubscribed, causing it to fire on a disposed object
-- [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` returning a JPEG-format bitmap backed by a prematurely disposed `MemoryStream`
 - [SIL.Windows.Forms] Fixed ImageCropper `Image` setter leaking the previous temp file and cropping image on re-set; fields are now nulled after disposal so a mid-setter failure does not leave disposed-but-non-null references
 - [SIL.Windows.Forms] Fixed ImageCropper not downscaling tall images before cropping (height condition was checking width)
 - [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` throwing `NullReferenceException` when `Image` property is set directly rather than via `SetImage`

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -48,39 +48,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		}
 
 		[Test]
-		public void GetCroppedImage_JpegImage_ReturnsJpegBitmapUsableAfterReturn()
-		{
-			using (var tempFile = TempFile.WithExtension(".jpg"))
-			{
-				using (var bmp = new Bitmap(100, 80))
-					bmp.Save(tempFile.Path, ImageFormat.Jpeg);
-
-				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
-				using (var cropper = new ImageCropper())
-				{
-					cropper.Size = new Size(400, 300);
-					cropper.SetImage(palasoImage);
-
-					Image result;
-					// GetCroppedImage returns a Bitmap backed by a MemoryStream for JPEG.
-					// The stream must still be alive after the method returns.
-					result = cropper.GetCroppedImage();
-					try
-					{
-						Assert.IsNotNull(result);
-						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
-						// Re-encode to force GDI+ to re-read the pixel data from the backing stream.
-						using (var ms = new MemoryStream())
-							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
-					}
-					finally
-					{
-						result?.Dispose();
-					}
-				}
-			}
-		}
-		[Test]
 		public void GetCroppedImage_JpegImage_SetViaPropertyDirectly_ReturnsJpegBitmap()
 		{
 			// Setting Image directly (not via SetImage) must still initialize _originalFormat so
@@ -130,39 +97,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					{
 						Assert.IsNotNull(result);
 						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
-					}
-				}
-			}
-		}
-
-		[Test]
-		public void SetImage_ReCropPreviouslyCroppedJpeg_DoesNotThrow()
-		{
-			// GetImage() returns a JPEG Bitmap backed by a MemoryStream; feeding that result
-			// back into a new cropper re-saves it in the Image setter (value.Image.Save), which
-			// crashed once the backing stream had been disposed.
-			using (var tempFile = TempFile.WithExtension(".jpg"))
-			{
-				using (var bmp = new Bitmap(1200, 900))
-					bmp.Save(tempFile.Path, ImageFormat.Jpeg);
-
-				// GetImage() returns the same PalasoImage instance, now holding the cropped JPEG,
-				// so the outer using disposes it exactly once.
-				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
-				{
-					PalasoImage cropped;
-					using (var cropper1 = new ImageCropper())
-					{
-						cropper1.Size = new Size(400, 300);
-						cropper1.SetImage(palasoImage);
-						cropped = cropper1.GetImage();
-					}
-					Assert.That(cropped, Is.Not.Null);
-
-					using (var cropper2 = new ImageCropper())
-					{
-						cropper2.Size = new Size(400, 300);
-						Assert.DoesNotThrow(() => cropper2.SetImage(cropped));
 					}
 				}
 			}

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -429,24 +429,15 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					if (_originalFormat.Guid == ImageFormat.Jpeg.Guid)
 					{
 						//We've sadly lost our jpeg formatting, so now we encode a new image in jpeg
-						var stream = new MemoryStream();
-						try
+						using (var stream = new MemoryStream())
 						{
 							cropped.Save(stream, ImageFormat.Jpeg);
 							stream.Position = 0;
-							// Do not dispose stream on success: GDI+ bitmaps reference the stream for lazy
-							// decoding. The stream is collected when the returned Bitmap is disposed.
 							var oldCropped = cropped;
 							cropped = (Bitmap)System.Drawing.Image.FromStream(stream);
 							oldCropped.Dispose();
+							Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
 						}
-						catch
-						{
-							stream.Dispose();
-							cropped.Dispose();
-							throw;
-						}
-						Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
 					}
 					return cropped;
 				}


### PR DESCRIPTION
Alternative to the current #1521 handling of the JPEG re-encode stream, addressing only the CodeQL *MemoryStream created but not disposed* warning.

## What changed
Restores the original `using (var stream = new MemoryStream())` around the JPEG re-encode in `GetCroppedImage`, so the stream is disposed. Keeps the independent improvements already on the branch (`stream.Position = 0`, direct `(Bitmap)` cast) and drops the `try/catch` that only existed to dispose the stream in the absence of a `using`.

## Trade-off (read before merging)
This **does not** fix the #1275 re-crop crash. With the stream disposed, the returned JPEG bitmap is again backed by a disposed stream, so accessing its pixels after return (e.g. re-cropping) throws a generic GDI+ error — the original #1275 behavior. The two tests that exercised that scenario are removed because they no longer pass:
- `GetCroppedImage_JpegImage_ReturnsJpegBitmapUsableAfterReturn`
- `SetImage_ReCropPreviouslyCroppedJpeg_DoesNotThrow`

If you want the leak resolved **and** #1275 fixed, see the companion copy-out PR instead.

## Tests
Remaining `ImageCropperTests` pass locally (net8.0-windows): `Dispose_CalledTwice`, `GetCroppedImage_PngImage_ReturnsUsableBitmap`, `GetCroppedImage_JpegImage_SetViaPropertyDirectly_ReturnsJpegBitmap`, `SetImage_Reassign_UpdatesFormatAndDoesNotThrow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1526)
<!-- Reviewable:end -->
