### PR TITLE
Drop three test sleeps that wait for nothing

### DIFF
--- a/SIL.Core.Desktop.Tests/Progress/Commands/CommandTests.cs
+++ b/SIL.Core.Desktop.Tests/Progress/Commands/CommandTests.cs
@@ -63,7 +63,6 @@ namespace SIL.Tests.Progress.Commands
 		{
 			TestCommand cmd = new TestCommand();
 			cmd.BeginInvoke();
-			Thread.Sleep(10);
 			Assert.IsFalse(cmd.Enabled);
 			cmd.Cancel();
 			Assert.IsTrue(cmd.Canceling);

--- a/SIL.Media.Tests/AudioRecorderTests.cs
+++ b/SIL.Media.Tests/AudioRecorderTests.cs
@@ -98,7 +98,6 @@ namespace SIL.Media.Tests
 
 					ctrl.CreateControl();
 
-					Thread.Sleep(10);
 					Assert.That(() => recorder.BeginRecording("blah.wav"), Throws.InvalidOperationException);
 
 				}
@@ -128,7 +127,6 @@ namespace SIL.Media.Tests
 
 					ctrl.CreateControl();
 
-					Thread.Sleep(10);
 					Assert.That(() => recorder.BeginMonitoring(), Throws.InvalidOperationException);
 
 				}


### PR DESCRIPTION
Each of these sleeps sits between a call and an assertion about state the call
already set on the calling thread before returning:

- `AsyncCommand.BeginInvoke` sets `Enabled = false` before `BeginInvokeCore`.
- `AudioRecorder.BeginRecording` sets `RecordingState = Recording` under lock
  before returning, and `CreateControl` fires `HandleCreated` synchronously.

They cost time and imply a race that is not there.

CI failure: none. This is not a flakiness fix -- these assertions could not have
failed for timing reasons. Note that `AudioRecorderTests` is categorized
`RequiresAudioInputDevice`, so CI does not run the two tests changed there.

Devin review: https://app.devin.ai/review/sillsdev/libpalaso/pull/1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/libpalaso/1541)
<!-- Reviewable:end -->