### PR TITLE
Dispose the ImageCropper JPEG re-encode MemoryStream and keep the crop usable (copy-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.Windows.Forms] Fixed ImageCropper crash when switching between Crop and Choose tabs: `Application.Idle` handler was never unsubscribed, causing it to fire on a disposed object
-- [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` returning a JPEG-format bitmap backed by a prematurely disposed `MemoryStream`
+- [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` returning a JPEG bitmap backed by a `MemoryStream` that was either disposed too early (crash on later access) or never disposed (leak); the re-encoded bitmap is now copied into a stand-alone `Bitmap` so the stream can be disposed with its `using` without breaking the returned image
 - [SIL.Windows.Forms] Fixed ImageCropper `Image` setter leaking the previous temp file and cropping image on re-set; fields are now nulled after disposal so a mid-setter failure does not leave disposed-but-non-null references
 - [SIL.Windows.Forms] Fixed ImageCropper not downscaling tall images before cropping (height condition was checking width)
 - [SIL.Windows.Forms] Fixed ImageCropper `GetCroppedImage` throwing `NullReferenceException` when `Image` property is set directly rather than via `SetImage`

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -48,7 +48,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		}
 
 		[Test]
-		public void GetCroppedImage_JpegImage_ReturnsJpegBitmapUsableAfterReturn()
+		public void GetCroppedImage_JpegImage_ReturnsUsableBitmap()
 		{
 			using (var tempFile = TempFile.WithExtension(".jpg"))
 			{
@@ -61,30 +61,25 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					cropper.Size = new Size(400, 300);
 					cropper.SetImage(palasoImage);
 
-					Image result;
-					// GetCroppedImage returns a Bitmap backed by a MemoryStream for JPEG.
-					// The stream must still be alive after the method returns.
-					result = cropper.GetCroppedImage();
-					try
+					using (var result = cropper.GetCroppedImage())
 					{
 						Assert.IsNotNull(result);
-						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
-						// Re-encode to force GDI+ to re-read the pixel data from the backing stream.
+						// The crop is a stand-alone in-memory bitmap, not backed by a file or stream, so
+						// it reports MemoryBmp format even for a JPEG source; the caller chooses the actual
+						// save format via the file extension.
+						Assert.AreEqual(ImageFormat.MemoryBmp.Guid, result.RawFormat.Guid);
+						// Re-encode to force GDI+ to re-read the pixel data from the backing store.
 						using (var ms = new MemoryStream())
 							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
-					}
-					finally
-					{
-						result?.Dispose();
 					}
 				}
 			}
 		}
+
 		[Test]
-		public void GetCroppedImage_JpegImage_SetViaPropertyDirectly_ReturnsJpegBitmap()
+		public void GetCroppedImage_JpegImage_SetViaPropertyDirectly_ReturnsUsableBitmap()
 		{
-			// Setting Image directly (not via SetImage) must still initialize _originalFormat so
-			// GetCroppedImage does not throw NullReferenceException on JPEG re-encoding.
+			// Setting Image directly (not via SetImage) must still yield a usable crop.
 			using (var tempFile = TempFile.WithExtension(".jpg"))
 			{
 				using (var bmp = new Bitmap(100, 80))
@@ -99,15 +94,16 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					using (var result = cropper.GetCroppedImage())
 					{
 						Assert.IsNotNull(result);
-						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
 						Assert.Greater(result.Width, 0);
+						using (var ms = new MemoryStream())
+							Assert.DoesNotThrow(() => result.Save(ms, ImageFormat.Png));
 					}
 				}
 			}
 		}
 
 		[Test]
-		public void SetImage_Reassign_UpdatesFormatAndDoesNotThrow()
+		public void SetImage_Reassign_DoesNotThrow()
 		{
 			using (var tempFile1 = TempFile.WithExtension(".png"))
 			using (var tempFile2 = TempFile.WithExtension(".jpg"))
@@ -129,7 +125,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					using (var result = cropper.GetCroppedImage())
 					{
 						Assert.IsNotNull(result);
-						Assert.AreEqual(ImageFormat.Jpeg.Guid, result.RawFormat.Guid);
+						Assert.Greater(result.Width, 0);
 					}
 				}
 			}
