### PR TITLE
Unsubscribe ImageCropper's Application.Idle handler on Dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms] Updated ImageToolbox UI to consistently use "image" (not "picture").
 - [SIL.Windows.Forms.Keyboarding] Removed Timer-based deferred IME conversion status restore from WindowsKeyboardSwitchingAdapter, which disrupted active Chinese Pinyin IME compositions (LT-22442). Added diagnostic tracing for keyboard switching and IME state.
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
+- [SIL.Windows.Forms] Fixed ImageCropper crash caused by its `Application.Idle` handler never being unsubscribed, so it could fire on a disposed instance
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -1,0 +1,35 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Threading;
+using NUnit.Framework;
+using SIL.IO;
+using SIL.Windows.Forms.ImageToolbox;
+using SIL.Windows.Forms.ImageToolbox.Cropping;
+
+namespace SIL.Windows.Forms.Tests.ImageToolbox
+{
+	[Apartment(ApartmentState.STA)]
+	[TestFixture]
+	public class ImageCropperTests
+	{
+		[Test]
+		public void Dispose_CalledTwiceAfterSettingImage_DoesNotThrow()
+		{
+			using (var tempFile = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+					bmp.Save(tempFile.Path, ImageFormat.Png);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				{
+					var cropper = new ImageCropper();
+					cropper.Size = new Size(400, 300);
+					cropper.SetImage(palasoImage);
+
+					Assert.DoesNotThrow(() => cropper.Dispose());
+					Assert.DoesNotThrow(() => cropper.Dispose());
+				}
+			}
+		}
+	}
+}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -34,7 +34,10 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 			}
 		}
 
+		// Garbage collection is non-deterministic, so this test may be flaky.
+		// If it turns out to be a problem, drop this test and its supporting method.
 		[Test]
+
 		public void Dispose_AllowsGarbageCollection()
 		{
 			// The ImageCropper subscribes to the static Application.Idle event in its

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using NUnit.Framework;
 using SIL.IO;
@@ -23,12 +25,49 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 
 				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
 				{
-					var cropper = new ImageCropper();
-					cropper.Size = new Size(400, 300);
+					var cropper = new ImageCropper { Size = new Size(400, 300) };
 					cropper.SetImage(palasoImage);
 
 					Assert.DoesNotThrow(() => cropper.Dispose());
 					Assert.DoesNotThrow(() => cropper.Dispose());
+				}
+			}
+		}
+
+		[Test]
+		public void Dispose_AllowsGarbageCollection()
+		{
+			// The ImageCropper subscribes to the static Application.Idle event in its
+			// constructor, so it needs to unsubscribe on Dispose.
+			var reference = CreateAndDisposeImageCropper();
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			Assert.That(reference.IsAlive, Is.False,
+				"ImageCropper was not garbage collected after disposal. " +
+				"It may be subscribed to a static event.");
+		}
+
+		// Kept in a separate, non-inlined method so the local ImageCropper reference is
+		// guaranteed out of scope before the caller forces garbage collection.
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private static WeakReference CreateAndDisposeImageCropper()
+		{
+			using (var tempFile = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+					bmp.Save(tempFile.Path, ImageFormat.Png);
+
+				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
+				{
+					var cropper = new ImageCropper { Size = new Size(400, 300) };
+					cropper.SetImage(palasoImage);
+
+					var reference = new WeakReference(cropper);
+					cropper.Dispose();
+					return reference;
 				}
 			}
 		}
@@ -42,12 +81,11 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					bmp.Save(tempFile.Path, ImageFormat.Png);
 
 				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
-				using (var cropper = new ImageCropper())
+				using (var cropper = new ImageCropper { Size = new Size(400, 300) })
 				{
-					cropper.Size = new Size(400, 300);
 					cropper.SetImage(palasoImage);
 
-					// Not owned by this test -- the cropper still holds and will dispose this itself.
+					// Don't dispose this: the cropper owns _croppingImage and disposes it itself.
 					var croppingImage = GetCroppingImage(cropper);
 
 					Assert.Less(croppingImage.Height, 1200,
@@ -65,12 +103,11 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					bmp.Save(tempFile.Path, ImageFormat.Png);
 
 				using (var palasoImage = PalasoImage.FromFile(tempFile.Path))
-				using (var cropper = new ImageCropper())
+				using (var cropper = new ImageCropper { Size = new Size(400, 300) })
 				{
-					cropper.Size = new Size(400, 300);
 					cropper.SetImage(palasoImage);
 
-					// Not owned by this test -- the cropper still holds and will dispose this itself.
+					// Don't dispose this: the cropper owns _croppingImage and disposes it itself.
 					var croppingImage = GetCroppingImage(cropper);
 
 					Assert.Less(croppingImage.Width, 1200,

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -482,6 +482,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					components = null;
 				}
 
+				Application.Idle -= Application_Idle;
+
 				try
 				{
 					if (_savedOriginalImage != null)


### PR DESCRIPTION
ImageCropper subscribed to the static `Application.Idle` event in its constructor but never unsubscribed in `Dispose`, so the handler could still fire after the control was disposed.

Tests: `Dispose_CalledTwiceAfterSettingImage_DoesNotThrow` is a smoke test, and `Dispose_AllowsGarbageCollection` is a regression test that asserts the control is garbage-collected after disposal — it fails without the unsubscribe fix and passes with it.

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1532/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1532)
<!-- Reviewable:end -->
