### PR TITLE
ImageCropper: dispose the state built for the previous image on re-set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [SIL.DictionaryServices] Fix memory leak in LiftWriter
 - [SIL.Windows.Forms] Fixed ImageCropper crash caused by its `Application.Idle` handler never being unsubscribed, so it could fire on a disposed instance
 - [SIL.Windows.Forms] Fixed ImageCropper not downscaling tall images before cropping (height condition was checking width)
+- [SIL.Windows.Forms] Fixed ImageCropper leaking the temp file and cropping bitmap built for the previous image each time it is given a new one to crop
 - [SIL.WritingSystems] Fix IetfLanguageTag.GetGeneralCode to handle cases when zh-CN or zh-TW is a prefix and not the whole string.
 - [SIL.WritingSystems] More fixes to consistently use 繁体中文 and 简体中文 for Traditional and Simplified Chinese native language names, and Chinese (Traditional) and Chinese (Simplified) for their English names.
 - [SIL.Windows.Forms] Prevent BetterLabel from responding to OnTextChanged when it has been disposed.

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -119,10 +120,87 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 			}
 		}
 
+		[Test]
+		public void SetImage_Reassigned_DisposesStateBuiltForPreviousImage()
+		{
+			using (var tempFile1 = TempFile.WithExtension(".png"))
+			using (var tempFile2 = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+				{
+					bmp.Save(tempFile1.Path, ImageFormat.Png);
+					bmp.Save(tempFile2.Path, ImageFormat.Png);
+				}
+
+				using (var firstImage = PalasoImage.FromFile(tempFile1.Path))
+				using (var secondImage = PalasoImage.FromFile(tempFile2.Path))
+				using (var cropper = new ImageCropper { Size = new Size(400, 300) })
+				{
+					cropper.SetImage(firstImage);
+
+					var firstSavedOriginalPath = GetSavedOriginalImage(cropper).Path;
+					var firstCroppingImage = GetCroppingImage(cropper);
+					Assert.That(File.Exists(firstSavedOriginalPath), Is.True,
+						"Sanity check: the first saved-original temp file should exist before reassignment");
+
+					cropper.SetImage(secondImage);
+
+					Assert.That(File.Exists(firstSavedOriginalPath), Is.False,
+						"Temp file holding the first original should have been deleted on reassignment");
+					Assert.Throws<ArgumentException>(() => { var unused = firstCroppingImage.Width; },
+						"Cropping image for the first original should have been disposed on reassignment");
+				}
+			}
+		}
+
+		[Test]
+		public void SetImage_NewImageFailsToLoad_LeavesPreviousImageStateIntact()
+		{
+			using (var tempFile = TempFile.WithExtension(".png"))
+			{
+				using (var bmp = new Bitmap(100, 80))
+					bmp.Save(tempFile.Path, ImageFormat.Png);
+
+				using (var goodImage = PalasoImage.FromFile(tempFile.Path))
+				using (var cropper = new ImageCropper { Size = new Size(400, 300) })
+				{
+					cropper.SetImage(goodImage);
+
+					var savedOriginalPath = GetSavedOriginalImage(cropper).Path;
+					var croppingImage = GetCroppingImage(cropper);
+
+					// A PalasoImage whose underlying bitmap has been disposed out from under it:
+					// the setter throws while saving the new original.
+					var unusableBitmap = new Bitmap(100, 80);
+					unusableBitmap.Dispose();
+					var unusableImage = PalasoImage.FromImage(unusableBitmap);
+
+					Assert.Throws<ArgumentException>(() => cropper.SetImage(unusableImage));
+
+					Assert.That(File.Exists(savedOriginalPath), Is.True,
+						"A failed reassignment must not delete the temp file we are still cropping from");
+					Assert.That(GetCroppingImage(cropper), Is.SameAs(croppingImage),
+						"A failed reassignment must leave the cropper on the image it was already showing");
+					Assert.DoesNotThrow(() => { var unused = croppingImage.Width; },
+						"A failed reassignment must not dispose the cropping image still in use");
+				}
+			}
+		}
+
+		private static TempFile GetSavedOriginalImage(ImageCropper cropper)
+		{
+			return (TempFile)GetPrivateField(cropper, "_savedOriginalImage");
+		}
+
 		private static Image GetCroppingImage(ImageCropper cropper)
 		{
-			return (Image)typeof(ImageCropper)
-				.GetField("_croppingImage", BindingFlags.NonPublic | BindingFlags.Instance)
+			return (Image)GetPrivateField(cropper, "_croppingImage");
+		}
+
+		private static object GetPrivateField(ImageCropper cropper, string fieldName)
+		{
+			return typeof(ImageCropper)
+				.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
 				.GetValue(cropper);
 		}
 	}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -154,7 +154,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 		}
 
 		[Test]