@@ -138,9 +134,10 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		[Test]
 		public void SetImage_ReCropPreviouslyCroppedJpeg_DoesNotThrow()
 		{
-			// GetImage() returns a JPEG Bitmap backed by a MemoryStream; feeding that result
-			// back into a new cropper re-saves it in the Image setter (value.Image.Save), which
-			// crashed once the backing stream had been disposed.
+			// Regression test for issue #1275: cropping a JPEG, then feeding the result back into a
+			// new cropper (which re-saves it in the Image setter via value.Image.Save) crashed when
+			// the cropped bitmap was backed by a disposed stream. The crop is now a stand-alone
+			// bitmap, so the round-trip must not throw.
 			using (var tempFile = TempFile.WithExtension(".jpg"))
 			{
 				using (var bmp = new Bitmap(1200, 900))

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -4,7 +4,6 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Windows.Forms;
-using SIL.Code;
 using SIL.IO;
 using SIL.Reporting;
 
@@ -429,24 +428,19 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					if (_originalFormat.Guid == ImageFormat.Jpeg.Guid)
 					{
 						//We've sadly lost our jpeg formatting, so now we encode a new image in jpeg
-						var stream = new MemoryStream();
-						try
+						using (var stream = new MemoryStream())
 						{
 							cropped.Save(stream, ImageFormat.Jpeg);
 							stream.Position = 0;
-							// Do not dispose stream on success: GDI+ bitmaps reference the stream for lazy
-							// decoding. The stream is collected when the returned Bitmap is disposed.
 							var oldCropped = cropped;
-							cropped = (Bitmap)System.Drawing.Image.FromStream(stream);
+							// Copy into a stream-independent Bitmap so the stream can be disposed with
+							// this using: a Bitmap from Image.FromStream keeps a lazy reference to its
+							// stream and throws a generic GDI+ error on later pixel access once the stream
+							// is gone (issue #1275).
+							using (var reloaded = (Bitmap)System.Drawing.Image.FromStream(stream))
+								cropped = new Bitmap(reloaded);
 							oldCropped.Dispose();
 						}
-						catch
-						{
-							stream.Dispose();
-							cropped.Dispose();
-							throw;
-						}
-						Require.That(ImageFormat.Jpeg.Guid == cropped.RawFormat.Guid, "lost jpeg formatting");
 					}
 					return cropped;
 				}


### PR DESCRIPTION
Resolves the #1521 memory-leak concern (CodeQL *MemoryStream created but not disposed*) **and** keeps the #1275 crash fixed.

## What changed
Restores the `using (var stream = new MemoryStream())` around the JPEG re-encode in `GetCroppedImage`, and copies the reloaded bitmap into a stand-alone `new Bitmap(...)` before the stream is disposed.

A `Bitmap` from `Image.FromStream` keeps a lazy reference to its stream and throws a generic GDI+ error on later pixel access once the stream is gone (issue #1275). Copying severs that tie, so:
- the stream is disposed with its `using` — **no leak**, CodeQL warning resolved;
- the returned bitmap survives — **no crash** on re-crop.

This is the same defensive copy `PalasoImage.SaveImageSafely` already performs before saving.

## Behavior note
The returned bitmap's `RawFormat` becomes `MemoryBmp` rather than `Jpeg`. Nothing reads it — `PalasoImage.Save` picks the format from the file extension — so the `Require.That("lost jpeg formatting")` check is dropped and the tests assert the new contract. The now-unused `SIL.Code` using is removed.

## Tests
All `ImageCropperTests` pass locally (net8.0-windows), including `SetImage_ReCropPreviouslyCroppedJpeg_DoesNotThrow`, the #1275 regression test.

Companion to the restore-`using`-only PR (which resolves the leak but not the crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1527)
<!-- Reviewable:end -->
