### PR TITLE
Fix flaky PlayAndStopPlaying_NonWindows_DoesNotThrow test

### DIFF
--- a/SIL.Media.Tests/AudioSessionTests.cs
+++ b/SIL.Media.Tests/AudioSessionTests.cs
@@ -380,16 +380,8 @@ namespace SIL.Media.Tests
 			// at least it has been queued to start.
 			Assert.That(session.IsPlaying, Is.True);
 			Assert.DoesNotThrow(() => session.StopPlaying());
-			if (session.IsPlaying)
-			{
-#if NET462 || NET48
-				Thread.Sleep(TestNAudioWaveOutEvent.kDelayWhenStopping * 2);
-#else
-				Thread.Sleep(1000);
-#endif
-				Assert.That(session.IsPlaying, Is.False,
-					"Stop playing should have (immediately or eventually) stopped playback.");
-			}
+			Assert.That(() => session.IsPlaying, Is.False.After(10000, 20),
+				"Stop playing should have (immediately or eventually) stopped playback.");
 		}
 
 #if NET462 || NET48 // These tests won't compile in .NET 8 because WindowsAudioSession is not


### PR DESCRIPTION
Polls for `IsPlaying` instead of sleeping twice `kDelayWhenStopping` and asserting.
Stopping is asynchronous, so the fixed sleep left ~50 ms of slack, which a loaded
CI agent does not always have.

CI failure: https://github.com/sillsdev/libpalaso/actions/runs/28372918756/job/84055017433?pr=1520#step:14:1653

Part of #1516

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1539)
<!-- Reviewable:end -->