-		public void SetImage_NewImageFailsToLoad_LeavesPreviousImageStateIntact()
+		public void Image_NewImageFailsToLoad_LeavesPreviousImageStateIntact()
 		{
 			using (var tempFile = TempFile.WithExtension(".png"))
 			{
@@ -166,23 +166,27 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 				{
 					cropper.SetImage(goodImage);
 
-					var savedOriginalPath = GetSavedOriginalImage(cropper).Path;
+					var savedOriginalImage = GetSavedOriginalImage(cropper);
 					var croppingImage = GetCroppingImage(cropper);
 
-					// A PalasoImage whose underlying bitmap has been disposed out from under it:
-					// the setter throws while saving the new original.
+					// A PalasoImage whose underlying bitmap has been disposed out from under it, so
+					// that the setter throws partway through building the state for the new image.
 					var unusableBitmap = new Bitmap(100, 80);
 					unusableBitmap.Dispose();
 					var unusableImage = PalasoImage.FromImage(unusableBitmap);
 
-					Assert.Throws<ArgumentException>(() => cropper.SetImage(unusableImage));
+					// Assign the property rather than calling SetImage: SetImage reads
+					// image.Image.RawFormat first, which would throw before the setter is entered.
+					Assert.Throws<ArgumentException>(() => cropper.Image = unusableImage);
 
-					Assert.That(File.Exists(savedOriginalPath), Is.True,
-						"A failed reassignment must not delete the temp file we are still cropping from");
+					Assert.That(GetSavedOriginalImage(cropper), Is.SameAs(savedOriginalImage),
+						"A failed assignment must leave us cropping from the original we already saved");
+					Assert.That(File.Exists(savedOriginalImage.Path), Is.True,
+						"A failed assignment must not delete the temp file we are still cropping from");
 					Assert.That(GetCroppingImage(cropper), Is.SameAs(croppingImage),
-						"A failed reassignment must leave the cropper on the image it was already showing");
+						"A failed assignment must leave the cropper on the image it was already showing");
 					Assert.DoesNotThrow(() => { var unused = croppingImage.Width; },
-						"A failed reassignment must not dispose the cropping image still in use");
+						"A failed assignment must not dispose the cropping image still in use");
 				}
 			}
 		}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -2,11 +2,11 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using NUnit.Framework;
 using SIL.IO;
+using SIL.Reflection;
 using SIL.Windows.Forms.ImageToolbox;
 using SIL.Windows.Forms.ImageToolbox.Cropping;
 
@@ -191,19 +191,12 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 
 		private static TempFile GetSavedOriginalImage(ImageCropper cropper)
 		{
-			return (TempFile)GetPrivateField(cropper, "_savedOriginalImage");
+			return (TempFile)ReflectionHelper.GetField(cropper, "_savedOriginalImage");
 		}
 
 		private static Image GetCroppingImage(ImageCropper cropper)
 		{
-			return (Image)GetPrivateField(cropper, "_croppingImage");
-		}
-
-		private static object GetPrivateField(ImageCropper cropper, string fieldName)
-		{
-			return typeof(ImageCropper)
-				.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)
-				.GetValue(cropper);
+			return (Image)ReflectionHelper.GetField(cropper, "_croppingImage");
 		}
 	}
 }

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -147,7 +147,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 
 					Assert.That(File.Exists(firstSavedOriginalPath), Is.False,
 						"Temp file holding the first original should have been deleted on reassignment");
-					Assert.Throws<ArgumentException>(() => { var unused = firstCroppingImage.Width; },
+					Assert.That(() => firstCroppingImage.Width, Throws.TypeOf<ArgumentException>(),
 						"Cropping image for the first original should have been disposed on reassignment");
 				}
 			}
@@ -170,7 +170,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					var croppingImage = GetCroppingImage(cropper);
 
 					// A PalasoImage whose underlying bitmap has been disposed out from under it, so
-					// that the setter throws partway through building the state for the new image.
+					// the setter throws partway through.
 					var unusableBitmap = new Bitmap(100, 80);
 					unusableBitmap.Dispose();
 					var unusableImage = PalasoImage.FromImage(unusableBitmap);
