### PR TITLE
Fix flaky HotSpotMouseClick_MouseClickOverHotSpot_FiresMouseClick test

### DIFF
--- a/SIL.Windows.Forms.Tests/Hotspot/MouseSimulator.cs
+++ b/SIL.Windows.Forms.Tests/Hotspot/MouseSimulator.cs
@@ -56,8 +56,10 @@ public static class MouseSimulator
 
 	public static void SimulateMouseClick(this Control control, int x, int y)
 	{
-		SimulateMouseDown(control, x, y);
-		SimulateMouseUp(control, x, y);
+		// Not WM_LBUTTONDOWN/UP: WinForms only synthesizes a click from those when the
+		// control is the topmost window at that screen point, which a test cannot rely on.
+		ReflectionHelper.CallMethod(control, "OnMouseClick",
+			new MouseEventArgs(MouseButtons.Left, 1, x, y, 0));
 	}
 
 	public static void SimulateMouseMove(this HotSpot hotspot)


### PR DESCRIPTION
`SimulateMouseClick` sent `WM_LBUTTONDOWN`/`WM_LBUTTONUP`, but `Control.WmMouseUp`
raises `Click`/`MouseClick` only when `WindowFromPoint` for the message's screen
position returns the control's own handle. A test cannot rely on its form being
the topmost window there, so on CI the click sometimes never fired.

Raise `OnMouseClick` directly instead, as `SimulateMouseHover` already does.

Verified with a covering `TopMost` window: the old helper drops the click, the new
one does not, and a click off the hot spot still correctly fires nothing.

CI failure: https://github.com/sillsdev/libpalaso/actions/runs/33097992679/job/98607862662?pr=1537#step:14:1787

Closes #1516

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1540)
<!-- Reviewable:end -->