### PR TITLE
Raise TestNAudioWaveOutEvent.PlaybackStopped outside its lock

### DIFF
--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -380,8 +380,16 @@ namespace SIL.Media.Tests
 			// at least it has been queued to start.
 			Assert.That(session.IsPlaying, Is.True);
 			Assert.DoesNotThrow(() => session.StopPlaying());
-			Assert.That(() => session.IsPlaying, Is.False.After(10000, 20),
-				"Stop playing should have (immediately or eventually) stopped playback.");
+			if (session.IsPlaying)
+			{
+#if NET462 || NET48
+				Thread.Sleep(TestNAudioWaveOutEvent.kDelayWhenStopping * 2);
+#else
+				Thread.Sleep(1000);
+#endif
+				Assert.That(session.IsPlaying, Is.False,
+					"Stop playing should have (immediately or eventually) stopped playback.");
+			}
 		}
 
 #if NET462 || NET48 // These tests won't compile in .NET 8 because WindowsAudioSession is not

--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -380,16 +380,8 @@ namespace SIL.Media.Tests
 			// at least it has been queued to start.
 			Assert.That(session.IsPlaying, Is.True);
 			Assert.DoesNotThrow(() => session.StopPlaying());
-			if (session.IsPlaying)
-			{
-#if NET462 || NET48
-				Thread.Sleep(TestNAudioWaveOutEvent.kDelayWhenStopping * 2);
-#else
-				Thread.Sleep(1000);
-#endif
-				Assert.That(session.IsPlaying, Is.False,
-					"Stop playing should have (immediately or eventually) stopped playback.");
-			}
+			Assert.That(() => session.IsPlaying, Is.False.After(10000, 20),
+				"Stop playing should have (immediately or eventually) stopped playback.");
 		}
 
 #if NET462 || NET48 // These tests won't compile in .NET 8 because WindowsAudioSession is not

--- a/SIL.Media.Tests/TestNAudioWaveOutEvent.cs
+++ b/SIL.Media.Tests/TestNAudioWaveOutEvent.cs
@@ -39,11 +39,7 @@ namespace SIL.Media
 			lock (_lock)
 			{
 				_timer = new Timer(_simulatedMediaTime);
-				_timer.Elapsed += (sender, args) =>
-				{
-					lock (_lock)
-						MediaPlaybackStopped();
-				};
+				_timer.Elapsed += (sender, args) => MediaPlaybackStopped();
 				_timer.Start();
 				PlaybackState = PlaybackState.Playing;
 			}
@@ -54,21 +50,29 @@ namespace SIL.Media
 			lock (_lock)
 			{
 				if (_provider != null && PlaybackState == PlaybackState.Playing)
+				{
 					_timer.Interval = kDelayWhenStopping;
-				else
-					MediaPlaybackStopped();
+					return;
+				}
 			}
+
+			MediaPlaybackStopped();
 		}
 
 		private void MediaPlaybackStopped()
 		{
-			_timer?.Dispose();
-
-			if (PlaybackState == PlaybackState.Playing)
+			lock (_lock)
 			{
+				_timer?.Dispose();
+
+				if (PlaybackState != PlaybackState.Playing)
+					return;
 				PlaybackState = PlaybackState.Stopped;
-				PlaybackStopped?.Invoke(this, new StoppedEventArgs());
 			}
+
+			// Raised outside the lock to avoid deadlock: the session holds its own lock
+			// across Stop, and the handler takes it.
+			PlaybackStopped?.Invoke(this, new StoppedEventArgs());
 		}
 	}
 }


### PR DESCRIPTION
`MediaPlaybackStopped` raised `PlaybackStopped` while holding this class's lock.
The handler takes `WindowsAudioSession`'s lock, and `StopPlaying` holds that lock
across its call to `Stop()`, so the two could be acquired in opposite orders and
deadlock. Raise the event after releasing the lock.

The state transition to `Stopped` stays inside the lock, so the event is still
raised exactly once.

CI failure: none known. This deadlock has not been observed; it would show up as a
hang rather than a failure, and would be caught by `--blame-hang-timeout`.

Part of #1516

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1538)
<!-- Reviewable:end -->