@@ -185,7 +185,7 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 						"A failed assignment must not delete the temp file we are still cropping from");
 					Assert.That(GetCroppingImage(cropper), Is.SameAs(croppingImage),
 						"A failed assignment must leave the cropper on the image it was already showing");
-					Assert.DoesNotThrow(() => { var unused = croppingImage.Width; },
+					Assert.That(() => croppingImage.Width, Throws.Nothing,
 						"A failed assignment must not dispose the cropping image still in use");
 				}
 			}

--- a/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
+++ b/SIL.Windows.Forms.Tests/ImageToolbox/ImageCropperTests.cs
@@ -169,8 +169,6 @@ namespace SIL.Windows.Forms.Tests.ImageToolbox
 					var savedOriginalImage = GetSavedOriginalImage(cropper);
 					var croppingImage = GetCroppingImage(cropper);
 
-					// A PalasoImage whose underlying bitmap has been disposed out from under it, so
-					// the setter throws partway through.
 					var unusableBitmap = new Bitmap(100, 80);
 					unusableBitmap.Dispose();
 					var unusableImage = PalasoImage.FromImage(unusableBitmap);

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -182,11 +182,16 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					throw;
 				}
 
-				DisposeImageState(_savedOriginalImage, _croppingImage);
+				var previousSavedOriginalImage = _savedOriginalImage;
+				var previousCroppingImage = _croppingImage;
+
 				_savedOriginalImage = savedOriginalImage;
 				_croppingImage = croppingImage;
-
 				_image = value;
+
+				// Let go of the previous image only once every field is on the new one, so that a
+				// failure to clean it up cannot leave us showing a disposed image.
+				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
 
 				CalculateSourceImageArea();
 				CreateGrips();
@@ -516,11 +521,9 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 			{
 				savedOriginalImage?.Dispose();
 			}
-			// BL-2680, somehow user can get in a state where we CAN'T delete a temp file.
-			// I think we can afford to just ignore it. One temp file will be leaked.
-			catch (IOException)
-			{
-			}
+			// BL-2680, somehow user can get in a state where we CAN'T delete a temp file. We can
+			// afford to just ignore it; one temp file will be leaked. TempFile.Dispose already
+			// ignores an IOException, but leaves this one to us.
 			catch (UnauthorizedAccessException)
 			{
 			}

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -148,8 +148,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
 
-				// Nothing we hold for the current image is touched until the new one is ready, so
-				// that a failure here leaves us on the image we are already showing.
+				// Nothing we hold for the current image is disposed until the new one is built and
+				// every field is on it, so that a failure on either side leaves us on a usable image.
 
 				// save the original in a temp file instead of an Image object to free up memory
 				var savedOriginalImage = TempFile.CreateAndGetPathButDontMakeTheFile();
@@ -189,8 +189,6 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				_croppingImage = croppingImage;
 				_image = value;
 
-				// Let go of the previous image only once every field is on the new one, so that a
-				// failure to clean it up cannot leave us showing a disposed image.
 				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
 
 				CalculateSourceImageArea();

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -145,6 +145,11 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				if (value == null)
 					return;
 
+				// Hold on to what we built for the previous image until the new one is fully in
+				// place, so that a failure below leaves us on the image we were already showing.
+				var previousSavedOriginalImage = _savedOriginalImage;
+				var previousCroppingImage = _croppingImage;
+
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
 
@@ -171,6 +176,9 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				}
 
 				_image = value;
+
+				// These used to be simply overwritten above, leaking the temp file and the bitmap.
+				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
 
 				CalculateSourceImageArea();
 				CreateGrips();
@@ -484,30 +492,34 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 
 				Application.Idle -= Application_Idle;
 
-				try
-				{
-					if (_savedOriginalImage != null)
-					{
-						_savedOriginalImage.Dispose();
-						_savedOriginalImage = null;
-					}
-
-					if (_croppingImage != null)
-					{
-						_croppingImage.Dispose();
-						_croppingImage = null;
-					}
-				}
-				// BL-2680, somehow user can get in a state where we CAN'T delete a temp file.
-				// I think we can afford to just ignore it. One temp file will be leaked.
-				catch (IOException)
-				{
-				}
-				catch (UnauthorizedAccessException)
-				{
-				}
+				DisposeImageState(_savedOriginalImage, _croppingImage);
+				_savedOriginalImage = null;
+				_croppingImage = null;
 			}
 			base.Dispose(disposing);
