### PR TITLE
SettingsLauncherButton: dispose the SettingsProtectionHelper it creates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [build] Fixed the update-language-data workflow so the generated pull request commit message shows the actual update date instead of a literal `$(date ...)` string.
 - [SIL.Archiving] Fixed ArchiveAccessProtocol.GetDocumentationUri failing to create a missing documentation file because the resource lookup stripped the file extension and no longer matched the embedded resource name.
 - [SIL.Windows.Forms.Archiving] Fixed formatting of message in ArchivingDlg so that the name of the auxiliary archive upload program (e.g., "RAMP") is displayed.
-- [SIL.Windows.Forms] Fixed SettingsLauncherButton never disposing the SettingsProtectionHelper it creates, which left an enabled timer running after the button was disposed.
+- [SIL.Windows.Forms] Fixed SettingsLauncherButton never disposing the SettingsProtectionHelper it creates, which left an enabled timer running after the button was disposed. Also removed the button's own unused visibility timer, which had no handler but was posting timer messages for the life of the control.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [build] Fixed the update-language-data workflow so the generated pull request commit message shows the actual update date instead of a literal `$(date ...)` string.
 - [SIL.Archiving] Fixed ArchiveAccessProtocol.GetDocumentationUri failing to create a missing documentation file because the resource lookup stripped the file extension and no longer matched the embedded resource name.
 - [SIL.Windows.Forms.Archiving] Fixed formatting of message in ArchivingDlg so that the name of the auxiliary archive upload program (e.g., "RAMP") is displayed.
+- [SIL.Windows.Forms] Fixed SettingsLauncherButton never disposing the SettingsProtectionHelper it creates, which left an enabled timer running after the button was disposed.
 
 ### Changed
 

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
@@ -12,12 +12,15 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 		[Test]
 		public void Dispose_DisposesTheSettingsProtectionHelperItCreated()
 		{
+			var helperField = typeof(SettingsLauncherButton).GetField("_helper",
+				BindingFlags.NonPublic | BindingFlags.Instance);
+			Assert.That(helperField, Is.Not.Null,
+				"SettingsLauncherButton no longer has a _helper field; update this test");
+
 			SettingsProtectionHelper helper;
 			using (var button = new SettingsLauncherButton())
 			{
-				helper = (SettingsProtectionHelper)typeof(SettingsLauncherButton)
-					.GetField("_helper", BindingFlags.NonPublic | BindingFlags.Instance)
-					.GetValue(button);
+				helper = (SettingsProtectionHelper)helperField.GetValue(button);
 				Assert.That(helper, Is.Not.Null, "Precondition: the button creates a helper");
 			}
 

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
@@ -21,8 +21,6 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 				Assert.That(helper, Is.Not.Null, "Precondition: the button creates a helper");
 			}
 
-			// An undisposed helper keeps an enabled timer running, and the timer roots the helper,
-			// so it is never finalized either.
 			Assert.That(() => helper.CanExtend(new object()),
 				Throws.InstanceOf<ObjectDisposedException>());
 		}

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using SIL.Windows.Forms.SettingProtection;
+
+namespace SIL.Windows.Forms.Tests.SettingsProtection
+{
+	[TestFixture]
+	[Apartment(System.Threading.ApartmentState.STA)]
+	public class SettingsLauncherButtonTests
+	{
+		[Test]
+		public void Dispose_DisposesTheSettingsProtectionHelperItCreated()
+		{
+			SettingsProtectionHelper helper;
+			using (var button = new SettingsLauncherButton())
+			{
+				helper = (SettingsProtectionHelper)typeof(SettingsLauncherButton)
+					.GetField("_helper", BindingFlags.NonPublic | BindingFlags.Instance)
+					.GetValue(button);
+				Assert.That(helper, Is.Not.Null, "Precondition: the button creates a helper");
+			}
+
+			// An undisposed helper keeps an enabled timer running, and the timer roots the helper,
+			// so it is never finalized either.
+			Assert.That(() => helper.CanExtend(new object()),
+				Throws.InstanceOf<ObjectDisposedException>());
+		}
+	}
+}

--- a/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
+++ b/SIL.Windows.Forms.Tests/SettingsProtection/SettingsLauncherButtonTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using NUnit.Framework;
 using SIL.Windows.Forms.SettingProtection;
