### PR TITLE
Fix ImageCropper skipping downscale for tall images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
+- [SIL.Windows.Forms] Fixed ImageCropper not downscaling tall images before cropping (height condition was checking width)
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -1,0 +1,43 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.Windows.Forms.ImageToolbox;
+using SIL.Windows.Forms.ImageToolbox.Cropping;
+
+namespace SIL.Windows.Forms.Tests.ImageToolbox
+{
+	[Apartment(ApartmentState.STA)]
+	[TestFixture]
+	public class ImageCropperTests
+	{
+		[Test]
+		public void SetImage_TallImage_DownscalesCroppingImage()
+		{
+			// A tall image (height > 1000, width <= 1000) should be downscaled before cropping,
+			// same as a wide image (width > 1000, height <= 1000).
+			using (var tempFile = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(100, 1200))
+					bmp.Save(tempFile.Path, ImageFormat.Png);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				using (var cropper = new ImageCropper())
+				{
+					cropper.Size = new Size(400, 300);
+					cropper.SetImage(palasoImage);
+
+					// Not owned by this test -- the cropper still holds and will dispose this itself.
+					var croppingImage = (Image)typeof(ImageCropper)
+						.GetField("_croppingImage", BindingFlags.NonPublic | BindingFlags.Instance)
+						.GetValue(cropper);
+
+					Assert.Less(croppingImage.Height, 1200,
+						"Tall image should have been downscaled before cropping");
+				}
+			}
+		}
+	}
+}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -16,8 +16,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		[Test]
 		public void SetImage_TallImage_DownscalesCroppingImage()
 		{
-			// A tall image (height > 1000, width <= 1000) should be downscaled before cropping,
-			// same as a wide image (width > 1000, height <= 1000).
 			using (var tempFile = TempFile.WithExtension(".png"))
 			{
 				using (var bmp = new Bitmap(100, 1200))
@@ -30,14 +28,42 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					cropper.SetImage(palasoImage);
 
 					// Not owned by this test -- the cropper still holds and will dispose this itself.
-					var croppingImage = (Image)typeof(ImageCropper)
-						.GetField("_croppingImage", BindingFlags.NonPublic | BindingFlags.Instance)
-						.GetValue(cropper);
+					var croppingImage = GetCroppingImage(cropper);
 
 					Assert.Less(croppingImage.Height, 1200,
 						"Tall image should have been downscaled before cropping");
 				}
 			}
+		}
+
+		[Test]
+		public void SetImage_WideImage_DownscalesCroppingImage()
+		{
+			using (var tempFile = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(1200, 100))
+					bmp.Save(tempFile.Path, ImageFormat.Png);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				using (var cropper = new ImageCropper())
+				{
+					cropper.Size = new Size(400, 300);
+					cropper.SetImage(palasoImage);
+
+					// Not owned by this test -- the cropper still holds and will dispose this itself.
+					var croppingImage = GetCroppingImage(cropper);
+
+					Assert.Less(croppingImage.Width, 1200,
+						"Wide image should have been downscaled before cropping");
+				}
+			}
+		}
+
+		private static Image GetCroppingImage(ImageCropper cropper)
+		{
+			return (Image)typeof(ImageCropper)
+				.GetField("_croppingImage", BindingFlags.NonPublic | BindingFlags.Instance)
+				.GetValue(cropper);
 		}
 	}
 }

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -153,7 +153,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				value.Image.Save(_savedOriginalImage.Path, ImageFormat.Png);
 
 				// make a reasonable sized copy to crop
-				if ((value.Image.Width > 1000) || (value.Image.Width > 1000))
+				if ((value.Image.Width > 1000) || (value.Image.Height > 1000))
 				{
 					_croppingImage = CreateCroppingImage(value.Image.Height, value.Image.Width);
 


### PR DESCRIPTION
The pre-crop downscale threshold checked `Image.Width` twice instead of checking `Width` and `Height`, so a tall image (height > 1000, width <= 1000) was never downscaled before cropping.

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1531

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1531)
<!-- Reviewable:end -->