+		}
+
+		/// <summary>
+		/// Disposes the temp file and cropping image built for a given image, whether because we
+		/// are being given a new image to crop or because we are being disposed.
+		/// </summary>
+		private static void DisposeImageState(TempFile savedOriginalImage, Image croppingImage)
+		{
+			// Dispose the bitmap first: unlike deleting the temp file, it cannot fail.
+			croppingImage?.Dispose();
+
+			try
+			{
+				savedOriginalImage?.Dispose();
+			}
+			// BL-2680, somehow user can get in a state where we CAN'T delete a temp file.
+			// I think we can afford to just ignore it. One temp file will be leaked.
+			catch (IOException)
+			{
+			}
+			catch (UnauthorizedAccessException)
+			{
+			}
 		}
 	}
 }

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -468,8 +468,10 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 			}
 			else
 			{
-				_originalFormat = image.Image.RawFormat;
+				var originalFormat = image.Image.RawFormat;
 				Image = image;
+				// If the Image setter throws, _originalFormat must still describe the previous image.
+				_originalFormat = originalFormat;
 			}
 		}
 

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -149,7 +149,7 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				//so we better keep our own.
 
 				// Nothing we hold for the current image is disposed until the new one is built and
-				// every field is on it, so that a failure on either side leaves us on a usable image.
+				// the control fully switched to it, so a failure on either side leaves us usable.
 
 				// save the original in a temp file instead of an Image object to free up memory
 				var savedOriginalImage = TempFile.CreateAndGetPathButDontMakeTheFile();
@@ -189,8 +189,6 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				_croppingImage = croppingImage;
 				_image = value;
 
-				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
-
 				CalculateSourceImageArea();
 				CreateGrips();
 
@@ -200,6 +198,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				}
 
 				Invalidate();
+
+				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
 			}
 		}
 

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -148,9 +148,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
 
-				// Build everything for the new image into locals before touching what we hold for
-				// the current one, so that a failure here leaves us on the image we are already
-				// showing rather than in a half-updated state.
+				// Nothing we hold for the current image is touched until the new one is ready, so
+				// that a failure here leaves us on the image we are already showing.
 
 				// save the original in a temp file instead of an Image object to free up memory
 				var savedOriginalImage = TempFile.CreateAndGetPathButDontMakeTheFile();
@@ -183,8 +182,6 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 					throw;
 				}
 
-				// Only now that the new image is ready do we let go of the previous one. These used
-				// to be simply overwritten, leaking the temp file and the bitmap.
 				DisposeImageState(_savedOriginalImage, _croppingImage);
 				_savedOriginalImage = savedOriginalImage;
 				_croppingImage = croppingImage;
@@ -510,10 +507,6 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 			base.Dispose(disposing);
 		}
 
-		/// <summary>
-		/// Disposes the temp file and cropping image built for a given image, whether because we
-		/// are being given a new image to crop or because we are being disposed.
-		/// </summary>
 		private static void DisposeImageState(TempFile savedOriginalImage, Image croppingImage)
 		{
 			// Dispose the bitmap first: unlike deleting the temp file, it cannot fail.

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -148,8 +148,8 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
 
-				// Nothing we hold for the current image is disposed until the new one is built and
-				// the control fully switched to it, so a failure on either side leaves us usable.
+				// Nothing we hold for the current image is disposed until the new one is built, so
+				// a failure while building leaves us on the image we are already showing.
 
 				// save the original in a temp file instead of an Image object to free up memory
 				var savedOriginalImage = TempFile.CreateAndGetPathButDontMakeTheFile();
@@ -189,17 +189,22 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				_croppingImage = croppingImage;
 				_image = value;
 
-				CalculateSourceImageArea();
-				CreateGrips();
-
-				foreach (var grip in Grips)
+				try
 				{
-					grip.UpdateRectangle();
+					CalculateSourceImageArea();
+					CreateGrips();
+
+					foreach (var grip in Grips)
+					{
+						grip.UpdateRectangle();
+					}
+
+					Invalidate();
 				}
-
-				Invalidate();
-
-				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
+				finally
+				{
+					DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
+				}
 			}
 		}
 

--- a/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
+++ b/SIL.Windows.Forms/ImageToolbox/Cropping/ImageCropper.cs
@@ -145,40 +145,51 @@ namespace SIL.Windows.Forms.ImageToolbox.Cropping
 				if (value == null)
 					return;
 
-				// Hold on to what we built for the previous image until the new one is fully in
-				// place, so that a failure below leaves us on the image we were already showing.
-				var previousSavedOriginalImage = _savedOriginalImage;
-				var previousCroppingImage = _croppingImage;
-
 				//other code changes the image of this palaso image, at which time the PI disposes of its copy,
 				//so we better keep our own.
 
