### PR TITLE
Fix Replace failing forever after an interrupted writing system update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.Windows.Forms.Archiving] Fixed formatting of message in ArchivingDlg so that the name of the auxiliary archive upload program (e.g., "RAMP") is displayed.
 - [SIL.Windows.Forms] Fixed SettingsLauncherButton never disposing the SettingsProtectionHelper it creates, which left an enabled timer running after the button was disposed. Also removed the button's own unused visibility timer, which had no handler but was posting timer messages for the life of the control.
 - [SIL.Windows.Forms] Fixed `SettingsProtectionHelper.Dispose` so that it only touches managed resources when disposing, is safe to call more than once, and no longer disposes the Ctrl+Shift timer explicitly (the timer is owned by the component container that disposes it).
+- [SIL.WritingSystems] Fixed `GlobalWritingSystemRepository.Replace` silently failing to update a writing system, after several seconds of retries, when an earlier interrupted update had left a `.localrepoupdate` file behind. It now recovers from the interruption instead of failing on every later attempt, and no longer stalls when the writing system has no file on disk yet.
 
 ### Changed
 

--- a/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
+++ b/SIL.WritingSystems.Tests/GlobalWritingSystemRepositoryTests.cs
@@ -437,6 +437,74 @@ namespace SIL.WritingSystems.Tests
 		}
 
 		[Test]
+		public void Replace_StaleLocalRepoUpdateFileExists_ReplacesAndRemovesStaleFile()
+		{
+			using (var e = CreateTemporaryFolder(TestContext.CurrentContext.Test.Name))
+			{
+				var repo = new GlobalWritingSystemRepository(e.Path);
+				var ws = new WritingSystemDefinition("en-US");
+				repo.Set(ws);
+				repo.Save();
+				string wsFilePath = repo.GetFilePathFromLanguageTag("en-US");
+				Assert.That(File.Exists(wsFilePath), Is.True);
+
+				// Simulate debris left behind by a process that died mid-Replace on a previous run.
+				string staleFile = wsFilePath + ".localrepoupdate";
+				File.WriteAllText(staleFile, "stale");
+
+				var newWs = new WritingSystemDefinition("en-US") {WindowsLcid = "test"};
+				repo.Replace("en-US", newWs);
+
+				Assert.That(repo.Get("en-US").WindowsLcid, Is.EqualTo("test"), "Replace should have taken effect");
+				Assert.That(File.Exists(staleFile), Is.False, "Stale .localrepoupdate file should not be left behind");
+			}
+		}
+
+		[Test]
+		public void Replace_StaleLocalRepoUpdateFileExistsAndLdmlFileMissing_ReplacesAndRemovesStaleFile()
+		{
+			using (var e = CreateTemporaryFolder(TestContext.CurrentContext.Test.Name))
+			{
+				var repo = new GlobalWritingSystemRepository(e.Path);
+				var ws = new WritingSystemDefinition("en-US");
+				repo.Set(ws);
+				repo.Save();
+				string wsFilePath = repo.GetFilePathFromLanguageTag("en-US");
+				Assert.That(File.Exists(wsFilePath), Is.True);
+
+				// Simulate a process that died after stashing the old file but before restoring it.
+				string staleFile = wsFilePath + ".localrepoupdate";
+				File.Copy(wsFilePath, staleFile);
+				File.Delete(wsFilePath);
+
+				var newWs = new WritingSystemDefinition("en-US") {WindowsLcid = "test"};
+				repo.Replace("en-US", newWs);
+
+				Assert.That(repo.Get("en-US").WindowsLcid, Is.EqualTo("test"), "Replace should have taken effect");
+				Assert.That(File.Exists(staleFile), Is.False, "Stale .localrepoupdate file should not be left behind");
+			}
+		}
+
+		[Test]
+		public void Replace_NoLdmlFileAndNoLocalRepoUpdateFile_Replaces()
+		{
+			using (var e = CreateTemporaryFolder(TestContext.CurrentContext.Test.Name))
+			{
+				var repo = new GlobalWritingSystemRepository(e.Path);
+				var ws = new WritingSystemDefinition("en-US");
+				repo.Set(ws); // in memory only; never saved, so no .ldml file exists yet
+				string wsFilePath = repo.GetFilePathFromLanguageTag("en-US");
+				Assert.That(File.Exists(wsFilePath), Is.False);
+
+				var newWs = new WritingSystemDefinition("en-US") {WindowsLcid = "test"};
+				repo.Replace("en-US", newWs);
+
+				Assert.That(repo.Get("en-US").WindowsLcid, Is.EqualTo("test"), "Replace should have taken effect");
+				Assert.That(File.Exists(wsFilePath + ".localrepoupdate"), Is.False, "No stash file should be created when there is nothing to stash");
+			}
+		}
+
+		[Test]
 		public void AllWritingSystems_LdmlCheckingSetEmptyCanNotSave()
 		{
 			using (var tf = CreateTemporaryFolder(TestContext.CurrentContext.Test.Name))

--- a/SIL.WritingSystems/GlobalWritingSystemRepository.cs
+++ b/SIL.WritingSystems/GlobalWritingSystemRepository.cs
@@ -546,17 +546,28 @@ namespace SIL.WritingSystems
 
 		private class WsStasher : IDisposable
 		{
-			private string _wsFile;
+			private readonly string _wsFile;
+			private readonly string _stashFile;
+			private readonly bool _stashed;
 			private const string _localrepoupdate = ".localrepoupdate";
 
 			public WsStasher(string wsFile)
 			{
 				_wsFile = wsFile;
-				RobustFile.Copy(wsFile, wsFile + _localrepoupdate);
+				_stashFile = wsFile + _localrepoupdate;
+
+				// An interrupted update left the stash as the only copy of the file, so put it back.
+				if (!File.Exists(_wsFile) && File.Exists(_stashFile))
+					RobustFile.Move(_stashFile, _wsFile);
+
+				_stashed = File.Exists(_wsFile);
+				if (_stashed)
+					RobustFile.Copy(_wsFile, _stashFile, overwrite: true);
 			}
 			public void Dispose()
 			{
-				RobustFile.Move($"{_wsFile}{_localrepoupdate}", _wsFile);
+				if (_stashed)
+					RobustFile.Move(_stashFile, _wsFile);
 			}
 		}
 	}


