### PR TITLE
Fix flaky Play_InvalidAudioFileThrowsBackgroundException test

### DIFF
--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -463,9 +463,8 @@ namespace SIL.Media.Tests
 			{
 				AudioFactory.PlaybackErrorMessage = "Yikes!";
 				using var e = new ErrorReport.NonFatalErrorReportExpected();
-				// The extension decides which NAudio reader gets the file: .wav fails fast in
-				// managed code, whereas an unrecognized one goes to Media Foundation, whose
-				// first-use startup on a CI agent can take seconds.
+				// .wav so NAudio rejects it in managed code rather than handing it to Media
+				// Foundation, whose first-use startup on CI can take seconds.
 				using var file = TempFile.WithExtension(".wav");
 				RobustFile.WriteAllText(file.Path, "not valid audio");
 				using var session =
@@ -477,8 +476,6 @@ namespace SIL.Media.Tests
 				};
 				Assert.DoesNotThrow(() => session.Play(),
 					"Error should not happen in main thread");
-				// IsPlaying goes false before PlaybackStopped is raised and the error is reported,
-				// so wait for the report rather than for playback to stop.
 				Assert.That(() => e.Exception != null, Is.True.After(10000, 20),
 					"Playback failure should have been reported as a non-fatal error.");
 				Assert.That(e.Exception, Is.EqualTo(reportedExceptionInPlaybackStopped));

--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -457,14 +457,17 @@ namespace SIL.Media.Tests
 		/// </summary>
 		[Test]
 		[Platform(Exclude = "Linux", Reason = "Not sure where Linux implementation would fail")]
-		[Timeout(4000)]
 		public void Play_InvalidAudioFileThrowsBackgroundException_NonFatalErrorReported()
 		{
 			try
 			{
 				AudioFactory.PlaybackErrorMessage = "Yikes!";
 				using var e = new ErrorReport.NonFatalErrorReportExpected();
-				using var file = new TempFile("not valid audio");
+				// The extension decides which NAudio reader gets the file: .wav fails fast in
+				// managed code, whereas an unrecognized one goes to Media Foundation, whose
+				// first-use startup on a CI agent can take seconds.
+				using var file = TempFile.WithExtension(".wav");
+				RobustFile.WriteAllText(file.Path, "not valid audio");
 				using var session =
 					(ISimpleAudioWithEvents)AudioFactory.CreateAudioSession(file.Path);
 				Exception reportedExceptionInPlaybackStopped = null;
@@ -474,8 +477,10 @@ namespace SIL.Media.Tests
 				};
 				Assert.DoesNotThrow(() => session.Play(),
 					"Error should not happen in main thread");
-				while (session.IsPlaying)
-					Thread.Sleep(20);
+				// IsPlaying goes false before PlaybackStopped is raised and the error is reported,
+				// so wait for the report rather than for playback to stop.
+				Assert.That(() => e.Exception != null, Is.True.After(10000, 20),
+					"Playback failure should have been reported as a non-fatal error.");
 				Assert.That(e.Exception, Is.EqualTo(reportedExceptionInPlaybackStopped));
 				Assert.That(e.Message, Is.EqualTo("Yikes!"));
 			}


### PR DESCRIPTION
Waits for the reported error instead of `IsPlaying`, which goes false before
`PlaybackStopped` is raised and the error is reported. The bounded wait replaces
`[Timeout(4000)]`, which CI overran (13 s) while initializing audio. The `.wav`
extension keeps NAudio from routing the file through Media Foundation.

Part of #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1537

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1537)
<!-- Reviewable:end -->