+				// Build everything for the new image into locals before touching what we hold for
+				// the current one, so that a failure here leaves us on the image we are already
+				// showing rather than in a half-updated state.
+
 				// save the original in a temp file instead of an Image object to free up memory
-				_savedOriginalImage = TempFile.CreateAndGetPathButDontMakeTheFile();
-				value.Image.Save(_savedOriginalImage.Path, ImageFormat.Png);
-
-				// make a reasonable sized copy to crop
-				if ((value.Image.Width > 1000) || (value.Image.Height > 1000))
+				var savedOriginalImage = TempFile.CreateAndGetPathButDontMakeTheFile();
+				Image croppingImage = null;
+				try
 				{
-					_croppingImage = CreateCroppingImage(value.Image.Height, value.Image.Width);
+					value.Image.Save(savedOriginalImage.Path, ImageFormat.Png);
 
-					var srcRect = new Rectangle(0, 0, value.Image.Width, value.Image.Height);
-					var destRect = new Rectangle(0, 0, _croppingImage.Width, _croppingImage.Height);
-
-					using (var g = Graphics.FromImage(_croppingImage))
+					// make a reasonable sized copy to crop
+					if ((value.Image.Width > 1000) || (value.Image.Height > 1000))
 					{
-						g.DrawImage(value.Image, destRect, srcRect, GraphicsUnit.Pixel);
+						croppingImage = CreateCroppingImage(value.Image.Height, value.Image.Width);
+
+						var srcRect = new Rectangle(0, 0, value.Image.Width, value.Image.Height);
+						var destRect = new Rectangle(0, 0, croppingImage.Width, croppingImage.Height);
+
+						using (var g = Graphics.FromImage(croppingImage))
+						{
+							g.DrawImage(value.Image, destRect, srcRect, GraphicsUnit.Pixel);
+						}
+					}
+					else
+					{
+						croppingImage = (Image)value.Image.Clone();
 					}
 				}
-				else
+				catch
 				{
-					_croppingImage = (Image)value.Image.Clone();
+					DisposeImageState(savedOriginalImage, croppingImage);
+					throw;
 				}
 
-				_image = value;
+				// Only now that the new image is ready do we let go of the previous one. These used
+				// to be simply overwritten, leaking the temp file and the bitmap.
+				DisposeImageState(_savedOriginalImage, _croppingImage);
+				_savedOriginalImage = savedOriginalImage;
+				_croppingImage = croppingImage;
 
-				// These used to be simply overwritten above, leaking the temp file and the bitmap.
-				DisposeImageState(previousSavedOriginalImage, previousCroppingImage);
+				_image = value;
 
 				CalculateSourceImageArea();
 				CreateGrips();


### PR DESCRIPTION
The `Image` setter holds two things for the image it is cropping: a temp file with the original at full resolution, and a possibly-downscaled bitmap to display. It mishandles both when given a new image.

It overwrites the two fields without disposing what was there, leaking a temp file and a bitmap on every re-set — the normal path, since re-entering the Crop tab re-sets `Image`. The leaked bitmap is a clone of a file-backed image, so it also holds a lock on the previous source file: disposing that `PalasoImage` trips `Debug.Fail("Not able to delete image temp file")` with `IOException: the process cannot access the file ... because it is being used by another process`.

It also assigns `_savedOriginalImage` before `value.Image.Save` can throw. If it does, the field is left pointing at the new, empty temp file while the cropper still displays the previous image, so `GetCroppedImage` crops from the empty file.

### The change

Build the temp file and the cropping bitmap into locals and store them only once both are ready — disposing the previous pair at that point, or the partial state if anything throws. The BL-2680-tolerant disposal is factored out of `Dispose` so the three call sites share it.

`SetImage` likewise commits `_originalFormat` only after the setter succeeds, so a failure no longer leaves it on the new image while everything else is on the old.

### Tests

Both fail without the change.

- `SetImage_Reassigned_DisposesStateBuiltForPreviousImage` — the previous temp file is still on disk after a re-set.
- `Image_NewImageFailsToLoad_LeavesPreviousImageStateIntact` — after a failed assignment the cropper still holds the same temp file and bitmap.

`--filter ImageToolbox` is green on net8.0-windows and net48: 47 passed, 1 pre-existing skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1536)
<!-- Reviewable:end -->