### PR DESCRIPTION
**One interrupted writing system update breaks that writing system permanently.** Nothing recovers on its own, and nothing is reported.

`GlobalWritingSystemRepository.Replace` copies the `.ldml` file aside — as `<tag>.ldml.localrepoupdate` — so the old content is still on disk when `Save()` round-trips unknown LDML elements out of it. `WsStasher` makes that copy; its `Dispose` moves it back.

If a process dies part-way through, the copy is left behind, and every later `Replace` for that tag throws in the `WsStasher` **constructor**. That placement is what makes it stick: the `using` body never runs, so the writing system is never updated; `Dispose` never runs, so the debris is never cleared.

It is also slow and silent: `RobustFile` retries ten times 200 ms apart and `OnChangeNotifySharedStore` swallows the exception, so it surfaced only as ~1.8 s added to *every* `LcmCache.Dispose()`, with nothing logged.

## The fix

`base.Replace` removes the file before adding it back, so an interruption leaves one of two states:

1. **`.ldml` still present**, copy stale → copy with `overwrite: true`, making it self-correcting.
2. **`.ldml` already deleted**, copy is the only surviving version → move it back, exactly what the interrupted `Dispose` would have done.

A third route to the same stall: `Replace` on a never-saved writing system had no file to copy. Nothing to preserve, so it no longer tries.

## Tests

Three tests, one per case, asserting the replacement took effect and no debris remains. Each fails before and passes after; 28 green on `net8.0` and `net48`.

## Caveat

`Replace` is the only mutating override here that doesn't take `_mutex.Lock()`. This change makes one narrow concurrent case worse: two racing stashers previously collided harmlessly (the second threw in its constructor, touching nothing); now the second can clobber the first's stash, leaving the first's `Dispose` to fail. No permanent debris. Flagging rather than changing locking semantics here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8yM1naBeYePxhPBgtLj2p

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1535)
<!-- Reviewable:end -->