@@ -12,6 +13,9 @@ namespace SIL.Windows.Forms.Tests.SettingsProtection
 		[Test]
 		public void Dispose_DisposesTheSettingsProtectionHelperItCreated()
 		{
+			// The helper only registers itself with the button's container at run time.
+			Assume.That(LicenseManager.UsageMode, Is.EqualTo(LicenseUsageMode.Runtime));
+
 			var helperField = typeof(SettingsLauncherButton).GetField("_helper",
 				BindingFlags.NonPublic | BindingFlags.Instance);
 			Assert.That(helperField, Is.Not.Null,

--- a/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.Designer.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.Designer.cs
@@ -33,7 +33,6 @@ namespace SIL.Windows.Forms.SettingProtection
 		{
 			this.components = new System.ComponentModel.Container();
 			this._image = new System.Windows.Forms.PictureBox();
-			this._checkVisibilityTmer = new System.Windows.Forms.Timer(this.components);
 			this.l10NSharpExtender1 = new L10NSharp.Windows.Forms.L10NSharpExtender(this.components);
 			this._linkLabel = new BetterLinkLabel();
 			((System.ComponentModel.ISupportInitialize)(this._image)).BeginInit();
@@ -52,10 +51,6 @@ namespace SIL.Windows.Forms.SettingProtection
 			this._image.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
 			this._image.TabIndex = 2;
 			this._image.TabStop = false;
-			//
-			// _checkVisibilityTmer
-			//
-			this._checkVisibilityTmer.Enabled = true;
 			//
 			// l10NSharpExtender1
 			//
@@ -105,7 +100,6 @@ namespace SIL.Windows.Forms.SettingProtection
 		#endregion
 
 		private System.Windows.Forms.PictureBox _image;
-		private System.Windows.Forms.Timer _checkVisibilityTmer;
 		private L10NSharp.Windows.Forms.L10NSharpExtender l10NSharpExtender1;
 		private Widgets.BetterLinkLabel _linkLabel;
 

--- a/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.cs
@@ -16,7 +16,9 @@ namespace SIL.Windows.Forms.SettingProtection
 			this.SetStyle(ControlStyles.SupportsTransparentBackColor, true);
 			InitializeComponent();
 			_linkLabel.Click += OnLinkClicked;
-			_helper = new SettingsProtectionHelper(Container);
+			// Give the helper this control's own container, not Container (the site's container,
+			// which is null at run time), so that disposing this control disposes the helper.
+			_helper = new SettingsProtectionHelper(components);
 			_helper.SetSettingsProtection(this, true);
 		}
 

--- a/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.cs
+++ b/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.cs
@@ -16,8 +16,6 @@ namespace SIL.Windows.Forms.SettingProtection
 			this.SetStyle(ControlStyles.SupportsTransparentBackColor, true);
 			InitializeComponent();
 			_linkLabel.Click += OnLinkClicked;
-			// Give the helper this control's own container, not Container (the site's container,
-			// which is null at run time), so that disposing this control disposes the helper.
 			_helper = new SettingsProtectionHelper(components);
 			_helper.SetSettingsProtection(this, true);
 		}

--- a/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.resx
+++ b/SIL.Windows.Forms/SettingProtection/SettingsLauncherButton.resx
@@ -120,7 +120,4 @@
   <metadata name="l10NSharpExtender1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
 	<value>178, 17</value>
   </metadata>
-  <metadata name="_checkVisibilityTmer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-	<value>17, 17</value>
-  </metadata>
 </root>


### PR DESCRIPTION
## Summary

`SettingsLauncherButton` creates a `SettingsProtectionHelper` in its constructor and passes `Container` — that is `Component.Container`, the *site's* container, which is non-null only at design time. `SettingsProtectionHelper` calls `container?.Add(this)` only at run time, so the two never coincide and nothing ever takes ownership of the helper. The button's `Dispose` disposes only its own `components` container, which the helper was never added to.

So the helper is never disposed. It is never finalized either: its enabled `System.Windows.Forms.Timer` roots it, which means even the `Dispose(false)` "Missing Dispose() call" debug warning cannot surface the leak. The timer goes on ticking and running `UpdateDisplay()` after the button is gone, and the helper keeps a reference to the disposed button in its tracking set.

I confirmed the rooting with a throwaway probe: an abandoned undisposed helper survives `GC.Collect()` + `WaitForPendingFinalizers()`, while the same helper disposed first is collected.

The fix is to hand the helper the button's own `components` container. `InitializeComponent()` has already created it by that line, and `SettingsLauncherButton.Dispose` already disposes it.

Also removes `_checkVisibilityTmer`, a second timer on this control that was dead code: created with `Enabled = true`, never given a `Tick` handler, and referenced nowhere else, so it posted a `WM_TIMER` every 100 ms for the life of every button and dispatched it to nothing. Checking visibility is the job of the helper's own `_checkForCtrlKeyTimer`; this one looks like a leftover from an earlier approach. Its `.resx` designer-tray entry is removed with it.

---

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1534

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1534)
<!-- Reviewable:end -->
